### PR TITLE
fix(tooling,#15489): garde de collision d'index rename-aware + canon de nommage partage

### DIFF
--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -300,6 +300,11 @@ PILOT: list[Guard] = [
         source=FAST_LANE_NATIVE,
         paths=NOTEBOOK_GLOBS + [
             "scripts/notebook_tools/check_duplicate_notebook_index.py",
+            # Grammaire partagee (#15489) : une modification du canon change le
+            # verdict des DEUX gardes de nommage. Sans ce path, le canon pourrait
+            # deriver sans qu'aucun des deux ne soit rejoue -- l'angle mort
+            # inverse de celui que cette tranche ferme.
+            "scripts/notebook_tools/naming_canon.py",
         ],
         argv=["python", "scripts/notebook_tools/check_duplicate_notebook_index.py",
               "--base", "{base_ref}", "--head", "HEAD"],
@@ -355,6 +360,7 @@ TRANCHE1: list[Guard] = [
         paths=[
             "MyIA.AI.Notebooks/GameTheory/**",
             "scripts/notebook_tools/check_series_zero_pad.py",
+            "scripts/notebook_tools/naming_canon.py",
             ".github/workflows/series-naming-gate.yml",
         ],
         argv=["python", "scripts/notebook_tools/check_series_zero_pad.py"],

--- a/scripts/notebook_tools/check_duplicate_notebook_index.py
+++ b/scripts/notebook_tools/check_duplicate_notebook_index.py
@@ -29,6 +29,16 @@ serait rouge des sa naissance et chaque PR echouerait sur une dette qu'elle n'a 
 creee. Il empeche la recurrence, il ne solde pas le passe. Les collisions existantes
 se traitent par une issue (cf. #12753), pas par un gate qui bloque tout le monde.
 
+RENAMES -- un ajout deguise (#15489)
+------------------------------------
+Un `git mv vers-un-index-deja-pris` est precisement la collision que ce garde
+existe pour attraper, et c'etait le seul chemin qui lui echappait : par defaut Git
+presente un rename de contenu identique comme `R100`, que `--diff-filter=A` ecarte.
+La revision est donc lue en `--no-renames`, ou le rename apparait pour ce qu'il est
+du point de vue de l'index : une position liberee et une position occupee. Le
+rename reste une manoeuvre legitime (cf. #12753) ; c'est l'index en conflit qui est
+fautif, pas le deplacement.
+
 DEUX FAUX POSITIFS QUE LE PREMIER JET PRODUISAIT
 ------------------------------------------------
 Mesure repo-wide au moment d'ecrire ce fichier : 1116 notebooks sur `main`, un
@@ -62,53 +72,19 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
+from pathlib import Path
 
-# Suffixes marquant un rendu ALTERNATIF du meme item, pas un item concurrent.
-# -Csharp / -Python : paires de langage (GameTheory/SocialChoice).
-# _en / _fr         : siblings i18n (#4980).
-LANG_SUFFIXES = ("-csharp", "-python", "_en", "-en", "_fr", "-fr")
-
-# Index en tete de nom : un ou plusieurs nombres separes par . ou -, suivis d'un
-# separateur puis du titre. On capture TOUS les niveaux : "04-1" et non "04".
-#   3.1-Retropropagation      -> 3.1
-#   04-13-Audiobook           -> 04-13
-#   22_Evaluating             -> 22
-#   MGS-26-Equilibrium        -> (prefixe alphabetique : aucun index, ignore)
-#
-# Le suffixe de lettre est CAPTURE separement et fait partie de l'index. La serie
-# `02-ML-Cours` porte `2.3b`, `2.5b`, `2.8b`, `2.8c` : la lettre designe une variante
-# inseree entre deux items numerotes, c'est un index a part entiere. Sans le groupe
-# `[a-z]?`, le moteur retrograde par-dessus la lettre et rend `2` pour les quatre --
-# quatre notebooks legitimes deviennent six collisions. Ce faux positif n'a PAS ete
-# trouve par les tests unitaires mais par le balayage des 1116 notebooks de `main` :
-# un jeu de cas ecrit a la main ne contient que les formes auxquelles on a pense.
-_INDEX_RE = re.compile(r"^(\d+(?:[.\-]\d+)*)([a-z]?)[._\-\s]", re.I)
-
-
-def index_key(filename):
-    """Index de serie d'un nom de fichier, ou None s'il n'en porte pas."""
-    stem = re.sub(r"\.ipynb$", "", filename, flags=re.I)
-    m = _INDEX_RE.match(stem)
-    if not m:
-        return None
-    # Normalise separateurs de niveau et zero-padding : 04-1 et 4.1 sont le meme
-    # index. Sans cette normalisation, un zero-pad partiel ouvrirait une porte de
-    # contournement silencieuse.
-    parts = re.split(r"[.\-]", m.group(1))
-    return ".".join(str(int(p)) for p in parts) + m.group(2).lower()
-
-
-def strip_lang(filename):
-    """Nom sans son suffixe de langue, pour apparier les rendus d'un meme item."""
-    stem = re.sub(r"\.ipynb$", "", filename, flags=re.I)
-    low = stem.lower()
-    for suf in LANG_SUFFIXES:
-        if low.endswith(suf):
-            return stem[: -len(suf)]
-    return stem
+# Grammaire de nom partagee avec les autres gardes de nommage (#5081/#15489).
+# `LANG_SUFFIXES`, `INDEX_RE` (index multi-niveaux + lettre d'accretion) et les
+# deux primitives vivaient ici avant d'etre extraites dans `naming_canon.py` :
+# le garde de zero-pad lisait la meme realite avec un autre motif. Une seule
+# lecture, un seul endroit ou la corriger.
+_here = str(Path(__file__).resolve().parent)
+if _here not in sys.path:
+    sys.path.insert(0, _here)
+from naming_canon import index_key, strip_lang  # noqa: E402
 
 
 def _git(args):
@@ -121,7 +97,17 @@ def _git(args):
 
 
 def added_notebooks(base, head):
-    out = _git(["diff", "--diff-filter=A", "--name-only", "%s...%s" % (base, head)])
+    """Notebooks AJOUTES par la revision, RENAMES repliés en suppressions + additions.
+
+    `--no-renames` est le coeur du garde, pas un detail d'invocation. Sans lui,
+    `git mv 3.1-Autre.ipynb 3.1-Retropropagation.ipynb` sort en `R` (similarite
+    100 %), `--diff-filter=A` ne le retient pas, et la collision d'index -- qui est
+    exactement ce qu'un rename produit -- reste invisible. Le rename est une
+    manoeuvre legitime (cf. #12753) ; c'est l'index occupe qui est fautif, et une
+    vue qui l'efface transforme le garde en filtre a trous.
+    """
+    out = _git(["diff", "--no-renames", "--diff-filter=A", "--name-only",
+                "%s...%s" % (base, head)])
     return [l.strip() for l in out.splitlines() if l.strip().lower().endswith(".ipynb")]
 
 

--- a/scripts/notebook_tools/check_series_zero_pad.py
+++ b/scripts/notebook_tools/check_series_zero_pad.py
@@ -25,24 +25,37 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# Grammaire de nom partagee (#5081/#15489) : le numero d'un `Prefixe-NN` se lit
+# avec les autres gardes de nommage, pas avec un motif local.
+_here = str(Path(__file__).resolve().parent)
+if _here not in sys.path:
+    sys.path.insert(0, _here)
+from naming_canon import parse_name  # noqa: E402
+
 
 def violations(series_dir: Path, prefix: str = "GameTheory") -> list[dict]:
     """Fichiers de la serie dont le numero n'est PAS zero-pade.
 
-    Le lookahead ``(?!\\d)`` est ce qui distingue le chiffre unique du premier
-    chiffre d'un numero a deux chiffres : sur ``GameTheory-26-`` il echoue
-    (6 suit 2), sur ``GameTheory-3a-`` il reussit (a suit 3).
+    Le chiffre unique se lit dans le numero rendu par le parseur du canon
+    (#15489) : ``GameTheory-3a`` livre ``number="3"`` (un chiffre), ``GameTheory-26``
+    livre ``"26"``, ``GameTheory-04c`` livre ``"04"``. La regle porte sur la
+    LONGUEUR du numero et non sur un motif du nom complet -- un motif local
+    re-encode la grammaire du canon, et deux encodages divergent au premier cas
+    limite (c'est ce que #15489 corrige).
     """
-    pattern = re.compile(rf"^{re.escape(prefix)}-(\d)(?!\d)")
     out: list[dict] = []
     for path in sorted(series_dir.rglob(f"{prefix}-*")):
-        if path.is_file() and pattern.match(path.name):
+        if not path.is_file():
+            continue
+        parsed = parse_name(path.name)
+        if parsed.series != prefix or parsed.number is None:
+            continue
+        if len(parsed.number) == 1:
             try:
                 shown = path.relative_to(REPO_ROOT).as_posix()
             except ValueError:

--- a/scripts/notebook_tools/naming_canon.py
+++ b/scripts/notebook_tools/naming_canon.py
@@ -1,0 +1,150 @@
+"""Canon de nommage des notebooks (#5081) — primitives partagees par les gardes.
+
+Origine — W0 de #5081/#11840 (`guard(#5081): securiser les renames`). Les organes
+de nommage se sont ecrits separement et ont chacun leur grammaire : le garde de
+collision d'index lit un index multi-niveaux avec lettre d'accretion
+(`^\\d+([.\\-]\\d+)*[a-z]?`), le garde de zero-pad lit un numero apres prefixe de
+serie (`^GameTheory-(\\d)(?!\\d)`). Deux lectures du meme nom, deux verites
+possibles. Ce module est la lecture unique : les deux organes l'importent au lieu
+de redefinir leur motif.
+
+PORTEE — ce que ce module certifie, et ce qu'il ne certifie pas
+--------------------------------------------------------------
+Il couvre les formes **reellement en service** dans le depot, telles que les deux
+organes les traitent aujourd'hui :
+
+    GameTheory-04c-NashExistence-Csharp.ipynb   serie + numero + accretion + langue
+    04-1-Educational-Audio-Content.ipynb        index a deux niveaux (categorie.item)
+    2.3b-Naive-Bayes-Generatif.ipynb            index decimal + lettre de variante
+    22_Evaluating_Generated_Text.ipynb          index nu, separateur underscore
+    MGS-26-EquilibriumOptimizer-vs-Mealpy.ipynb serie a prefixe alphabetique
+    07-Shapley_en.ipynb                         sibling i18n
+
+Il ne certifie **pas** : la casse canonique des suffixes de langue (`Python` /
+`CSharp` / `Lean`), la reservation d'un slot contre les PR ouvertes, ni la
+configuration par serie du zero-pad. Ce sont les points 3 a 5 de #15489, laisses
+hors de cette tranche — les revendiquer ici sans les implementer ferait passer un
+module partiel pour le canon entier.
+
+REGLE DE NON-REGRESSION — extraction a comportement constant
+------------------------------------------------------------
+Ce module a ete extrait des organes existants, il ne les reinterprete pas. La
+preuve n'est pas un raisonnement mais leurs self-tests : `check_duplicate_notebook_index.py
+--self-test` et `scripts/tests/test_check_series_zero_pad.py` doivent rester verts
+sans qu'aucun de leurs cas ait ete modifie.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Suffixes marquant un rendu ALTERNATIF du meme item, pas un item concurrent.
+# -Csharp / -Python : paires de langage (GameTheory/SocialChoice).
+# _en / _fr / -en / -fr : siblings i18n (#4980).
+LANG_SUFFIXES = ("-csharp", "-python", "_en", "-en", "_fr", "-fr")
+
+# Index en tete de nom : un ou plusieurs nombres separes par . ou -, suivis d'un
+# separateur puis du titre. On capture TOUS les niveaux : "04-1" et non "04".
+#   3.1-Retropropagation      -> 3.1
+#   04-13-Audiobook           -> 04-13
+#   22_Evaluating             -> 22
+#   MGS-26-Equilibrium        -> (prefixe alphabetique : aucun index, ignore)
+#
+# Le suffixe de lettre est CAPTURE separement et fait partie de l'index. La serie
+# `02-ML-Cours` porte `2.3b`, `2.5b`, `2.8b`, `2.8c` : la lettre designe une variante
+# inseree entre deux items numerotes, c'est un index a part entiere. Sans le groupe
+# `[a-z]?`, le moteur retrograde par-dessus la lettre et rend `2` pour les quatre --
+# quatre notebooks legitimes deviennent six collisions. Ce faux positif n'a PAS ete
+# trouve par les tests unitaires mais par le balayage des 1116 notebooks de `main` :
+# un jeu de cas ecrit a la main ne contient que les formes auxquelles on a pense.
+INDEX_RE = re.compile(r"^(\d+(?:[.\-]\d+)*)([a-z]?)[._\-\s]", re.I)
+
+# Numero d'un notebook a prefixe de serie alphabetique : `Prefixe-NN` (+ lettre
+# d'accretion). Le `(?!\d)` distingue le premier chiffre d'un numero a deux
+# chiffres (`GameTheory-26` : le `6` suit le `2`, pas de coupure) du chiffre
+# unique (`GameTheory-3a` : le `a` suit le `3`, coupure).
+SERIES_NUM_RE = re.compile(r"^(?P<prefix>[A-Za-z][A-Za-z0-9]*)-(?P<num>\d+)(?P<accr>[a-z])?(?!\d)")
+
+_IPYNB_RE = re.compile(r"\.ipynb$", re.I)
+
+
+@dataclass(frozen=True)
+class NotebookName:
+    """Lecture structuree d'un nom de notebook. Champs optionnels : `None` = absent.
+
+    `number` et `index` ne repondent pas a la meme question et ne sont donc pas
+    redondants : `number` est le numero tel qu'ecrit apres le prefixe de serie
+    (`04`, `26`), `index` est la position de navigation normalisee, zero-pad et
+    separateurs resorbes (`4.1`, `2.3b`). Un notebook sans prefixe de serie porte
+    un `index` et pas de `number` ; un notebook a prefixe porte les deux quand son
+    numero est en tete.
+    """
+
+    stem: str
+    series: str | None
+    number: str | None
+    accr: str | None
+    index: str | None
+    lang: str | None
+    title: str
+
+
+def strip_lang(filename: str) -> str:
+    """Nom sans son suffixe de langue, pour apparier les rendus d'un meme item."""
+    stem = _IPYNB_RE.sub("", filename)
+    low = stem.lower()
+    for suf in LANG_SUFFIXES:
+        if low.endswith(suf):
+            return stem[: -len(suf)]
+    return stem
+
+
+def index_key(filename: str) -> str | None:
+    """Index de serie d'un nom de fichier, ou None s'il n'en porte pas."""
+    stem = _IPYNB_RE.sub("", filename)
+    m = INDEX_RE.match(stem)
+    if not m:
+        return None
+    # Normalise separateurs de niveau et zero-padding : 04-1 et 4.1 sont le meme
+    # index. Sans cette normalisation, un zero-pad partiel ouvrirait une porte de
+    # contournement silencieuse.
+    parts = re.split(r"[.\-]", m.group(1))
+    return ".".join(str(int(p)) for p in parts) + m.group(2).lower()
+
+
+def lang_of(filename: str) -> str | None:
+    """Suffixe de langue d'un nom, normalise sans son separateur, ou None."""
+    stem = _IPYNB_RE.sub("", filename)
+    low = stem.lower()
+    for suf in LANG_SUFFIXES:
+        if low.endswith(suf):
+            return suf.lstrip("-_")
+    return None
+
+
+def parse_name(filename: str) -> NotebookName:
+    """Lecture structuree d'un nom de notebook selon le canon #5081.
+
+    La langue est retiree en premier : `01-Arrow-Csharp` doit livrer son index `1`
+    et non un index faussé par le suffixe. Le prefixe de serie est ensuite teste
+    sur le nom deja delangue, puis l'index en tete.
+    """
+    stem = _IPYNB_RE.sub("", filename)
+    lang = lang_of(stem)
+    base = strip_lang(stem) if lang else stem
+
+    series = number = accr = None
+    m = SERIES_NUM_RE.match(base)
+    if m:
+        series = m.group("prefix")
+        number = m.group("num")
+        accr = m.group("accr")
+
+    idx = index_key(base)
+    if m:
+        title = base[m.end():].lstrip("-_ ")
+    else:
+        mm = INDEX_RE.match(base)
+        title = base[mm.end():] if mm else base
+    return NotebookName(stem=stem, series=series, number=number, accr=accr,
+                        index=idx, lang=lang, title=title)

--- a/scripts/tests/test_check_duplicate_notebook_index.py
+++ b/scripts/tests/test_check_duplicate_notebook_index.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tests du garde de collision d'index, angle mort des renames (#15489).
+
+Le defaut corrige est un angle mort de la VUE `git diff` : un `git mv` vers un
+index deja tenu sort en `R100` et `--diff-filter=A` l'ecarte. Le tester sur une
+liste d'ajouts fabriquee ne prouverait rien -- la liste fabriquee n'a pas de
+renames, c'est-a-dire pas de defaut. Les deux controles de l'acceptance sont donc
+joues contre un **vrai depot git temporaire**, et le positif commence par
+verifier que Git voit effectivement un rename : sans cette assertion, le test
+passerait au vert meme sur un garde aveugle, et ne controlerait rien.
+
+    positif : git mv <fichier> -> index deja pris  => le garde rougit
+    negatif : git mv <fichier> -> index libre      => le garde reste vert
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "notebook_tools" / \
+    "check_duplicate_notebook_index.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git"] + list(args), cwd=str(repo), capture_output=True,
+                       text=True, encoding="utf-8", errors="replace")
+    if r.returncode != 0:
+        raise AssertionError("git %s -> %s" % (" ".join(args), r.stderr.strip()[:200]))
+    return r.stdout
+
+
+def _write(repo: Path, rel: str, body: str = "{}\n") -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def _init_repo(repo: Path) -> str:
+    """Depot initial avec deux notebooks d'index distincts. Rend le sha de base."""
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "config", "diff.renames", "true")
+    _write(repo, "a/03-DL/3.1-Retropropagation.ipynb")
+    _write(repo, "a/03-DL/5.2-Annexe.ipynb", '{"cells": []}\n')
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def _run_guard(repo: Path, base: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--base", base, "--head", "HEAD"],
+        cwd=str(repo), capture_output=True, text=True, encoding="utf-8",
+        errors="replace")
+
+
+class TestRenameAwareness(unittest.TestCase):
+    """Acceptance #15489 : un rename ne doit plus etre un trou dans le garde."""
+
+    def test_positive_control_rename_onto_taken_index_reddens(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            _git(repo, "mv", "a/03-DL/5.2-Annexe.ipynb",
+                 "a/03-DL/3.1-Autre.ipynb")
+            _git(repo, "commit", "-qm", "rename onto taken index")
+
+            # Le controle n'a de valeur que si Git classe bien ce commit comme un
+            # rename : c'est ce classement qui rendait le defaut invisible.
+            status = _git(repo, "diff", "--name-status", base, "HEAD")
+            self.assertIn("R", status,
+                          "Git ne classe pas ce commit en rename : le controle "
+                          "positif ne reproduit plus la condition du defaut.")
+
+            r = _run_guard(repo, base)
+            self.assertEqual(r.returncode, 1,
+                             "un rename vers un index deja tenu doit rougir\n"
+                             "stdout:\n%s\nstderr:\n%s" % (r.stdout, r.stderr))
+            self.assertIn("3.1-Autre.ipynb", r.stdout)
+            self.assertIn("COLLISION", r.stdout)
+
+    def test_negative_control_rename_onto_free_index_stays_green(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            _git(repo, "mv", "a/03-DL/5.2-Annexe.ipynb",
+                 "a/03-DL/5.3-Annexe.ipynb")
+            _git(repo, "commit", "-qm", "rename onto free index")
+
+            r = _run_guard(repo, base)
+            self.assertEqual(r.returncode, 0,
+                             "un rename vers un index libre doit rester vert\n"
+                             "stdout:\n%s\nstderr:\n%s" % (r.stdout, r.stderr))
+            self.assertIn("OK", r.stdout)
+
+    def test_plain_addition_onto_taken_index_reddens(self):
+        """Le chemin historique (ajout pur) ne doit pas regresser."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            _write(repo, "a/03-DL/3.1-Retropropagation-From-Scratch.ipynb")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "addition onto taken index")
+
+            r = _run_guard(repo, base)
+            self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+            self.assertIn("COLLISION", r.stdout)
+
+    def test_language_sibling_rename_stays_green(self):
+        """Un rename vers le rendu de langue du meme item reste legitime."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            _git(repo, "mv", "a/03-DL/5.2-Annexe.ipynb",
+                 "a/03-DL/3.1-Retropropagation-Csharp.ipynb")
+            _git(repo, "commit", "-qm", "rename to language sibling")
+
+            r = _run_guard(repo, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-enrichment #15497

## Résumé

Tranche **W0** de #15489 (EPIC #5081, sécuriser les renames) : deux gardes de nommage qui ne voyaient pas la même réalité, et un chemin de collision qui leur échappait. **Aucun notebook renommé, aucun rename de contenu** — c'est une tranche de gardes et de tests.

## Défaut 1 — le rename était un trou dans le garde de collision

`added_notebooks()` lisait la révision en `git diff --diff-filter=A --name-only`. Or `git mv 5.2-Annexe.ipynb 3.1-Retropropagation.ipynb` sort en **`R100`** (contenu identique) : `--diff-filter=A` l'écarte, et la collision d'index — précisément ce qu'un rename produit — restait invisible. Le rename est une manœuvre légitime (#12753) ; c'est l'index occupé qui est fautif, et une vue qui l'efface transformait le garde en filtre à trous.

**Correctif** : lecture en `--no-renames`, où le rename apparaît pour ce qu'il est du point de vue de l'index — une position libérée et une position occupée.

**Mesure sur un commit réel** (`7331d304df`, 12 renames de notebooks MGS-*) :

| vue | notebooks vus |
|-----|---------------|
| `--diff-filter=A` (avant) | **0** |
| `--no-renames --diff-filter=A` (après) | **12** |

Verdict vert dans les deux cas sur ce commit : le garde n'invente pas de faux positif sur des renames légitimes — il voit simplement ce qu'il regardait.

## Défaut 2 — deux grammaires pour une même réalité

Le garde de collision lisait `^(\d+(?:[.\-]\d+)*)([a-z]?)[._\-\s]`, le garde de zero-pad lisait `^GameTheory-(\d)(?!\d)`. Deux encodages de la même grammaire divergent au premier cas limite. Les primitives vivent désormais dans **`scripts/notebook_tools/naming_canon.py`**, importé par les deux :

- `index_key` / `strip_lang` / `LANG_SUFFIXES` — extraits à l'identique du garde de collision ;
- `parse_name` — lecture structurée (série, numéro, accrétion, index, langue, titre) ;
- le garde de zero-pad juge maintenant sur la **longueur du numéro** rendu par le parseur, plus sur un motif local du nom complet.

**Extraction à comportement constant** : aucun cas des self-tests existants n'a été modifié, et ils restent verts.

## Preuves

- **Contrôles positive/négative de l'acceptance, sur de vrais dépôts git temporaires** (`scripts/tests/test_check_duplicate_notebook_index.py`, 4 tests) : rename vers index pris → **rouge** ; rename vers index libre → **vert** ; ajout pur vers index pris → rouge (non-régression du chemin historique) ; rename vers le rendu de langue du même item → vert.
- **Le test mord** : aller-retour contrôlé sur le code sans `--no-renames` → `1 failed, 3 passed` (le contrôle positif précisément) ; avec → `4 passed`. Sans cette vérification, un test vert ne prouverait rien.
- **87 tests verts** (`test_check_duplicate_notebook_index.py` + `test_check_series_zero_pad.py` (11) + `test_fast_lane.py`), `--self-test` du garde de collision : **23 cas, 0 échec**, `pyflakes` CLEAN, `py_compile` OK.
- **Câblage fast lane** : `naming_canon.py` déclaré dans les `paths` des deux gardes (`scripts/ci/fast_lane_registry.py`) — sans quoi une dérive du canon ne rejouerait aucun des deux (l'angle mort inverse de celui que cette tranche ferme).
- Aucun notebook touché, catalogue byte-identique à `main`.

## Hors tranche (résiduel assumé, non revendiqué)

Points 3 à 5 de #15489 — garde dédié à la casse canonique `Python`/`CSharp`/`Lean`, registre ou preflight de réservation des slots contre les PR ouvertes, configuration explicite des séries ayant adopté le padding — plus le câblage de la fast lane **après** baseline verte (le garde de collision reste `blocking=True` avec sa dette pré-existante documentée).

See #15489 (tranche 1/2 — points 1 et 2 du livrable) · See #5081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
