### PR TITLE
feat(genai,#15041): espace de travail du challenge 01-1b-Video-Slideshow (2 exemples + 3 exercices C.1)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-1b-Video-Slideshow-Bonus.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-1b-Video-Slideshow-Bonus.ipynb
@@ -2,7 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "d3fe6867",
    "metadata": {
+    "papermill": {
+     "duration": 0.001785,
+     "end_time": "2026-09-10T20:23:17.927899",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.926114",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -47,15 +55,395 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77a3b27a",
    "metadata": {
+    "papermill": {
+     "duration": 0.00119,
+     "end_time": "2026-09-10T20:23:17.930615",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.929425",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
-    "***\n\n## CHALLENGE BONUS - Générateur de Slideshow Vidéo\n\n**Points : 0.5 pts**\n\n## Objectif\n\nCréer une vidéo **slideshow** à partir de frames générées programmatiquement.\n\n## Ce que vous avez appris\n\nLa Section 1 montre:\n- Génération de frames avec PIL (`Image.new`, `ImageDraw`)\n- Assemblage avec imageio (`get_writer`, `append_data`)\n\n## Critères de succes\n\n- [ ] Générer **5 frames** affichant un message différent chacune:\n  - Frame 1: \"Bienvenue\"\n  - Frame 2: \"Voici le sujet\"\n  - Frame 3: \"Point important\"\n  - Frame 4: \"Conclusion\"\n  - Frame 5: \"Merci\"\n- [ ] Chaque frame doit avoir:\n  - Une couleur de fond différente (gradient ou palette cohérente)\n  - Le texte centré\n- [ ] Assembler en vidéo **5 secondes @ 1 FPS**\n- [ ] Sauvegarder dans `OUTPUT_DIR`\n\n## Contraintes techniques\n\n- Résolution: 640x480\n- Utiliser PIL pour les frames, imageio pour l'assemblage\n- FPS = 1 signifie chaque frame dure 1 seconde\n\n***\n\n**Soumission** : PR avec titre \"Challenge #7 - [Votre Nom]\", aperçu des frames et vidéo générée"
+    "***\n",
+    "\n",
+    "## CHALLENGE BONUS - Générateur de Slideshow Vidéo\n",
+    "\n",
+    "**Points : 0.5 pts**\n",
+    "\n",
+    "## Objectif\n",
+    "\n",
+    "Créer une vidéo **slideshow** à partir de frames générées programmatiquement.\n",
+    "\n",
+    "## Ce que vous avez appris\n",
+    "\n",
+    "La Section 1 montre:\n",
+    "- Génération de frames avec PIL (`Image.new`, `ImageDraw`)\n",
+    "- Assemblage avec imageio (`get_writer`, `append_data`)\n",
+    "\n",
+    "## Critères de succes\n",
+    "\n",
+    "- [ ] Générer **5 frames** affichant un message différent chacune:\n",
+    "  - Frame 1: \"Bienvenue\"\n",
+    "  - Frame 2: \"Voici le sujet\"\n",
+    "  - Frame 3: \"Point important\"\n",
+    "  - Frame 4: \"Conclusion\"\n",
+    "  - Frame 5: \"Merci\"\n",
+    "- [ ] Chaque frame doit avoir:\n",
+    "  - Une couleur de fond différente (gradient ou palette cohérente)\n",
+    "  - Le texte centré\n",
+    "- [ ] Assembler en vidéo **5 secondes @ 1 FPS**\n",
+    "- [ ] Sauvegarder dans `OUTPUT_DIR`\n",
+    "\n",
+    "## Contraintes techniques\n",
+    "\n",
+    "- Résolution: 640x480\n",
+    "- Utiliser PIL pour les frames, imageio pour l'assemblage\n",
+    "- FPS = 1 signifie chaque frame dure 1 seconde\n",
+    "\n",
+    "***\n",
+    "\n",
+    "**Soumission** : PR avec titre \"Challenge #7 - [Votre Nom]\", aperçu des frames et vidéo générée"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7c3e97a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001196,
+     "end_time": "2026-09-10T20:23:17.933053",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.931857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Espace de travail du challenge\n",
+    "\n",
+    "Le challenge ci-dessus était resté **sans endroit où répondre** : ce notebook ajoute l'espace de travail. Deux **exemples guidés** rappellent les primitives posées dans [01-1](01-1-Video-Operations-Basics.ipynb) (une frame PIL centrée, un mini assemblage imageio) ; trois **exercices** portent le livrable complet. Tout tourne sur CPU (VRAM 0, conformément à l'en-tête) : `Pillow` pour les frames, `imageio` + `imageio-ffmpeg` (binaire ffmpeg embarqué) pour l'assemblage. Les artefacts sont écrits dans `outputs/video_01_1b_slideshow/` (non versionné).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccdb454e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001382,
+     "end_time": "2026-09-10T20:23:17.935687",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.934305",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple guidé 1 — Une frame PIL : fond coloré, message centré\n",
+    "\n",
+    "La brique de base du slideshow. La fonction `frame_demo` crée une image RGB 640x480, remplit le fond, puis centre le texte en calculant sa boîte englobante :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4a21ec0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T20:23:17.939212Z",
+     "iopub.status.busy": "2026-09-10T20:23:17.938823Z",
+     "iopub.status.idle": "2026-09-10T20:23:17.992989Z",
+     "shell.execute_reply": "2026-09-10T20:23:17.992416Z"
+    },
+    "papermill": {
+     "duration": 0.057157,
+     "end_time": "2026-09-10T20:23:17.993997",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.936840",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frame exemple sauvegardee : outputs\\video_01_1b_slideshow\\frame_demo.png ((640, 480))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "from PIL import Image, ImageDraw\n",
+    "\n",
+    "OUTPUT_DIR = Path(\"outputs\") / \"video_01_1b_slideshow\"\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "\n",
+    "def frame_demo(message, couleur, taille=(640, 480), chemin=None):\n",
+    "    \"\"\"Genere une frame PIL : fond colore uniforme, message centre, texte blanc.\"\"\"\n",
+    "    img = Image.new(\"RGB\", taille, couleur)\n",
+    "    dessin = ImageDraw.Draw(img)\n",
+    "    bbox = dessin.textbbox((0, 0), message)\n",
+    "    x = (taille[0] - (bbox[2] - bbox[0])) // 2\n",
+    "    y = (taille[1] - (bbox[3] - bbox[1])) // 2\n",
+    "    dessin.text((x, y), message, fill=\"white\")\n",
+    "    if chemin is not None:\n",
+    "        img.save(chemin)\n",
+    "    return img\n",
+    "\n",
+    "\n",
+    "frame_exemple = frame_demo(\"Demo A\", (40, 60, 120), chemin=OUTPUT_DIR / \"frame_demo.png\")\n",
+    "print(f\"Frame exemple sauvegardee : {OUTPUT_DIR / 'frame_demo.png'} ({frame_exemple.size})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e188539b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001373,
+     "end_time": "2026-09-10T20:23:17.996867",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.995494",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple guidé 2 — Mini assemblage : 2 frames @ 1 FPS\n",
+    "\n",
+    "Le montage minimal : à 1 FPS, chaque frame dure une seconde. Deux frames donnent donc une vidéo de 2 secondes — le livrable du challenge est la même mécanique répétée 5 fois :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "750b5135",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T20:23:18.000507Z",
+     "iopub.status.busy": "2026-09-10T20:23:18.000142Z",
+     "iopub.status.idle": "2026-09-10T20:23:18.295182Z",
+     "shell.execute_reply": "2026-09-10T20:23:18.294579Z"
+    },
+    "papermill": {
+     "duration": 0.298178,
+     "end_time": "2026-09-10T20:23:18.296345",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:17.998167",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Video exemple : mini_slideshow_exemple.mp4 (2340 octets, 2 frames @ 1 FPS = 2 s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import imageio.v2 as imageio\n",
+    "\n",
+    "frames_exemple = [\n",
+    "    frame_demo(\"Demo A\", (40, 60, 120)),\n",
+    "    frame_demo(\"Demo B\", (120, 60, 40)),\n",
+    "]\n",
+    "video_exemple = OUTPUT_DIR / \"mini_slideshow_exemple.mp4\"\n",
+    "with imageio.get_writer(video_exemple, fps=1) as writer:\n",
+    "    for f in frames_exemple:\n",
+    "        writer.append_data(np.asarray(f))\n",
+    "print(f\"Video exemple : {video_exemple.name} ({video_exemple.stat().st_size} octets, \"\n",
+    "      f\"{len(frames_exemple)} frames @ 1 FPS = {len(frames_exemple)} s)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edf98817",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001396,
+     "end_time": "2026-09-10T20:23:18.299444",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.298048",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 — Les 5 frames du challenge\n",
+    "\n",
+    "Produire la liste des 5 frames imposées par les critères de succès : une par message, chacune sur un fond **distinct** (palette cohérente de votre choix), texte centré, résolution 640x480. Réutiliser `frame_demo` en variant la couleur, ou généraliser si vous préférez un dégradé.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "63246f44",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T20:23:18.303307Z",
+     "iopub.status.busy": "2026-09-10T20:23:18.302887Z",
+     "iopub.status.idle": "2026-09-10T20:23:18.306295Z",
+     "shell.execute_reply": "2026-09-10T20:23:18.305860Z"
+    },
+    "papermill": {
+     "duration": 0.006591,
+     "end_time": "2026-09-10T20:23:18.307413",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.300822",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (a completer) : les 5 frames du challenge\n",
+    "MESSAGES = [\"Bienvenue\", \"Voici le sujet\", \"Point important\", \"Conclusion\", \"Merci\"]\n",
+    "# TODO Etudiant : construire frames_challenge = liste de 5 PIL Images (640x480),\n",
+    "# une par message de MESSAGES, chaque frame sur une couleur de fond distincte\n",
+    "# (palette coherente), texte centre.\n",
+    "frames_challenge = None  # TODO etudiant : liste de 5 PIL.Image\n",
+    "print(\"Exercice 1 a completer :\",\n",
+    "      None if frames_challenge is None else f\"{len(frames_challenge)} frames generees\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8641e6f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002879,
+     "end_time": "2026-09-10T20:23:18.311936",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.309057",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 — L'assemblage : 5 secondes @ 1 FPS\n",
+    "\n",
+    "Assembler `frames_challenge` en vidéo **slideshow 5 s @ 1 FPS** (5 frames, une seconde chacune), exactement comme la vidéo exemple, et sauvegarder dans `OUTPUT_DIR` sous le nom `slideshow_5s.mp4`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4bb360d7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T20:23:18.317195Z",
+     "iopub.status.busy": "2026-09-10T20:23:18.317012Z",
+     "iopub.status.idle": "2026-09-10T20:23:18.320078Z",
+     "shell.execute_reply": "2026-09-10T20:23:18.319516Z"
+    },
+    "papermill": {
+     "duration": 0.005984,
+     "end_time": "2026-09-10T20:23:18.320916",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.314932",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (a completer) : assembler le livrable video\n",
+    "# TODO Etudiant : ecrire frames_challenge dans OUTPUT_DIR / 'slideshow_5s.mp4'\n",
+    "# via imageio.get_writer(..., fps=1), comme la video exemple.\n",
+    "video_challenge = None  # TODO etudiant : Path du fichier slideshow_5s.mp4 produit\n",
+    "print(\"Exercice 2 a completer :\", video_challenge)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ac24531",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001457,
+     "end_time": "2026-09-10T20:23:18.323941",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.322484",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 — Vérifier le livrable\n",
+    "\n",
+    "Un livrable se vérifie avant de se soumettre. Contrôler que `slideshow_5s.mp4` existe, que sa taille est non nulle, et que ses métadonnées coïrent avec l'attendu : 5 frames, durée 5 secondes. Indices : `imageio.get_reader(...)` expose `count_frames()` et `get_meta_data()` (clés `fps`, `duration`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "786445a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T20:23:18.327743Z",
+     "iopub.status.busy": "2026-09-10T20:23:18.327547Z",
+     "iopub.status.idle": "2026-09-10T20:23:18.330768Z",
+     "shell.execute_reply": "2026-09-10T20:23:18.330368Z"
+    },
+    "papermill": {
+     "duration": 0.006074,
+     "end_time": "2026-09-10T20:23:18.331534",
+     "exception": false,
+     "start_time": "2026-09-10T20:23:18.325460",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (a completer) : verification du livrable\n",
+    "# TODO Etudiant : construire verdict_livrable = {\"existe\": bool, \"nframes\": int|None,\n",
+    "# \"duree_s\": float|None, \"ok\": bool} pour slideshow_5s.mp4, ou ok = existe ET\n",
+    "# nframes == 5 ET duree_s == 5.0 (a tolerance pres).\n",
+    "verdict_livrable = None  # TODO etudiant\n",
+    "print(\"Exercice 3 a completer :\", verdict_livrable)\n"
    ]
   }
  ],
  "metadata": {
+  "authors": [
+   {
+    "name": "MyIA",
+    "role": "author"
+   }
+  ],
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -71,15 +459,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.3"
   },
-  "title": "Video Slideshow Bonus - Générateur de Slideshow Vidéo (Bonus)",
-  "authors": [
-   {
-    "name": "MyIA",
-    "role": "author"
-   }
-  ]
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.567742,
+   "end_time": "2026-09-10T20:23:21.752988",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "01-1b-Video-Slideshow-Bonus.ipynb",
+   "output_path": "01-1b-exec.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-10T20:23:16.185246",
+   "version": "2.6.0"
+  },
+  "title": "Video Slideshow Bonus - Générateur de Slideshow Vidéo (Bonus)"
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15496

## Résumé

Tranche **01-1b-Video-Slideshow-Bonus** de #15041 (Cas C, claim amendé [issuecomment-5624910464](https://github.com/jsboige/CoursIA/issues/15041#issuecomment-5624910464)) : le notebook bonus portait son **CHALLENGE BONUS complet en markdown sans AUCUNE cellule code** (2 cellules, 0 code) — l'espace de réponse n'existait pas (pattern « Cas B » du digest po-2026). Remède calqué sur ce digest : le challenge markdown reste **byte-identique**, on ajoute l'espace de travail autour.

## Contenu ajouté (+403/-9, challenge markdown inchangé)

- **Intro espace de travail** : lien vers 01-1, primitives rappelées, artefacts dans `outputs/video_01_1b_slideshow/` (gitignoré).
- **Exemple guidé 1** — `frame_demo(message, couleur)` : frame PIL 640×480, fond coloré uniforme, texte centré via `textbbox` ; sauvegarde `frame_demo.png`.
- **Exemple guidé 2** — mini assemblage : 2 frames via `imageio.get_writer(fps=1)` + `writer.append_data(np.asarray(f))` → vidéo 2 s (2 340 octets).
- **Exercice 1** (stub C.1) — produire les 5 frames imposées `MESSAGES = ["Bienvenue", "Voici le sujet", "Point important", "Conclusion", "Merci"]`, une couleur de fond distincte par frame.
- **Exercice 2** (stub C.1) — assembler `slideshow_5s.mp4`, 5 s @ 1 FPS, dans `OUTPUT_DIR`.
- **Exercice 3** (stub C.1) — vérifier le livrable (`existe`, `nframes`, `duree_s`, `ok`) via `imageio.get_reader` / `count_frames()` / `get_meta_data()`.
- Zéro paire de cellules code consécutives ; chaque exercice précédé d'un markdown énoncé + indices. Ids de cellules ajoutés (exigés par nbformat 4.5 ; les sources existantes restent byte-identiques, vérifié par assert contre `origin/main`).

CPU seul, VRAM 0 (conforme à l'en-tête du notebook) : Pillow + imageio/imageio-ffmpeg (binaire ffmpeg embarqué, aucun ffmpeg système requis).

## Validation (EXEC_PROVED)

- Papermill kernel `python3`, re-exec **complète** 13/13 cellules : **0 erreur**, 5,6 s. Les 2 exemples produisent des artefacts réels (frame (640, 480) + mp4 2 340 octets) ; les 3 stubs s'exécutent et impriment leur consigne (« Exercice N à completer »).
- Toutes les cellules code committées avec `execution_count` remplis et outputs réels (C.2). Grep mécanique `raise NotImplementedError|assert False|1/0` = **0** (C.1).
- Stdout sans chemin machine (uniquement `outputs\video_01_1b_slideshow\...` relatif et basenames) ; `metadata.papermill` normalisée aux basenames.
- Classification par contenu : les 2 cellules ajoutées résolues = **Exemples guidés** ; les 3 stubs = **Exercices**. Aucun exemple résolu stubbé.
- Catalogue byte-identique à `main` (aucun artefact régénéré).

Il reste sur #15041 : le volet `10e_LLamaSharp` (re-exec .NET/GGUF à évaluer, reporté avec justification au claim).

See #15041 (tranche 01-1b ; Cas C partiel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

