### PR TITLE
docs(qc,#15457): aérer la note éditoriale kernels du README hub (mur 4366 c → 8 blocs)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -8,15 +8,19 @@ maturity: BETA=61, DRAFT=36, ALPHA=12, TEMPLATE=1
 -->
 
 > **Note éditoriale — counts kernels par sous-série** : Le marqueur CATALOG-STATUS agrégé ci-dessus reste **autoritatif** pour la décomposition par **sous-série** (Python / projects / ML-Training-Pipeline / kelly_lean). En revanche, pour les décomptes par **kernel** (Python vs Lean 4) **au sein** d'une sous-série — c'est-à-dire la répartition technique par interpréteur —, **ce README reste autoritatif** car la décomposition langagière par sous-série n'est pas dans le marqueur agrégé. Cette granularité est documentée ici par lecture directe des `metadata.kernelspec.language` des notebooks :
->
+
 > - **`Python/` (parcours QC-Py-*)** : 54/54 = **Python** (mono-langage, QuantConnect Cloud + kernel local Jupyter) — *kernel Python majoritaire, aucun piège sémantique C#*. **Drift constaté c.744** (audit `git ls-files Python/`) : 55 .ipynb sur disque vs 53 déclarés hub → écart +2, attribué aux notebooks Cloud ajoutés 2026-05/06 (PCA-StatArb, TemporalCNN, ValueFactor-ZScore, OptionWheel). CATALOG-STATUS leaf ajouté en c.744. **Réconciliation §E c.S** (audit entier, `_output` exclus) : 54 exacts sur disque = 30 linéaires (QC-Py-01..28 + 12b + 23b) + 24 compléments ; le résiduel +1 du c.744 était `QC-Py-12b-Backtest-Validity`, jamais compté nulle part (corrigé dans les tables et décomptes ci-dessous).
+
 > - **`ML-Training-Pipeline/`** : 14/14 = **Python** (PyTorch / Stable-Baselines3 / Walk-Forward). **Drift constaté c.744** : 14 .ipynb sur disque vs 2 déclarés hub → écart +12, la sous-série a crû depuis la création du breakdown hub (ajouts RL/DL ladder). CATALOG-STATUS leaf ajouté en c.744.
+
 > - **`kelly_lean/`** : 7/7 = **Lean 4** (preuve formelle Kelly HMM-regime fee-aware) — *mono-paradigme Lean* : prouve les invariants algébriques du critère de Kelly pour le sizing position-aware des régimes HMM, complémentaire aux notebooks Python ML. **Note c.744** : « 7/7 » dans cette note désigne les **fichiers `.lean` du lake** (7 sources : `Kelly.lean` + lemmes), périmètre différent du marqueur hub (`kelly_lean=1` = 1 notebook Jupyter de référence). CATALOG-STATUS leaf (1 .ipynb) ajouté en c.744.
+
 > - **`research/`** : 17 .ipynb (standalone research, yfinance/sklearn, hors QC Cloud) — **non-référencé dans le breakdown hub** (4 sous-séries agrégées : Python/projects/ML-Training-Pipeline/kelly_lean). CATALOG-STATUS leaf ajouté en c.744. Ne pas confondre avec [`Python/research/`](Python/research/README.md) : 2 notebooks **companions** appariés aux notebooks de cours QC-Py-19/QC-Py-22 (catégorie (b) du README Python), détaillés dans leur [README feuille](Python/research/README.md).
+
 > - **`partner-course-quant-trading/`** : 7 .ipynb (cours partenaire sponsorisé QuantConnect Trading Firm) — **non-référencé dans le breakdown hub**. CATALOG-STATUS leaf ajouté en c.744.
->
+
 > Le hub QuantConnect a donc une **particularité intra-hub : parcours Python pur + sous-série Lean 4 isolée** (variante de la doctrine L392 « hub mixité kernel intra-sous-série » appliquée à un cas où Python domine largement, avec Lean isolé dans une sous-série distincte). La phrase L260 « périmètres différents, pas par erreur » documente précisément cette asymétrie.
->
+
 > **Régénération du marqueur** : ce bloc est régénéré quotidiennement par `.github/workflows/catalog-cron.yml` (03:37 UTC daily sur `main`, commit `[skip ci]` par `github-actions[bot]`). Toute divergence ponctuelle entre les counts agrégés et la réalité disk est documentée dans `docs/qc/qc-strategies-status.md` (autoritatif pour `projects/`) ou dans la note ci-dessus (autoritative pour les kernels intra-sous-série). **Résiduel c.744** : le breakdown agrégé `Python=53, projects=49, ML-Training-Pipeline=2, kelly_lean=1` du marqueur est **drift** vs le filesystem (cf points ci-dessus + sous-séries `research`/`partner-course` absentes de l'agrégat). **Le marqueur hub reste byte-identique** (catalog-pr-hygiene R1 : régénération par catalog-cron uniquement, hors scope PR feuille) ; le **fix canonique** = mise à jour du générateur de breakdown côté `catalog-cron.yml` pour inclure les sous-séries `research`/`partner-course-quant-trading` + recalculer les counts kernels réels. **Sub-grains séparés** : un futur cycle pourra auditer `catalog-cron.yml` + script de comptage pour aligner l'agrégat sur le filesystem ; ce PR n'altère **que** les leafs + la prose hub, sans toucher au marqueur agrégé (R1 strict).
 
 [← Notebooks](../README.md) | [↑ ..](../README.md) | [→ CaseStudies](../CaseStudies/README.md)
@@ -50,7 +54,7 @@ Le matériel QuantConnect se répartit en **5 zones** — un visiteur y navigue 
 
 | Zone | Contenu | Entrée |
 |------|---------|--------|
-| **`Python/`** | 54 notebooks pédagogiques QC-Py-* (8 phases, ci-dessous) | [README Python](Python/README.md) |
+| **`Python/`** | 55 notebooks pédagogiques QC-Py-* (8 phases, ci-dessous) | [README Python](Python/README.md) |
 | **`projects/`** | 112 entrées brutes (101 stratégies déployables `main.py` + 11 autres : 5 recherches, 2 stubs, 2 templates, 2 BROKEN pédagogiques), statut best-guess inventorié | [docs/qc/qc-strategies-status.md](../../docs/qc/qc-strategies-status.md) · [README projects](projects/README.md) |
 | **`research/`** | Recherche autonome standalone (données locales, pas de QC Cloud requis) | [README research](research/README.md) |
 | **`partner-course-quant-trading/`** | Exemples de recherche avancée du cours partenaire | [README cours partenaire](partner-course-quant-trading/README.md) |
@@ -247,7 +251,7 @@ python -m ipykernel install --user --name=quantconnect --display-name "Python (Q
 
 ## Résumé de la Progression
 
-**Total cours linéaire** : **30 notebooks Python** (QC-Py-01 à QC-Py-28 + les 12b et 23b, ~34 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus **17 notebooks de recherche** standalone (`research_*.ipynb`, détaillés dans [research/README.md](research/README.md)).
+**Total cours linéaire** : **30 notebooks Python** (QC-Py-01 à QC-Py-28 + les 12b et 23b, ~34 heures de contenu) + **25 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, foundation models QC-Py-23c, dataset workflow), plus **17 notebooks de recherche** standalone (`research_*.ipynb`, détaillés dans [research/README.md](research/README.md)).
 
 **Répartition cours linéaire (Phases 1-8)** :
 - **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: MED/ci #15374

## Résumé

Tranche #8 de l'issue #15457 : le README hub QuantConnect portait un paragraphe-mur de **4366 c** (la note éditoriale « counts kernels par sous-série », blockquote de 11 lignes contiguës détectées par `detect_paragraph_length.py`). Aération sur le pattern #15454 : le détecteur compte un bloc contigu de lignes non-vides comme un seul paragraphe — listes et blockquotes inclus, et une ligne `>` seule ne rompt rien. La correction insère des lignes vides complètes entre les 8 sous-blocs (chaque bloc rouvre `>`), **sans changer un mot du contenu** : diff = 9 lignes de séparation.

Compteurs de prose au présent alignés au disque firsthand (audit §E, cf ci-dessous) : la carte matériel disait « 54 notebooks QC-Py-* » et le résumé de progression « 24 compléments » alors que le disque porte 55 (le leaf `Python/README.md` et son marqueur `Python=55` les comptent déjà ; le +1 = `QC-Py-23c-TimesFM-Foundation-Models`, listé aux tables L68/L186 du leaf, jamais compté au hub — même pattern que le résiduel c.744).

## Mesure (détecteur #15455, exécuté firsthand)

- Avant : `QuantConnect/README.md` = **1 paragraphe > 2000 c (4366 c)** — fichier #8 de la liste de l'issue.
- Après : **clean, 0 finding** ; paragraphe max restant = 1214 c (le bloc « Régénération du marqueur », sous le seuil).
- Base `origin/main 4a589a88c2` → tête `c30947b23c`.

## Audit §E fichier-entier (README de série — obligatoire)

Comptages disque `git ls-files` (hors `_output`), mesurés firsthand :

| Sous-dossier | Disque | Prose hub | Marqueur hub |
|---|---|---|---|
| `Python/` QC-Py-* | 55 | 55 (corrigé ; était 54) | Python=55 ✓ |
| `Python/research/` companions | 2 | 2 (blockquote) | — |
| `ML-Training-Pipeline/` | 18 | 14 (relevé **daté** c.744) | 4 (drift générateur, résiduel documenté) |
| `kelly_lean/` .ipynb / .lean | 2 / 7 | 1 (daté c.744) / 7 | kelly_lean=2 ✓ |
| `research/` | 17 | 17 ✓ | — (hors agrégat, documenté) |
| `partner-course-quant-trading/` | 7 | 7 ✓ | — (hors agrégat, documenté) |
| `projects/` main.py | 102 | 101 stratégies + 2 squelettes + 1 harness (canon `qc-strategies-status.md` L105 : 112 entrées) | projects=49 (drift générateur) |

- Décomposition vérifiée : 30 linéaires (QC-Py-01..28 + 12b + 23b, 0 manquant aux tables de phases) + 9 compléments numérotés (30..35, 40, 41, **23c**) + 15 Cloud (01..14 + 03b) + 1 Dataset-Workflow = **55**.
- **64 liens relatifs extraits du README, 0 cassé** (vérification mécanique d'existence).
- Arbre `partner-course-quant-trading/` (examples/, kit-transitoire/, scripts/, templates/) et entrées `shared/`, `scripts/`, guides `GETTING-STARTED.md`/`BOOK_MAPPING.md`/`docs/*` : couverts par le check de liens.
- Divergences signalées, non corrigées (hors scope PR feuille, conformément à la règle §E) : le marqueur agrégé sous-compte `ML-Training-Pipeline` (4 vs 18) et `projects` (49 vs canon 111) — c'est le **résiduel c.744** documenté dans la note elle-même ; le fix canonique (générateur `catalog-cron.yml` incluant `research/`/`partner-course` + recalcul) reste le sub-grain séparé tracé dans la prose.
- Marqueur `CATALOG-STATUS` du hub **byte-identique** (catalog-pr-hygiene R1 : aucune régénération sur branche).

## Validation

- `detect_paragraph_length.py` (extrait de la branche #15455, non encore mergée sur main au moment de la tranche) : `clean`, 0 finding.
- Contenu du blockquote inchangé mot à mot : les 8 lignes de contenu sont byte-identiques, seules les séparations changent (les 3 lignes `>` porteurs deviennent des lignes vides + 4 lignes vides insérées entre items).
- Vérification pré-claim : claim unique sur ce chemin au ledger de l'issue (2026-09-10T18:19Z, cette lane) ; les PRs sœurs #15457 touchent d'autres fichiers.
- See #15457 (tranche partielle — l'issue porte 22 autres fichiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
