### PR TITLE
fix(gametheory,#15461): GT-02c weak domination + r=1 multi-equilibria regimes

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb
@@ -5,10 +5,10 @@
    "id": "f33ea1ef",
    "metadata": {
     "papermill": {
-     "duration": 0.004031,
-     "end_time": "2026-09-07T13:09:09.667253",
+     "duration": 0.002724,
+     "end_time": "2026-09-10T12:37:24.059104",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.663222",
+     "start_time": "2026-09-10T12:37:24.056380",
      "status": "completed"
     },
     "tags": []
@@ -26,10 +26,10 @@
    "id": "c9ea0d81",
    "metadata": {
     "papermill": {
-     "duration": 0.002614,
-     "end_time": "2026-09-07T13:09:09.672936",
+     "duration": 0.001876,
+     "end_time": "2026-09-10T12:37:24.063154",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.670322",
+     "start_time": "2026-09-10T12:37:24.061278",
      "status": "completed"
     },
     "tags": []
@@ -53,10 +53,10 @@
    "id": "f08a6b8a",
    "metadata": {
     "papermill": {
-     "duration": 0.001942,
-     "end_time": "2026-09-07T13:09:09.676924",
+     "duration": 0.001963,
+     "end_time": "2026-09-10T12:37:24.067043",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.674982",
+     "start_time": "2026-09-10T12:37:24.065080",
      "status": "completed"
     },
     "tags": []
@@ -77,10 +77,10 @@
    "id": "6de64818",
    "metadata": {
     "papermill": {
-     "duration": 0.001924,
-     "end_time": "2026-09-07T13:09:09.680892",
+     "duration": 0.001975,
+     "end_time": "2026-09-10T12:37:24.070950",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.678968",
+     "start_time": "2026-09-10T12:37:24.068975",
      "status": "completed"
     },
     "tags": []
@@ -103,10 +103,10 @@
    "id": "320bea43",
    "metadata": {
     "papermill": {
-     "duration": 0.001943,
-     "end_time": "2026-09-07T13:09:09.684847",
+     "duration": 0.002334,
+     "end_time": "2026-09-10T12:37:24.075420",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.682904",
+     "start_time": "2026-09-10T12:37:24.073086",
      "status": "completed"
     },
     "tags": []
@@ -120,10 +120,10 @@
    "id": "98a7c129",
    "metadata": {
     "papermill": {
-     "duration": 0.002007,
-     "end_time": "2026-09-07T13:09:09.688938",
+     "duration": 0.001935,
+     "end_time": "2026-09-10T12:37:24.079384",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.686931",
+     "start_time": "2026-09-10T12:37:24.077449",
      "status": "completed"
     },
     "tags": []
@@ -149,10 +149,10 @@
    "id": "f9c23f5b",
    "metadata": {
     "papermill": {
-     "duration": 0.001939,
-     "end_time": "2026-09-07T13:09:09.692945",
+     "duration": 0.001976,
+     "end_time": "2026-09-10T12:37:24.083390",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.691006",
+     "start_time": "2026-09-10T12:37:24.081414",
      "status": "completed"
     },
     "tags": []
@@ -167,16 +167,16 @@
    "id": "2afb149c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:09.698010Z",
-     "iopub.status.busy": "2026-09-07T13:09:09.697787Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.192930Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.192403Z"
+     "iopub.execute_input": "2026-09-10T12:37:24.088532Z",
+     "iopub.status.busy": "2026-09-10T12:37:24.088144Z",
+     "iopub.status.idle": "2026-09-10T12:37:24.821370Z",
+     "shell.execute_reply": "2026-09-10T12:37:24.820911Z"
     },
     "papermill": {
-     "duration": 0.498773,
-     "end_time": "2026-09-07T13:09:10.193838",
+     "duration": 0.736893,
+     "end_time": "2026-09-10T12:37:24.822244",
      "exception": false,
-     "start_time": "2026-09-07T13:09:09.695065",
+     "start_time": "2026-09-10T12:37:24.085351",
      "status": "completed"
     },
     "tags": []
@@ -224,10 +224,10 @@
    "id": "3c356459",
    "metadata": {
     "papermill": {
-     "duration": 0.002079,
-     "end_time": "2026-09-07T13:09:10.198313",
+     "duration": 0.002245,
+     "end_time": "2026-09-10T12:37:24.826855",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.196234",
+     "start_time": "2026-09-10T12:37:24.824610",
      "status": "completed"
     },
     "tags": []
@@ -243,10 +243,10 @@
    "id": "cfa312b9",
    "metadata": {
     "papermill": {
-     "duration": 0.00382,
-     "end_time": "2026-09-07T13:09:10.204241",
+     "duration": 0.002112,
+     "end_time": "2026-09-10T12:37:24.831081",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.200421",
+     "start_time": "2026-09-10T12:37:24.828969",
      "status": "completed"
     },
     "tags": []
@@ -260,10 +260,10 @@
    "id": "27e6b87a",
    "metadata": {
     "papermill": {
-     "duration": 0.00199,
-     "end_time": "2026-09-07T13:09:10.208334",
+     "duration": 0.002134,
+     "end_time": "2026-09-10T12:37:24.837363",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.206344",
+     "start_time": "2026-09-10T12:37:24.835229",
      "status": "completed"
     },
     "tags": []
@@ -280,16 +280,16 @@
    "id": "6258e8cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.213544Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.213158Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.217316Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.216880Z"
+     "iopub.execute_input": "2026-09-10T12:37:24.842529Z",
+     "iopub.status.busy": "2026-09-10T12:37:24.842284Z",
+     "iopub.status.idle": "2026-09-10T12:37:24.846296Z",
+     "shell.execute_reply": "2026-09-10T12:37:24.845873Z"
     },
     "papermill": {
-     "duration": 0.007547,
-     "end_time": "2026-09-07T13:09:10.217950",
+     "duration": 0.007504,
+     "end_time": "2026-09-10T12:37:24.846990",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.210403",
+     "start_time": "2026-09-10T12:37:24.839486",
      "status": "completed"
     },
     "tags": []
@@ -308,7 +308,13 @@
    ],
    "source": [
     "def best_response(y: int, r: float = 2.0, c_max: int = C_MAX) -> tuple[int, float]:\n",
-    "    \"\"\"Meilleure reponse de Ligne a la reclamation y de Colonne.\"\"\"\n",
+    "    \"\"\"Meilleure reponse de Ligne a la reclamation y de Colonne.\n",
+    "\n",
+    "    En cas d'egalite de paiement, max() parcourt x par x croissant et garde\n",
+    "    le PREMIER maximum atteint : la convention algorithmique retient le plus\n",
+    "    petit argmax. Ce n'est pas une unicite mathematique -- a r = 1 la vraie\n",
+    "    meilleure reponse est multi-valuee {y-1, y} (cf. section 4).\n",
+    "    \"\"\"\n",
     "    vals = [(x, u1(x, y, r, c_max)) for x in range(C_MIN, c_max + 1)]\n",
     "    x_star, v_star = max(vals, key=lambda t: t[1])\n",
     "    return x_star, v_star\n",
@@ -316,7 +322,7 @@
     "print(\"y=100 -> x*\", best_response(100))\n",
     "print(\"y=2   -> x*\", best_response(2))\n",
     "print(\"y=55  -> x*\", best_response(55))\n",
-    "print(\"y=3   -> x*\", best_response(3))"
+    "print(\"y=3   -> x*\", best_response(3))\n"
    ]
   },
   {
@@ -324,10 +330,10 @@
    "id": "a10d0120",
    "metadata": {
     "papermill": {
-     "duration": 0.002111,
-     "end_time": "2026-09-07T13:09:10.222286",
+     "duration": 0.002126,
+     "end_time": "2026-09-10T12:37:24.851274",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.220175",
+     "start_time": "2026-09-10T12:37:24.849148",
      "status": "completed"
     },
     "tags": []
@@ -335,7 +341,9 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "La meilleure réponse est **systématiquement `max(C_MIN, y-1)`** : réclamer *un de moins* que l'autre donne le minimum (=$y-1$) **plus** le bonus, soit $y-1+2 = y+1$, ce qui bat réclamer la même chose ($y$) ou davantage. Seule exception : quand l'autre a déjà réclamé le **plancher** ($y=2$), on ne peut pas descendre en dessous — on est forcé à l'égalité (2,2)."
+    "La meilleure réponse est **systématiquement `max(C_MIN, y-1)`** : réclamer *un de moins* que l'autre donne le minimum (=$y-1$) **plus** le bonus, soit $y-1+2 = y+1$, ce qui bat réclamer la même chose ($y$) ou davantage. Seule exception : quand l'autre a déjà réclamé le **plancher** ($y=2$), on ne peut pas descendre en dessous — on est forcé à l'égalité (2,2).\n",
+    "\n",
+    "Ce calcul est fait à $r = 2$. À $r = 1$ il change de nature : sous-coter à $y-1$ rapporte $(y-1)+1 = y$, soit **exactement autant** que rester à $y$ — la meilleure réponse devient l'**ensemble** $\\{y-1,\\, y\\}$, et la cellule ci-dessus n'en montre qu'un représentant (le plus petit, par convention de tie-breaking)."
    ]
   },
   {
@@ -343,16 +351,16 @@
    "id": "c3c487f4",
    "metadata": {
     "papermill": {
-     "duration": 0.001997,
-     "end_time": "2026-09-07T13:09:10.226361",
+     "duration": 0.002295,
+     "end_time": "2026-09-10T12:37:24.855790",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.224364",
+     "start_time": "2026-09-10T12:37:24.853495",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. L'élimination itérée des stratégies strictement dominées"
+    "## 3. L'élimination itérée des stratégies faiblement dominées\n"
    ]
   },
   {
@@ -360,10 +368,10 @@
    "id": "cffe927f",
    "metadata": {
     "papermill": {
-     "duration": 0.002011,
-     "end_time": "2026-09-07T13:09:10.230468",
+     "duration": 0.002499,
+     "end_time": "2026-09-10T12:37:24.860803",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.228457",
+     "start_time": "2026-09-10T12:37:24.858304",
      "status": "completed"
     },
     "tags": []
@@ -371,7 +379,7 @@
    "source": [
     "### Le raisonnement qui mène à (2,2)\n",
     "\n",
-    "La meilleure réponse à une réclamation $y$ est **$y-1$** : réclamer un de moins que l'autre rapporte $y-1+r$ (le minimum majoré du bonus), ce qui bat réclamer la même chose ($y$) ou davantage. La conséquence n'est pas un gain global immédiat, mais une **élimination de haut en bas** : dans le jeu réduit aux stratégies restantes, la plus haute réclamation $k$ est strictement dominée par $k-1$ — les seules situations où $k-1$ était moins bon (un adversaire réclamant au-dessus de $k$) ont déjà été éliminées. En cascade, 100 est éliminé, puis 99, … jusqu'à ce qu'il ne reste que **$x = 2$**."
+    "La meilleure réponse à une réclamation $y$ est **$y-1$** : réclamer un de moins que l'autre rapporte $y-1+r$ (le minimum majoré du bonus), ce qui bat réclamer la même chose ($y$) ou davantage. La conséquence n'est pas un gain global immédiat, mais une **élimination de haut en bas** : dans le jeu réduit aux stratégies restantes, la plus haute réclamation $k$ est **faiblement dominée** par $k-1$ — jamais *strictement* dominée, car face à un adversaire qui réclame $y < k-1$, les deux stratégies sont également pénalisées ($y - r$ chacune). La domination est *faible au sens exact* : $k-1$ rapporte **au moins autant partout** (égalité stricte contre $y < k-1$) et **strictement plus quelque part** (contre $y = k-1$, où $k$ écope de la pénalité ; contre $y = k$ dès que $r > 1$). En cascade, 100 est éliminé, puis 99, … jusqu'à ce qu'il ne reste que **$x = 2$**."
    ]
   },
   {
@@ -380,16 +388,16 @@
    "id": "ca1211dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.235597Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.235402Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.297751Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.297362Z"
+     "iopub.execute_input": "2026-09-10T12:37:24.866791Z",
+     "iopub.status.busy": "2026-09-10T12:37:24.866562Z",
+     "iopub.status.idle": "2026-09-10T12:37:24.933972Z",
+     "shell.execute_reply": "2026-09-10T12:37:24.933001Z"
     },
     "papermill": {
-     "duration": 0.065956,
-     "end_time": "2026-09-07T13:09:10.298559",
+     "duration": 0.071412,
+     "end_time": "2026-09-10T12:37:24.934754",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.232603",
+     "start_time": "2026-09-10T12:37:24.863342",
      "status": "completed"
     },
     "tags": []
@@ -400,7 +408,9 @@
      "output_type": "stream",
      "text": [
       "Strategies eliminées (du haut vers le bas), extrait: [100, 99, 98, 97, 96, 95] ...\n",
-      "Strategies survivantes: [2]  (unique equilibre = plancher)\n",
+      "Strategies survivantes: [2]\n",
+      " -> pour r = 2 (canonique), (2,2) est l'unique equilibre de Nash ;\n",
+      "    a r = 1 l'unicite tombe (equilibres diagonaux multiples, cf. section 4).\n",
       "\n",
       "u1(2,2) = 2  | devier a 3 pour Ligne : 0.0  -> pas profitable\n",
       "u1(2,2) = 2  | devier a 3 pour Colonne : 0.0  -> pas profitable\n"
@@ -409,14 +419,16 @@
    ],
    "source": [
     "def iteratively_dominated(c_max: int = C_MAX) -> tuple[list[int], list[int]]:\n",
-    "    \"\"\"Elimination iteree des strategies strictement dominees (de haut en bas).\n",
+    "    \"\"\"Elimination iteree des strategies faiblement dominees (de haut en bas).\n",
     "\n",
-    "    Dans le jeu reduit a l'ensemble `remaining`, la strategie x est strictement\n",
-    "    dominee par x-1 si x-1 rapporte au moins autant partout (sur `remaining`) ET\n",
-    "    strictement plus quelque part. A chaque etape la plus haute restante est\n",
-    "    dominee ; on l'elimine et on recommence jusqu'au plancher.\n",
+    "    Dans le jeu reduit a l'ensemble `remaining`, la strategie x est\n",
+    "    FAIBLEMENT dominee par x-1 si x-1 rapporte au moins autant partout\n",
+    "    (sur `remaining`) ET strictement plus quelque part. Ce n'est jamais une\n",
+    "    domination stricte : contre les reclamations basses y < x-1, x-1 et x\n",
+    "    sont egalement penalisees (y - r chacune). A chaque etape la plus haute\n",
+    "    restante est dominee ; on l'elimine et on recommence jusqu'au plancher.\n",
     "    \"\"\"\n",
-    "    def dominated_by_prev(x, remaining, r=2.0):\n",
+    "    def weakly_dominated_by_prev(x, remaining, r=2.0):\n",
     "        if x - 1 not in remaining:\n",
     "            return False\n",
     "        weakly = all(u1(x - 1, y, r, c_max) >= u1(x, y, r, c_max) for y in remaining)\n",
@@ -427,7 +439,7 @@
     "    eliminated = []\n",
     "    while True:\n",
     "        candidates = [x for x in remaining\n",
-    "                      if x > C_MIN and dominated_by_prev(x, remaining)]\n",
+    "                      if x > C_MIN and weakly_dominated_by_prev(x, remaining)]\n",
     "        if not candidates:\n",
     "            break\n",
     "        to_eliminate = max(candidates)  # on elimine la plus haute d'abord\n",
@@ -437,11 +449,13 @@
     "\n",
     "final, order = iteratively_dominated()\n",
     "print(\"Strategies eliminées (du haut vers le bas), extrait:\", order[:6], \"...\")\n",
-    "print(\"Strategies survivantes:\", final, \" (unique equilibre = plancher)\")\n",
+    "print(\"Strategies survivantes:\", final)\n",
+    "print(\" -> pour r = 2 (canonique), (2,2) est l'unique equilibre de Nash ;\")\n",
+    "print(\"    a r = 1 l'unicite tombe (equilibres diagonaux multiples, cf. section 4).\")\n",
     "print()\n",
     "# Verification : a l'equilibre (2,2), aucun joueur ne veut bouger seul\n",
     "print(\"u1(2,2) =\", u1(2,2), \" | devier a 3 pour Ligne :\", u1(3,2), \" -> pas profitable\")\n",
-    "print(\"u1(2,2) =\", u1(2,2), \" | devier a 3 pour Colonne :\", u2(2,3), \" -> pas profitable\")"
+    "print(\"u1(2,2) =\", u1(2,2), \" | devier a 3 pour Colonne :\", u2(2,3), \" -> pas profitable\")\n"
    ]
   },
   {
@@ -449,10 +463,10 @@
    "id": "ae570cfb",
    "metadata": {
     "papermill": {
-     "duration": 0.00205,
-     "end_time": "2026-09-07T13:09:10.303116",
+     "duration": 0.002386,
+     "end_time": "2026-09-10T12:37:24.939881",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.301066",
+     "start_time": "2026-09-10T12:37:24.937495",
      "status": "completed"
     },
     "tags": []
@@ -460,7 +474,7 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "L'élimination itérée ne laisse qu'une seule stratégie : **réclamer 2 $**. À (2,2), chaque joueur reçoit 2 $, et s'écarter seul (monter) fait passer à $\\min=2 - r$ : **0 $**, donc strictement pire. L'équilibre de Nash unique du jeu est donc **$(2,2)$** — la prédiction formelle. C'est l'apogée du paradoxe : la théorie dit « le minimum », l'intuition humaine dit autre chose (voir §4 et §5)."
+    "L'élimination itérée ne laisse qu'une seule stratégie : **réclamer 2 $**. À (2,2), chaque joueur reçoit 2 $, et s'écarter seul (monter) fait passer à $\\min=2 - r$ : **0 $**, donc strictement pire. Pour $r > 1$ — le cas canonique $r=2$ comme tout $r$ plus grand — l'équilibre de Nash unique du jeu est donc **$(2,2)$**, et c'est la prédiction formelle. À $r = 1$ exactement, cette unicité tombe : chaque profil diagonal $(y,y)$ devient lui aussi un équilibre de Nash (section 4 le mesure). C'est l'apogée du paradoxe : la théorie dit « le minimum », l'intuition humaine dit autre chose (voir §4 et §5)."
    ]
   },
   {
@@ -468,10 +482,10 @@
    "id": "17f2bce5",
    "metadata": {
     "papermill": {
-     "duration": 0.002039,
-     "end_time": "2026-09-07T13:09:10.307391",
+     "duration": 0.002359,
+     "end_time": "2026-09-10T12:37:24.944618",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.305352",
+     "start_time": "2026-09-10T12:37:24.942259",
      "status": "completed"
     },
     "tags": []
@@ -485,10 +499,10 @@
    "id": "fda1d303",
    "metadata": {
     "papermill": {
-     "duration": 0.002189,
-     "end_time": "2026-09-07T13:09:10.311747",
+     "duration": 0.002397,
+     "end_time": "2026-09-10T12:37:24.949519",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.309558",
+     "start_time": "2026-09-10T12:37:24.947122",
      "status": "completed"
     },
     "tags": []
@@ -496,9 +510,15 @@
    "source": [
     "### Le paradoxe dépend de $r$\n",
     "\n",
-    "Le raisonnement d'élimination ci-dessus ne tient pas pour tout $r$ : il exige **$r \\ge 1$**. Comparer la plus haute réclamation $k$ à $k-1$ face à un adversaire qui réclame lui aussi $k$ donne $k-1+r$ contre $k$ — le sous-cotage ne rapporte qu'à partir de $r = 1$. La table du §4 ci-dessous le mesure : $r = 0{,}5$ n'atteint pas le plancher, $r = 1$ si. Mais l'expérience — humaine et expérimentale — montre que les gens jouent haut **quand $r$ est petit** et bas **quand $r$ est grand**. Le paradoxe n'est pas un fait : c'est une fonction de $r$.\n",
+    "Le raisonnement d'élimination ci-dessus distingue **trois régimes** selon le bonus :\n",
     "\n",
-    "On mesure la différence entre l'équilibre théorique (2) et la prédiction « naïve » qu'un joueur stratégiquement **superficiel** ferait : viser le maximum $\\bar c$, puisqu'il s'agit avant tout de capter le bonus."
+    "* **$r > 1$** : le sous-cotage est *strictement* profitable — comparer la plus haute réclamation $k$ à $k-1$ face à un adversaire en $k$ donne $k-1+r > k$. La spirale descend jusqu'au plancher et $(2,2)$ est l'**équilibre unique**.\n",
+    "* **$r = 1$** : sous-coter à $y-1$ et rester à $y$ rapportent **autant** ($y$ chacun). La meilleure réponse est multi-valuée $\\{y-1, y\\}$, chaque profil diagonal $(y,y)$ est un équilibre de Nash, et l'élimination — qui repose sur la domination *faible* — ne descend jusqu'au plancher que moyennant la convention de tie-breaking. L'unicité de $(2,2)$ n'est plus un théorème : c'est un artefact d'ordre.\n",
+    "* **$r < 1$** : le gain de sous-cotage est négatif — l'élimination de haut en bas **ne démarre même pas**.\n",
+    "\n",
+    "L'expérience — humaine et expérimentale — montre que les gens jouent haut **quand $r$ est petit** et bas **quand $r$ est grand**. Le paradoxe n'est pas un fait : c'est une fonction de $r$.\n",
+    "\n",
+    "On mesure la différence entre l'équilibre théorique (2) et la prédiction « naïve » qu'un joueur stratégiquement **superficiel** ferait : viser le maximum $\bar c$, puisqu'il s'agit avant tout de capter le bonus."
    ]
   },
   {
@@ -507,16 +527,16 @@
    "id": "f0c1eb83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.317158Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.316826Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.616827Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.616366Z"
+     "iopub.execute_input": "2026-09-10T12:37:24.959771Z",
+     "iopub.status.busy": "2026-09-10T12:37:24.959551Z",
+     "iopub.status.idle": "2026-09-10T12:37:25.264405Z",
+     "shell.execute_reply": "2026-09-10T12:37:25.263755Z"
     },
     "papermill": {
-     "duration": 0.303709,
-     "end_time": "2026-09-07T13:09:10.617604",
+     "duration": 0.311173,
+     "end_time": "2026-09-10T12:37:25.265251",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.313895",
+     "start_time": "2026-09-10T12:37:24.954078",
      "status": "completed"
     },
     "tags": []
@@ -528,35 +548,33 @@
      "text": [
       "  r  |  gain de sous-cotage (r-1)  |  la spirale atteint (2,2) ?\n",
       " 0.5 |     -0.5 | NON\n",
-      " 1.0 |      0.0 | OUI\n"
+      " 1.0 |      0.0 | OUI\n",
+      " 1.5 |      0.5 | OUI\n",
+      " 2.0 |      1.0 | OUI\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1.5 |      0.5 | OUI\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 2.0 |      1.0 | OUI\n",
-      " 5.0 |      4.0 | OUI\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      " 5.0 |      4.0 | OUI\n",
       "10.0 |      9.0 | OUI\n",
+      "\n",
+      "r=1 :: BR(100) = [99, 100]\n",
+      "r=1 :: BR(55) = [54, 55]\n",
+      "r=1 :: BR(3) = [2, 3]\n",
+      "r=1 :: BR(2) = [2]\n",
+      "r=1 :: equilibres de Nash diagonaux : 99 au total, de 2 a 100\n",
+      "r=2 :: equilibres de Nash diagonaux : [2]\n",
       "\n",
       "Lecture : le gain de sous-cotage vaut r-1, independant du point de depart c.\n",
       "  -> r < 1 : sous-coter ne rapporte rien (gain negatif) -> grimper n'est pas puni,\n",
       "             la spirale ne demarre pas -> le paradoxe est VIVANT (humains jouent haut).\n",
-      "  -> r > 1 : sous-coter devient rentable -> la spirale descend forcement vers (2,2)\n",
-      "             -> le paradoxe SE DISSOUT. Le seuil est r* = 1.\n"
+      "  -> r = 1 : egalites partout -- BR multi-valuee {y-1, y}, chaque (y,y) est un\n",
+      "             equilibre de Nash ; l'elimination faible n'atteint le plancher que\n",
+      "             par convention d'ordre. PAS d'equilibre unique.\n",
+      "  -> r > 1 : sous-coter devient strictement rentable -> la spirale descend\n",
+      "             forcement vers (2,2), unique equilibre -> le paradoxe SE DISSOUT.\n"
      ]
     }
    ],
@@ -571,10 +589,10 @@
     "def elimination_reaches_floor(r: float = 2.0, c_max: int = C_MAX) -> bool:\n",
     "    \"\"\"L'elimination de haut en bas atteint-elle le plancher pour ce bonus r ?\n",
     "\n",
-    "    Reutilise le raisonnement de la cellule 3 (domination stricte de la plus\n",
+    "    Reutilise le raisonnement de la cellule 3 (domination FAIBLE de la plus\n",
     "    haute restante par son precedesseur), en propageant r partout.\n",
     "    \"\"\"\n",
-    "    def dominated_by_prev(x, remaining):\n",
+    "    def weakly_dominated_by_prev(x, remaining):\n",
     "        if x - 1 not in remaining:\n",
     "            return False\n",
     "        weakly = all(u1(x - 1, y, r, c_max) >= u1(x, y, r, c_max) for y in remaining)\n",
@@ -584,7 +602,7 @@
     "    remaining = list(range(C_MIN, c_max + 1))\n",
     "    while True:\n",
     "        candidates = [x for x in remaining\n",
-    "                      if x > C_MIN and dominated_by_prev(x, remaining)]\n",
+    "                      if x > C_MIN and weakly_dominated_by_prev(x, remaining)]\n",
     "        if not candidates:\n",
     "            break\n",
     "        remaining.remove(max(candidates))\n",
@@ -599,11 +617,34 @@
     "    print(f\"{r:>4} | {g:>8} | {'OUI' if ok else 'NON'}\")\n",
     "\n",
     "print()\n",
+    "# Cas a part r = 1 : meilleure reponse multi-valuee + equilibres diagonaux\n",
+    "def best_response_set(y: int, r: float, c_max: int = C_MAX) -> list[int]:\n",
+    "    \"\"\"TOUTES les meilleures reponses a y (pas seulement le plus petit argmax).\"\"\"\n",
+    "    vals = {x: u1(x, y, r, c_max) for x in range(C_MIN, c_max + 1)}\n",
+    "    top = max(vals.values())\n",
+    "    return [x for x, v in sorted(vals.items()) if v == top]\n",
+    "\n",
+    "def is_nash_diagonal(y: int, r: float) -> bool:\n",
+    "    \"\"\"(y, y) est-il un equilibre de Nash ? Aucun des deux ne gagne a devier.\"\"\"\n",
+    "    me = u1(y, y, r)\n",
+    "    return all(u1(x, y, r) <= me for x in range(C_MIN, C_MAX + 1))\n",
+    "\n",
+    "for y in [100, 55, 3, 2]:\n",
+    "    print(f\"r=1 :: BR({y}) = {best_response_set(y, 1.0)}\")\n",
+    "diag_r1 = [y for y in range(C_MIN, C_MAX + 1) if is_nash_diagonal(y, 1.0)]\n",
+    "diag_r2 = [y for y in range(C_MIN, C_MAX + 1) if is_nash_diagonal(y, 2.0)]\n",
+    "print(f\"r=1 :: equilibres de Nash diagonaux : {len(diag_r1)} au total, de {diag_r1[0]} a {diag_r1[-1]}\")\n",
+    "print(f\"r=2 :: equilibres de Nash diagonaux : {diag_r2}\")\n",
+    "\n",
+    "print()\n",
     "print(\"Lecture : le gain de sous-cotage vaut r-1, independant du point de depart c.\")\n",
     "print(\"  -> r < 1 : sous-coter ne rapporte rien (gain negatif) -> grimper n'est pas puni,\")\n",
     "print(\"             la spirale ne demarre pas -> le paradoxe est VIVANT (humains jouent haut).\")\n",
-    "print(\"  -> r > 1 : sous-coter devient rentable -> la spirale descend forcement vers (2,2)\")\n",
-    "print(\"             -> le paradoxe SE DISSOUT. Le seuil est r* = 1.\")"
+    "print(\"  -> r = 1 : egalites partout -- BR multi-valuee {y-1, y}, chaque (y,y) est un\")\n",
+    "print(\"             equilibre de Nash ; l'elimination faible n'atteint le plancher que\")\n",
+    "print(\"             par convention d'ordre. PAS d'equilibre unique.\")\n",
+    "print(\"  -> r > 1 : sous-coter devient strictement rentable -> la spirale descend\")\n",
+    "print(\"             forcement vers (2,2), unique equilibre -> le paradoxe SE DISSOUT.\")\n"
    ]
   },
   {
@@ -611,10 +652,10 @@
    "id": "a07e5d3e",
    "metadata": {
     "papermill": {
-     "duration": 0.002378,
-     "end_time": "2026-09-07T13:09:10.622683",
+     "duration": 0.002362,
+     "end_time": "2026-09-10T12:37:25.270189",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.620305",
+     "start_time": "2026-09-10T12:37:25.267827",
      "status": "completed"
     },
     "tags": []
@@ -625,7 +666,8 @@
     "Le moteur du paradoxe est le **gain de sous-cotage** : si l'autre réclame $c$, réclamer $c-1$ rapporte $(c-1)+r$ au lieu de $c$ (l'égalité), soit un gain de $r-1$ — **indépendant** du point de départ. Ce gain unique pilote toute la spirale.\n",
     "\n",
     "* **$r < 1$** : le gain de sous-cotage est négatif — sous-coter ne rapporte rien, grimper n'est pas puni. L'élimination de haut en bas **ne démarre même pas** : un joueur peut rationnellement rester haut, et les humains jouent en effet ~100 $. **Le paradoxe est vivant.**\n",
-    "* **$r > 1$** : le gain est positif — sous-coter devient rentable à chaque étage, la spirale descend **forcément** jusqu'à (2,2), et la prédiction théorique coïncide avec le comportement. **Le paradoxe se dissout.**\n",
+    "* **$r = 1$** : le gain est exactement nul — sous-coter et rester rapportent autant. La meilleure réponse est multi-valuée $\\{y-1, y\\}$, et la sonde ci-dessus exhibe **chaque profil diagonal $(y,y)$ comme équilibre de Nash** ($99$ d'entre eux, contre un seul à $r=2$). L'élimination faible élimine bien tout jusqu'au plancher, mais elle écarte ainsi des stratégies qui sont d'authentiques meilleures réponses : l'unicité de $(2,2)$ est une **convention d'ordre**, pas un théorème.\n",
+    "* **$r > 1$** : le gain est positif — sous-coter devient strictement rentable à chaque étage, la spirale descend **forcément** jusqu'à (2,2), et la prédiction théorique coïncide avec le comportement. **Le paradoxe se dissout.**\n",
     "\n",
     "Le seuil est donc **$r^* = 1$** (dans la version canonique $r=2$, on est bien au-dessus). C'est exactement le fait expérimental de Basu : la gravité du paradoxe est une fonction de $r$, pas une constante."
    ]
@@ -635,10 +677,10 @@
    "id": "24237143",
    "metadata": {
     "papermill": {
-     "duration": 0.002176,
-     "end_time": "2026-09-07T13:09:10.627325",
+     "duration": 0.002465,
+     "end_time": "2026-09-10T12:37:25.275038",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.625149",
+     "start_time": "2026-09-10T12:37:25.272573",
      "status": "completed"
     },
     "tags": []
@@ -652,10 +694,10 @@
    "id": "ceb12d11",
    "metadata": {
     "papermill": {
-     "duration": 0.002606,
-     "end_time": "2026-09-07T13:09:10.632231",
+     "duration": 0.00247,
+     "end_time": "2026-09-10T12:37:25.279768",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.629625",
+     "start_time": "2026-09-10T12:37:25.277298",
      "status": "completed"
     },
     "tags": []
@@ -674,16 +716,16 @@
    "id": "fc69c01e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.638655Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.638263Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.645365Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.644781Z"
+     "iopub.execute_input": "2026-09-10T12:37:25.285461Z",
+     "iopub.status.busy": "2026-09-10T12:37:25.285252Z",
+     "iopub.status.idle": "2026-09-10T12:37:25.291973Z",
+     "shell.execute_reply": "2026-09-10T12:37:25.291516Z"
     },
     "papermill": {
-     "duration": 0.011549,
-     "end_time": "2026-09-07T13:09:10.646117",
+     "duration": 0.010723,
+     "end_time": "2026-09-10T12:37:25.292785",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.634568",
+     "start_time": "2026-09-10T12:37:25.282062",
      "status": "completed"
     },
     "tags": []
@@ -734,10 +776,10 @@
    "id": "ad38e84f",
    "metadata": {
     "papermill": {
-     "duration": 0.002531,
-     "end_time": "2026-09-07T13:09:10.651282",
+     "duration": 0.002676,
+     "end_time": "2026-09-10T12:37:25.298026",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.648751",
+     "start_time": "2026-09-10T12:37:25.295350",
      "status": "completed"
     },
     "tags": []
@@ -753,10 +795,10 @@
    "id": "131c648d",
    "metadata": {
     "papermill": {
-     "duration": 0.002471,
-     "end_time": "2026-09-07T13:09:10.656364",
+     "duration": 0.002901,
+     "end_time": "2026-09-10T12:37:25.303509",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.653893",
+     "start_time": "2026-09-10T12:37:25.300608",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +815,16 @@
    "id": "71b175da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.662088Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.661884Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.665357Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.664956Z"
+     "iopub.execute_input": "2026-09-10T12:37:25.309258Z",
+     "iopub.status.busy": "2026-09-10T12:37:25.309035Z",
+     "iopub.status.idle": "2026-09-10T12:37:25.312817Z",
+     "shell.execute_reply": "2026-09-10T12:37:25.312415Z"
     },
     "papermill": {
-     "duration": 0.007218,
-     "end_time": "2026-09-07T13:09:10.666039",
+     "duration": 0.007613,
+     "end_time": "2026-09-10T12:37:25.313556",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.658821",
+     "start_time": "2026-09-10T12:37:25.305943",
      "status": "completed"
     },
     "tags": []
@@ -829,10 +871,10 @@
    "id": "895c4edd",
    "metadata": {
     "papermill": {
-     "duration": 0.002418,
-     "end_time": "2026-09-07T13:09:10.671225",
+     "duration": 0.002361,
+     "end_time": "2026-09-10T12:37:25.318420",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.668807",
+     "start_time": "2026-09-10T12:37:25.316059",
      "status": "completed"
     },
     "tags": []
@@ -849,16 +891,16 @@
    "id": "f79012d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.676837Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.676614Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.680303Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.679918Z"
+     "iopub.execute_input": "2026-09-10T12:37:25.325212Z",
+     "iopub.status.busy": "2026-09-10T12:37:25.324972Z",
+     "iopub.status.idle": "2026-09-10T12:37:25.328653Z",
+     "shell.execute_reply": "2026-09-10T12:37:25.328235Z"
     },
     "papermill": {
-     "duration": 0.00734,
-     "end_time": "2026-09-07T13:09:10.680987",
+     "duration": 0.008237,
+     "end_time": "2026-09-10T12:37:25.329388",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.673647",
+     "start_time": "2026-09-10T12:37:25.321151",
      "status": "completed"
     },
     "tags": []
@@ -898,10 +940,10 @@
    "id": "10d16727",
    "metadata": {
     "papermill": {
-     "duration": 0.002469,
-     "end_time": "2026-09-07T13:09:10.686036",
+     "duration": 0.002591,
+     "end_time": "2026-09-10T12:37:25.334726",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.683567",
+     "start_time": "2026-09-10T12:37:25.332135",
      "status": "completed"
     },
     "tags": []
@@ -918,16 +960,16 @@
    "id": "a1ac1133",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T13:09:10.691891Z",
-     "iopub.status.busy": "2026-09-07T13:09:10.691614Z",
-     "iopub.status.idle": "2026-09-07T13:09:10.694880Z",
-     "shell.execute_reply": "2026-09-07T13:09:10.694506Z"
+     "iopub.execute_input": "2026-09-10T12:37:25.340709Z",
+     "iopub.status.busy": "2026-09-10T12:37:25.340503Z",
+     "iopub.status.idle": "2026-09-10T12:37:25.344050Z",
+     "shell.execute_reply": "2026-09-10T12:37:25.343657Z"
     },
     "papermill": {
-     "duration": 0.007008,
-     "end_time": "2026-09-07T13:09:10.695545",
+     "duration": 0.00752,
+     "end_time": "2026-09-10T12:37:25.344840",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.688537",
+     "start_time": "2026-09-10T12:37:25.337320",
      "status": "completed"
     },
     "tags": []
@@ -968,10 +1010,10 @@
    "id": "46982c9b",
    "metadata": {
     "papermill": {
-     "duration": 0.002616,
-     "end_time": "2026-09-07T13:09:10.700798",
+     "duration": 0.004329,
+     "end_time": "2026-09-10T12:37:25.352660",
      "exception": false,
-     "start_time": "2026-09-07T13:09:10.698182",
+     "start_time": "2026-09-10T12:37:25.348331",
      "status": "completed"
     },
     "tags": []
@@ -979,14 +1021,17 @@
    "source": [
     "### À retenir\n",
     "\n",
-    "* **L'objet formel** : un jeu à deux joueurs à stratégies bornées $[2,\\bar c]$, paiement $\\min(x,y)$ plus bonus $r$ au plus petit / pénalité $r$ au plus grand.\n",
-    "* **Le claim exact** : l'élimination itérée des stratégies strictement dominées laisse l'unique équilibre $(2,2)$ dès que $r \\geq 1$.\n",
-    "* **Le contre-claim** : cet équilibre n'est pas une prédiction comportementale — il ne tient que sous connaissance commune de la rationalité. Une probabilité $\\varepsilon > \\varepsilon^*$ de jouer haut fait **sauter** la meilleure réponse du joueur prudent vers le plafond. Le seuil mesuré $\\varepsilon^* \\approx 0.03$ (cellule de calcul de l'exercice 3) borne la **fragilité** de (2,2) : au-delà d'une fraction même infime d'adversaire « grimpeur », (2,2) n'est plus la meilleure réponse.\n",
-    "* **Le seuil** : le paradoxe se dissout quand $r$ devient grand ($r \\geq 1$, équilibre unique) ; il n'est paradoxal que pour $r$ petit ($r < 1$, élimination ne démarre pas).\n",
+    "* **L'objet formel** : un jeu à deux joueurs à stratégies bornées $[2,\bar c]$, paiement $\\min(x,y)$ plus bonus $r$ au plus petit / pénalité $r$ au plus grand.\n",
+    "* **Le claim exact** : l'élimination itérée des stratégies **faiblement** dominées descend jusqu'au plancher dès que $r \\ge 1$ ; l'équilibre $(2,2)$ qu'elle laisse est **unique pour $r > 1$** — à $r = 1$, chaque profil diagonal $(y,y)$ est aussi un équilibre de Nash, et la survie du seul plancher est un artefact de la convention de tie-breaking.\n",
+    "* **Le contre-claim** : cet équilibre n'est pas une prédiction comportementale — il ne tient que sous connaissance commune de la rationalité. Une probabilité $\u000b",
+    "arepsilon > \u000b",
+    "arepsilon^*$ de jouer haut fait **sauter** la meilleure réponse du joueur prudent vers le plafond. Le seuil mesuré $\u000b",
+    "arepsilon^* \u0007pprox 0.03$ (cellule de calcul de l'exercice 3) borne la **fragilité** de (2,2) : au-delà d'une fraction même infime d'adversaire « grimpeur », (2,2) n'est plus la meilleure réponse.\n",
+    "* **Le seuil** : le paradoxe se dissout quand $r$ devient grand ($r > 1$, équilibre unique au plancher) ; à $r = 1$ exactement, la multiplicité des équilibres rend la prédiction indéterminée ; il n'est paradoxal que pour $r$ petit ($r < 1$, élimination ne démarre pas).\n",
     "\n",
     "> **Expérience ICT candidate** : mesurer en TP le taux de « montée » (réclamation > 50) pour $r=2$ vs $r=25$, et confronter à la courbe bascule de l'exercice 3 — c'est un test falsifiable du contre-claim.\n",
     "\n",
-    "> **Palier parent** : [GameTheory-02-NormalForm](GameTheory-02-NormalForm.ipynb) (forme normale, dominance, élimination itérée) · **Sibling** : [GameTheory-02b-Lean-Definitions](GameTheory-02b-Lean-Definitions.ipynb) · **Série** : [GameTheory](README.md)\n"
+    "> **Palier parent** : [GameTheory-02-NormalForm](GameTheory-02-NormalForm.ipynb) (forme normale, dominance, élimination itérée) · **Sibling** : [GameTheory-02b-Lean-Definitions](GameTheory-02b-Lean-Definitions.ipynb) · **Série** : [GameTheory](README.md)"
    ]
   }
  ],
@@ -1009,12 +1054,12 @@
    "version": "3.13.3"
   },
   "papermill": {
-   "duration": 5.13532,
-   "end_time": "2026-09-07T13:09:13.469069",
+   "duration": 3.279773,
+   "end_time": "2026-09-10T12:37:25.589038",
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb",
-   "start_time": "2026-09-07T13:09:08.333749"
+   "input_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
+   "output_path": "GameTheory-02c-Travelers-Dilemma.ipynb",
+   "start_time": "2026-09-10T12:37:22.309265"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15436

## Les deux défauts corrigés (issue #15461, révélée par le twin C# 02d)

**1. Domination faible présentée comme stricte.** Le prédicat d'élimination itérée (`u1(k-1,y) >= u1(k,y)` pour tout y restant, `>` pour au moins un) est la définition de la **domination faible** : face à un adversaire `y < k-1`, les stratégies `k-1` et `k` reçoivent toutes deux `y - r` (égalité stricte) — `k-1` n'est jamais strictement meilleure partout. Titre de section, prose du raisonnement, docstrings et nommage interne (`weakly_dominated_by_prev`) alignés sur « élimination itérée de stratégies **faiblement dominées** », avec la justification de l'égalité explicite.

**2. Le cas `r = 1` invalide « équilibre unique (2,2) dès que r ≥ 1 ».** À `r = 1`, sous-coter à `y-1` rapporte `(y-1)+1 = y`, exactement autant que rester à `y` : la meilleure réponse est multi-valuée `{y-1, y}` et **chaque profil diagonal (y,y) est un équilibre de Nash**. Le tie-breaking de `best_response` (`max` garde le plus petit argmax) est maintenant documenté comme convention algorithmique, pas unicité mathématique. La prose distingue trois régimes (`r > 1` : sous-cotage strictement profitable, équilibre pur unique au plancher · `r = 1` : égalités de BR, équilibres diagonaux multiples, élimination faible dépendante de la convention d'ordre · `r < 1` : la spirale ne démarre pas).

## Sonde exécutée (r = 1, miroir de la sonde du fix C# #15437)

```
r=1 :: BR(100) = [99, 100]
r=1 :: BR(55) = [54, 55]
r=1 :: BR(3) = [2, 3]
r=1 :: BR(2) = [2]
r=1 :: equilibres de Nash diagonaux : 99 au total, de 2 a 100
r=2 :: equilibres de Nash diagonaux : [2]
```

## Acceptance (issue #15461)

- [x] Section élimination : « strictement dominées » → « faiblement dominées » partout (titre §3, prose, docstrings, nommage — la table du §4 aussi)
- [x] `r = 1` traité comme cas à part (BR multi-valuée mesurée, équilibres diagonaux comptés, rôle de la convention de tie-breaking explicité dans `best_response` et §4)
- [x] Le claim « équilibre unique » restreint à `r > 1` (§3 lecture, §4 trois régimes, « À retenir »)
- [x] Réexécution complète (C.2) + sorties cohérentes

## Preuves d'exécution (H.1)

- Papermill kernel `python3`, rc=0, **32/32 cellules** exécutées, **8/8 cellules code** avec `execution_count` réel 1..8, **0 erreur**, **0 output vide**.
- Vérif C.1 : `grep` des erreurs volontaires (`raise NotImplementedError` / `assert False` / `1/0`) : néant.
- Seuls `metadata.papermill.input/output_path` normalisés au basename (exception tolérée règle 6) ; aucun path machine, aucune IPv4 privée, aucun identifiant de trafic dans les outputs.

## Twin audit

Twin GT-02d (C#, `GameTheory-02d`) audité : **FIXED** dans #15437 par po-2024 (domination faible nommée `WeaklyDominatedByPrev` + sonde r=1 `BR(y)={99,100}/{54,55}/{2,3}`) — la présente PR livre la correction miroir côté Python d'origine, formulations convergentes. GT-02c n'est pas enregistré au registre twin (`twin_pairs.d/` : aucune paire travelers/02c — vérifié), pas de rebaseline requis.

## Périmètre

Le notebook `MyIA.AI.Notebooks/GameTheory/GameTheory-02c-Travelers-Dilemma.ipynb` seul (sources des cellules §2-§4 + « À retenir », outputs de la re-exécution complète). Catalogue byte-identique à main (non régénéré). Exercices §6 intouchés.

Closes #15461 — See #12208 (Chantier 5), révélé par la review de #15437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
