### PR TITLE
feat(picker,#15491): umbrella last-real-delivery age signal (Phase 1, boost 0)

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -156,12 +156,21 @@ REPO = "jsboige/CoursIA"
 # pour le diagnostic complet (EPIC decoupe en 9 filles = 9 veines invisibles).
 from series_saturation import (  # noqa: E402
     CONSOLIDATION,
+    DEFAULT_WINDOW_DAYS,
+    DELIVERY_DELIVERED,
+    DELIVERY_EMPTY_CORPUS,
+    DELIVERY_NONE_IN_WINDOW,
+    DELIVERY_UNAVAILABLE,
+    MERGED_FETCH_LIMIT,
     enrich_parent_families,
     EXPANSION,
     NEUTRAL,
     SERIES_SCALE_DEFAULT,
     cited_issues,
+    delivery_factor,
+    fetch_merged,
     fetch_series_visits,
+    measure_delivery,
     zone_balance,
     zone_umbrellas,
     zone_verdict,
@@ -720,7 +729,8 @@ def admissibility(item: dict, balance: dict | None,
 def weight(item: dict, prev_genre: str | None,
            visits: dict[int, int] | None = None,
            series: dict[str, dict] | None = None,
-           issue_to_family: dict[int, str] | None = None) -> float:
+           issue_to_family: dict[int, str] | None = None,
+           delivery: dict[int, float] | None = None) -> float:
     """Trois facteurs, tous doux, tous explicables en une ligne.
 
     Trop de ponderation reproduirait une monoculture avec des etapes en plus :
@@ -778,19 +788,26 @@ def weight(item: dict, prev_genre: str | None,
             w /= 1.0 + (factor - 1.0) / 2.0
     item["family"] = fam
     item["family_new_notebooks"] = nb_new
+    # Age de derniere livraison reelle (#15491) : UMBRELLAS seulement -- c'est
+    # un signal de distribution entre EPICs, pas un bonus par grain. Neutre
+    # (1.0) tant que --delivery-boost-max vaut 0 : Phase 1 instrumente, la
+    # composition ne bouge pas.
+    if delivery and item.get("klass") == "umbrella":
+        w *= delivery.get(item["number"], 1.0)
     return w
 
 
 def draw(items: list[dict], n: int, rng: random.Random, prev_genre: str | None,
          visits: dict[int, int] | None = None,
          series: dict[str, dict] | None = None,
-         issue_to_family: dict[int, str] | None = None) -> list[dict]:
+         issue_to_family: dict[int, str] | None = None,
+         delivery: dict[int, float] | None = None) -> list[dict]:
     """Tirage pondere sans remise (Efraimidis-Spirakis : cle = u^(1/w))."""
     if not items:
         return []
     keyed = []
     for it in items:
-        w = weight(it, prev_genre, visits, series, issue_to_family)
+        w = weight(it, prev_genre, visits, series, issue_to_family, delivery)
         u = rng.random() or 1e-12
         keyed.append((u ** (1.0 / w), w, it))
     keyed.sort(key=lambda t: t[0], reverse=True)
@@ -885,7 +902,8 @@ def check_claims(numbers: list[int], lane: str) -> dict[int, str]:
     return verdicts
 
 
-def draw_unclaimed(by_class, args, rng, visits, series, issue_to_family):
+def draw_unclaimed(by_class, args, rng, visits, series, issue_to_family,
+                   delivery=None):
     """Tire, puis REMPLACE tout candidat qu une autre lane tient deja.
 
     Deux raisons de remplacer plutot que d annoter :
@@ -914,7 +932,7 @@ def draw_unclaimed(by_class, args, rng, visits, series, issue_to_family):
             if len(got) >= want or not pool:
                 break
             cand = draw(pool, want - len(got), rng, prev, visits,
-                        series, issue_to_family)
+                        series, issue_to_family, delivery)
             if not cand:
                 break
             nums = [c["number"] for c in cand]
@@ -1108,6 +1126,48 @@ _PR_STATE_FRAGMENT = """
     } } } } } }
   }
 """
+
+
+def print_delivery(sig: dict, boost_max: float) -> None:
+    """Section texte du signal d'age de livraison (#15491 Phase 1).
+
+    Rend la fenetre demandee vs effective, la troncature, et par umbrella
+    l'etat, la date/l'age, le nombre de livraisons et le facteur theorique
+    au plafond de calibration. Une umbrella sans livraison reste TIRABLE :
+    l'annotation route vers le coordinateur (#13906), jamais vers un veto.
+    """
+    if not sig["items"]:
+        return
+    window = ("fenetre {}/{} j".format(sig["window_days_effective"],
+                                       sig["window_days_requested"]))
+    if sig["truncated"]:
+        window += " (TRONQUEE par la limite de fetch)"
+    if sig["corpus_error"]:
+        window += f" -- corpus: {sig['corpus_error']}"
+    print(f"Livraison umbrella ({window}, corpus {sig['corpus_size']} PRs "
+          f"mergees, boost applique x{boost_max:g}) :")
+    order = {DELIVERY_NONE_IN_WINDOW: 0, DELIVERY_DELIVERED: 1,
+             DELIVERY_UNAVAILABLE: 2, DELIVERY_EMPTY_CORPUS: 3}
+    rows = sorted(sig["items"].items(),
+                  key=lambda kv: (order.get(kv[1]["state"], 9),
+                                  -(kv[1]["age_days"] or 0.0)))
+    for num, it in rows[:8]:
+        line = "  #{:<6d} [{:>15s}] ".format(num, it["state"])
+        if it["state"] == DELIVERY_DELIVERED:
+            line += ("derniere {} (age {} j, {} livraison(s))".format(
+                (it["last_delivery"] or "")[:10], it["age_days"],
+                it["deliveries"]))
+        elif it["state"] == DELIVERY_NONE_IN_WINDOW:
+            line += "aucune declaration dans la fenetre"
+        else:
+            line += "mesure indisponible -- NEUTRE, jamais negligence prouvee"
+        line += " -- facteur theorique x{:.2f}".format(it["factor_theoretical"])
+        if it.get("body_route"):
+            line += " -- route: mise a jour body par le coordinateur (#13906)"
+        print(line)
+    if len(rows) > 8:
+        print(f"  (+{len(rows) - 8} autres umbrellas dans le JSON)")
+    print()
 
 
 def _hours_since(iso: str) -> float:
@@ -2432,6 +2492,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--dwell-hours", type=float, default=DWELL_HOURS_DEFAULT,
                     help="delai avant qu'une issue neuve soit consommable "
                          f"(defaut {DWELL_HOURS_DEFAULT:.0f} h ; 0 desactive le garde)")
+    ap.add_argument("--delivery-boost-max", type=float, default=0.0,
+                    help="#15491 Phase 1 : plafond du facteur d'age de derniere "
+                         "livraison des umbrellas (defaut 0 = inactif, kill "
+                         "switch ; activation proposee a 0.5 apres calibration)")
     ap.add_argument("--admit-reason", default=None, metavar="TEXTE",
                     help="passer outre le garde d'admission -- exige une "
                          "justification ECRITE, a reporter sur l'issue")
@@ -2644,6 +2708,28 @@ def main(argv: list[str] | None = None) -> int:
         pool, issue_to_family, series)
     balance = zone_balance(series, issue_to_family, pool)
 
+    # Age de derniere livraison reelle des umbrellas (#15491 Phase 1). Le
+    # fetch repasse par le meme payload cache que fetch_series_visits : hit,
+    # pas de requete gh supplementaire. Fenetre identique a celle de la
+    # saturation, pour que les deux mesures se lisent ensemble.
+    umbrella_numbers = [it["number"] for it in pool if it["klass"] == "umbrella"]
+    delivery_prs, delivery_fetch_err = fetch_merged(
+        DEFAULT_WINDOW_DAYS,
+        cache=payload_cache,
+        cache_mode=effective_cache_mode,
+        cache_status=cache_status,
+        cache_ttl_seconds=SERIES_CACHE_TTL_SECONDS,
+    )
+    delivery_sig = measure_delivery(
+        delivery_prs, umbrella_numbers, now=NOW, days=DEFAULT_WINDOW_DAYS,
+        fetch_error=delivery_fetch_err)
+    delivery_weights = {
+        num: delivery_factor(item["state"], item["age_days"],
+                             delivery_sig["window_days_effective"],
+                             args.delivery_boost_max)
+        for num, item in delivery_sig["items"].items()
+    }
+
     # Admission AVANT les urnes : un grain inadmissible ne doit pas
     # apparaitre dans le tirage, sinon il est sous les yeux quand le
     # refus arrive -- et c'est lui qui gagne (meme raison que le garde
@@ -2765,7 +2851,8 @@ def main(argv: list[str] | None = None) -> int:
         else None)
 
     picks, claims, claim_conflicts = draw_unclaimed(
-        by_class, args, rng, visits, series, issue_to_family)
+        by_class, args, rng, visits, series, issue_to_family,
+        delivery=delivery_weights if args.delivery_boost_max > 0 else None)
     withheld.extend(claim_conflicts)
     delivery = recent_delivery(picks)
 
@@ -2791,6 +2878,12 @@ def main(argv: list[str] | None = None) -> int:
             "visits_error": visits_err,
             "visits_top": sorted(({"issue": k, "n": v} for k, v in visits.items()),
                                  key=lambda d: (-d["n"], d["issue"]))[:10],
+            "umbrella_delivery": {
+                **delivery_sig,
+                "items": {str(k): v for k, v in delivery_sig["items"].items()},
+                "boost_max_applied": args.delivery_boost_max,
+                "calibration_max": 0.5,
+            },
             "recent_delivery": {str(k): v for k, v in delivery.items()},
             "red_backlog": backlog,
             "substance_drought": drought,
@@ -2884,6 +2977,7 @@ def main(argv: list[str] | None = None) -> int:
                   "en a aucun, d'en declarer un : une zone chaude sans EPIC "
                   "n'a personne de comptable pour la contrepartie.")
             print()
+    print_delivery(delivery_sig, args.delivery_boost_max)
     print(f"Pool ouvert : {len(pool)} issues.")
     print(f"Candidats apres admission/filtres : "
           f"{len(by_class['grain'])} grains "

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -58,6 +58,10 @@ SERIES_SCALE_DEFAULT = 2.0
 # pedagogique reel fait des milliers de lignes, un fichier de config non.
 NEW_NB_MIN_ADDITIONS = 200
 
+# Plafond du `gh pr list` de la fenetre mergee : l'atteindre tronque le
+# corpus, et `measure_delivery` doit pouvoir le signaler.
+MERGED_FETCH_LIMIT = 400
+
 _PARENT_RE = re.compile(
     r"(?:enfant\s+de|fille\s+de|sous-t\w+\s+de|part\s+of"
     r"|paire\s+\d+\s*/\s*\d+\s+de)[^#\n]{0,40}#(\d{4,6})\b",
@@ -181,12 +185,12 @@ def fetch_merged(
     stamp = (now - dt.timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
     command = [
         "gh", "pr", "list", "--repo", REPO, "--state", "merged",
-        "--limit", "400", "--search", "merged:>=" + stamp,
+        "--limit", str(MERGED_FETCH_LIMIT), "--search", "merged:>=" + stamp,
         "--json", "number,title,body,files,mergedAt",
     ]
     identity = [
         "gh", "pr", "list", "--repo", REPO, "--state", "merged",
-        "--limit", "400", "--window-days", str(days),
+        "--limit", str(MERGED_FETCH_LIMIT), "--window-days", str(days),
         "--json", "number,title,body,files,mergedAt",
     ]
 
@@ -230,6 +234,116 @@ def fetch_merged(
     except (subprocess.CalledProcessError, json.JSONDecodeError,
             subprocess.TimeoutExpired, OSError) as exc:
         return [], "{}: {}".format(type(exc).__name__, exc)
+
+
+# --- Age de derniere livraison reelle d'une umbrella (#15491, Phase 1) -------
+#
+# Distinct du delaissement (`updatedAt`) : une vieille Epic alimentee chaque
+# jour et une vieille Epic sans merge depuis des semaines restent mal
+# distinguees par les facteurs existants. Le signal mesure la derniere PR
+# mergee qui DECLARE servir l'umbrella -- via `cited_issues`, la regle de
+# declaration existante : le vocabulaire declare (`closes|fixes|resolves|see|
+# refs|part of`), les formes structurelles et les refs de titre. Une mention
+# incidente (`voir #N`, bare `EPIC #N` en prose) n'est pas une livraison.
+#
+# Quatre etats non confondables : un zero de corpus ne doit jamais se lire
+# comme un zero de livraison (lecon fetch_series_visits ci-dessus).
+
+DELIVERY_UNAVAILABLE = "unavailable"      # fetch/cache indisponible : neutre
+DELIVERY_EMPTY_CORPUS = "empty_corpus"    # fenetre valide mais 0 PR mergee
+DELIVERY_NONE_IN_WINDOW = "none_in_window"  # mesure valide, aucune declaration
+DELIVERY_DELIVERED = "delivered"          # livraison datee, age calculable
+
+
+def delivery_factor(state, age_days, window_days, boost_max):
+    """Facteur theorique d'age de livraison, gradue de 1.0 a 1.0 + boost_max.
+
+    Livraison toute recente (age 0) = 1.0 ; l'age croit vers le plafond quand
+    la derniere livraison vieillit jusqu'a l'horizon de la fenetre ; absence
+    valide dans la fenetre = plafond. Indisponible ou corpus vide = neutre :
+    un defaut de mesure ne doit jamais peser comme un delaissement prouve.
+    """
+    if boost_max <= 0:
+        return 1.0
+    if state == DELIVERY_NONE_IN_WINDOW:
+        return 1.0 + boost_max
+    if state != DELIVERY_DELIVERED or not window_days or window_days <= 0:
+        return 1.0
+    frac = min(max(age_days or 0.0, 0.0) / window_days, 1.0)
+    return 1.0 + boost_max * frac
+
+
+def measure_delivery(prs, umbrella_numbers, *, now, days,
+                     fetch_error=None, fetch_limit=MERGED_FETCH_LIMIT,
+                     calibration_max=0.5):
+    """Mesure l'age de derniere livraison reelle pour chaque umbrella.
+
+    Rend un dict stable (JSON-ready) : fenetre demandee vs effective,
+    troncature par la limite de fetch, et par umbrella l'etat, la date/l'age,
+    le nombre de livraisons, le facteur theorique au plafond de calibration
+    et la route coordinateur quand le body est suspect de peremption.
+
+    `body_route` suit #13906 : une umbrella sans livraison valide dans la
+    fenetre reste TIRABLE -- l'annotation route vers une mise a jour du body
+    par le coordinateur, jamais vers un veto du tirage.
+    """
+    requested = list(dict.fromkeys(int(n) for n in umbrella_numbers))
+    sig = {
+        "window_days_requested": days,
+        "window_days_effective": days,
+        "truncated": bool(prs) and len(prs) >= fetch_limit,
+        "corpus_size": len(prs or []),
+        "corpus_error": fetch_error,
+        "items": {},
+    }
+    corpus = list(prs or [])
+    if fetch_error and not corpus:
+        state = DELIVERY_UNAVAILABLE
+    elif not corpus:
+        state = DELIVERY_EMPTY_CORPUS
+    else:
+        state = None
+
+    if corpus:
+        stamps = sorted(
+            p["mergedAt"] for p in corpus
+            if p.get("mergedAt")
+        )
+        if stamps:
+            oldest = dt.datetime.fromisoformat(stamps[0].replace("Z", "+00:00"))
+            effective = (now - oldest).total_seconds() / 86400.0
+            sig["window_days_effective"] = round(min(float(days), effective), 2)
+
+    declared_by: dict[int, list[dict]] = {n: [] for n in requested}
+    if corpus and requested:
+        for pr in corpus:
+            for num in cited_issues(pr):
+                if num in declared_by:
+                    declared_by[num].append(pr)
+
+    for num in requested:
+        item = {"state": None, "last_delivery": None, "age_days": None,
+                "deliveries": 0, "factor_theoretical": None,
+                "body_route": None}
+        if state is not None:
+            item["state"] = state
+        else:
+            hits = declared_by.get(num) or []
+            if hits:
+                newest = max(h["mergedAt"] for h in hits if h.get("mergedAt"))
+                when = dt.datetime.fromisoformat(newest.replace("Z", "+00:00"))
+                item["state"] = DELIVERY_DELIVERED
+                item["last_delivery"] = newest
+                item["age_days"] = round((now - when).total_seconds() / 86400.0, 2)
+                item["deliveries"] = len(hits)
+            else:
+                item["state"] = DELIVERY_NONE_IN_WINDOW
+                item["body_route"] = "coord_update_13906"
+        item["factor_theoretical"] = round(delivery_factor(
+            item["state"], item["age_days"], sig["window_days_effective"],
+            calibration_max), 4)
+        sig["items"][num] = item
+    return sig
 
 
 _CAMEL_RE = re.compile(r"[a-z][A-Z]")

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -2037,3 +2037,63 @@ def test_unaddressed_review_points_pr_illisible_ne_bloque_pas_les_autres(monkeyp
     monkeypatch.setattr(nits, "analyse_pr", flaky_analyse_pr)
     assert pig.unaddressed_review_points([15049, 15081]) == {15081: 1}
     assert calls == [15049, 15081]
+
+
+# --- age de derniere livraison reelle : hook weight (#15491 Phase 1) ---------
+
+def _umbrella(n, age=120, idle=40):
+    return {"number": n, "age": age, "idle": idle, "genre": "docs",
+            "klass": "umbrella", "polarity": "neutral",
+            "title": "EPIC %d" % n}
+
+
+def test_delivery_factor_boosts_umbrellas_only():
+    """Le signal est un facteur de distribution ENTRE EPICs : un grain
+    classique ne doit jamais le recevoir, meme present dans le dict."""
+    grain = {"number": 5, "age": 30, "idle": 1, "genre": "docs"}
+    factors = {5: 1.5, 6: 1.5}
+    assert pig.weight(dict(grain), None, None, None, None, factors) == \
+        pig.weight(dict(grain), None, None, None, None, None)
+    umb = _umbrella(6)
+    assert pig.weight(dict(umb), None, None, None, None, factors) == \
+        pig.weight(dict(umb), None, None, None, None, None) * 1.5
+
+
+def test_delivery_boost_zero_leaves_weight_unchanged():
+    """Phase 1 : --delivery-boost-max 0 (defaut) = kill switch. Les facteurs
+    calcules a 0 valent tous 1.0, le poids d'une umbrella ne bouge pas."""
+    umb = _umbrella(1101)
+    neutre = {1101: pig.delivery_factor(
+        pig.DELIVERY_NONE_IN_WINDOW, None, 14, 0.0)}
+    assert pig.weight(dict(umb), None, None, None, None, neutre) == \
+        pig.weight(dict(umb), None, None, None, None, None)
+
+
+def test_delivery_boost_spreads_without_monopoly():
+    """Acceptance statistique : a boost 0.5, la part de tirage des umbrellas
+    sans livraison croit, sans qu'aucune umbrella monopolise le tirage.
+    Deterministe : rng reseedes pareil pour les deux compositions."""
+    import random
+    starved = [_umbrella(1101), _umbrella(1102)]           # aucune livraison
+    fed = [_umbrella(1103), _umbrella(1104), _umbrella(1105)]  # age 0
+    items = starved + fed
+
+    def composition(factors):
+        rng = random.Random(42)
+        counts = {it["number"]: 0 for it in items}
+        for _ in range(400):
+            pick = pig.draw([dict(i) for i in items], 1, rng, None,
+                            {}, {}, {}, factors)
+            counts[pick[0]["number"]] += 1
+        return counts
+
+    baseline = composition(None)
+    boosted = composition({1101: 1.5, 1102: 1.5, 1103: 1.0,
+                           1104: 1.0, 1105: 1.0})
+    share_starved_base = sum(baseline[n] for n in (1101, 1102)) / 400
+    share_starved_boost = sum(boosted[n] for n in (1101, 1102)) / 400
+    assert share_starved_boost > share_starved_base, (
+        f"le boost doit favoriser les sans-livraison : "
+        f"{share_starved_boost:.2f} vs {share_starved_base:.2f}")
+    assert max(boosted.values()) / 400 < 0.5, (
+        f"aucune umbrella ne doit monopoliser : {boosted}")

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -572,3 +572,112 @@ def test_informative_is_false_on_an_empty_candidate_list():
     assert ss._informative([], None) is False
     assert ss._informative([], {}) is False
     assert ss._informative(["X"], None) is True
+
+
+# --- age de derniere livraison reelle des umbrellas (#15491 Phase 1) ---------
+
+import datetime as _dt  # noqa: E402
+
+
+def _delivery_pr(number, merged_at, body=""):
+    return {"number": number, "title": "pr %d" % number, "body": body,
+            "mergedAt": merged_at, "files": []}
+
+
+_NOW = _dt.datetime(2026, 9, 10, 12, 0, tzinfo=_dt.timezone.utc)
+
+
+def test_delivery_unavailable_when_fetch_failed_empty():
+    """Fetch/cache indisponible : toutes les umbrellas neutres, l'erreur rendue."""
+    sig = ss.measure_delivery([], [1101, 1102], now=_NOW, days=14,
+                              fetch_error="CalledProcessError: gh down")
+    assert sig["corpus_error"] == "CalledProcessError: gh down"
+    assert sig["corpus_size"] == 0
+    for num in (1101, 1102):
+        assert sig["items"][num]["state"] == ss.DELIVERY_UNAVAILABLE
+        assert sig["items"][num]["factor_theoretical"] == 1.0
+
+
+def test_delivery_empty_corpus_distinct_from_no_delivery():
+    """0 PR mergee dans la fenetre : EMPTY_CORPUS, pas NONE_IN_WINDOW --
+    un zero de corpus ne doit jamais se lire comme un zero de livraison."""
+    sig = ss.measure_delivery([], [1101], now=_NOW, days=14, fetch_error=None)
+    assert sig["items"][1101]["state"] == ss.DELIVERY_EMPTY_CORPUS
+    assert sig["items"][1101]["factor_theoretical"] == 1.0
+    assert sig["items"][1101]["body_route"] is None
+
+
+def test_delivery_none_in_window_routes_body_update():
+    """Mesure valide, aucune declaration : NONE_IN_WINDOW + route #13906.
+    L'umbrella reste tirable : le signal annote, il ne met pas de veto."""
+    corpus = [_delivery_pr(900, "2026-09-08T10:00:00Z", "See #1999")]
+    sig = ss.measure_delivery(corpus, [1101], now=_NOW, days=14)
+    item = sig["items"][1101]
+    assert item["state"] == ss.DELIVERY_NONE_IN_WINDOW
+    assert item["body_route"] == "coord_update_13906"
+    # Plafond du facteur au max de calibration, pas 1.0 : le delaissement
+    # de LIVRAISON est prouve, distinct du delaissement updatedAt.
+    assert item["factor_theoretical"] == 1.5
+
+
+def test_delivery_delivered_takes_newest_and_counts():
+    """Plusieurs PRs declarent l'umbrella : la plus recente porte la date,
+    le compte empeche de lire 'la livraison' comme l'unique."""
+    corpus = [
+        _delivery_pr(901, "2026-09-01T10:00:00Z", "Closes #1101"),
+        _delivery_pr(902, "2026-09-09T18:00:00Z", "See #1101"),
+    ]
+    sig = ss.measure_delivery(corpus, [1101], now=_NOW, days=14)
+    item = sig["items"][1101]
+    assert item["state"] == ss.DELIVERY_DELIVERED
+    assert item["last_delivery"] == "2026-09-09T18:00:00Z"
+    assert item["deliveries"] == 2
+    assert item["age_days"] == round((_NOW - _dt.datetime(
+        2026, 9, 9, 18, tzinfo=_dt.timezone.utc)).total_seconds() / 86400.0, 2)
+    assert item["body_route"] is None
+
+
+def test_delivery_incidental_mention_is_not_a_delivery():
+    """La regle de declaration existante (cited_issues) fait le tri : un
+    bare `EPIC #N` en prose mi-corps raconte le contexte, ne declare pas."""
+    corpus = [
+        _delivery_pr(903, "2026-09-09T10:00:00Z",
+                     "dont l'EPIC #1101 porte la consolidation"),
+    ]
+    sig = ss.measure_delivery(corpus, [1101], now=_NOW, days=14)
+    assert sig["items"][1101]["state"] == ss.DELIVERY_NONE_IN_WINDOW
+
+
+def test_delivery_window_effective_and_truncation():
+    """Fenetre demandee vs reelle rendues separement, et la troncature par
+    la limite de fetch signalelee -- sinon une fenetre courte se lirait
+    comme une absence de livraison."""
+    corpus = [_delivery_pr(904, "2026-09-08T10:00:00Z", "See #1999")]
+    sig = ss.measure_delivery(corpus, [], now=_NOW, days=14)
+    # Le plus vieux merge couvre 2 j : la fenetre EFFECTIVE est 2 j, pas 14.
+    assert sig["window_days_requested"] == 14
+    assert sig["window_days_effective"] == 2.08
+    assert sig["truncated"] is False
+    truncated = [_delivery_pr(n, "2026-09-09T10:00:00Z") for n in range(400)]
+    sig2 = ss.measure_delivery(truncated, [1101], now=_NOW, days=14,
+                               fetch_limit=400)
+    assert sig2["truncated"] is True
+
+
+def test_delivery_factor_graduation():
+    """Livraison toute recente = 1.0 ; age croissant vers le plafond quand
+    la derniere livraison vieillit jusqu'a l'horizon ; absence valide =
+    plafond ; indisponible = neutre ; boost 0 = kill switch total."""
+    assert ss.delivery_factor(ss.DELIVERY_DELIVERED, 0.0, 14, 0.5) == 1.0
+    assert ss.delivery_factor(ss.DELIVERY_DELIVERED, 7.0, 14, 0.5) == 1.25
+    assert ss.delivery_factor(ss.DELIVERY_DELIVERED, 14.0, 14, 0.5) == 1.5
+    assert ss.delivery_factor(ss.DELIVERY_DELIVERED, 40.0, 14, 0.5) == 1.5
+    assert ss.delivery_factor(
+        ss.DELIVERY_NONE_IN_WINDOW, None, 14, 0.5) == 1.5
+    assert ss.delivery_factor(
+        ss.DELIVERY_UNAVAILABLE, None, 14, 0.5) == 1.0
+    assert ss.delivery_factor(
+        ss.DELIVERY_EMPTY_CORPUS, None, 14, 0.5) == 1.0
+    for state in (ss.DELIVERY_DELIVERED, ss.DELIVERY_NONE_IN_WINDOW,
+                  ss.DELIVERY_UNAVAILABLE, ss.DELIVERY_EMPTY_CORPUS):
+        assert ss.delivery_factor(state, 12.0, 14, 0.0) == 1.0


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/notebook-dotnet #15462

Phase 1 de #15491 : instrumentation de l'âge de dernière **livraison réelle** des umbrellas dans le picker. `Part of #13420`, see #11900, #13906, #5081.

## Signal

Pour chaque umbrella du pool, mesure de la dernière PR mergée qui la **déclare réellement** servir — via `cited_issues` (la règle de déclaration existante : vocabulaire déclaré `closes|fixes|resolves|see|refs|part of`, formes structurelles, refs de titre). Une mention incidente (`voir #N`, bare `EPIC #N` en prose) n'est pas une livraison — contrôlé par test.

Quatre états non confondables :

| État | Lecture | Facteur théorique (plafond 0.5) |
|---|---|---|
| `unavailable` | fetch/cache indisponible | 1.0 neutre, jamais « négligée » |
| `empty_corpus` | fenêtre valide mais 0 PR mergée | 1.0 neutre — distinct de none_in_window |
| `none_in_window` | mesure valide, aucune déclaration | 1.5 (plafond) + `body_route: coord_update_13906` |
| `delivered` | livraison datée | gradué 1.0 (âge 0) → 1.5 (âge = fenêtre) |

## Déploiement

- `--delivery-boost-max` défaut **0** (kill switch) : le facteur appliqué vaut 1.0 partout, la composition du tirage ne bouge pas (test dédié).
- Le facteur **théorique** au plafond de calibration 0.5 est rendu en texte et JSON pour la calibration 7 jours (acceptance « activation à 0.5 seulement après bilan »).
- Hook `weight()` : facteur appliqué aux **umbrellas seulement** (test : un grain classique ne le reçoit jamais, même présent dans le dict).
- JSON : clé additive unique `umbrella_delivery` — les consommateurs existants (`variation_volet_bc.py`) lisent des clés inchangées.

## Preuves

- Tests : `test_series_saturation.py` **54 passed** (7 nouveaux : 4 états, mention incidente exclue, fenêtre effective/troncature, graduation du facteur) ; `test_pick_idle_grain.py` **114 passed** (3 nouveaux : umbrella-only, boost 0 = poids inchangé, statistique déterministe — à boost 0.5 la part des umbrellas sans livraison croît sans qu'aucune ne dépasse 50 % des 400 tirages).
- Smoke réel (lecture seule, `--ignore-red`) sur les données du jour : 64 umbrellas mesurées, fenêtre demandée 14 j / **effective 5.23 j**, drapeau `TRONQUEE par la limite de fetch` posé (corpus saturé à 400 PRs) — exactement la limite de corpus que l'issue demande d'exposer : un `none_in_window` se lit « aucune livraison dans ~5 j », pas dans 14 j.

## Comparaison à `epic_neglect_sweep.py`

Même règle de déclaration (`cited_issues`, réutilisée), mais : (a) le sweep agrège un rapport hors-ligne ; le signal vit **dans le picker** au moment du tirage ; (b) le sweep ne distingue pas corpus vide/indisponible/négligence — le signal rend les 4 états + la fenêtre effective ; (c) le sweep ne connecte pas la mesure à un facteur gradué plafonné avec kill switch. La calibration 7 jours (acceptance) comparera les deux sorties avant toute activation à 0.5.

## Hors scope (Phase 2, après calibration)

Activation à `--delivery-boost-max 0.5`, quotas umbrella supplémentaires, réécriture des bodies (#13906).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
