### PR TITLE
ci(ict,#15471): planchers de collecte 746->1046 et 42->670 + garde bidirectionnelle

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -12,18 +12,24 @@ name: ICT-Series Tests
 #       sensitivity consolides depuis ict/tests/, #9478).
 #       ict/tests/ = 42 strates package.
 #   - test-floor compte la COLLECTION parametree (items developpes par
-#     @pytest.mark.parametrize) : tests/ = 746 items, ict/tests/ = 42 items.
-#     55 != 746 PAR CONSTRUCTION (une strate se developpe en N items parametres) :
+#     @pytest.mark.parametrize) : tests/ = 1046 items, ict/tests/ = 670 items.
+#     55 != 1046 PAR CONSTRUCTION (une strate se developpe en N items parametres) :
 #     NE PAS "harmoniser" le floor sur le compte de strates, ni inversement. Le
-#     floor garde la collection (746/42), le label garde les strates (55/42).
+#     floor garde la collection (1046/670), le label garde les strates (55/42).
 #
 # Provenance : a l'intro du workflow (59ac5fc10) le header reclamait 34/119
 # tests, mais la CI a TOUJOURS collecte davantage (run d'origine 30896333149) :
-# le 34 etait faux des l'inception. Les floors actuels (746/42) sont mesures
-# firsthand sur origin/main (ai-01 @ dbfbf73ab) et enforce par la collection
-# floor-guard ci-dessous, pas seulement par ce commentaire. Quand la collection
-# change (ex. consolidation #9478), ajuster matrix.test-floor dans la meme PR
-# -- le message d'erreur du guard nomme la valeur a ajuster.
+# le 34 etait faux des l'inception. Les floors precedents (746/42, ai-01 @
+# dbfbf73ab) ont DERIVE en silence -- la collecte croissait sans que rien ne
+# le signale (746 -> 1046 / 42 -> 670, #15471). Les floors actuels (1046/670)
+# sont mesures firsthand sur origin/main@5302d974aa (po-2023, venv Python 3.9
+# + pyphi 1.2.0 + numpy 1.26.4, deux collectes consecutives identiques) et
+# confirmes par la CI au run 34307798875 (main@9433e9a09d : 1046/670). Ils
+# sont enforce par la collection floor-guard ci-dessous, pas seulement par ce
+# commentaire -- et depuis #15471 le guard emet aussi un ::warning quand la
+# collecte DEPASSE le floor (drift ascendant = floor a remonter dans la PR qui
+# l'introduit). Quand la collection change, ajuster matrix.test-floor dans la
+# meme PR.
 # Imposer un troisieme rootdir depuis la racine reproduirait le ModuleNotFoundError
 # documente dans #9387 (acceptance : une panne d'infra doit se distinguer d'un finding).
 #
@@ -73,25 +79,29 @@ jobs:
       matrix:
         include:
           # tests/ : 55 strates (34 originales + 21 edge-cases spectral/bistable/
-          # sensitivity consolides depuis ict/tests/, #9478) -> 746 items collectes
+          # sensitivity consolides depuis ict/tests/, #9478) -> 1046 items collectes
           # (cf. test-floor : le floor compte la COLLECTION parametree, PAS les
-          # strates ; 55 != 746 par construction). Rootdir herite du pyproject.toml
-          # d'ICT-Series/ (pip install -e . rend le package ict/ importable depuis
-          # n'importe quel cwd).
+          # strates ; 55 != 1046 par construction ; compte mesure 2x sur
+          # origin/main@5302d974aa, CI-confirme run 34307798875). Rootdir herite du
+          # pyproject.toml d'ICT-Series/ (pip install -e . rend le package ict/
+          # importable depuis n'importe quel cwd).
           - suite-name: "tests/ (55)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series
             test-args: tests
-            test-floor: 746
+            test-floor: 1046
           # ict/tests/ : 42 strates package (85 - 43 consolides dans tests/,
-          # #9478) -> 42 items collectes (strates == collection ici, pas de
-          # parametrize massif). Rootdir = ict/tests/ pour que le pytest.ini local
+          # #9478) -> 670 items collectes (le "strates == collection" d'origine
+          # est tombe : le parametrize est devenu massif ici aussi ; compte mesure
+          # 2x sur origin/main@5302d974aa, CI-confirme run 34307798875 -- mesure
+          # separee exigee par le scope #15471 avant de toucher ce floor).
+          # Rootdir = ict/tests/ pour que le pytest.ini local
           # (mode prepend, neutralise --import-mode=importlib) s'applique -- sinon
           # test_reversibility_budget / test_time_arrow n'executent jamais
           # (sys.path.insert module-level ignore sous importlib).
           - suite-name: "ict/tests/ (42 package)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests
             test-args: .
-            test-floor: 42
+            test-floor: 670
 
     steps:
       - uses: actions/checkout@v4
@@ -148,10 +158,13 @@ jobs:
       # hors du glob). pytest reste vert, mais 50 ou 200 tests ont evapore. La
       # gate reste verte alors que la couverture a chute. Ce step re-collecte
       # (--co -q, import-only, rapide) et echoue si le compte passe sous le
-      # plancher. Floors = comptes observes sur origin/main (4/4 runs CI stables
-      # 2026-08-04, suite deterministe). Quand des tests sont retires
-      # INTENTIONNELLEMENT, abaisser matrix.test-floor dans la meme PR -- le
-      # message d'erreur nomme la valeur a ajuster.
+      # plancher. Floors = comptes observes sur origin/main@5302d974aa
+      # (1046/670, deux collectes consecutives identiques, po-2023, #15471 ;
+      # CI-confirme run 34307798875 -- suite deterministe). Quand des tests
+      # sont retires INTENTIONNELLEMENT, abaisser matrix.test-floor dans la
+      # meme PR -- le message d'erreur nomme la valeur a ajuster. Symetriquement,
+      # un compte SUPERIEUR au floor emet un ::warning (drift ascendant, #15471)
+      # -- remonter le floor dans la PR qui fait croitre la collection.
       #
       # Robustesse : on parse la ligne de resume CANONIQUE de pytest ("N tests
       # collected"), pas les nodeids via `grep -c '::'`. Le premier essai
@@ -191,5 +204,13 @@ jobs:
           if [ "$collected" -lt "$ICT_TEST_FLOOR" ]; then
             echo "::error title=ICT coverage regression (${{ matrix.suite-name }})::Collected $collected < floor $ICT_TEST_FLOOR -- FINDING : des tests ont disparu silencieusement (module en skip, parametrize casse, fichier hors-glob) alors que la collecte a reussi. Si cette baisse est INTENTIONNELLE (ex. consolidation de doublons), abaissez matrix.test-floor ($ICT_TEST_FLOOR) dans .github/workflows/ict-tests.yml a la meme PR que la suppression qui la justifie. Sinon, c'est une regression de couverture a corriger avant merge."
             exit 1
+          fi
+          # Ratchet a deux sens (#15471) : le drift ASCENDANT etait silencieux
+          # (746 -> 1046 / 42 -> 670 passes inapercus) -- collected > floor
+          # passait vert sans rien dire. Non bloquant (l'ajout de tests n'est
+          # pas un finding), mais visible en annotation a chaque run tant que
+          # le floor n'est pas rattrape.
+          if [ "$collected" -gt "$ICT_TEST_FLOOR" ]; then
+            echo "::warning title=ICT collection floor stale (${{ matrix.suite-name }})::Collected $collected > floor $ICT_TEST_FLOOR -- DRIFT ASCENDANT : la collecte a grandi depuis le dernier rattrapage (#15471). Remonter matrix.test-floor ($ICT_TEST_FLOOR -> $collected) dans la PR qui introduit ces tests, sinon une suppression future jusqu'a l'ancien floor resterait verte."
           fi
           echo "Floor OK ($collected >= $ICT_TEST_FLOOR)."


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15484

## Contexte

L'issue #15471 (réévaluée CONFIRMED) : `matrix.test-floor` de la suite `tests/ (55)` était gelé à **746**
(mesuré sur `origin/main@dbfbf73ab` le 2026-08-05) alors que la collection courante est bien plus haute.
La mesure de cette PR révèle que la suite `ict/tests/ (42 package)` subissait le **même** drift : floor 42,
collection réelle 670. Dans les deux cas le garde ne voit rien : il n'échoue que *sous* le plancher.

## Mesure (acceptance : SHA exact + sortie complète, avant modification)

Base de mesure : `origin/main@5302d974aae0054bfc677e2e99b685d4f1cc50f7` (tête de PR — le diff ne touche
que le workflow, la collection est inchangée par construction). Environnement reproduisant la CI :
venv **Python 3.9.23** + `pip install -e MyIA.AI.Notebooks/IIT/ICT-Series` (pyphi 1.2.0, numpy 1.26.4, pytest).

Deux collectes consécutives par suite, sorties canoniques `N tests collected` :

```
tests/       (cwd ICT-Series,  `pytest tests --co -q`) : 1046 tests collected  (x2, identique)
ict/tests/   (cwd ict/tests/,  `pytest .     --co -q`) :  670 tests collected  (x2, identique)
```

Confirmation indépendante par la CI, run **34307798875** (main@9433e9a09d, 2026-09-09), lignes du floor-guard :

```
Collected: 670 tests (floor: 42) for ict/tests/ (42 package)
Collected: 1046 tests (floor: 746) for tests/ (55)
```

L'écart avec le « 1050 » de la réévaluation (mesuré @8d15698734b, plus ancien) vient de la tête mesurée :
le compte déterministe **de la tête de PR** est 1046, CI à l'appui.

## Livrable

1. `test-floor` : **746 → 1046** (`tests/`) et **42 → 670** (`ict/tests/`) — chacun avec sa mesure
   séparée, comme l'exige le scope de l'issue avant de toucher la seconde suite.
2. **Garde bidirectionnelle** : le drift *ascendant* était silencieux (746→1046 et 42→670 passés inaperçus
   parce que `collected > floor` passe vert). Le floor-guard émet désormais un `::warning` non bloquant
   quand `collected > floor`, nommant la valeur de rattrapage — plus jamais de drift muet, dans aucun sens.
3. Commentaires de provenance actualisés (header + matrice + garde) : les comptes d'**items** (1046/670)
   restent explicitement distingués des comptes de **strates** des labels (55/42) ; l'affirmation obsolète
   « strates == collection » pour `ict/tests/` est corrigée (le parametrize y est devenu massif aussi).
   Les labels des suites ne changent pas (hors scope de l'issue).

## Contrôle négatif (acceptance)

Logique exacte du garde (pipeline `grep -oE '[0-9]+ tests? collected'` + comparaison entière), jouée
localement avec les floors mutés, puis mutation retirée :

```
floor=1047, collected=1046  -> FAIL (coverage regression)   [exit 1]
floor=1046, collected=1046  -> OK   (floor exact)           [exit 0]
floor=671,  collected=670   -> FAIL (coverage regression)   [exit 1]
floor=670,  collected=670   -> OK   (floor exact)           [exit 0]
```

## Validation

- YAML parsé : matrice lue (`tests/ (55)` → 1046, `ict/tests/ (42 package)` → 670).
- `scripts/ci/check_self_hosted_runner_policy.py` : OK (151 workflows, 193 jobs — le `runs-on` n'a pas bougé).
- Le workflow se déclenche sur cette PR (`paths:` inclut `.github/workflows/ict-tests.yml`) : la CI
  exécutera les deux suites + le garde sur la tête — attendu `Floor OK (1046 >= 1046)` / `(670 >= 670)`.
- La suite `ict/tests/` elle-même n'est pas modifiée (aucun test déplacé/retiré — seuls workflow et floors).

Closes #15471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

