### PR TITLE
fix(ci,#15472): PR gate rouge muet — porter la raison du verdict en annotation ::error::

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -900,6 +900,17 @@ def wait_and_decide(
         sleep(poll_sec)
 
 
+def _workflow_command_escape(text: str) -> str:
+    """Escape text for a GitHub workflow-command (`::error::`) annotation.
+
+    A raw LF would end the annotation (truncating the reason), a raw CR
+    mangles it, and a raw `%` swallows the following bytes as a bogus
+    escape. Order is load-bearing: `%` must be escaped FIRST -- doing CR/LF
+    first would re-escape the `%` those substitutions introduce (%250D).
+    """
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 def _optional_int(raw: str) -> "int | None":
     """`--pr ""` vaut « pas de PR », pas une erreur d'argparse.
 
@@ -1047,10 +1058,12 @@ def main(argv: Iterable[str] | None = None) -> int:
             advisory_jobs,
         )
     except GateError as exc:
-        # Rule 1: an unreadable state is a failure, never a pass.
-        print(f"[pr-gate] FAIL -- cannot establish check state: {exc}", file=sys.stderr)
-        _maybe_post_check_run(args, 1, f"FAIL -- cannot establish check state: {exc}")
-        return 1
+        # Rule 1: an unreadable state is a failure, never a pass. Fall
+        # through to the single emission tail instead of returning here: the
+        # old early return exited BEFORE the ::error:: point, leaving the
+        # most opaque failure mode (API unreadable at all) mute in the UI
+        # (#15472). Verdict semantics unchanged: code 1, same message.
+        code, message = 1, f"FAIL -- cannot establish check state: {exc}"
 
     # #13510: render a starvation as CANCELLED, not FAILURE. The PR stays
     # BLOCKED (a cancelled required check is not success), but the leg no
@@ -1133,7 +1146,14 @@ def main(argv: Iterable[str] | None = None) -> int:
         # dans l'UI. Legs DWELL rendus muets mesures sur #15472 (2026-09-10) :
         # 8 PR gates rouges sans cause organique, tous des DWELL (plancher de
         # merge, mandat 07/09) dont la re-agregation ne rend jamais compte.
-        print(f"::error::[pr-gate] {message}", file=sys.stderr, flush=True)
+        # Le message peut porter %, CR ou LF (stderr gh multi-ligne) : un LF
+        # brut tronque l'annotation, un % brut avale les octets suivants --
+        # echappement protocolaire workflow-command, % EN PREMIER (#15472).
+        print(
+            f"::error::[pr-gate] {_workflow_command_escape(message)}",
+            file=sys.stderr,
+            flush=True,
+        )
     return code
 
 

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -1127,6 +1127,13 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     print(f"[pr-gate] {message}", flush=True)
     _maybe_post_check_run(args, code, message)
+    if code != 0:
+        # Le check-run derive du job ne porte qu'« Process completed with exit
+        # code 1 » sur un rouge : seul l'annotation donne la RAISON du verdict
+        # dans l'UI. Legs DWELL rendus muets mesures sur #15472 (2026-09-10) :
+        # 8 PR gates rouges sans cause organique, tous des DWELL (plancher de
+        # merge, mandat 07/09) dont la re-agregation ne rend jamais compte.
+        print(f"::error::[pr-gate] {message}", file=sys.stderr, flush=True)
     return code
 
 

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -70,6 +70,78 @@ def test_unreadable_api_exits_one(monkeypatch):
     assert pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"]) == 1
 
 
+def test_unreadable_api_carries_annotation(capsys, monkeypatch):
+    """#15472 repair 1: the `cannot establish check state` early return is
+    the most opaque failure mode (the API cannot be read at all); it must
+    reach the same ::error:: emission point as any other red, not exit
+    before it."""
+    def boom(*_args, **_kwargs):
+        raise pr_gate.GateError("gh api exploded")
+
+    monkeypatch.setattr(pr_gate, "wait_and_decide", boom)
+    assert pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    captured = capsys.readouterr()
+    assert (
+        "::error::[pr-gate] FAIL -- cannot establish check state: gh api exploded"
+        in captured.err
+    )
+    # One log line, one annotation -- the same verdict never printed twice
+    # on the same surface.
+    assert captured.out.count("cannot establish check state") == 1
+    assert captured.err.count("cannot establish check state") == 1
+
+
+def test_annotation_escapes_workflow_command_metacharacters(capsys, monkeypatch):
+    """#15472 repair 2: an exception message can be multi-line and carry `%`
+    (raw gh stderr). A raw CR/LF splits or truncates the ::error::
+    annotation; a raw `%` eats the following bytes as a bogus escape.
+    Escape per the workflow-command protocol, `%` FIRST."""
+    def boom(*_args, **_kwargs):
+        raise pr_gate.GateError(
+            "gh api o/r failed (exit 1): HTTP 502\r\n100% of requests failed\ntrace end"
+        )
+
+    monkeypatch.setattr(pr_gate, "wait_and_decide", boom)
+    assert pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    annotation = next(
+        ln for ln in capsys.readouterr().err.splitlines()
+        if ln.startswith("::error::")
+    )
+    assert "HTTP 502%0D%0A100%25 of requests failed" in annotation
+    assert "failed%0Atrace end" in annotation
+    # Order proof: `%` escaped before CR/LF, so %0D/%0A are never re-escaped.
+    assert "%250D" not in annotation and "%250A" not in annotation
+
+
+def test_workflow_command_escape_percent_first():
+    """Unit pin of the helper: the substitution order is load-bearing."""
+    assert (
+        pr_gate._workflow_command_escape("100% done\r\nnext")
+        == "100%25 done%0D%0Anext"
+    )
+
+
+def test_posted_check_run_message_is_not_escaped(monkeypatch):
+    """Escaping belongs to the workflow-command surface ONLY; the Checks-API
+    check-run (the PR's mergeState surface) carries the message verbatim."""
+    posted = {}
+
+    def fake_post(repo, sha, name, code, message):
+        posted["message"] = message
+        return {}
+
+    def boom(*_args, **_kwargs):
+        raise pr_gate.GateError("gh api failed (exit 1): 50%\r\nline2")
+
+    monkeypatch.setattr(pr_gate, "post_check_run", fake_post)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", boom)
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"])
+    assert code == 1
+    assert posted["message"] == (
+        "FAIL -- cannot establish check state: gh api failed (exit 1): 50%\r\nline2"
+    )
+
+
 def test_completed_without_conclusion_is_pending_not_pass():
     """`status=completed, conclusion=null` is a transient GitHub state."""
     pending, bad, ok, _adv = pr_gate.classify([run("Odd", None)])

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1289,7 +1289,27 @@ def test_dwell_red_is_prefixed_so_the_cause_is_readable(capsys, monkeypatch):
         ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
     )
     assert code == 1
-    assert "DWELL -- tete du 2026-09-07T11:55:00Z" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "DWELL -- tete du 2026-09-07T11:55:00Z" in captured.out
+    # #15472 : le check-run derive du job ne montre que « exit code 1 » sans
+    # annotation — la RAISON du rouge doit etre portee par un ::error:: mot
+    # pour mot (c'est la surface que lisent humains et balayages).
+    assert "::error::[pr-gate] DWELL -- tete du 2026-09-07T11:55:00Z" in captured.err
+
+
+def test_red_ci_verdict_carries_annotation(capsys, monkeypatch):
+    """Un rouge de CI porte aussi l'annotation -- pas seulement le plancher."""
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_kw: (1, "FAIL -- failing checks: Lean CI"),
+    )
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--no-self-cancel"]
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "::error::[pr-gate] FAIL -- failing checks: Lean CI" in err
 
 
 def test_empty_pr_argument_means_no_pr(monkeypatch):


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15451

## Résumé

Le check-run « PR gate » (job dérivé) ne montre, sur un rouge, que « Process completed with exit code 1 » : le verdict — DWELL, FAIL, STARVED — vit uniquement dans le log du step. Émission d'une annotation `::error::` portant le message du verdict sur tout exit non-zero : la raison du rouge devient visible dans l'UI du check et pour les balayages (Hermes, NanoClaw).

## Investigation host-side (demande #15472)

Logs du run 34468961959 (PR #15459, head `d0e202538a`), révélés à 16:00Z :

- `[pr-gate] settled: 17 check(s) green` puis `DWELL -- tete du 2026-09-10T10:59:39Z, 55 min -- plancher 120 min, reste 65 min` → exit 1. **L'agrégateur n'est pas incohérent** : les 17 subchecks sont verts, le rouge est le plancher de merge (mandat user 2026-09-07, `--dwell-min 120`), rendu volontairement rouge (l'attente doit bloquer le merge).
- Les 8 PRs rouges du sweep Hermes 14:09Z (#15469, #15466, #15465, #15464, #15456, #15455, #15454, #15449) montrent le même pattern (heads jeunes < 120 min) — vérifié sur #15469 (gate failure 13:36Z, verdict DWELL au log).

**Défaut aggravant mesuré** : la sweep de re-agrégation pr-gate-stale-sweep.yml (−17H1Z−, `cron '7 * * * *'`) n'a plus produit de run entre 11:51Z et 16:00Z (dernier run 34469954097, démarré 11:11Z, terminé 11:51Z) ; l'advisory sweep-health pulse ~4h au lieu de 30 min (runs 00:09, 04:36, 09:08, 13:32). C'est la récidive du mode #15332 (livraison de l'événement `schedule` dégradée) : les legs DWELL ne sont **jamais re-rendus** une fois le plancher écoulé — #15459 avait 3 h d'âge à 16:00Z, toujours le seul leg rouge `failure` de son SHA. Ce volet (service scheduler) est hors de cette PR : il est observé par l'organe liveness (#15451, dispatch ai-01) et par le cap de la sweep (#15375, po-2026).

## Changement

`scripts/pr_gate.py` — dans `main()`, sur `code != 0` : `print(f"::error::[pr-gate] {message}", file=sys.stderr, flush=True)`. Aucun changement de sémantique de verdict (exit codes inchangés).

## Validation

- `python -m pytest scripts/tests/test_pr_gate.py` : **79 passed**, dont deux assertions nouvelles : annotation `::error::` sur le verdict DWELL (`test_dwell_red_is_prefixed_so_the_cause_is_readable`, étendu) et sur un rouge CI générique (`test_red_ci_verdict_carries_annotation`).
- Les 6 suites voisines de l'organe (merge_dwell, pr_gate_missing, sweep_select, sweep_timing, rerun_noop_guard, derive_rerun_workflows) : **67 passed**.

Closes #15472 — l'issue demandait l'investigation host-side (rendue ci-dessus, verdicts firsthand) et un agrégat qui s'explique : c'est le cas après ce diff.
🤖 Generated with [Claude Code](https://claude.com/claude-code)