### PR TITLE
fix(probas,#15022): couleur de texte explicite sur les nœuds mermaid stylés (lisibilité mode sombre)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -47,7 +47,8 @@ flowchart LR
     P1 --> U1["Incertitude<br/>non quantifiée"]
     P2 --> U2["Incertitude<br/>native<br/>(intervalles de crédibilité)"]
     U2 --> DEC["Décision basée sur<br/>E[U] (utilité espérée)"]
-    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
     class P2,U2,DEC dist;
 ```
 
@@ -176,9 +177,10 @@ flowchart TD
     PYMC --> PIVOT2{"Besoin de message passing<br/>déterministe (VMP/EP) ou .NET ?"}
     PIVOT1 -->|"oui"| PYMC
     PIVOT2 -->|"oui"| INFER
-    classDef infer fill:#d4edda,stroke:#28a745,stroke-width:2px;
-    classDef pymc fill:#cce5ff,stroke:#004085,stroke-width:2px;
-    classDef entry fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    classDef infer fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#155724;
+    classDef pymc fill:#cce5ff,stroke:#004085,stroke-width:2px,color:#004085;
+    classDef entry fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
     class INFER infer;
     class PYMC pymc;
     class IN101 entry;
@@ -649,12 +651,13 @@ flowchart LR
     %% NB_EP (Infer.NET EP / VMP) = inférence bayésienne approximative ;
     %% la passerelle Dung ↔ argumentation_lean est couverte par le tableau §E ci-dessus (ligne SymbolicAI ↔ Probas),
     %% pas par un lien direct depuis ce nœud de simulation.
-    style LK_DT fill:#e8f5e9,stroke:#2e7d32
-    style LK_CO fill:#e8f5e9,stroke:#2e7d32
-    style LK_PAC fill:#e8f5e9,stroke:#2e7d32
-    style LK_GIT fill:#e8f5e9,stroke:#2e7d32
-    style LK_KELLY fill:#e8f5e9,stroke:#2e7d32
-    style LK_SC fill:#e8f5e9,stroke:#2e7d32
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    style LK_DT fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style LK_CO fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style LK_PAC fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style LK_GIT fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style LK_KELLY fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style LK_SC fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
 ```
 
 La double culture Probas tient en deux gestes complémentaires. D'un côté, **simuler** : PyMC fait tourner NUTS/HMC sur des modèles hiérarchiques, Infer.NET propage des messages EP/VMP sur des graphes factoriels, et les notebooks PAC entraînent des hypothèses parERM. De l'autre, **prouver** : `decision_theory_lean` (VNM et Coherence certifiés, `0 sorry`) certifie que les axiomes de rationalité impliquent l'existence d'une utilité espérée, et la chaîne PAC iter-2 démontre `pac_agnostic_generalization` de bout en bout sans `sorry`. Les deux faces du même raisonnement bayésien et décisionnel — l'une touche l'intuition numérique, l'autre ancre la garantie formelle.

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -47,7 +47,7 @@ flowchart LR
     P1 --> U1["Incertitude<br/>non quantifiée"]
     P2 --> U2["Incertitude<br/>native<br/>(intervalles de crédibilité)"]
     U2 --> DEC["Décision basée sur<br/>E[U] (utilité espérée)"]
-    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
     classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
     class P2,U2,DEC dist;
 ```
@@ -177,7 +177,7 @@ flowchart TD
     PYMC --> PIVOT2{"Besoin de message passing<br/>déterministe (VMP/EP) ou .NET ?"}
     PIVOT1 -->|"oui"| PYMC
     PIVOT2 -->|"oui"| INFER
-    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
     classDef infer fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#155724;
     classDef pymc fill:#cce5ff,stroke:#004085,stroke-width:2px,color:#004085;
     classDef entry fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
@@ -651,7 +651,7 @@ flowchart LR
     %% NB_EP (Infer.NET EP / VMP) = inférence bayésienne approximative ;
     %% la passerelle Dung ↔ argumentation_lean est couverte par le tableau §E ci-dessus (ligne SymbolicAI ↔ Probas),
     %% pas par un lien direct depuis ce nœud de simulation.
-    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022)
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
     style LK_DT fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
     style LK_CO fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
     style LK_PAC fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: MED/notebook-dotnet #15462

`See #15022` (contribution partielle : le résidu de 24 fichiers reste ouvert).

## Le défaut, mesuré firsthand

`MyIA.AI.Notebooks/Probas/README.md` porte 3 blocs mermaid. Dans le `flowchart LR` (l.626), les 6 nœuds du sous-graphe LEAN portent `style ... fill:#e8f5e9` — un **fond vert clair figé, sans `color:`**. GitHub rend le libellé d'un nœud avec la couleur de texte du thème : en mode sombre il est clair, et il reste clair sur un fond forcé clair → **clair sur clair**. Les nœuds **sans** style (sous-graphe SIM) suivent le thème et restent lisibles.

C'est exactement l'asymétrie décrite par le user le 2026-09-08 sur cette issue (« la partie racine est correctement affichée et la partie à droite est en clair sur clair ») — et la lecture du fichier la localise : les deux autres blocs (`classDef dist` l.50, `classDef infer/pymc/entry` l.179-181) portent le même motif.

## Le correctif

`color:` foncé explicite ajouté à côté de chaque `fill:` clair, en paires fond-clair / texte-foncé cohérentes avec les `stroke:` déjà présents (vert `#155724`/`#1b5e20`, bleu `#004085`, ambre `#856404`, sarcelle `#0c5460`). **Aucune couleur pédagogique n'est retirée** : le code couleur des sous-graphes est préservé et le libellé est lisible dans les deux thèmes. Une ligne `%%` par bloc nomme la raison (un futur éditeur pourrait sinon lire le `color:` comme redondant avec le `fill:`).

## Ce qui est vérifié ici — et ce qui ne l'est pas

**Vérifié (mécanique, reproductible)** :
- 0 règle `fill:` sans `color:` dans les 3 blocs (contrôle scripté : 1+3+6 = 10 règles, 10 portent `color:`), fences équilibrées (22).
- Le locus et l'ampleur sont établis par `git grep` sur `origin/main` (a361ab047), pas par hypothèse.

**Non vérifié ici** : le **rendu** en mode sombre. Aucun renderer headless mermaid n'est installé sur cette machine, et cette lane est GLM — elle ne voit pas (cf `model-delegation.md` §« Capacité vision »). Le QA visuel doit donc être fait par une lane **CoursIA-2 (MiniMax)** ou **ai-01** avant merge ; cette PR ne revendique à aucun moment une vérification visuelle. Le mécanisme est en revanche déterministe : `color:` explicite prime sur la couleur de texte du thème.

## Résidu nommé (hors scope)

**24 autres `.md`** portent le même motif `fill:#` (`git grep -l 'fill:#' origin/main -- '*.md'`), dont `README.md` racine, `ML/`, `GameTheory/`, `SymbolicAI/`, `QuantConnect/` et 6 README Probas. Les traiter ici ferait > 15 fichiers (seuil §A de `pr-review-discipline.md` : split obligatoire). Ce lot demande un arbitrage — retirer les couleurs, ou les compléter comme ici — et reste ouvert sur #15022.

## Déclaration G-VAR-2 (transparence, pas dissimulation)

Mesure firsthand de la lane, `scripts/variation_light_cap.py --genre-signals --lane myia-po-2026:CoursIA` sur les 28 PRs mergées du 2026-09-10 : `light_genre=2` (genres `guard` + `ledger`) pour un **cap de 1** → `CAP-EXCEEDED-BY-GENRE=true`. Cette PR est déclarée **`LIGHT/readme`** — le tier honnête (la déclarer MED serait une TIER-INFLATION) — donc l'overrun reste visible et non blanchi. Le choix de livrer plutôt que de différer : le défaut est un bug de lisibilité rapporté par le user il y a 3 jours sur du contenu public, et le cycle n'est pas monotone (la lane a aussi livré lean et notebook-dotnet aujourd'hui). La décision de merge reste au coordinateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
