### PR TITLE
fix(qc): make DL-LSTM QuantBook deterministic

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "cell_id": "cell-0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -30,17 +29,9 @@
    ]
   },
   {
-   "cell_id": "cell-1",
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:20.561268Z",
-     "iopub.status.busy": "2026-07-28T23:12:20.560935Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.133527Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.132277Z"
-    }
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -48,22 +39,43 @@
      "text": [
       "QuantBook initialisé.\n",
       "PyTorch version: 2.8.0+cu128\n",
-      "CUDA disponible: False\n"
+      "CUDA disponible: False\n",
+      "Graine PyTorch active: 42\n",
+      "Algorithmes déterministes: True\n"
      ]
     }
    ],
    "source": [
     "# Setup QuantBook\n",
     "from AlgorithmImports import *\n",
+    "import hashlib\n",
+    "import os\n",
+    "import random\n",
+    "from io import BytesIO\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "import warnings\n",
+    "\n",
+    "# Required by deterministic CUDA matrix operations (CUDA >= 10.2).\n",
+    "os.environ.setdefault(\"CUBLAS_WORKSPACE_CONFIG\", \":4096:8\")\n",
+    "\n",
     "import torch\n",
     "import torch.nn as nn\n",
-    "from torch.utils.data import Dataset, DataLoader\n",
-    "from io import BytesIO\n",
+    "from torch.utils.data import DataLoader, Dataset\n",
+    "import warnings\n",
+    "\n",
     "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "SEED = 42\n",
+    "random.seed(SEED)\n",
+    "np.random.seed(SEED)\n",
+    "torch.manual_seed(SEED)\n",
+    "if torch.cuda.is_available():\n",
+    "    torch.cuda.manual_seed_all(SEED)\n",
+    "torch.use_deterministic_algorithms(True)\n",
+    "torch.backends.cudnn.benchmark = False\n",
+    "torch.backends.cudnn.deterministic = True\n",
     "\n",
     "plt.style.use('seaborn-v0_8-darkgrid')\n",
     "plt.rcParams['figure.figsize'] = (14, 5)\n",
@@ -71,11 +83,12 @@
     "qb = QuantBook()\n",
     "print(\"QuantBook initialisé.\")\n",
     "print(f\"PyTorch version: {torch.__version__}\")\n",
-    "print(f\"CUDA disponible: {torch.cuda.is_available()}\")"
+    "print(f\"CUDA disponible: {torch.cuda.is_available()}\")\n",
+    "print(f\"Graine PyTorch active: {torch.initial_seed()}\")\n",
+    "print(f\"Algorithmes déterministes: {torch.are_deterministic_algorithms_enabled()}\")"
    ]
   },
   {
-   "cell_id": "cell-2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -85,17 +98,9 @@
    ]
   },
   {
-   "cell_id": "cell-3",
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.164856Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.164455Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.614063Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.612562Z"
-    }
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -133,27 +138,19 @@
    ]
   },
   {
-   "cell_id": "cell-4",
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.616467Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.616095Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.622662Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.621347Z"
-    }
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Prix: 2766 jours de trading\n",
-      "Premier prix: $182.10\n",
-      "Dernier prix: $681.92\n",
-      "Prix min: $165.46\n",
-      "Prix max: $690.38\n"
+      "Premier prix: $169.64\n",
+      "Dernier prix: $678.32\n",
+      "Prix min: $154.29\n",
+      "Prix max: $686.73\n"
      ]
     }
    ],
@@ -188,7 +185,6 @@
    ]
   },
   {
-   "cell_id": "cell-5",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -198,17 +194,9 @@
    ]
   },
   {
-   "cell_id": "cell-6",
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.624493Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.624320Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.630240Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.629100Z"
-    }
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -262,17 +250,9 @@
    ]
   },
   {
-   "cell_id": "cell-7",
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.632122Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.631956Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.637556Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.636381Z"
-    }
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -280,7 +260,9 @@
      "text": [
       "Train samples: 2192\n",
       "Test samples:  534\n",
-      "Scaler range: [165.46, 477.71]\n"
+      "Scaler range: [154.29, 449.49]\n",
+      "Empreinte des données: 897a5cb445127e6b1af3b69799235cd56da745fb45c4ddac624d37041d732f49\n",
+      "Ordre du DataLoader d'entraînement seedé avec seed=42.\n"
      ]
     }
    ],
@@ -292,6 +274,7 @@
     "\n",
     "# Normalisation\n",
     "normalized_prices, scaler_min, scaler_max = normalize_prices(prices, TRAIN_SIZE)\n",
+    "data_sha256 = hashlib.sha256(np.asarray(prices).tobytes()).hexdigest()\n",
     "\n",
     "# Split train/test\n",
     "split_idx = int(len(normalized_prices) * TRAIN_SIZE)\n",
@@ -302,17 +285,27 @@
     "train_dataset = PriceDataset(train_prices, SEQ_LENGTH)\n",
     "test_dataset = PriceDataset(test_prices, SEQ_LENGTH)\n",
     "\n",
+    "# Le générateur explicite gouverne l'ordre de shuffle indépendamment du RNG global.\n",
+    "train_generator = torch.Generator()\n",
+    "train_generator.manual_seed(SEED)\n",
+    "\n",
     "# Créer les dataloaders\n",
-    "train_loader = DataLoader(train_dataset, batch_size=BATCH_SIZE, shuffle=True)\n",
+    "train_loader = DataLoader(\n",
+    "    train_dataset,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    shuffle=True,\n",
+    "    generator=train_generator,\n",
+    ")\n",
     "test_loader = DataLoader(test_dataset, batch_size=BATCH_SIZE, shuffle=False)\n",
     "\n",
     "print(f\"Train samples: {len(train_dataset)}\")\n",
     "print(f\"Test samples:  {len(test_dataset)}\")\n",
-    "print(f\"Scaler range: [{scaler_min:.2f}, {scaler_max:.2f}]\")"
+    "print(f\"Scaler range: [{scaler_min:.2f}, {scaler_max:.2f}]\")\n",
+    "print(f\"Empreinte des données: {data_sha256}\")\n",
+    "print(f\"Ordre du DataLoader d'entraînement seedé avec seed={SEED}.\")"
    ]
   },
   {
-   "cell_id": "cell-8",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -324,7 +317,6 @@
    ]
   },
   {
-   "cell_id": "cell-9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -332,17 +324,9 @@
    ]
   },
   {
-   "cell_id": "cell-10",
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.639419Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.639252Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.648254Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.646994Z"
-    }
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -404,7 +388,6 @@
    ]
   },
   {
-   "cell_id": "cell-11",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -412,17 +395,9 @@
    ]
   },
   {
-   "cell_id": "cell-12",
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.650077Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.649919Z",
-     "iopub.status.idle": "2026-07-28T23:12:23.656582Z",
-     "shell.execute_reply": "2026-07-28T23:12:23.655344Z"
-    }
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -487,58 +462,20 @@
    ]
   },
   {
-   "cell_id": "cell-13",
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:12:23.659464Z",
-     "iopub.status.busy": "2026-07-28T23:12:23.659239Z",
-     "iopub.status.idle": "2026-07-28T23:13:03.089455Z",
-     "shell.execute_reply": "2026-07-28T23:13:03.087474Z"
-    }
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Début de l'entraînement (50 epochs)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch  10/50 - Train Loss: 0.000343, Test Loss: 0.021194\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch  20/50 - Train Loss: 0.000279, Test Loss: 0.008710\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch  30/50 - Train Loss: 0.000229, Test Loss: 0.003310\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch  40/50 - Train Loss: 0.000185, Test Loss: 0.001244\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch  50/50 - Train Loss: 0.000162, Test Loss: 0.000836\n",
+      "Début de l'entraînement (50 epochs)...\n",
+      "Epoch  10/50 - Train Loss: 0.000356, Test Loss: 0.035653\n",
+      "Epoch  20/50 - Train Loss: 0.000260, Test Loss: 0.012881\n",
+      "Epoch  30/50 - Train Loss: 0.000198, Test Loss: 0.003780\n",
+      "Epoch  40/50 - Train Loss: 0.000210, Test Loss: 0.002270\n",
+      "Epoch  50/50 - Train Loss: 0.000209, Test Loss: 0.001946\n",
       "\n",
       "Entraînement terminé.\n"
      ]
@@ -573,7 +510,6 @@
    ]
   },
   {
-   "cell_id": "cell-14",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -581,17 +517,9 @@
    ]
   },
   {
-   "cell_id": "cell-15",
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:13:03.092665Z",
-     "iopub.status.busy": "2026-07-28T23:13:03.092101Z",
-     "iopub.status.idle": "2026-07-28T23:13:03.149761Z",
-     "shell.execute_reply": "2026-07-28T23:13:03.148109Z"
-    }
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -599,10 +527,10 @@
      "text": [
       "\n",
       "Métriques de performance (Test set):\n",
-      "  MSE:  78.6938\n",
-      "  MAE:  $6.88\n",
-      "  MAPE: 1.15%\n",
-      "  Direction Accuracy: 53.1%\n"
+      "  MSE:  161.8630\n",
+      "  MAE:  $10.15\n",
+      "  MAPE: 1.71%\n",
+      "  Direction Accuracy: 53.3%\n"
      ]
     }
    ],
@@ -631,7 +559,6 @@
    ]
   },
   {
-   "cell_id": "cell-16",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,7 +571,6 @@
    ]
   },
   {
-   "cell_id": "cell-17",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -652,28 +578,10 @@
    ]
   },
   {
-   "cell_id": "cell-18",
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:13:03.152324Z",
-     "iopub.status.busy": "2026-07-28T23:13:03.152087Z",
-     "iopub.status.idle": "2026-07-28T23:13:03.823313Z",
-     "shell.execute_reply": "2026-07-28T23:13:03.822135Z"
-    }
-   },
+   "execution_count": 22,
+   "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3hUddrG8e+Zmt5DQug1QaSKNFGkqIjyuiq2tXdXseKqq64F17oqtrUXRFHsHSsqFlBEeu8tkN7rtPP+McmQkEICIQnx/lyX1yZz2u/MSZaTZ55z/wzTNE1EREREREREREREpFWwtPQARERERERERERERGQPFW1FREREREREREREWhEVbUVERERERERERERaERVtRURERERERERERFoRFW1FREREREREREREWhEVbUVERERERERERERaERVtRURERERERERERFoRFW1FREREREREREREWhFbSw9AREREREREpDHee+890tLSGDZsGEOHDm3p4UgL2bZtG59++ilOp5MLL7wQp9PZ0kOq1fz58/nzzz/p2LEjp556aksPR0QOEeq0FZE2aezYsSQnJ5OcnNzSQ+G2224LjOX3339v6eG0CXpPRURE/ro+/fRT7rzzTlauXMnAgQMbtE1d9w6Vr40dO7bJx/n0008H9v/hhx82+f7/6srKyrj22mt5+eWX6du3734XbH///ffAdbrtttsCrzfV/ebmzZu55ppr+OSTTxg2bFijtr3iiitITk7m4osv3u/j/xWZpskJJ5xAcnIy9957b0sPR2S/qdNWRBqlpKSEd999l2+//ZaNGzdSUlJCfHw8vXr1YuLEiZx44ok4HI6WHuYh4fzzz2fhwoXMnTuXjh07tvRwWpWdO3fy0UcfAdCnTx/Gjx/fwiMSERGRhnj66ad55plnarweFhZGr169OP3005k8eTKGYezX/jdt2sTdd9/N2LFjefLJJ1v0vrOgoIDXX38dgA4dOnDaaae12FgONR9++CH/+te/qr1msVgIDw8nOTmZyZMnc8opp9S7j2nTprF9+3aef/55RowYcTCHW813333HmjVrADj11FPrvY8vLS3l+uuvJz4+npkzZ5KYmNjg4yxdupR58+YBcOGFFwL+QnLlPfK+TJkyhWuvvbbBx2uIxpz7wVbfWAzD4IILLmDatGm89957XHHFFbRv376lhiqy31S0FZEG27hxI1dddRU7duyo9npqaiqpqan8+OOP9O7dmz59+rTQCKWtSE1NDfzBd+qpp9Yo2l511VVMnjwZoFV0U4uIiEj9ioqKWLJkCUuWLGHx4sU8+OCD+7WfdevWcc0113DhhRdit9sPeFyzZs0C2K8uzYKCgsD9ytChQ2sUbU8//fRAMbFbt24HONK2z+fzkZ+fz8KFC1m4cCH5+flccMEFta6blZVFUlISr776KoMHDz4o46nrfvO7774LFE6HDh1ab+Fy/fr1nHDCCZxxxhkkJCQ06vivvvoqAO3atWP06NGNHf5B0Zhzb+mxnHLKKTz00EO4XC5mzpzJrbfe2hLDFDkgKtqKSIPk5eVx+eWXs2vXLsB/83DppZeSnJxMcXExCxcubBWPfZWUlBASEtLSw2jTWsN73LVrV7p27dqiYxAREZH6HXPMMVx55ZW4XC7mzJnDe++9B/i7LP/+97/Tr1+/Orf1+Xy43e4axdSJEyc26RiHDBnSpPurKikpiaSkpIO2/7aiT58+3HnnnRQXF/PKK68EogjeeOONOou2cXFxTJky5aCOqynuNwcMGMCAAQMavV1ubi7ff/89AMcdd1ygM71qIRnghRde4KeffgLgtNNO4/TTTw8s+6v/7IWFhTFy5Eh+/PFHPvvsM6ZOnYrNphKYHFr0EysiDfLqq68GCrbh4eG8//771T4tHj9+PFdeeSVWqzXwmsvlYsaMGXzxxRds27YN0zTp0qULJ598MhdddFG1x9kqP73u0KFD4AYF9kQIAIEYgZ07dzJu3DjA/6nqddddx6OPPsqaNWuYOHEiDz30ULWx5+Tk8PDDD/P999/j8/k49thjuf3224mNja223qJFi3j55ZdZunQpRUVFtGvXjuOOO46rr76ayMjIBr1Pb775JjNmzCAjI4PevXszderUBm1X6b333uOrr75i06ZN5OXl4fV6ad++PUcffTTXXHMNMTExtb43n376KbNnz+bLL7+krKyMYcOGcccdd9C5c+fA+mPHjiU1NRWAX3/9lQcffJB58+Zhmmat70nVa/Lcc8/x0EMPsXTpUg4//HDeeOMNAHbs2MELL7zAr7/+SmZmJuHh4QwbNoxrr72WHj16BPZV9RG4KVOm0LlzZ1566SW2bt1Khw4duP766wN/hFU9L4CPPvoo8Cn6qaeeykMPPVTt0bCZM2cG8sF+//13nnvuOVavXk1xcTHh4eF07NiRgQMHcv311xMeHg7A119/zYwZM1i/fj3l5eVERkbSuXNnBg8ezM0334xhGJSUlPDwww+zYsUK0tLSKCgowOl00rNnTyZPnswZZ5xR7dqVlZXx2GOP8dlnn1FeXs6wYcO48847ueCCCwLv+7p16wLrm6bJhx9+yHvvvcf69evxeDx07dqV008/nfPPPx+LRbHzIiJyaIuNjQ0URUeMGMGCBQvYuXMnAH/++Sf9+vWrFqdw//33k5GREZhkbMaMGQwbNqzGv5lut7vav5lV7z+hcfdjdd2Der1eZs+ezaeffsrGjRtxu90kJiYyfPhwpk2bVuMx9YULFwb2NXToUN54441q5/bggw9W68RdtWoVL7zwAn/++Sf5+flERkZyxBFHcMUVV3D44YcH1mvMPRT4i33Tp0/n559/JjMzE7vdTrt27ejbty9nn312nZO2ud1uRo0aRV5eHlFRUfz666/VClwnnHACW7duxeFw8MsvvxAZGdmg+6mGCA8PD/ycxMXFBd6n3bt311h373vPsLAwhg0bxpQpU+jVq1dgvfT0dJ544glWrVpFeno6RUVFhIaGkpKSwgUXXNCg6K297zc7dOgQ+BukUtWictV70tr+rhg3bhzXXHMNUVFR+zz2vHnzcLvdABx11FGB1/cuJL///vuBr5OSkqp9CGGaJh988EGD7jXXrl3Lk08+ydKlSykoKCAsLIzExEQGDBjAVVddhc/na/C512b27Nm8++67bNmyBbfbTXR0ND169OCoo47i8ssvD6zndrt58803+eyzz9i8eTMAvXr14rzzzgvEZVT9W3BfY6ks2mZmZrJ06dKD+iGNyMGgoq2INMicOXMCX1900UW1Pt5TteDncrm45JJL+OOPP6qts27dOtatW8dPP/3Eq6++esA5ZFu3buXSSy+lvLy8znUuuuiiasWyzz//nA0bNvD+++8Hjv/ee+9x11134fP5AuulpqYyY8YM5s2bxzvvvLPPwu0rr7zCI488Evh+xYoVXH755dUKp/vy1Vdf8csvv1R7bdu2bWzbto0FCxbw0Ucf1fr43vXXX8+WLVsC3//444+sWbOGTz75hOjo6Brrn3feedXWr+09qVRQUMAFF1xAXl5etddXrVrFRRddREFBQeC1nJwcvvzyS+bNm8frr79O//79axz7k08+qRaxsXXrVqZOnUpKSgrdu3ev453Zt82bN3PFFVdQVlYWeC03N5fc3FxWrFjB+eefT3h4OAsXLuSGG26odq2zsrLIyspi8eLF3HjjjdhsNoqLi5k9e3a1Y7jdbpYuXcrSpUtJT0+v1uFx0003MXfu3MD3P/zwA2vXrqW0tLTW8d522218/PHH1V5bt24dDzzwAEuXLmX69On7/V6IiIi0NoZhEBYWFvje5XLVWOf555+vEcMFtf+buX79eh588EEWL17Mk08+GSgQNsX9mNvt5qqrrqrznmzatGkN3ldt5s6dy/XXXx8oyoH/XuTrr7/m+++/58knn6xRlIKG3UPdcMMN/Pbbb9XOZevWrWzdupVOnTrVWbS12+1MmDCB2bNnk5eXx++//x4oFq5du5atW7cCMHr0aCIjIxt8P9VYpmkGvm7Xrl21ZbXde+bm5vLVV1/x008/8dprrwUmptu9e3eNpwDz8/P5/fff+f3333n44Yf529/+1ujxNURdf1fMnDmTn376iXfeeWefhdvFixcHvu7bt+9+jaOh95q5ublcfPHF5OTkBNbLy8sjLy+PtWvXMmHChEb9/uzt448/5u677672WkZGBhkZGWzevDlQtHW73Vx++eUsWLCg2rrLly/nlltuYf369fzzn/9s1LGrvneLFy9W0VYOOSraisg+FRcXV7tBPOKII/a5zYwZMwIF2/bt2wc+bX/00UfZtWsXf/zxBzNmzOCKK644oLFlZGTQpUsXpkyZQmRkZLWb30olJSVMnz6d8vJyHn74YXJzc1m3bh3vvPMO559/Punp6UybNg2fz0doaCg33XQTXbt25YsvvuDDDz9ky5YtPP744/XOPJqfn89TTz0V+P7888/n6KOP5vPPP+fTTz+tdZvKbtWqJk6cyMSJE4mLiyM4OJjS0lLmzJnDxx9/zKZNm/jmm2+YNGlSje3y8vJ48MEHCQkJ4dFHH2XHjh2kp6fzwgsvVJsFt5LH46n3PamqsLCQ2NhY7rvvPpKSksjOzsY0TW677bbATfMll1zCqFGjWL16NdOnT6ekpIR//etffP755zW6LHbs2MHkyZM57rjjmDFjBgsWLMDn8/Hee+9x6623cuedd7Jw4UL+85//AHserQR/90Vd5s+fHyjYXnDBBYwdO5aCggI2b97Md999FxjHDz/8ELiJvummm+jfvz+5ubmsX7+eb7/9NrBecHAw1113Hd27dyciIgKbzUZ2djZPPvkkW7du5ZVXXuGKK64IdJxUFmydTic33XQTHTt25Nlnn2XVqlU1xvrVV18FbqK7devGtddeS0hICM8//zxLly5lzpw5HHfccU3+CKiIiEhLqIxHqPohem2Z9Dt27GDSpElMmjSJ3NxcEhISqv2b2aFDB2644QZCQ0N56qmnWLt2LV9//TWff/45kyZN2q/7sdq88cYbgYJtcHAwV1xxBf369SMtLY133nkH8D+mfuyxx3L99dcDex7xBwJP9tSmpKSEO+64I3DPes455zBmzBh+/PFH3nrrLdxuN3fccQcjRoyoEUe1r3uooqKiQLTAYYcdxrXXXovNZmPXrl3Mnz9/n/FW//d//xf4wPrrr78OFG2//vrrautAw++nGqKwsJBFixYF4hEqnX322YGv9773POeccxg3bhzLli3j6aefDtx7fvHFF1gsFuLi4pg6dSpdu3YlPDwci8XC7t27efjhh8nJyeG5555rdNG2Xbt2zJo1q1okwZ133hmYzyM5Obna3xVOp5Mbb7yRnj178sEHH/Dll1+ydetWHnvsMe677756j7Vp0yYAHA5HoyYvq9SYe82lS5cGCrYnn3wyp59+OiUlJWzfvp0ffvgBi8XSoHOvS2UHu81m49///jddunQhKyuL1atXs2zZssB6M2fODBRsBw4cyOWXX47X62X69Ols2bKFl19+meOPP54+ffo0eCxVi80bN25s9Pso0tJUtBWRfSoqKqr2/d6fetfm888/D3x99913M2bMGABCQkK46qqrAPjiiy8OuGhrsVh4/vnn6+3QnDZtGiNHjgT8xcrKG+rvvvuO888/ny+//DLQ7XHCCSeQkpIC+CeP+PLLLyktLeWLL77g7rvvrvOR9V9//TVQMOzXr1/gGKNGjWLRokWBaIl9GTlyJM8++yzz588nIyOjRhfKypUray3aTp06NfAoWUREBBdffHHgHGsr2u7rPdnbf//732qPZq1Zs4b169cD/j9SKrtBBg0aRP/+/VmyZAkbN25k1apV1R7xA0hJSeH+++8HIDo6OnBztn37dsB/o1W1q7fqo5X1qdrN0bFjR3r27El8fDwA//jHP2pdr0uXLqSkpBAdHc3EiRO54YYbAsvCwsI47LDDeOONN1i9ejUFBQV4vd7A8pKSEjZv3kxKSgrfffdd4PVzzz2Xiy66CIDu3btz4okn1hhr1T8czz333EDn+uTJk1m6dGlgHRVtRUTkUFY14qiqww8/nFGjRtV4ffDgwTz66KPVXqvaNTtt2rTAdtHR0ZxzzjkAfPbZZ0yaNKnJ7sc++eSTwNf/+te/OOusswLfV8Yjde3atdo9RdVH/Ovz66+/kpubC/i7AO+55x7A38G6bNkyVq1aRW5uLvPnz6/xCP++7qFsNhuGYWCaJtHR0XTp0oUuXbpgs9mqFUDrMnjw4EAU2Xfffcfdd9+N1WoNFG0jIiI49thjA8eqVN/9VEOsWbOGc889N/B9SEgI1157LZdcckngtbVr1wbuPQcNGhR4344++mgWL17Mr7/+yubNm1m5ciX9+/enY8eOxMfH8/rrr7N+/XoKCwurdfFu3bqVoqKiat3f++JwOBgyZEi1SILevXtXu+4ffPBB4P79oosuCtyTDxs2jHnz5lFSUsIXX3zBPffcUyPWo6rKn5GGRrTtrTH3mlWvZWJiIt26dSMxMRHDMKpdg32de10q92+32+nSpQv9+vUjLCysxt80Vcd80UUXBbqRJ02aFPgw5tNPP2XAgAENHkvV96/yPRU5lKhoKyL7tPfNTEZGRrW80tpUPkIFVAvfr/q4fNV19leXLl32+Uh91WNWnfCisnu46jg+/PDDWidUKywsJCMjo85Puivz2fY+htVqpW/fvg36I6GoqIizzz6btLS0Otep+jhYVVXPserXqampmKZZo9thX+9JVU6ns1rBFqgWrbD3jXZVmzZtqlG0PfLIIwNfV300rK5za6hx48Yxffp08vLyeOCBB3jggQeIjIykf//+nH766YHi6aRJk5gxYwYulyvQHRMbG8vgwYP5+9//Hihmf/PNN1x77bX1HrOwsBCo/r5VfW+7d+9OZGQk+fn51bar+jNX2VG8t8oOCxERkbbCbrdz4okncvvtt9dasKr8kL+qqv9mXnrppbXutzL7sinux/Y+ZmWRsqlUvYfae4Kq/v37B57QqbpepX3dQwUFBXHSSSfx2Wef8euvvzJx4kTsdjs9e/ZkzJgxXHLJJfV2ARuGwcknn8zzzz9PdnY2f/zxB3FxcYF7khNOOCEQo9XQ+6n9UVJSwqpVq/D5fIGGiarvx5IlS+rs7Ny8eTP9+/dnxowZPPjgg/UepzK7tSlV/dl54YUXeOGFF2qsU1xcTEZGBu3bt9/n/qoWmvd3HPu61xwyZAhdu3Zl69atvPzyy7z88suEhobSt29fJk2axOTJkw9oroXTTjuNOXPmUFpaGmhsSExM5Mgjj+TCCy8M/K5WHXNdhf/G3h/v7/sn0lqoaCsi+xQaGkqnTp0ChanFixczYsSI/drXvh6VqtrJCPv+RLS+x+X35/j1KSkp2a/tGnrM7777LlCw7d69O9deey3t2rVj5cqVgZvOg3Hjsa/x7T1hW2PUluda9RPv+joMGis+Pp4PP/yQt99+m8WLFwcmc/v555/5+eef8fl8nHTSSfTu3ZsPP/yQd955h+XLl7N582ays7P59ttvmTt3LrNmzWLw4MG8+eabgX2fdtppnHzyyTidTp599ll+/fVXgGpZZZUO5GesqrqycEVERA4VlRFHhmEQGhpK165dCQoKqnP9fd1zhIWF1frvbEPuJ5rq3+eDaV9jbMg91IMPPsiRRx7Jjz/+yMaNG9m5cydr1qxhzZo1LF++vFr8QG3+7//+j+effx7wxyJUvSZVOyMbej/VEEOHDuX1119n5cqV/OMf/yArK4vPP/+cgQMH1voEmN1ur/PnqPJviaoxZJdddhmjRo3Cbrdz7733Bjp2a7uPa0rBwcF15vrWNx8HEJiTYu8P/ptS5b1mcHAwb7/9Nm+//TYLFy5k06ZNZGZmsnDhQhYuXEheXt4BPR05atQo3n77bT788ENWrlzJli1bSEtL47PPPuO7777js88+o1OnTo0ac0NVff9qm+dDpLVT0VZEGmTixImBT4pnzJjB5MmTa0xGlp2djdVqJSoqiq5duwZyy5YvXx7oUqiaW1R15tPw8HAKCwvJy8vD7XZjt9vZuXNnoHOiLg25AV+xYkWgyLx8+fLA65U3B1XHMWXKlFq7K0tLSwkODq7zGB07dgx8vXLlysDXXq+32vf1SU9PD3x97rnnBh6NrzoRQV2WL18e6Dioeo4dOnSo9T3a13tSVW3bd+vWLfB15QzJe9vXe1afqp/mN/SG2jRNOnTowM033xx4bcWKFUyePBnwd86edNJJmKZJr169Ao9Mgv+Pkuuuuw6fz8d3333H4MGDq12PO++8k9DQUHw+X7XXK1XNy1qxYgUTJkwA/N0etd1sd+3aNdApUNdsuyraiojIoa6hEUeVarvnqPpv5jPPPFNr40BllFdT3I9VHnPt2rUAzJs3jzPPPLPW9fbnfqXqPVTVe7C9v6+6XmPYbDbOOuusQKRDUVERl112GUuWLOHXX3+lpKSk3mzbHj160LdvX1atWsW3334bKHS1b9++2iRmDb2faiiLxUL//v25+eabA9Fezz//PGeeeSZOp7Pa+9G/f3/eeuutGvuoGndQeb8WFRUVmLyqpKSEjIyMBo+pLlV/Tve+7lX/rrjoootq7RhtSCxDjx49WLRoEW63m927dzeoK3fvcTT0XtM0TWJiYrjmmmu45pprAP9TZP/3f/9HSUkJ33zzTaBoW9+518U0TQYNGsSgQYMC273++us89NBDlJaW8tNPP3HuuedW+7377rvvav27pOr9cUPGUhkdAtCzZ88GjVekNVHRVkQa5JJLLuGzzz5j165dFBQUcOaZZ3LJJZfQu3dviouLWbhwIR9++CFvvPEGUVFRnHzyyYGi7bRp0yguLg5MRFbppJNOCnzduXNnVq1aRVlZGVOnTuXII4/krbfeqtF5uz/uuusubrrpJsrLywOzpAKBHNYJEybw2GOP4XK5ePHFFzEMg4EDB1JWVsbOnTv57bffKC8v57XXXqvzGEcddRROp5Py8nKWL1/O/fffz6hRo5gzZ06DH8VLSkoKfP3BBx/QqVMntm3bxnPPPbfPbR9//HFsNhvBwcE8/vjjNc5xb/t6T/YlJSWF3r17s379ehYuXMgtt9zChAkTsNlspKamsnz5cr777rvAZHSNFREREfj6zz//ZN68eYSGhtKtW7c6u3A+//xzZs+ezfjx4+nYsSNhYWHVZk+uzBd76aWXWLhwIcceeyzt27cnJCSk2uzQlet16NAh8JjWU089xahRo/jkk09qncRg/PjxgT8eZs2aRWJiIu3bt+fZZ5+tdayTJk0KTFx2yy23cNVVV9G1a1dycnLYunUr8+bN45hjjmHKlCkNfctERETapNr+zezevTs5OTls2bKF77//njFjxnDttdc2yf0Y+LtNK4tHDz74INnZ2fTr14/09HTefffdwGRkVe9X1q9fz3fffUdUVBRJSUnV7uuqOuqoo4iKiiIvL4+VK1cybdo0Ro8ezU8//RQoLEdHR+93vMD48eM5/vjjSUlJoV27duTk5ARiI0zTxOVyNWhCslWrVpGZmUlmZibgn6CqapGsofdTjTVp0iSefPJJdu/eTVZWFh9//DFnnXVWtXvPP//8k6lTp3LSSScF7j2XLVvGN998E2h2qLyPy8vL48UXXyQ5OZmZM2dWmzdhf1XteP7000+xWq1YLBaGDBlS7e+Kl19+GYvFwuDBgwN/V8yfPx+Xy8WMGTPqPcbgwYMDP2erVq1qdNG2Mfeaixcv5v777+f444+nS5cuREdHs27dukA+dNVrWd+51+U///kPmZmZjBw5kvbt22O1Wlm0aFFgeeWkfJMmTQr83l111VVcdtllJCYmkpGRwebNm/n++++5+OKLA/N4NGQsq1evrvaeihxqVLQVkQaJioripZde4qqrrmLHjh2kpaXxwAMP1Ln+RRddxLx581i0aBGpqancdNNN1ZYfeeSRgUwjgLPOOou77roL8H9K//XXXxMSEkJiYmK9Ga8NYbFYanzK3bt370AHQmJiInfddRd33XUXLpeLp59+usY+qnYW1CYyMpIpU6bw2GOPAf5PtGfOnInFYqkWLVGfMWPGEB8fT2ZmJqtXrw58oj148OB9dtvGx8fXmHAsPj6eK6+8stb1g4OD631P9sUwDB566CEuuugiCgoK+OSTT6pN2nGgevToEXgvdu7cGXgvHnzwwcCN2t58Ph+LFi2qdhNY1cknnwz4J16rjEzYm8ViCWTfnnnmmYEYhBkzZjBjxgycTmeg+6Sqo446inHjxjF37lxKS0sD2WEJCQmBP8yqOvHEE/nxxx/5+OOPSUtLC0ymUdXRRx9dx7sjIiLy11H138yMjAymTZtWY53KLNymuB8DuOCCC/jll1+YP38+JSUlPPHEE7WuFxYWFrgvKCgoCHQp1vXkFvgn2br//vu54YYbcLvdzJo1i1mzZgWW2+127r///n0WVuuye/duXn311VqXjRo1qloWbl0mTpzII488Uq15Yu9Joxp6P9VYNpuN888/PzAB3auvvsoZZ5yBxWKpdu/5+eefV5v4eG9nnnlmYB+VPw/R0dF069at1rzgxhg2bFigmaPqfBjr1q2r9neF2+3mf//7X43t9/V3BfizlO12O263mwULFtSYlG5fGnOvaZomq1atqnF/W6nyHhrqP/e6lJWVBf6+21tQUFCgaaTy927BggVs3Lix1smUq2rIWObPnw/4/y6q7PQVOZTsf5q0iPzl9OzZk08//ZR//etfHHHEEURFRWG322nfvj2jRo3i4YcfDkxQ5nA4eO2115g6dSrJyckEBQXhdDrp3bs3U6dO5dVXXw1MZAD+mXivvPJKYmNjCQoKYvjw4bz11lvVHjvfXzNnzuTEE08kLCyM0NBQTjrpJF577TWcTme147/55pscf/zxxMXFYbPZiIuLo3///lx99dXcfffd+zzOFVdcwR133EGHDh1wOBz06dOHZ599tsGPBYaFhfHaa68xfPhwQkJCSEhI4LrrruO6667b57aPP/44559/PjExMQQFBXHMMccwa9YsYmJial1/xowZnHLKKYSHh9f5nuxL3759+fjjjzn77LPp1KkTdrudiIgIevfuzdlnn73PDoL62Gw2nn32WY444ghCQ0MbtM2gQYO44IIL6Nu3L9HR0Vit1sBMztOnTw90do8ePZqzzjqL3r17ExkZGYj0GDVqFK+88gpHHHEE4O/AnjZtGl27dsXpdNKvXz9efvllevfuXevxK69BVFQUwcHBHHvsscyaNSvwuNbe2WsPP/wwDz/8MEOHDiU8PBy73U5SUhIjRozgzjvv5O9///v+vn0iIiJtSmP+zTzQ+zHwF05feukl7rzzTvr3709ISAhOp5MuXbrUiEp4/PHHOfroo6t1/e3L+PHjmT17NieccAKxsbHYbDZiYmI4/vjjefvttxv85FNtbrzxRkaNGkViYiIOhwOHw0G3bt249NJLefLJJxu0j3bt2jF8+PDA98nJyTUm/mro/dT+OPPMMwP3f1u3bg10jDbm3rMymqBDhw4EBwcHcnPj4+P3e1yVxowZw6233krnzp1rzaxtir8roqKiGDt2LADffvvtfs1r0dDfm27dunH55ZczcODAwHhDQkLo168fd911F5dffnmDz702kyZN4tRTT6Vbt26Eh4djtVqJjY1l/PjxzJo1KxCD4HA4ePnllwO/d6GhoTidTjp27Mixxx7L/fffz3HHHdfgsRQVFQWKtpMmTWrSuTREmothajo9EZFD0vnnn8/ChQsBmDt3brUct9qMHTuW1NRUoP5Pw2X/mKZZI4tv06ZNgWzi5ORkPv3005YYmoiIiIgcYpYtWxb4kODFF19k9OjRLTyiQ8usWbOYNm0aDoeDb775ptEREyKtgTptRUREmsDDDz/MCy+8wPLly9m9eze//PILN954Y2B5ZfFWRERERGRfBgwYECjUHsgTbH9Fpmkyc+ZMwN/5rIKtHKqUaSsiItIE8vLy6pysbsiQIVx88cXNPCIREREROZS9+OKLLT2EQ5JhGLVm6IocalS0FRERaQJjxowhLS2NDRs2kJ+fj9PppGfPnpx00kmcc8452O32lh6iiIiIiIiIHCKUaSsiIiIiIiIiIiLSiijTVkRERERERERERKQVUdFWREREREREREREpBVR0VZERERERERERESkFdFEZEBmZmGzH9Nut+J2e5v9uNL0dC3bFl3PtkXXs23R9WxbmuJ6xseHN9FoDl26j5UDoWvZNug6th26lm2HrmXbcDCvY0PuY9Vp20IMo6VHIE1F17Jt0fVsW3Q92xZdz7ZF1/PQpWvXduhatg26jm2HrmXboWvZNrT0dVTRVkRERERERERERKQVUdFWREREREREREREpBVR0VZERERERERERESkFVHRVkRERERERERERKQVUdFWREREREREREREpBVR0VZERERERERERESkFVHRVkRERERERERERKQVUdFWREREREREREREpBVR0VZERERERERERESkFVHRVkRERERERERERKQVUdFWRERERESkAdxuNzNnvsrWrVtaeigiIiLSxqloKyIiItKGTJ48iXfffaulhyHS7JrjZ/+ZZ6azadNGunTp2qjt9HspIiIijWVr6QGIiIiI/BWNGjWk3uUXX3w5l156ZaP3+9JLMwkODt7fYQEwZcoV9OqVzPXXTz2g/Yjsj/vvv4cvv/wcAJvNRkJCIhMmnMT551+MzVb3ny9N8bNfn7lzv2XLls089tjTGIZx0I4jIiIiAiraioiIiLSITz75KvD13Lnf8sorz/PWWx8EXgsODgl8bZomXq+33oJVpejo6KYdqEgLGDZsJLfffhdut5sFC37l8ccfxmazcf75F9dY1+12Y7fbm/xn3+v1YhgGFov/4cRx445j3LjjmvQYIiIiInVRPIKIiIhIC4iNjQv8FxYWhmEYge+3bdvK8ccfw4IFv3LJJecxZswIli9fSmrqTm677SYmTTqe4447mssuu4A//vi92n73fgx71KghfPbZx/zrXzczbtxRnH32qfzyy7wDGvuPP87lvPPOZMyYEUyePIm3336z2vIPP3yPs88+lbFjRzJp0vHceectgWU//PAdF1xwFkcfPZyJE8dx/fVXU1paekDjkbbH4bATGxtHYmJ7Tj11MkOGDOWXX34C/J24//rXVF5//RVOOWUCf//76UD1n/3Fixdx7LHDWbZsSWCfs2a9zsknH0dOTnatx5wz5zMmTDiWX36Zx3nnncHYsSNJT0/D5XLxzDNP8Le/ncj48aO4/PILWbx4UbVtly1bytVXX8bYsUdx2mkn8cQT/9XPtYiIiBwQddq2dqYJPhdYnS09EhERkUOKaZqUeXzNeswgm6VJH5t+/vlnmDLlepKSOhIeHk56ejrDhx/FFVdcjd3u4KuvvuDWW2/irbc+IDExsc79vPbaS/zjH9dyzTXX8/7773Dvvf/mgw8+IyIistFjWrt2DXfd9S8uueQKxo49jpUrl/PYYw8RGRnJxImTWLt2NU8++Sh33nkv/foNoKAgn2XLlgKQlZXFPffcwdVXX8e4cePJzy9k2bIlmKa5v2+RNJJpmpQf4O+FzwCX29vg9Z1N8HvhdDrJz88PfL9o0R+EhIQyffr/al1/8OAhnHnmOdx3313MmPE2u3bt5OWXn+e++x4iJia2zuOUlZUxa9br3HrrnURGRhIdHcP06Y+wdetm7r33AeLi4pk37wduvvk6Xn99Np06dSY1dSc333wtl1/+D/71r7vIy8tl+vRHmD79EW6//e4DOm8REZFDSbnHh2maTfJvv6ho2+pFzLkEe9qf5Jz3M6az8X9YiYiI/BWZpslls5exfFdBsx53QFIEL509oMluUi+77EqOPHJ44PuIiEh69eod+P7yy//BTz/9wK+/zuP008+qcz8nnngyxx03AYArr7yG99+fzerVqxg+fGSjx/TOO7M44ogjueiiywDo3LkLW7du5q233mDixEmkp6cRFBTEUUcdTUhIKImJ7endOwWA7OwsvF4vo0ePJSkpibg4Lz169Gz0GGT/mKbJfV+vZ2NW8QHtxzCMRhXae8WHcufxvffr98I0TRYtWsjChb9V+xkPDg7mttv+jd1ur3Pbyy+/mj/++J1HHrmfzZs3MWHCyYwaNbre43k8Hm666bbA71laWhpz5nzGBx98TlxcPAB///v5/P77AubM+Ywrr7yGN954jeOOm8CZZ/4dgE6dOnP99f/k2muvYOrU23A61XwhIiJt3868Uu6asw6Pz4fNYiE8yEq400aY00Z0sJ0JfdrRJSZk3zuSABVtWzPTxLHjJwxvOdbcjXgSj2jpEYmIiBwy2sJn+ykph1X7vqSkhFdffZEFC34JFEDLy8tJT0+rdz89evQKfB0cHExoaCi5uTn7NaZt27bUKHz16zeAd999G6/Xy5FHDiMxsT1nnnkKw4aNYNiwkRxzzBiCgoLo2bMXRxwxlAsuOJvhw0cwZMgwjj12HBEREfs1Fmm8Q6XpZf78XzjuuKPxeDz4fD6OO24Cl1xyRWB59+496i3YAtjtdu666z9cdNE5JCQkct11N+3zuHa7nZ499/y+bN68Ea/XyznnnFZtPZfLRWSkv6Fi48YNbNq0gW+/3ZNTbZomPp+P3bt30bVrtwads4iIyKFswdZcPD7/0zwen4/cEh+5Je7A8t+35XLmoA4cnxKP5VC5IWlhKtq2YkZ5Hoa3HABLWV7LDkZEROQQYhgGL5094JCPRwgKCq72/f/+9wR//PE711xzAx07dsLpdHLnnbfidnvq3c/eE5g1tlOyMUJCQnnllTdZsuRP/vjjN15++XleffVFXnppJuHh4TzxxP9YsWIZixcv5IMP3uHFF5/lxRdnkJTU4aCMR/YwDIM7j+99wPEIDocVl+vgxiMMGnQEN9/8L2w2O3FxcTV+hoODg+vYsrqVK5cDUFBQQEFB/j63czqd1cZaWlqC1WrllVfewGKx1jqG0tISTjnlNCZPPrvG/hIS6o4tERERaUuWpfpjjC4Z1pnDkyIoKvNQWO6hoNzDwm25LNmZz1t/7mTl7gIuH9GFyOD6P3wVFW1bNUvR7sDXRnleyw1ERETkEGQYBsF2675XPISsWLGMiRMnMXr0GMDfeZuWtgtovqdxunTpxooVy2qMq1Onzlit/vfbZrNx5JHDOPLIYVx88RVMmHAsixf/wejRYzEMg/79BzJkyBGcf/6lTJ48iZ9++oGzzz6v2c7hr8wwDIIO8PfCYbdiOcgxxMHBwXTs2OmA9pGaupOnnnqcW265g7lzv+X+++/hiSeexWJp+FzMvXol4/V6yc3NZcCAQbWu07t3Clu2bDng8YqIiByqckpcbM/1T8A5uFMkEUF24kIdgeUju0bz/YYsZi1KZfmuAu74Yg2Xj+jCgA6KAa1Pw+9YpNlZi/c86qhOWxEREenYsTPz5n3Phg3r2LBhPffeewc+38GpnuXl5VYcZ89/OTnZnH32efz55x/MmPEy27dv48svP+eDD97lnHPOB+DXX3/mvfdms2HDOtLSdvPVV19gmiadOnVh1aqVzJz5KmvXriYtbTfz5v1AXl4uXbro8XFpWl6vl2nT/s2wYcM56aT/4/bb72bTpg3Mnv1mo/bTuXMXjj/+RP7zn7uZN+97du1KZfXqlbzxxmvMn/8LAOeeeyErVy7j8ccfZsOGdezYsZ2ff/6Rxx9/uOlPTERE5ACUub288ccOvt+Q1aRPXS1P9c8j0T0ulIigmh20hmEwrnc80yYm0zEqmIIyD4/9sIlZi3ZqQtp6qNO2FbNUKdoa5fn1rCkiIiJ/BddeeyMPPjiNq666hMjIKM4990KKiw9sUqm6fPvtV9UyOgEuu+wqLrroMqZNe5CXX36BGTNeJjY2jksvvYqJEycBEBYWzrx53/Pqqy/icpXTsWNn7r77frp378HWrVtYunQJ7777NiUlxSQkJDJlyg2MGHHUQTkH+euaOfNV0tJ288gj0wGIi4vjllvu4J577uDII4dXm9BvX26//W5ef/0VnnnmCTIzM4iMjKJv336MHHk0AD179uKZZ17kxRef5eqrLwdMkpI6Mm7ccQfj1ERERPbb6wt38OsW/7wGq3YXcvmIzgf8BA7AsorJfwcm1T9PQceoYO49MZnZi1P5dl0mX6/NICUhjCM6RR3wGNoiw1RJm8zMwmY/ZkOywEIWPk7oH48DUNL/EoqPntYcQ5NGamyum7Ruup5ti65n26Lr2bY0xfWMjw9votEculrrfawcGnQt2wZdx7ZD17LtaI3X8pfN2bw4fxuGYWAAPtMkKTKI647pTlJk0H7v1+P1cfV7yynz+Lj3xBS6xYbUv4HXhT11AdsWfkhh9m4KY/sx/OhJeOIPB0vr6i09mNexIfexrevdkGosxel7vlY8goiIiIiIiIiINNLugjJeX7gDgFP7JdK3fThP/7SFXfll3PPlWi4f2YUjO0fv177XZRRR5vEREWSjS0zdE35a8rbg3PINjm1zMVxF9PL62GmWkZA1l+Af5mMJCsfdfijuDiNwtx8CVud+jactafFM21mzZjF27Fj69evHGWecwfLly+tcd8OGDVx77bWMHTuW5ORkZsyYccD7bM0UjyAiIiIiIiIiIvvL7fXxv5+3UO7x0SchnP/rl0iv+DDum5hCcrswyjw+nv5pC7MXp+Ldj7kSKqMRBnSIxGIYNZZbCnYSPvdGIr65BueGTzBcRfiCY/H2O5ev213Fb7ah5HiDMVxFOLZ9T+j8+wmfexN4XQd87oe6Fi3azpkzhwcffJBrrrmGjz76iJSUFC699FKys7NrXb+0tJSOHTsydepU4uPjm2SfrVnVoq2lPK/lBiIiIiIiIiIiIoect/9MZXtuKeFOG1cd1SVQWI0MtnPb+F6ceFgCAHNWp/Pigm2NnhhsWcUkZAPqyLMN+fNJrNnrwLDg7jiSoqOnUXDy65Qdfj6J/cbzVtDZ/DtsGoXHPkR5779hOkKx5m3BufnrAzjrtqFFi7avvfYaZ555Jqeffjo9e/bk3nvvJSgoiA8++KDW9fv378+tt97KSSedhMPhaJJ9tmbWqp22ikcQEREREREREZEGWrQ9j+/WZwJwxcguRIdUr6VZLQbnDO7ANaO6YTEMFmzJ4b2luxu8/4zCcnYXlGExDA5vX7Noa81ajS1zFVisFJz4IsUj78TTfggY/nLksK7ROKwWdhW6WGt0p3TgFZT2uwiAoDVvg6d0P8+8bWixoq3L5WLVqlWMHDlyz2AsFkaOHMmSJUtazT5bjLccS+me7mCL4hFEREREWq2nn36a5OTkav9NmDABgLy8PO677z5OOOEE+vfvz7HHHst//vMfCgurTyK2a9currjiCgYMGMCIESN4+OGH8Xg8LXE6IiIicojLKirn5d+2AXDiYQkM6BBZ57rDukZzyfDOAHy+Ko3vKwq9+1IZjdC7XSghDmuN5UFr3gHA1XU8vrCkGsuD7VaGdokC4KdN/hqYq9sJ+MLaY5TlEbT+kwaNo61qsYnIcnNz8Xq9xMbGVns9NjaWzZs3N+s+7XYrtcRuHFQ2W80f5qqM/OpxDkZ5Hg67hWYfqOzTvq6lHFp0PdsWXc+2RdezbWmL17NXr1689tprge+tVv85ZmRkkJGRwa233krPnj1JTU3lnnvuISMjg6eeegoAr9fLlVdeSVxcHLNnzw6sb7fbuemmm1rkfEREROTQ9eKCbZS4vHSPDeGMAe33uf4x3aMpzk1jwaq1LJ+/hMOybHQLKgLDRlnyaZghNWNKl6X6GwwHJNUsCFvzNmPf/QcYBmXJk+s+bo9Yftmcw+9bczn3iI4E2W2U9j2P0N//i3Pd+5T3PAnTEd6IM287Wqxo25q43d4WOa7LVfdxbXmpAPiC47GUZmL4PLiKC8ER2lzDk0ao71rKoUfXs23R9WxbdD3blrZ2Pa1Wa63zLvTu3Zunn3468H3nzp254YYb+Oc//4nH48Fms/HLL7+wceNGXnvtNeLi4ujTpw/XX389jz76KFOmTKkzGkxERERkb5lF5axNL8IwDK45uhs2a/0P2tt3/Ubobw9zjqeM43wuCsu9WJYDEU6cNiuOrd9QOuAKXN2ODzQTlnt8rE4rAmBAh5rRCEFr3gXA3fFofOEd6jx2crsw2oU5ySgqZ9GOPEZ1j8XdeTTede/7s23XvkdZ/0v28504tLVYPEJ0dDRWq7XGBGHZ2dnExcW1mn22FGuRP8/WG9UV0+K/SddkZCIiIiKt17Zt2xg1ahTjxo1j6tSp7Nq1q851i4qKCAsLw2bz91AsXbqU3r17V7tnHTVqFEVFRWzcuPGgj11ERETajtVp/gimnnEhxIc561/Z6yJ4yQvgKQfDQnR8J3LDUlhoO4LZ7tEURfTCcJcSsuhJQn++C6MkC4A1aYV4fD5iQx10iAyqtktL4S7sO38GoKzPmfUe3jAMjunhf2J+3saKep5hoezwCwAI2vApRmlOo86/rWixTluHw0Hfvn1ZsGAB48ePB8Dn87FgwQLOO++8VrPPlmKpmITMG5qIJWgb1pIM/2Rk9Xw6ISIiIiIto3///jz44IN069aNzMxM/ve//3Huuefy2WefERYWVm3dnJwcnn32Wc4666zAa1lZWTWaDCq/z8ysO1euNcZ8/dUVFBTwzjtvc+qppxEXV7PzujXRtWwbdB3bDl3LtqOlr+WaDH+X7YCOUThqyZqtyr72K6wl6ZghMZRMegXsIXRxe3l9zjq25pSwwGXngb6riV33Fo70P3F8cxXlR1zFivRkDMNgcOconM7q5UXnpg8xMPF2OBJru17s690YkxLPh8t3sz6zmNwyNwkRQdBlBOb6w7BkriZs3WzKh157gO9K47X0dWzReISLL76YW2+9lcMPP5z+/fvz+uuvU1paymmnnQbALbfcQkJCAlOnTgX8E41t2rQp8HV6ejpr1qwhJCSELl26NGifh4rKoq0vNBHTGQUlGVjK82hbDxGKiIiItA2jR48OfJ2SksKAAQMYM2YMX375JWeccUZgWVFREVdeeSU9evRgypQpB3zc1hjz1VImT57EmWeew5ln/r3FxmCaJnfffSddu3YnIiKm3vfplVde4Oef5zFjxlsA3H//PRQVFfLgg48113CB1nktpfF0HdsOXcu2o6Wupc80WZFagGmaJMeH1j8OVzHBy2dhmlDS5++4TCe4vFiBG0d3596v17GrwMU1q5K5buADDN3xMtbstTgWPEbfku4ssJxJv4Tu1Y5hlGYTsvEbTBOKe5+JtwHvQ7jdSt/EcFbsLmDu2kwmD/RPWubreyFhP9yKdcMcPD3/VutkZgdbS/5OtmjRduLEieTk5PDUU0+RmZlJnz59ePnllwNdBbt378Zi2ZPgkJGRwd/+9rfA96+++iqvvvoqQ4cO5Y033mjQPg8V1Yq2Qf5AZ0PxCCIiIm3GqFFD6l1+8cWXc+mlV+73vh944FGOOebYJllPGi8iIoKuXbuyffv2wGtFRUVcdtllhIaG8r///Q+73R5YFhcXx/Lly6vtIyvL//hhbTm5bdn999/Dl19+DoDNZiMhIZEJE07i/PMvDsRJ1Oall2YSHBzcXMOs1VtvzSQ0NIyrrmp8Qf7662/GNM3A91OmXEGvXslcf/3UphyiiIi0cTtySyks9xBks9Ajrv55kYLWf4DhKsQX3gFXtxOqLYsKsXPHcb14+uctbMku4cGFXk7qcyPnJf2GbflMupWt4jbjMTpapwEDq+zzI/B58MQdhje+b4PHfUyPWFbsLuDnzdmcNqA9FsPAE9+PrKgB+HYu5Od3HqNo6M2c0m/fk6o1lGmarE4rZOH2PMb2iqNLTEiT7bsptPhEZOedd16d0QWVhdhKHTt2ZN26dQe0z0NFoGgblojPGeV/rSyv5QYkIiIiTeqTT74KfD137re88srzvPXWB4HXgoNb102jNE5xcTE7duwIFFyLioq49NJLcTgcPPfcczid1fPlBg4cyPPPP092djaxsf5ct/nz5xMWFkbPnj2bffwtbdiwkdx++1243W4WLPiVxx9/GJvNxvnnX1xjXbfbjd1uJzo6utnHWXnsSueee+F+72vvGA0REZH9saoizzY5IRybpe4MJaM0x19gBUr7XQSWmlEAcWFO/n18b95enMq36zL5Yk0mG9oNYGCHO+iRP53u1kxifrmDssPOoeywv2O4i3FumgNAWZ+zauyvPoM7RRLqsJJb4mbFrgI8PpM5q9MpSRvBLa4FDOZPXl+/BJqgaOszTRbvyOezVWlsyS4BwGmzqGgrDVM5EZm/0zYKAKM8vwVHJCIiIk0pNnbPU0BhYWEYhlHttc8++5jZs99k9+5dJCa2Z/LkszntNP9j9m63m6effpx5876nsLCQ6OgY/va30zn//IuZPHkSALfffjMAiYntef/9zxo9Pp/Px+uvv8Knn35EXl4uXbp046qrpjB8+Mh9jsE0TV599UW++OJTcnNziIiIZMyYcdxwwz/3+/1q7R5++GHGjBlDUlISGRkZPP3001gsFk4++WSKioq45JJLKC0t5b///S9FRUUUFflnW46JicFqtTJq1Ch69uzJLbfcwj//+U8yMzN54oknOPfcc3E4HC18ds3P4bAHfh9OPXUyP/30A7/88hPnn39xIEYgJeUwPvzwPRwOB++992m1eITFixdx001TePLJ5xgwYBAAs2a9zttvv8nMmbOJiYmtccw5cz7jqace4/bb7+HZZ58kIyOdgQMHc+utd5KQkAjsiTQ4/fQzmTnzVdLSdvPzz39QWFjI//73BL/8Mg+Xy01KSh+uvfYmevXqHdj/G2/M4N1336KsrIyxY8cTFVW9yFw1HuH+++9h6dLFLF26mPfeexuA9977lPbtm/+xUBERObRUTkLWNzG83vWCVr8FnnK8sSm4O4yscz2b1cL5R3YiuV0YLy/YxvqMItbjwBF8A/fFzSWhcD5Bq97ClrkSb0Rn8JThjeqGJ7H+p8r2ZrdaGNE1hu/WZzL9x834Kp4+sdo7kREyjHbZv3Nh5iOEffoWZlwKnpgUvLHJeKJ6gr1hT9p4fCYLtuTwxep0duWXBY57bM9YTumX2KjxNgcVbVsj06w2EZnP6Y9HsCgeQUREpOFMEzylzXtMWzBNMSvUN998ycsvP89NN91Cr17JbNiwjocfvp/g4GBOPPFk3ntvNr/88hPTpj1EQkIi6enpZGT47x1eemkmkyYdx+23382wYSOw1NI10RDvvfc2s2e/yT//eTu9eyfz+eefctttN/HGG+/SqVPnesfw449zeffdt7jnngfo1q0HOTlZbNy44YDfl9YsLS2Nm266iby8PGJiYjjiiCN49913iYmJ4ffff2fZsmUAHHfccdW2mzt3Lh07dsRqtfL8889zzz33cNZZZxEcHMypp57Kdddd17QDNU3wlh3YPixW8DQi380adMC/F06nk/z8PQ0Mixb9QUhIKNOn/6/W9QcPHsKZZ57DfffdxYwZb7Nr105efvl57rvvoVoLtpXKysqYOfNV7rzzXmw2O4899hD33HM7zz33amCd1NQd/Pjj99x//yOB369///tWnE4njz76FKGhYXzyyYfccMM/ePvtD4mIiGTu3G957bUXuemmW+jffyBffTWH999/h6Sk2icZvv76m9mxYzvduvXgssv8MSl7F3lFRET25vb6WJvu/2D48PZ1F20tBTtxbv4SgNL+Fzfo3+mhXaLpHB3MMz9vYXtuKS7DiWXUPynJ/oWQxf/DlrEcW4Y/6qks5cz9+rf/mJ6xfLc+E59pEuqwMqZXPMclxxHDzaycfSvtXVvwFGUSVJaDfed8/0ZWO0VHT8PTbkCN/bm9PrbllLI+s4iNmcWsyyiisNwDQLDdyvjkeE5IiSciyF5j29ZARdtWyCjPw/CWA+ALTfBPRAYYZeq0FRERaRDTJOrDU7GnLWrWw7rbH0neqR8ecIHqlVdeYMqUGxg9eiwASUkd2LJlM5988iEnnngyGRlpdOrUmf79B2IYBomJex4Tq3xEPCwsvFrnbmO9/fabnHvuhYwf7883u/rq61iyZBHvvvs2U6feWu8Y0tPTiImJ5cgjh2Gz2UhMTOSwww7f77EcCqZPn17nsmHDhjUo4qtDhw689NJLTTms6kyTsO9vxpa95oB2YxgQYu57vUqeuD4UjXl0v34vTNNk0aKFLFz4G6efvucxy+DgYG677d/Vogn2dvnlV/PHH7/zyCP3s3nzJiZMOJlRo0bXuT6Ax+PhxhtvoW9f/8/rnXfey7nnTmb16pWBn2G3282dd94b+F1btmwpa9as4rPPvg10RU+ZcgM///wjP/wwl1NOOY333nubk046hZNP/hsAV1xxNYsWLcTlctU6jrCwMGw2G0FBQQf0eywiIn8tm7KKcXl9RATZ6BAZVOd6wStngGniThqKJ75fg/efGBHEXSck88nKNIJsFhLCnbjCx+GJSSb0twex5m3BF9Yed6ej92v8XWNCuOqorpR7fIzoGk2Q3f/hqEk833a/k1U70rmsZznHRGRhy1mHLWsVRlkejm3fVyva/r41l2/XZbI5uwSPz1ftGBFBNk7sk8DY3nEE2/evuaG5qGjbCgXybIOiwRakTlsREZH90QQdry2htLSU1NSdPPTQfTzyyP2B171eL6Gh/szLE0+cxI03XsM555zO8OEjGDnyaIYOHd5kYyguLiIrK5N+/ap3LPTrNyDQMVvfGMaMGc+7777NmWeewrBhIxg+/CiOOuroeieRkmZyiPxazJ//C8cddzQejwefz8dxx03gkkuuCCzv3r1HvQVbALvdzl13/YeLLjqHhIRErrvupn0e12q10qfPYYHvu3TpSlhYONu2bQ0UbRMT21fLz924cT2lpaWcdNK4avsqLy8nNXUnAFu3buGUU06rtvzww/uxePGf+xyTiIhIQ63cXRGN0D4Co457YWv2Gn+XqmH4s2wbyWGzcMbA6nE9voiOFI6bjmPHT3jiDwfD0uj9VhrZLabW17vFBrN4p5PFrkSGpRxLOWBLW0zYT3diS1vsf5rIMPCZJq/8vp0yt/+poDCnjV7xofSOD6NXfCjdYkOwW/d/fM1Jd86tkKVKni2wJ9NWE5GJiIg0jGH4O14PwXiE0lL/ZAi33npnje5Ui8V/g5mcnMJ7733Cb7/NZ9Gihdx1120MGTKU//znkQM6dmPUN4aEhETefvsD/vhjIYsW/c7jjz/E22+/wTPPvKjCbUsyDH/H6wHGIzgcVlyugxuPMGjQEdx887+w2ezExcXV+LkJDm5Ydt3Klf7HNAsKCigoyG/wdvUJCqq+j9LSEmJj43j66RdqrBsWVn+eoIiISFNata88W9MkePlrALi6jscX2bXpDm514Oo6vun2t5euFZOEbcnZc3/vie8LVjuW0mwshTvwRXRme24pZW4vQXYr005MJiHcWWcBu7XTXXMrZK2SZwvgq4xH0ERkIiIiDWcYYG9dM8A2RExMLHFx8ezalcrxx59Y53qhoWGMG3c848Ydz7HHjmPq1GspKMgnIiISm82Gz9eIolot+46Li2fFimUMGnRE4PUVK5bRp0/fBo3B6Qxi1KhjGDXqGE477Qz+/vfJbNq0keTklP0elzQBw/B/uHAgbFY4gJ+vhggODqZjx04HtI/U1J089dTj3HLLHcyd+y33338PTzzxbODDj9p4vV7Wrl0d+MBk+/atFBUV0qVL1zq3SU5OIScnG6vVWudEYV27dmP16lWceOLJgddWrVpZ7/jtdvsB/R6LiMhfS4nLy+Zs/4f/dRVtrVmrsWWuBKud0r7nNefwDli3WP99fVpBWaAoi9WJJ+5wbOlLsKctpjyiM+sz/Jm+veNDSYyoOyLiUKCibSsUiEcIq+i0VTyCiIjIX8qll17JE0/8l9DQMIYNG4Hb7Wbt2tUUFhZw9tnnMXv2m8TGxtG7dwqGYfDDD98RGxsb6OpLTExi0aI/6NdvAHa7g4iIiDqPtXt3Khs2VM9b7dixM3//+/m88soLdOjQkV69evPFF5+xYcN67rrrPwD1jmHOnM/w+bwcdtjhOJ1BfP31lzidThITW9+svNI2eb1epk37N8OGDeekk/6PYcNGcuGFZzF79pv8/e8X1LmdzWZj+vT/csMN/8RqtTJ9+iP07duv3kzmIUOG0bdvP/71r5u5+urr6NSpM1lZmcyf/wujR48hJeUwzjjjbO6//15SUvrQr98Avv32K7Zs2VznRGTg/z1evXolu3fvIjg4hIiIiHoLziIi8te2Jr0Q0zRJjAgiNtRR6zqOnT8D4Op4NGZIfHMO74BFBNmJCXGQU+Jia04JKQn++153wiBs6UuwpS+hvPffWJdRDEDv+LCWHG6TUNG2FQrEI4QkAFXiEdRpKyIi8pcwadLfcDqDePvtmTz77JMEBQXTo0dPzjjjHABCQkJ5662Z7Ny5A4vFQkpKX/773ycDBZ0pU27gmWem89lnHxEf34733/+szmM9/XTNCbT+97+XmTz5bIqKinjmmSfIzc2ha9fuPPTQ43Tq1HmfYwgLC+fNN2fw9NPT8fl8dO/ek4cfnk5kZFTTv1kitZg581XS0nbzyCP+n++4uDhuueUO7rnnDo48cji9evWudbugoCDOO+9C7r33DrKyMunffyC33XZXvccyDINHH32SF198lgceuJe8vFxiYmIZOHAw0dH+XL5x444nNXUnzz33FOXlLo49dix/+9vpLFz4W537Peec87j//ns477wzKC8v5733Pq2zk1dERGTV7n1FI/iw7/wVAHenUc01rCbVNSakomhbGijaehIHw/JXsWeuwPS49nTatgttyaE2CcM0zUbM/do2ZWYWNvsx68sCi/j8Qpzb5lJ47EOU9T0PozSHuFf7A5B51Raw1j/pgjSvRue6Saum69m26Hq2LbqebUtTXM/4eOWFtrb72EPZnDmf8dRTj/HVVz+29FCaTVu9ln81uo5th65l29ES1/LWT1ezu6CM647pzpDOUTWWW7PXED53KqYtmPxT3gZr7d24rdknK3bzwbLdjOgWwz+O6up/0fQR+dl5GGV5bBt6H9f+YmCzGLxw1oB9TjhmKUwlaO272Hf+QunAK3F1O77a8oN5HRtyH6tO21YoEI8Q2h4A07nnkUbDVYAZHNsi4xIRERERERERkbrllbqJszdvnE1OiYvdBWUYhkFKQu2xAI6KLltP+yMPyYItVJmMrCK7FwDDgjthEI5tP1C45XdgOF1jQuot2FrythC85h3sO3+Gyl5Wn/sgjnz/qGjbClmL04E9E5FhseFzRGBxFWApz8eroq2IiIiIiIiISKuyancBD8/dSJeYEC4e1onusc3ziH5lNEK3mGDCnLWU+kwzEI3g6nR0s4zpYKgs2labjAzwVBRtbWmLgeEkt6u9cG3N3UjQqlnYd/0eeM3d/kjK+pyFN+6wgz7+xlLRtrXxurCUZgF7JiKDisnIXAUYZbktNTIRERERkTZr4sRJTJw4qaWHISIih7DFO/1zEW3PLeXer9ZzfHI8pw9oHyguHiyr0irybNvXPvmsNW8TluJ0sDpwJw4+qGM5mCKD65iMrN1AAEILNxMSXEzvWoq2lvxthM+9CXweMAzcHUf5i7VR3ZvzFBpF04+2MpbiDABMiwMzKCbwuq9iMjJLWV4LjEpEREREREREROqzIbMYgC4xwZimyddrM7j98zUs31Vw0I5pmuY+JyELTEDWfgjYgg/aWJpDZbft1pzSwGtmSBxloR3x+Hz09m6gV3zNDufg1W+Bz4Mn7jAKTniB4hH/atUFW1DRttXZk2ebAIYReN10RgFglOe3xLBERERERERERKQOZW4v23L9hcR/ju/F1DE9iA11kFXs4tHvN/Lcr1spdnma/Lip+WXkl7mxWy21FisxTRw7fwHA1eGoJj9+c+sW6y86b8kpqfb6zhB/vMFQ2+YaERGW/K3YK96D0sFX44vo2AwjPXAq2rYygaJtlWgEAJ8zEgCjPK+5hyQiIiIiIiIiIvXYlF2CaZrEhDiIDXUwoEMkD57chxNS2gGwYEsO93y5jp15pfvYU+NUdtkmtwurdfItS8F2LIWpYLHhThrWpMduCYFO2+zqRdvl9AagHxv2TC5WIXjVLDBN3B2PavXdtVWpaNvKWCuKtoFJyCqYlfEI6rQVEREREREREWlVNmQUAVTrdg2yWzl3SEfumpBMbKiD9MJypn21jj935DXZcZek+utEdUUjVHbZuhMHgz2kyY7bUiqLtrsrJiOrNL+kA16sxJm5WIp2BV635m32x0MYBqV9z2328R4IFW1bGUvRbgB8exdtKzttlWkrIiIiIiIiItKqVObZ1jYJVs+4UO49MZmUhDDKPD6enLeZD5fvxrdXR2hj7cgtZXVaIYZhMLRLVK3rBPJs20A0AvgnI4sOsQOwtSIiocztZUOej83WbjjtFuxpiwPrB61+CwB3x1H4Irs2+3gPhIq2rcyeTNu94xGi/MsVjyAiIiIiIiIi0mr4TJMNWf6iba25skBEkJ1bxvXi+Iq4hE+WpTLrmx/xpK8B07dfx/1qrX8y+yGdoogPc9ZYbilMxZq/FQwL7g7D9+sYrdHek5FtyirGNE1SQw7DZrFgS/cXbf1dtvP9XbaH/b3Fxru/bPteRZpTXZm2lfEImohMRERERERERKRpeX0muwvK6BAZhFFlYviG2Jnnf1Q/yGahU1Rw7SuZPpwFW7k0YhknR/1OaeoygraUUr7dIDqhI54ux+LqMgZvZLdqE9PXJa/UzYItOQBM6BNf6zqVXbaehAGYjtrjEw5F3WJCWLIzPzAZ2bqKaApP4iDI/g5bxnLweQhaNQsAd8ej8UV2abHx7i8VbVsZa1Flp21CtdcrJyKzKB5BRERERERERKRJfbYyjQ+X7+aCIzsxPrn2ImhdNmT6i4bd40KxWmoWXO07fiLkz2cwXP71ugLl4T62Fzkp90JMYQbB6z7Aue4DvBGdcXc+lvLuEwINfLX5fn0mHp9Jj7hQesXXjGQAcKT6i7auNhKNUKlbbPXJyNZXRFPEdjwMszAcw1WIc9Mc7KkLKrJsD70uW1DRtnUxzUCnbV0TkRmKRxARERERERERaVKLKiYH+2pNBmN7x2FpRLft+nrybDFNglfNwnAVYdqC8cT3xRPfH0+7/nyy1sb8TZlckpTGCc4V2HctxFqwHevKmdh3/kzhcc/U2nXr8vj4bn0WABP6tKt1TJbiNKw5G8AwcHcY0eBzORRUnYysqNzDxsr3PyECT85A7Dt+JnjZSwC4Oo3GF9G5xcZ6IFS0bUWM8nwMbzlQW6dtFACWMsUjiIiIiIiIiIg0laJyD9tz/fmoGUXlrNxdSP+kiAZvv6Hi8fzeteTZWvO3YCnYARYbBSe/junYU9hNTsjmp815zC1PYdSYUzBcRdhT5xOy5DmseVuw5qzHG5tcY5+/bsmhqNxDbKiDIZ2iah2Tfed8ADxxfTGDoht8LoeCysnIckvc/LQpG5fXR6jDSlJkEO6Ewdh3/Aw+LxgGZYdglm0lTUTWigTybJ1RYKuegWJWFG2N8jw4wNkFRURERERERETErzITtdLc9ZkN3ja3xEVWsQvDMOgZV7Noa9/xEwDu9kdWK9gCpCT4v9+SXUKZ24vpCMPV7XhcSf5Jwxw75tXYn880+bpiArITUtrVGscAe/Js3R2PbvC5HEoqu22/Xee/Vr3bhWExDNwJgwLruDofiy+iY4uMrymoaNuK1DUJGYCvMh7B5wZPaXMOS0RERERERESkzVqb7i/a9knwT9a1NLWA7GJXg7atjEboFBVEkN1afaFp4tjuL7y6Oo+usW18mJPYUAc+02RjVnHgdXfFuvYdP4Ppq7bNil0F7MovI8hmYXTP2FrHZNu9CFv2GjAMXG0sGqFSt4qibeV16l2R62uGtsMT3xfTHnxId9mCiratyp5JyGoWbbEFY1rsgCYjExERERERERFpKmvSCwEY2yuOlIQwTNPkx41ZDdp2Q2Weai2TgVlz1mEpTgdbEO72Q2vdPqUiB3dN+p5uX3fCYEx7CJbSbGxZq6ut/9Uaf5ft6J5xBO9dJAbwlBGy+H8AlPc6BTMkrkHncaipnIysUu92e7qci465n4KTZuAL79Dcw2pSKtq2InVNQgaAYVSPSBARERERERERkQNSNc82JSGMcb3iAfhxYzYe377jKTdk+outvdrVjEYIdNkmDQdbUK3bp1R0966tKBwDYHXg7ngUAPYqEQk7cktZlVaIYRgcnxJf6/6CVr+FpTgdX0gcpX3P3+f4D1WV8QgANosl0HkLgNWB6QhvgVE1LRVtW5FAPEJtRVv2RCRYVLQVERERERERETlglXm2SZFBRAbbOaJTJBFBNvJL3SzekVfvtmVuL1tz/AXfXnt32po+HDsr8mw7H1PnPvpU5Npuzi6h3LMnCsHVyb+NY8cv/km1gK8qsmyHdIoiPsxZY1+WvC0ErfsQgNLBV4M9uMY6bUXlZGQAPeJCsFnbXomz7Z3RIay+TFsA0xkJgKF4BBERERERERH5i/F4fSzZmU9+qbvJ9lkZS1AZU2CzWhjd0x8p8P2G+iMSNmeXYJom0SF24kId1ZbZMldilOZiOkJxJxxR5z7iwxxEh9jx+kw2Zu6JSPC0G4jpjMAoz8eWsYy8UjcLtuQAcGKfdjV3ZPoI/fNpMH24O4zAXTGZWVvWLcbf3ZzcrmY0RVugom0rYglk2ravdbk6bUVERERERETkr+qzVelM/3ETN360kpfmb2NbTskB77MylqByEjKAMb3iMAyD1WmFlC+aQdgP/8RStLvGtpXRCLXl2VZGI7g7HAVWe53HNwxjT0RCxp6iLRYrro6j/PvaMY/vN2Th8Zn0jAulZ3wtUQybv8SavRbTFkzJoH/s67TbhMkD2zO+dzwTaititwEq2rYi1voybanaaZvfbGMSEREREREREWkNluz010M8PpOfN2fz7zlruf+b9fyxPRefue/82b3tnWdbKS7UwcAOEYSaRdhWvoUtcxVhP9yCpXBXte0rJyHrtXcR1efBvvNnAFydR+9zHH0qOkXXVpmMDMBdsa1t53x+Wu8vGteWZWuU5hC8/DUAyvpd2GYnH9tbx6hgLhjaiTCnraWHclCoaNtaeF1YSv1t93XFI/gqJiJTp62IiIiIiIiI/JUUlXvYWtFZe8Ox3RnWJRqLYbAuo4inf9rCHZ+voajc06h97p1nW9XYXnEM8iyjqNyFaZpYSrMJ+/FWLIWpAPhMM1C03bvT1rp7MYarCDMoCk+7AfscR2XBeFNWMa4qubaeuL6YwTGUFueTVLSSiCAbQzpF1dg+ZOmLGO4SvDG9KO95csPfAGnVVLRtJSzF/jBp02LHDIqudR2zIh7BKFenrYiIiIiIiIj8daxO88cYdIgMYnDHKK45uhuPn9qXSYcnEuKwkppfxsLteY3a5955tlX1S4pglLkEnwmr407EG9EZS2k24T/egqVgB6l5ZZS6vThtFjpFV5/wy7btRwB/vIGx79JbQriTyGA7Hp/JpuziPQsMC65Ox1BQ5mGwZyljesXVmHDLtmsh9h0/gWFQcsR1DTqeHBp0JVsJS0k6AL7QhDp/wXyaiExERERERERE/oJWVRRt+7aPCLwWE+LgjIFJHJ/izzRdU7FOQ9WWZ1vJVpxGX+sOAN4qHUrB6AfwRnbBKM0l/Mdb2bVtLQA94kKxWow9G3rLse2cD4Cr87ENGodhGIHC8Zq9IhK2Rw6jzOOjn2clY7tVH6d956+ELXgAgPJef8Mb3aNBx5NDg4q2rURloLWvjjxbAFPxCCIiIiIiIiLyF7Rqd0XRNrFmgbVPRbzA2owizMpsW9PEmr0uEGewt7rybCs5tv9IWJCNjbZerMhzcNNXu3g9+noKQjpjlOXSZ/k0OnhT6b1Xnq199yJwl+ILiccbm9Lg8+tTcV6VheRKn6dHkWPEEG330i5/aeDcnOs/InTBA+B14U48gtLDz2/wseTQ0DaTeg9B+5qEDBSPICIiIiIiIiJ/PZlF5WQUlWMYRqBAW1WP2FBsFoP8UjcZufl0yp2Pc+NnWPO3YdpDKDhpBqaj+naVebYdasmzxTRxbP8Bi2EQmnICQTstZBe7+Hi9i2/Mc7nZ8yLtXDu4xXyMsB0DcIaMx9VpFGZQNI7tPwLg7nRMo6IKKjttN2aW4Pb6sFstlLi8zN+aS5htIH2DfsW6Yx7uDiMJXvoCzo2fA1DeYyKlg/4BFmuDjyWHBhVtWwlLRdG2rknIYE88gkXxCCIiIiIiIiLyF1HZZdszLoQge83ipMNmYVBUKUm7v6HdV0sJsbkCywx3CfbtP+Laa4KuQJ5tLdEI1tyNWAp2gtXOYcMm8szwIJam5vPb1lyWplp4lCs53zOLw7xriC1ej2XJBoKXPo+n3QBsWauAhkcjVGof4SQiyEZBmYfNWSUkJ4Txy+Zsyj0+UqOHE+RZALv/IPSXe7Cn/QlAaf9LKE8+HQxjH3uXQ5GKtq2EpaiiaFtvp61/gjJD8QgiIiIiIiIi8hdRW55tVc517zMl8wXy3G48hhVfQhfKe56M4SkhaNVbOLd8U7NoW7HP2qMRfgDAnTQc7CE4gKFdohnaJZoSl5fFO/P4c8c/KYsoJzF0LY7t87DmrMeWvhQAM7Ij3qjujTpHwzBISQhn4bZc1qQX0rtdKHPXZ/nP+7CB+LZ0xFKY6i/YWu0UD/0n7k6jGnUMObSoaNtKBDpt6ynaBjptXYXg84BFl09ERERERERE2i6fae4p2taSZ4u7lOBVszBsFhZae/FnyFj+ceKZGBYrRnk+QWvewZq7EWve5kAhtajcw468ijzbdnsVbU0fju3zAHB1GVPjcCEOK6O6xzKqeywA5fShvPepWIp2Y9/xE/bMFXj7/G2/ul9T2oWxcFsuazOK6JVWyO6CMoJsFkb1iMXlPZagVbMwnZEUHfVvvHGHNXr/cmhR1a+VaEg8gllRtAUwygswg2MO+rhERERERERERFrKjtxSiso9BNks9IgLrbHcsWsBeMqxRXXgef6B1wOnF3tICLdiOiNxdxiBfccvODZ/RengqwFYm153nq0tfSlGWS6mIwx3whENHqcvrD3lfc6ivM9ZOBxWcHkbfa6VXb8bMov5am0mAEd1jyXYbqUs+XRMRwSupGGYoe0avW859DQ8EVkOHtNs0ERkWGz4HP5PlSyKSBARERERERGRNq6yyzY5IRybpWb3qn2bP8rA03Us3SuKupVFWYDybicA+CcI8/qzbtekV0Yj1OzcdWz7HgBXp2PAaq+x/GDqEBlEmNOG2+tjWap/EvpxveP8C21BlPeapILtX4iKtq2AUZ6P4SkDwBeaUO+6ld22hiYjExEREREREZE2rnISstqiEYyyXOzpiwFwdR4TKMJWFmUBPAmD8IXEYbiKsKfOB/YUdWvk2XrKsKcu8O+vy9imPZEGMAyjWlxDSkIYHaOCm30c0jqoaNsKBKIRnFFgq/+X0eeM8m+jTlsRERERERERacPcXh9rM/wF1sPb19IVu+MnME28Mb3xhXegT0URdl3Gnk5bDAuurscD4NzyTb15tvZdv2N4SvGFJuCN7XMwTmmfqhaSx/eOb5ExSOugom0rsGcSsvq7bKFKp215/kEdk4iIiIiIiIhIS9qYVYzb6yMiyEaHyKAaywNRBhVdsT3jQrEYBtnFLjKLygPrubqNB8PAlr6U1Rs3ALXn2Tq2+6MWXJ2P3a+JxJpC/6QILIZBXKiDwZ2iWmQM0jqoaNsKWIrTgfonIatkBkUBikcQERERERERkbZtZWU0QvsIjL2KqJbCVKw5G8AwcHU6GoAgu5VusSEArKmSa+sLTcTTbgBgkrXsMwBGdqs+ubtRno999yIAXF3GHJTzaYjEiCDuOTGZO0/oXWuGr/x1qGjbCjRoErIKikcQERERERERkb+CyknIasuzdVRMQOZOGIwZFB14PRCRUKVoC/4JyYpdXg4r/JUwu8FxyVWiB0wT54ZPwPThjeqOL6JzU59Ko3SNCSEmxNGiY5CWp6JtK2ApqoxHaEinreIRRERERERERKRtK3Z52JJdAtRStDXNPVEGe00YllyRU1t1MjKA8qTh7C6zE2nmc0GHDILsVv8Cdykhvz9C0OrZ/vV6nNjUpyKyX1S0bQX2ZNq23+e6gU5bxSOIiIiIiIiISBu1Nr0I0zRJjAgiNrR616k1Zy2Wot1gC8LdYXi1ZcntwjAMg6xiF1nFrsDrf6SW8KsxGIsBx5h/+PeTt5mI767FsX0eGAalAy7B1V1FW2kdVLRtBQJF28Zk2qrTVkRERERERETaqFUVebaH1xON4OowAmzB1ZYF2a10i/G/VhmR4DNNPlmRxgLbMCKD7ISk/45z7fuEz70RS+EufCFxFI75L+XJk8FQqUxaB/0ktgLWRsQj+Jz+eARl2oqIiIiIiIhIW7WyMs+2/V5FW58Hx46fgJrRCJVSEvzbrK6ISPhzRx4780rJCepEUGIf8HkJXv4qeN242x9J4XHP4I077CCdicj+UdG2pXndGKVZ/i8bkmlbEY9gKB5BRERERERERNqgrKJy0grKMAyDlIqJxSrZ0hZjlBdgBkXhaTew1u1T2u2ZjMys6LIFOD45Hl/PCf6VDIPS/pdQPOpuTGfEQTsXkf1la+kB/NVZSjIwMDEtdszgmH2uX5lpq3gEEREREREREWlupmmyu6CclbsLWJteRJ/EcI5Ljm/S/b+5KBWAXvGhhDqql64CE5B1Gg0Wa6376F2Ra5tRVM7c9Vlszy0lyGZhQp92uBwTwLDije6BN7pnk41bpKmpaNvC9kxCltCg3JTKTFtLWR6YJhjGQRydiIiIiIiIiPzVlbm9LN9VwMrdhazYXUB2lQm+Fu3Io0NkEIfVkj27P37enMPinXlYLQbnDelYfaG7FEfqAgBcXcbUuY8Qh5Uu0cFszSnhrT/9BeDxye0Ic/rLYK7uJzTJWEUOJsUjtDBL0W6gYXm2UKXT1ucCT+nBGpaIiIiIiIiICAD3f7uBZ37ewo8bs8gudmGzWDgsMTxQqH1pwTbK3N4DPk5mUTlv/rEDgNP6t6drTEi15c4tX4HXhS88CW90r3r3VRmr4PH5cNosnNin3QGPT6Q5qdO2hVkrOm0bkmcLgD0E02LD8HmwlOfhs4fsexsRERERERERkf3g8vjYllMCwHHJ8fRPiiAlIRynzUKZ28vtn68hq9jFrD93cunwLvt9HJ9p8sL8bZR5fPSKD+Wkvgl7FpomznUf+CcPA8q7T9jnk8cpCWF8tSYDgHG94wkPUglMDi3qtG1hluJ0oCIeoSEMQ5ORiYiIiIiIiEizyC7xRyEE2SycN6QjAzpE4rT5y0lBditXjPQXaudtzGZZat3z76xNL+T9pbvILCqvdfmXqzNYn1FEkM3CVUd1xVJZlDV9BC95fk/BtvffKO992j7HndwujCCbhSB12cohSh8ztLA9mbYN7LQFfEFRWEqzsJTnc+APH4iIiIiIiIiI1C6zyF+0jQ11YtTS3ZqSEM4JKe34em0GL/+2nQdP7hPIjgXw+kw+Wr6bT1f66x9frE5nbK84/u/wRCKDbNjSFpGVlcG3y0KASM4d0on4MGfFxuWE/v5f7DvnA1A64DLKk/ddsAUIddi458QULAZEBtsP4B0QaRkq2rawQNE2rOFFW9MZCYBRnncwhiQiIiIiIiIiAkBWxaRj8WGOOtc5Y2ASy3YVkFZQxsw/dnD1qG4A5JS4ePaXrazPKAKgQ2QQqfllfLsuk53rfudKx9d08e3EXljG3V6TkrCu9Cgdgzt7GL6w9oT+Og1b1hqw2CgeOhV359GNGntSZNB+nrVIy1PRtoVZivaj07YiHsGieAQREREREREROYiyKjpt40LrLto6bBauHNmFaV+vJ2fj75i7/oUrNIlvsjtRaPYmyJHEJSO6MLxrDJs2rqH4t+fpVLQMgI04SLN0pJuxkxR7OtY17xC05h1/Zq1pYtpDKD7qLjzt+jfL+Yq0FiratiTTbPxEZFTttK07K0ZERERERERE5EBlF/szaOPq6bQF6BEXyikpkQxcNJuCsjx8OWmcwGL+z2ohOjIJa9ZQyIIjtnwNDh/F4UHMNY9ktm88RZZw/jkyljjLBuy7F2JL+xPDXYovOJaiY+7DF9m1Gc5UpHVR0bYFGa4CDE8p0Lh4BF9QFKBOWxERERERERE5uPZk2tZftAU42zKXPEs+ab5ofrCP5oSIbXRlM4YrBzZ/FVjPnTQcb/+LGRXeCee2PGxWg36donDRBVfX8eB1Y83dgC+iE6Yj/KCdm0hrpqJtCwpEIzgjwRbc4O3MingEZdqKiIiIiIiIyMGUXbLvTFsAa95mQjZ+jD3MyQ8xFzGo72g6dowi31uOLWMF9rRFWMryKO95Ep74fgBYgGFdo2vZmR1v3GFNfSoihxRLSw9g1qxZjB07ln79+nHGGWewfPnyetf/8ssvmTBhAv369WPSpEnMmzev2vLi4mKmTZvGMcccQ//+/Zk4cSJvv/32wTyF/RaYhKwR0QigeAQREREREREROfg8Xh+5JW4AYkPqKdqaPkL+fAZME7qM4qQTTmFwxyj/MqsTT/shlA66iuIRtwUKtiJSvxYt2s6ZM4cHH3yQa665ho8++oiUlBQuvfRSsrOza11/8eLFTJ06lcmTJ/Pxxx8zbtw4rrnmGtavXx9Y56GHHuLnn3/mv//9L3PmzOHCCy/kvvvuY+7cuc11Wg0WKNo2IhoBFI8gIiIiIiIiIgdfdkXB1m61EBFU98Pajs1fYc1ei2kLpmTgVc01PJE2rUWLtq+99hpnnnkmp59+Oj179uTee+8lKCiIDz74oNb1Z86cydFHH81ll11Gjx49uOGGGzjssMN48803A+ssWbKEv/3tbwwbNoyOHTty1llnkZKSss8O3pawP5OQQdV4BHXaioiIiIiIiMjBkVVUMQlZqAPDMGpdxyjLJXjFawCU9bsAMySu2cYn0pa1WNHW5XKxatUqRo4cuWcwFgsjR45kyZIltW6zdOlSRowYUe21UaNGsXTp0sD3gwYN4vvvvyc9PR3TNPntt9/YsmULo0aNOijncSACmbaNLNoGOm2VaSsiIiIiIiIiB0lWsb/Ttr482+ClL2G4ivFG96C856TmGppIm9diE5Hl5ubi9XqJjY2t9npsbCybN2+udZusrCzi4uJqrJ+VlRX4/t///jf//ve/OeaYY7DZbBiGwX/+8x+OPPLIOsdit1up4wOjg8Zms2IrzQDAEpmEw2Ft8LaWsBj//5bnNWo7OThsNl2DtkTXs23R9WxbdD3bFl1PERGR1i+r2N9pGxtae9HWlrYYx/YfwTAoOeJaMFp86iSRNqPFirYHyxtvvMHSpUt57rnnSEpKYtGiRdx77720a9euWldvVW63t5lH6eco3A2Ay9kOl6vhYzAs4YQDRnkBrjIXWPRHT0trzPWT1k/Xs23R9WxbdD3bFl1PERGR1i2ryAX44xFq8LoIWfw/AMp7nIw3pndzDk2kzWuxom10dDRWq7XGpGPZ2dk1umkrxcXFVeuq3Xv9srIypk+fzjPPPMOxxx4LQEpKCmvWrOGVV16ps2jbUvZ3IjLTGRn42nAVYAZFN+m4RERERERERESyiv1F29riEWxZq7EU7cZ0RlDa78LmHppIm9difesOh4O+ffuyYMGCwGs+n48FCxYwaNCgWrcZOHAgv/32W7XX5s+fz8CBAwHweDy43e4a4dhWqxXTNJv2BA6U142lJNP/ZSMzbbHa8dnDADDK8pp4YCIiIiIiIiIie4q2tcUjWPO3AOCJ6wv2kGYdl8hfQYuGjVx88cW8++67fPTRR2zatIl77rmH0tJSTjvtNABuueUWHnvsscD6F1xwAT///DOvvvoqmzZt4umnn2blypWcd955AISFhTF06FD++9//8vvvv7Njxw4+/PBDPv74Y8aPH98i51gXoyQDAxPTYscMjt33Bnup7LbVZGQiIiIiIiIi0tS8PpOckoqJyEKdNZZb8/xFW29Ut2Ydl8hfRYtm2k6cOJGcnByeeuopMjMz6dOnDy+//HIg7mD37t1YLHvqyoMHD+bRRx/liSee4PHHH6dr167873//o3fvPbkpjz/+OI8//jg333wz+fn5JCUlceONN3LOOec0+/nVx1JUEY0Q0m6/grp9QVFYi1LVaSsiIiIiIiIiTS63xIVpmtgsBhHBNctH1jz/JPLeSBVtRQ6GFp+I7Lzzzgt0yu7tjTfeqPHaiSeeyIknnljn/uLj43nwwQebbHwHi1Hkn4SssXm2lfZ02uY32ZhERERERERERKB6NIJlrxhKfF6sBdsBddqKHCwtGo/wVxbotG1snm0FMygKAEPxCCIiIiIiIiLSxDKL6s6ztRTuBJ8H0xa833UNEamfirYtpLJo2+hJyCr4nFH+/SgeQURERERERESaWGWnbXxY3ZOQeSO77lfko4jsm36zWkggHmF/O20r4hEMxSOIiIiIiIiISBOrLNrG1dJpWzkJmS+ya3MOSeQvRUXbFhKIR9jPTFtfRTyCRfEIIiIiIiIiItLEsgNFW2eNZZWdth7l2YocNCrathCjOB04kE7bKP9+ytRpKyIiIiIiIvJXl1/qZmdeaZPtrzLTtr5OW29U9yY7nohUp6JtSzBNLBXxCPufaeuPR1CnrYiIiIiIiMhfm880eei7DdzxxVo2ZhU3yf5ySiqKtntl2hrlBVhKs4GKTFsROShUtG0BhqsQw10CHECnbVC0f1+aiExERERERETkL21DRjGp+WWYpsmHy3Yf8P7ySt14fSYWwyA6xF5tmTV/KwC+0ASwhxzwsUSkdiratgBLcUWerTMS7MH7tQ9NRCYiIiIiIiIiAD9vzg58vXJ3Aeszig5of1kV0QgxIXYshlFtmTVvMwDeSOXZihxMKtq2gEDRdj+7bAF8FZm2lvI8MM0mGJWIiIiIiIiIHEzLUvN57fftzFmdzvJdBeSUuDAP8G96l8fHwm25AHSJ8Xe+frj8wLptM4trj0aAPZOQeTUJmchBZWvpAfwVWYoOvGhrBkUBYHjLwVO23x27IiIiIiIiInLwlbm9PP/rVopd3mqvhzqsdIgK5phecRzTLabR+128M48yj4/YUAfXHdONWz5dzeq0QtamF5KSEL5fY82u6LSND3XWWFYZj6BJyEQOLnXatgBrRaft/k5CBmDaQzENK6DJyERERERa2tNPP01ycnK1/yZMmBBYXl5ezr333suwYcMYNGgQ1157LVlZWdX2sWvXLq644goGDBjAiBEjePjhh/F4PM19KiIicpD8sjmHYpeX6BA7R3aOpn1EEIZhUOzysj6jiFcXbKPM7QXThy3tT0IXPEjkR6cTtHr2PvcLMKp7DPFhTkb3iAXgg8psW3cpmL5GjTWrotM2du9OW593T9FWk5CJHFTqtG0BgXiEsP0v2mIYmEFRGKXZGOV5ENa+aQYnIiIiIvulV69evPbaa4HvrVZr4OsHHniAefPm8cQTTxAeHs59993HlClTmD3b/4e41+vlyiuvJC4ujtmzZ5ORkcGtt96K3W7npptuavZzERGRpuUzTb5emwHASYclcHxKOwDcXh+78sv47/cbcZRm4F70Ku2yfsJSuiej1rnxU8r6nAV7ZcsC5JW4WbG7EICjKrp0/69fIj9tymZdRhEbtm5lyPLbMS02ikf+G29MrwaNt7JoGxdavWhrKdoFXjfYnPhUhxA5qNRp2wKaIh4BKiYyAyyajExERESkxVmtVuLj4wP/xcT4/3guLCzkgw8+4LbbbmPEiBEcfvjhPPDAAyxZsoSlS5cC8Msvv7Bx40b++9//0qdPH0aPHs3111/PrFmzcLlcLXhWIiLSFJanFpBeWE6w3coxFZ2wAHarhS5RTq50v8ldxf8hauN7WEqzMR1hlPc8GWxOjLK8QI7s3uZvzcE0TXrGhZIYEQRATIiDY3vGAZD520yMslwsJVmE/3Az9u0/Nmi8mUXlQM2ibSDPNrIrGCopiRxM+g1rAU0xERmAWTEZmVGWd4AjEhEREZEDtW3bNkaNGsW4ceOYOnUqu3btAmDlypW43W5GjhwZWLdHjx4kJSUFirZLly6ld+/exMXFBdYZNWoURUVFbNy4sVnPQ0REmt5XFV22o3vGEmS3Vlvm2DaXvuWLMYGtQYdRPOI28ie9Sengq3HHHQ6ALX1Jrfv9tUo0QlWTDk8glgJ6582j1O3zd9h63YT+9ghBy1+tNy7BNE2yi90AxO8Vj2DNqyzaahIykYNNRdsW0CTxCICvYjIyi4q2IiIiIi2qf//+PPjgg7z88svcc889pKamcu6551JUVERWVhZ2u52IiIhq28TGxpKZmQlAVlZWtYItEPi+ch0RETk07cgtZXVaIYZhcHxyfPWFXhdBq97EabXwqXMSr4X/A3enY8DqL5Z6EgcDYE9fXGO/23JK2JFXis1iMLRLdLVl0SEOroj8HSteVni7UDD2ccpSzgAgaO37hP5yD7iKax1vfpkHj8+HYRhEh9TVaauircjBpkzb5ubzYCnx33gfyERkAGZFPIKheAQRERGRFjV69OjA1ykpKQwYMIAxY8bw5ZdfEhQUdNCOa7dba4s4PKhsNuu+V5JDgq5l26Dr2Pp9tyELwzAY2jWapJiQasvs677GWpqFNTyen4uPxlpQhs1uwVL5f+4dj8RY9hL2rFU4LB6wOQPbLtiei2EYHNElmphwZ7X9GqXZDC2fz07gPXMcp2aVMnDIZbjieuD87XEcaYuw/3AjpcfehxmeVG3b/PxSDMMgNtROSFD1spG9YCuGAUZ8DxwO/ezVRb+XbUNLX0cVbZuZpSQDAxPTYsMMjt33BvXwVcYjlOcd+MBEREREpMlERETQtWtXtm/fzsiRI3G73RQUFFTrts3OziY+3t9xFRcXx/Lly6vtIysrCyCwTm3cbu9BGP2+uVwtc1xperqWbYOuY+uVX+rm543ZmKbJ8b3jql8rdynBK97GNMFz+LmwyEGpy0tqTikJlUXY4A44g2KxlGbj27U80Hnr9Zn8UrHfEV2iavwMBK94F6vPTXlMCuvKe/LOnzvpEx+KK+kYyo9tT+iv07Dk78QxbxqF458Cy57i1O7cUkzTJCbYUW2/hqsQijIwgfKQzpj6uauXfi/bhpa8jopHaGaVk5CZoe0OOLTbVDyCiIiISKtUXFzMjh07iI+P5/DDD8dut7NgwYLA8s2bN7Nr1y4GDhwIwMCBA1m/fj3Z2XtmC58/fz5hYWH07NmzuYcvIiJN5IcNWXh8PrrHhtAzLrTasqANn2CU5eELa4+n+/F0iAoGYHtuyZ6VDKPWiIQVuwooKPMQ7rTRPymy2n6Nslycm74AIHLYxdhtVrZkl7AmvQgAb0wvCsc/gekIw5q3BeeGT6ptX5lnG7d3nm3+VgB8IfGYjrD9eTtEpBFUtG1me/Js2x/wvhSPICIiItI6PPzwwyxcuJCdO3eyePFipkyZgsVi4eSTTyY8PJzTTz+dhx56iN9++42VK1dy++23M2jQoEDRdtSoUfTs2ZNbbrmFtWvX8vPPP/PEE09w7rnn4nA46j+4iIi0Sm6vj+/W++MRT+jTDqNKno3hKsS57n0ASvueBxYbXWL8RdsduaXV95PgL9pWnYzsly3+CchGdIvBZqmekxO07gPwuvHGJuPsPJTRPfxP+c5ZnR5YxwyOpbT/JQAEr3oTozgjsCyzqByA2NC9JyHbCoA3qnuD3wMR2X+KR2hmlUVb8wDzbKHKRGSKRxARERFpUWlpadx0003k5eURExPDEUccwbvvvktMjH8279tvvx2LxcJ1112Hy+Vi1KhR3H333YHtrVYrzz//PPfccw9nnXUWwcHBnHrqqVx33XUtdUoiInKAftuaS0GZh+gQO0d2rj5RmHPdBxjuEryRXXF39ueid4n2591u26to60kYCIaBNW8LRmkORdYIFu/wN2+N6hZTbd2qXbalh50LhsGEPu2YuyGL5bsK2J5bSudof3HY1e14HFu/xZa1hpAlz1E8yv/vUlaxC4D4vYu2+ZsB8EZ2PZC3RUQaSEXbZuYLTQDAkzTkgPdlBjJt1WkrIiIi0pKmT59e73Kn08ndd99drVC7tw4dOvDSSy819dBERKQFmKbJ12v93avje8dX64Y1ynIJqogkKOt3QSA6sUvFJGV7d9qazki8UT2w5m7Enr6Ehe4BeHw+OkQGBbpzKwWt+xA85XhjeuFJPAKAduFOhnaO4vdtucxZnc5VR3WtGIiFkiOuI+Kba7Dv+h176nzcHUaSXVG0rRGPkLcFAG9UtwN9e0SkARSP0MxcPU4i+6I/cQ2+8oD3VTkRmTJtRURERERERFqWaZpkFZWzdGc+7y3dxfbcUhxWC2N6xVVbL2j12/7Camwy7vbDAq93rijAZhW7KNlr8iN3wiAAbOmLWbQ9D4CR3WKqRy6U5we6bMsO+ztUWTbxMH8D2W9bcwOdtAC+yC6UpUwGIHjxc5iuksDyuKqdtqYPa8E2ALyRikcQaQ7qtG1mWUXlvLGoiLOHlNI+zHlA+6qciMxQPIKIiIiIiIhIs3N7fby3dBcbM4vZmVdKmcdXbfmo7jGEOfeUXizFaTg3fwlA6eEXViushjltxIQ4yClxsSO3lOSEPZN9eRIHw9r3sKYtZm3ROAAGdaw+AZlz/UfgKcMb3QN3+6HVlnWLDeGwxHBWpxXy9ZoMzh3SMbCsrM/ZOLbPw1KcjnXZTMo9/m2rZtpainaDpxysdnzhSfv1XolI46jTtpl9tTaTt/5MZdYfOw94X77ARGQF4PPuY20RERERERERaUq/b8vlqzUZbMwqpszjw2IYdIgMZnjXaM4clMSZgzrsWdnrInjJC+Dz4kkY6M+q3Utl3uz2vL1ybWP7gM2JqyiHdp5UYkIcdIgMCiy3FOwkaP1HQM0u20qV3bY/bsyiqNyzZ4EtiJLB1wDg3PgJHbw7iQy2Y7fuKRkFohEiuwbiHETk4FKnbTOrjLEpLPPUv2IDmJVFW0wMVwFmUPQ+thARERERERGRplI5IdjR3WM58bB2JIY7sVlrFjWNkizC5v8Ha856MAxK+11U6/46RQezNDWf7bkl1RdYHbjj+1GycT4p5jq8SQP2RCOYPkL/eBy8bjyJg3AnDa913/3ah9MpKpgdeaV8vz6L/+u3Z4J0T/shuDsdg3fT95xd/h5z4qdWP3x+ZdFWebYizUUfjzSzILsVgBJ3E3TGWh2YNn9QuaFcWxEREREREZFm4/b6WLG7AIDxyfF0jAqutWBrzVxFxHfXYc1Zj+kIo+jo+/DG9K51n4FO270mIwPwJAym1O0lxbuOfknhgded6z7Emr0W0x5M8ZAbau2yBTAMg4l9/d2236zLwO2tHuVQMvAKSgmis28HU9NuJuKrKwlZ+DiOTV9gy1wBaBIykeakom0zC6ks2roOvNMWwFeRa2spz2+S/YmIiIiIiIjIvq1OK6Tc4yM6xE7XiknEqjFNHJu+IPzHWzHK8vBGdqVw/JP+fNo6dKko2u7MK8NnmtWWpYUdjttn0sO7hb7x/jlyLPnbCF45E4DSgVdihsTXO+ZhXaKJDXVQUObh58051ZaV2iL5IvYScowY7BawFOzAsfU7Qv78H7bMlYA6bUWak+IRmllwRdG21O3bx5oNYzqjoGiXJiMTERERERERaUaLd/qbpwZ1iNwTVVDJ6yJkyfM4Nn8FgLvT0RQfeQPYainuVtEu3InDasHl9ZFWUE5SldzaxYUR9DAiSbAWEp6/Bo9zoD8WwefB3f5IXF2P2+eYbRaDCSntmPXnTr5cnc7R3WNYnVbI/C05/LkjH5e3M++H3slVg6MYHZWJNWcdtux1WHPWYQbH4KmjQ1hEmp6Kts0s2O5vbi5xNc3EYb4gf66tOm1FREREREREmofPNAN5toM7RdVYHrT6bX/BtiK/tjx5cp2xBVVZDIOO0cFszipme25JtaLt8t2FuK3JdLUvwZ6+BFvOBqw5GzAdoZQMua5B+wcY3TOWj1fsJr2wnGveW06ZZ09TWbswJ0d1j+HI5ATc1u64k4b5F5hmg/cvIk1DRdtmFuKo7LRtmqKt6YwClGkrIiIiIiIi0lw2Z5eQX+YmyGahT0JY9YVeN86KDtuSITfg6rbvDtiqugSKtqUM7+p/ze31sTqtEMOazGmO5di3/4hR0bxVOvAqzODYBu8/yG5lXO94Pl2ZRpnHR0SQjWFdohnRLYYesSE1u4ZBBVuRFqCibTMLxCM0WadtFAAWxSOIiIiIiIiINIslFdEI/ZIise81+Zh9128Y5fmYwdG4uoxt9L47RdWcjGx9ZjHlHh+7Qw/DgQVK/Xm07qTh+3WMU/olEhFkIzEiiL6J4VgtKsqKtDYq2jazyqJtSZN12vrjEYwyxSOIiIiIiIiINIfFO/IAGNwpssayyi7b8q7Hg8Xa6H13jq5ZtF2xqwCAHh3b4y3uiTV3I6YjjJIh1+5XF6zdauH4lHaN3k5Emo9l36tIUwqpKNqWe3x4feY+1t43X0U8gjptRURERERERA6+9MJyUvPLMAyDAUkR1ZZZitOwpS8BwNX9hP3af2XRNq/UTWGZB4DlFUXb/kkRlPc4CdMeQsmRN2AGRe/vaYhIK6dO22YW7NjzKVup20uY88AugTJtRURERERERJpPZTRCn4SwGn/TOzZ/DYAnYRC+0MT92n+Q3Up8mJPMonK255bQPjKInXmlGIbB4e0jcDlPwNXteOXMirRx6rRtZg6rgbXi/1ebYjKyykzbygByERERERERETl4/qyIRhjUYa9oBJ8X59ZvASjvPuGAjhGISMgrDUQjdI8N2VMkVsFWpM1T0baZGYZBUGWubRNMRmYqHkFERERERESkWRSVe1ifWQzUzLO1p/2BUZqD6YzEnTT8gI7TqbJom1MaiEbot1cUg4i0bYpHaAEhDivFLi9lbt8B78sMqpiITEVbERERERERkYNqaWo+pmnSKSqY+DBntWWOTV8C4Oo6Dqz2AzpOl4qi7dacEnJK3IA/z1ZE/jpUtG0BwZWdtk0Rj1DZaatMWxEREREREZGDavEOfzThoI7Vu2yNkizsaYsAKO92YNEIsCceITW/DIBQp43usSEHvF8ROXQoHqEFNGXR1qzMtPWWg6f0gPcnIiIiIiIiIjW5vT5W7PZHFewdjeDc8jWYJp74w/FFdDzgY8WFOgLRigD92odjUY6tyF+KirYtIMTuf9vLmqJoaw/DNPz/R27RZGQiIiIiIiIiDZJX6mbWop3sLihr0Pqr0wop9/iIDrHTLaZK16vpw7HlGwBcBzgBWSXDMOgcFRz4XtEIIn89Ktq2gGBH001EhmFgOitybRWRICIiIiIiItIgc1an8/XaDB7/YVODmqoW76yIRugQiVGl69WWthhLSSamIwxXx1FNNr7KiASAfu1VtBX5q1HRtgVUxiOUNkGnLYCvomhr0WRkIiIiIiIiIg2yJr0IgPTCct5enFrvuiUuL3/uyANq5tk6t3wFgKvLWLA6mmx8XSq6ebvEhBAZfGATm4nIoUcTkbWAPUVbX5PszwyKgnwwyhSPICIiIiIiIrIvJS4v23P3zAvzw4YsBnSIYHDHqBrrerw+nvppMwVlHqJD7ByWGB5YZilOw576GwDlTRSNUGlkt2gyiso5Yq/8XBH5a1CnbQsIacKJyAB8zigADHXaioiIiIiIiOzT+owiTNMkIdzJiYclAPDygu3klbqrreczTV5asI3VaYUE2SzceGwP7FZ/KcVSnEbYj/8C04cn7jB8kV2bdIx2q4UzBibRPTa0SfcrIocGFW1bQOUMkKVNkWkLgUxbTUQmIiIiIiIism9rM/zRCMntwpg8oD2dooIpKvfw8oJtmKYZWO/dJbtYsDUXi2Fw7THd6VoRWWAp3EXYD7dgKU7HF9ae4mG3tMh5iEjbpaJtCwhx+N/2psq0NYOiAE1EJiIiIiIiItIQa9MLAeiTEI7dauEfo7pis1hYvquAueuzAPh2XSZzVqcDcOnwzvRL8k8GZinYQfiPt2ApycIX3oHCMY9ghrZrmRMRkTZLRdsWoInIRERERERERFpGmdvLlhx/nm1yQhgAHaOCOXtwEgBv/ZnKF6vSeeOPHQBMHpDE0T1iAbDkbyX8x1sxSnPwRnT2F2yDY1vgLESkrdNEZC2gsmhb0lTxCEHRABiKRxARERERERGp1/rMYkzTJC7UQVyoI/D6+OR4lqYWkLtzNWW/fcyJhoNuie04OiwHdm0F00fIoqcwygvwRnWj6Jj7A0++iog0NRVtW0DlRGSlHl+T7K9yIjKL4hFERERERERE6rU23Z9nm1LRZVvJYhhcPqIzGW/dRTvPLkLsVhKKHPCHUW09b0wvio75D6YjvNnGLCJ/PSratoBgx8GZiMxQPIKIiIiIiIhIvSrzbJPb1Sy6xnqz6BCaQ6knCHvyRNzeEgx3IYarCMNVhDe6J8VHXAeO0OYetoj8xaho2wKC7f4o4ZKmyrSteBxDnbYiIiIiIiIidSv3+NiSUwJAn706bQHsu+bjsFqwJA2kaOh1uJp7gCIiFTQRWQuojEcoa6KirVkRj6BOWxEREREREZG6bcwswusziQ6xEx/mqLHcvnMBAK4OI5t7aCIi1aho2wIq4xGaaiIyXyAeoQDMpsnJFREREREREWlr1mZU5tmGYxjVs2qNslxsOWsBcCcNb/axiYhUpXiEFhBcORFZU3XaBlUUbTExygs0e6WIiIiIiIi0Cfmlbt5duov4UAeDOkbSOTq4RrG1MQKTkLWrJRohdQGYJt6Y3pghcft9DBGRpqCibQuoLNq6vCYen4nNsv//4ABgdWLagjE8pRjleSraioiIiIiISJvwxep0ft6UDcCHy3cTE+JgYIcIBnWM/H/27js6jvpq4/h3tu+qN8uWu9x7N7YxmI7pnRQIJQ4kBJJAKAkhJNSQAm+AQEgIoZgSSGgBTAmEUG0D7rj3Jsuyetu+M+8fK8mWLRvZSNqV/HzO8TGamf3NHU0i7V7fuZfh3dNw2nc/QGwEKnAWf47lziDSc+o+a0ViJhvKDtDPtkitEUQkeShpmwCNPW0h3tc21f31b4PpycReF8AWqkYNEkRERERERKSzsyyLL7ZWAVCY42NbVZAKf5j315Xx/royfE4bt0/z0aduCa4d87CXr4m/0DCoOeUxzNQezdbbUFZP1DTJ8DjJT3M3P1m4HueuJQBElLQVkSSgpG0COO0GdsMgZln4w22TtLXcmVBXjBGs+tpriYiIiIiIiCTapgo/5fVhXHYbN584GANYVVLLou3VlG/4nDOrnqf7+9V4vc7dL7I7IRbBUbqc8F5J21WNrRHyU/dpseDc+QWYMcz0Xpjpvdr70kREvpKStglgGAY+l53aULTN+to2DiOzharbZD0RERERERGRRPpiSxUAY3pm4HbYmv57TI8UAhv+RdAqI2i68XWfQKTnVCIFR+Be9288q1/EUbaCcP8Tm623ZtfupO3eXGqNICJJRknbBPG2cdK2sY+tEapqk/VEREREREREEmXP1giT+2Q22+fa+iFOs5IyI5W/5N/JzUePa9oXyx0BxJO2e4rGTNaV1gMwZO8hZLEwjuIFgFojiEjysH31IdIevM74t97fZpW2mQDY1B5BREREREREOrmtlQF21YVw2GyM6Zm+e4dl4V7zEi67jQ+dR7Gp1oZlWU27o7nDAbDVFjVrH7ix3E8kZpLmdtAzw9PsXI6SJRjRAKY3h1jWoHa9LhGR1jqoStuamhreffddFixYwI4dOwgGg2RlZTF8+HCmT5/O+PHj2yvOLsfnig8jC0TaZmyY1dAewVB7BBEREREREenkPm+osh3TMx3PHsO8HSWLsFdvxnB5+SQ2nWAkRnUgSqYv3tfWcqURS++DvWYrjvJVRHpOBWB1Qz/bId327WfrKpoLED92r30iIonSqkrbkpISbrnlFqZPn84jjzxCKBRi2LBhTJkyhe7du/PZZ5/x3e9+l1NPPZU333zzoAJ49tlnOe644xg1ahQXXHABy5YtO+Dxb731FjNnzmTUqFGcccYZfPjhh/scs2HDBn7wgx8wYcIExo4dy3nnnceOHTsOKq725mv4pRMIt1GlrScLQIPIREREREREpFOzLIvPt1QCMGmv1gieNS8BEBlwCmlp8X1FNcFmx8RbJNCsRcLq/fWztUycOz6Lr9mQ4BURSQatqrQ955xzOPvss3n55ZcZOHBgi8cEg0Hee+89nnrqKYqLi5k1a9ZXrvvmm29yzz33cPvttzNmzBieeuopZs2axdtvv01OTs4+xy9atIjrr7+en/70pxx77LG8/vrrXH311bz88ssMHjwYgK1bt/Ltb3+b8847jx//+Mekpqaybt063G53ay61wzRW2rZVewSraRBZVZusJyIiIiIiIpIIRdVBSmpDOGwG43plNG23V67HUbIEDIPQoLPoUVlHSW2I4uogI7qnNR0XzR2Oa+NbOMpWxr82LdaVNiZt05qdy1G2EiNUjeVKJZo3qv0vTkSklVqVtJ0zZw5ZWVkHPMbj8XD66adz+umnU1lZ2aqTP/HEE1x44YWcd955ANx+++188MEHvPTSS1x55ZX7HD979myOOuoovve97wFw7bXXMnfuXJ555hnuuOMOAP74xz9y9NFHc9NNNzW9rk+fPq2KpyN5Gyptg22WtM0ENIhMREREREREOrfG1gijCtKbPjsDeFa/CEC49wzMlHwKMqIsKapmR3XzSttoXrzS1l65DqJBtlbHCEVNUlx2emU272frbGyN0GMy2DSrXUSSR6vaI3xVwvZQjg+Hw6xYsYJp03ZPZrTZbEybNo3Fixe3+JolS5YwdWrzxxWmT5/OkiVLADBNkw8++IB+/foxa9Yspk6dygUXXMB77713UPF3BG9jpW2btUfIBDSITERERERERDq3L1pojWCr34lz+8cAhIaeD0CP9HgCdsde7RFMXz6WNxvMGI7KdWws8wMwIDcF2549ay0LZ9E8QK0RRCT5tCppC3DbbbdRX1/f9PUbb7yB3+9v+rqmpoYrrrii1SeurKwkFovt0wYhJyeHsrKyFl9TVlZGbm7ufo8vLy/H7/fzt7/9jaOOOorHH3+cE088kWuuuYbPP/+81bF1hKaetm3cHkGDyERERERERKSzKqoOUFQdxG4zGNtzd2sE99pXwbKI5o8jllkIQEFGvA1i8V5JWwyDaGNf29IVbKqI5y76ZfuaHWav3oStvgTsLiLdJ7TTFYmIHJpW1/6/8MIL/OhHPyIlJQWAX/3qV4wZMwafL/5DLxwO88knn7RPlK1kmiYAxx9/PJdddhkAw4YNY9GiRTz//PNMnjy5xdc5nfYOHxCZ4o5PtgybFi6X/SuO/mpGWjz5bQtVtcl60noOh77fXYnuZ9ei+9m16H52LbqfIiLSkgUNrRFGdE8j1R1PWRihGtyb3gEgOOS8pmMbK20r/RGCkRiePVopRHNH4Nz2MfayFWyuGQNA/5zmSVvn1vhg80j3CeBo3jZBRCTRWp20tSzrgF8frKysLOx2O+Xl5c22l5eX71NN2yg3N3efKtw9j8/KysLhcDBgwIBmxwwYMICFCxfuN5ZIG1W7HgyPI54lrg1GCbdBiwTDFp+AaUSDhP31+oXTwdriHkry0P3sWnQ/uxbdz65F91NERPb2RUPSdlKf3W0X3RvmQDRELLM/0fxxTdtT3Q7SPQ5qglF21AQpzElp2tdYaWsvW0mR3w8YzSttYyHcG98GINz3uPa7IBGRQ9Tq9ghtzeVyMWLECObNm9e0zTRN5s2bx7hx41p8zdixY5k/f36zbXPnzmXs2LFNa44aNYpNmzY1O2bz5s307NmzbS/ga/I1VMMG2ujDiuVKwzLit9OmFgkiIiIiIiKShCzL4sEPN3LNi8t4ZVkx9eFo076dNUG2VgYwDIMJvdIxwrXYarbhXv86AKEh57H3Y7KN1bbF1aFm22MZ/bAcXiLBOrrHikn3OMj2OZv2u7Z+iBGuxUzppn62IpKUEjoa8fLLL+dnP/sZI0eOZPTo0Tz11FMEAgHOPfdcAG666Sby8/O5/vrrAbjkkkv4zne+w+OPP86MGTN48803Wb58OXfccUfTmrNmzeK6665j0qRJHHHEEXz88cf873//Y/bs2Qm5xv3xtnFPWwwbljsDI1iJEayClPy2WVdERERERESkjawsqWPBtioAXllWzFurdnHikDxOGZxJ9KM/8HP/aro7A/R6PQqW2fQ605dHuPfR+6xXkOFhza46iqr36mtrsxPLHUpo8+cUmhupyR6K0ZjwtSzc6/4NQGjA6WAkrJ5NRGS/Dipp+8ADD+D1egGIRCI88sgjpKWlARAIBA765KeeeioVFRU8+OCDlJaWMmzYMB577LGmdgfFxcXYbLt/eI4fP557772X+++/n//7v/+jX79+PPzwwwwePLjpmBNPPJHbbruNRx99lLvuuov+/fvz4IMPMnHixIOOrz15XW2ctAVMdwa2YCW2UBV62FBERERERESSzevLdwIwskc6lf4IRdUBXl++k+iS5zgt9D9SLMh1uMCKpysshxfLm0Vg1OVg2zeFUdBYabv3MDLiLRLCG+YzILaJyj1aIzjKVmCv2gR2F+HCk9vjMkVEvrZWJ20nTZrUrO3AuHHj2LZtW7NjDiUxevHFF3PxxRe3uO/pp5/eZ9spp5zCKaeccsA1zz//fM4///yDjqUj+Roqbf0R8yuObD3LnQmAofYIIiIiIiIikmTWl9azcmctNsPgu1P6kO1zsnBbFe8vWcXxO94hBrzuPp3zTzwdMz0Xy50OdtcB1yzIiCdtd+xdaQtEc4YTipoUmpuo2GMIWWOVbbjv8ViutLa7QBGRNtTqpG1LCVQ5dN427mkLYHkyAeLtEURERERERESSyGsNVbZHFmaTmxJPxk7qk8WMog+J1thYw2AyR1+Er3sPWjv6vEdD0rakNkTUtHDYdve89WcMJhSDTKrI9tYDmRj1u3AWzQUgOPD0Nrs2EZG29rV72kajUUKhECkpKV99sDTxtXVPW+LtEUCDyERERERaY8OGDcyZM4cFCxawY8cOgsEgWVlZDB8+nOnTp3PyySfjch24wktERFpnS4WfJUXVGIbBGSN2z2Bx7FqGa9vHuNwOBp74c/pn9jiodbN9TtwOG6Goya7aUFPlLcDWWot6Wy/6W9vIqV9DJLcn7g1zwLKIdhuNmdm/za5PRKSttbrb9vvvv8/LL7/cbNsjjzzCuHHjmDRpEt/97neprlaysLV87dDTtqnSNlTVZmuKiIiIdDUrVqzgsssu4+yzz2bhwoWMGTOGSy+9lJ/85CeceeaZWJbFH//4R4466igeffRRwuFwokMWEen0Xl9RAsDkPpl0b+hDixnFu/gRAEIDTiWWWXjQ69oMo2m9vfvabqrws9HeH7fDhqNsJcRCuDe+FT/foDMP9VJERDpEqyttn3jiCWbOnNn09aJFi3jwwQf58Y9/zIABA/jjH//In//8Z26++eZ2CbSr8Tb1tG3LSttMAGxqjyAiIiKyXz/60Y+YNWsWDz74IOnp6fs9bvHixcyePZvHH3+cH/zgBx0YoYhI17KzJsjnWyoBOHNk96bt7vVvYK/eguVKIzjykkNevyDDw5YKP0XVQSb03r19c4WfGnt/XMZcHGUrcW39ECNch5nSjUjBlEM+n4hIR2h10nb9+vWMGzeu6et33nmHadOmcdVVVwHgdru5++67lbRtpcZK20jMIhozcdhbXfS8X7sHkVV97bVEREREuqp33nkHp9P5lceNGzeOcePGEYlEOiAqEZGuq7HKdlyvDHpneQEwgpV4VsRn5wRGXfq1BoIVpLsBKN5rGNmmcj9VtkLcNhv2mi14Vv8TgNCA08H4+p/BRUTaU6t/StXX15OZmdn09cKFC5k6dWrT1wMHDmTXrl1tGlxX1pi0BQhEzDZZ02xoj2BT0lZERERkv1qTsP06x4uIyG5ldSE+3VgBwBl7VNl6v3wSIxIgljWAcOHM/b28VRr72O7Yoz1COGpSVB2kzpaGLaMXWBa22h1gdxEuPPlrnU9EpCO0Ommbn5/Phg0bgHgCd/Xq1c0qb6uqqvB4PPt7uezFabdhb5hq2VYtEkxfHgC26q1tsp6IiIjI4Wbu3Lk8+OCDvP/++4kORUSkS3hz5S5My2J49zQG5sYHmNvLV+Ha9C4A/nFXfe2q1x6NPW2rg1iWBcDWygCWZZHucWDkj2o6Ntz3+K9V1Ssi0lFa/ZNx5syZ/OY3v+HVV1/l1ltvJS8vj7FjxzbtX758Of37a/LiwfA523YYWbTbGAAc1ZswAhVtsqaIiIhIV3Xbbbdx//33N339zjvv8L3vfY8PPviA6667jieeeCJxwYmIdAFVgQgfrC8HdveytdVsI+Xz+wAI9zueWO7wr32e/DQ3hmEQjJpUBuItbTZV+AHol+0jljei6djgwNO/9vlERDpCq5O2V199NaNGjeLuu+9m1apV/OEPf8Bu3/2I/xtvvMGxxx7bLkF2VV5n/NvfVklby5NFNGsgAM6SRW2ypoiIiEhX9dlnnzFp0qSmr5944gmuu+46Xn75Zf7whz/w3HPPJTA6EZHOKxQ1+XB9Ob//73qipsnA3BSG5afi2vI+6e/9BFvtDixvNoHR322T8zntNrqluoDdfW03l8eTtv1zfER6TMLyZhHueyxmporNRKRzaPUgMo/Hw+9///v97n/66afbJKDDibeh0tYfbpukLUAkfwKOyvU4di4k3O+ENltXREREpKt46KGHACguLua///0vixcvBuJPjg0dOpSHHnqIcDhMcXFx07HXXHNNwuIVEeksSmpD/HdtKR9vKKe+4XOuy27jW2PySFn4EK6NbwEQ7Taa+ik/w/Jktdm5CzI8lNSG2FETYkSP3ZW2/XN8WJ5Mqs94FhpaJ4iIdAatTtpK22scRhZso0FkANHu42H1Czh3LmizNUVERES6knPOOQeA559/nmnTpjFs2DAWLFhAbm4uV155JZZlEQgEePrppzn33HOb+iOKiEjLqvwRHv9sK0uKqpu25aa4OH5wHsfmB8lfdCv2qk1gGASHfZPgiIu+dh/bvfVI97CYaoqrg4QahpBBvD1CE8No03OKiLSnVidtL7nkklYdN3v27EMO5nDTVGnbRu0RACLdJwLgLFkCZhRsysuLiIiI7Klnz54AjBkzhr///e9cdNFFPPPMM5xwwgkUFBQAsGzZMnr16tX0tYiItMwfjnHv/9aztTIAwOiCdI4fnMeYnum4di0h5aO7MKIBLHcG9UfcQLT7hHaJoyAjPoxsR02QrZX+piFkWV5nu5xPRKS9tTqj9/nnn1NQUMAxxxyDw6FEYFtoTNoG2rA9Qix7EKYrHVu4Bkf5aqJ5I9tsbREREZGu5Oabb+amm27i1ltvZcKECc1aILzwwgua1yAi8hUiMZMHPtzI1soA6R4HPz9hEL0yvQAYgQpS5v0WIxogmjeC+iN+huXLbbdYCtIbkrbVQTZXxBPI/XNSMFRdKyKdVKuzrzfccAMvv/wyb7/9NmeccQbnnXcegwcPbs/YurympG0bVtpi2Ijmj8O17UMcOxcoaSsiIiKyH7169drvsLG77767g6MREelcTMvir3O3sKqkFo/Dxg3HDWxK2GJZ+L74I0a4llhmf+qOvhvsrnaNp0eGG4CqQIRVO2sB6J/tbddzioi0p1Y3kfne977Hm2++ycMPP0x9fT3f+ta3OP/88/nHP/5BXV1de8bYZflc8W9/W7ZHAIg0PG7i3LmwTdcVERERERERsSyLZxds5/MtldhtBj+ZUdisd6xrw5z451G7k/ojbmr3hC1AistBhifeCqGxt26/HN+BXiIiktQOuvP3uHHjuOuuu/jkk0+46KKLeOmllzjqqKOUuD0E7VJpy55J20Vtuq6IiIhIV/Doo48SDAZbdezSpUv54IMP2jcgEZFO5s2Vu3h3TSkA35/WlxE90pv22Wq24Vv6NwACo7+LmdG3w+Jq7GsbNeMDJPtnK2krIp3XITenXbFiBZ9//jkbNmxg0KBB6nN7CHYnbc02XTeaPw4LA3vNFgx/KZYvr03XFxEREenM1q9fzzHHHMPMmTM59thjGTVqFNnZ2QBEo1HWr1/PwoULef3119m1axe/+93vEhyxiEjy+GRjOS8sLgLg2xN6MaVf9u6dsQgpn/0eYhGi3ccRGnhGh8bWI93NqpJ4a4QMj5MsX/tX+IqItJeDyrSWlJTwyiuv8Morr1BXV8eZZ57Jv/71LwYOHNhe8XVpPlfbDyIDsNzpxLIH46hYg3PnQsKFM9t0fREREZHO7Pe//z2rV6/mmWee4YYbbqCurg673Y7T6WyqwB02bBgXXHAB5557Lm63O8ERi4gknmVZvLVqFy8s3gHAqcPzmTmsW7NjPCufw165AcuVSv2kn4Jx0A/3fi2Nlbag1ggi0vm1Oml7xRVX8Nlnn3HkkUdy4403cswxx6i69mvyNFTatnVPW4i3SFDSVkRERKRlQ4cO5a677uKOO+5gzZo1FBUVEQqFyMrKYujQoU2VtyIiAqGoyePztzBvcyUAxw7K5cJxBc2OsZeuwLP6nwD4J/wYy5vT4XHumbTtr6StiHRyrc66fvzxx+Tl5VFcXMzDDz/Mww8/3OJxr7zySpsF19X5nPF/dWzrnrYQT9p6Vz6nYWQiIiIiB2Cz2Rg2bBjDhg1LdCgiIkmprC7E/R9uZGtlAJthcNHEXpwwOBfDMHYfFPGT8vm9YFmE+x1PpPf0hMTarNI225uQGERE2kqrk7bXXHNNe8ZxWGqvQWQA0e4TAXDsWgqxcIdM6xQREREREZGuY+XOWh76eBN1oShpbgc/Oro/Q/PT9jnO++WT2OpLMFPy8Y+7KgGRxmV5neSmuKgNRRmQk5KwOERE2oKStgnU2NPW38Y9bQFimYWY7kxsoSocZSuI5o9r83OIiIiIiIhI1/TpxgoenbcFy7Lom+3jJzMKyU3ZtxjIXrEW94Y5APgn/hiciWtLYBgGvzhxEOGYRYbXmbA4RETaQsd2BZdmGittgxGz7Rc3DCLdJwCoRYKIiIiIiIi0mmVZPL+4CMuymNo/m1tPGtxiwhYzhm/hn+JtEfoemxTFQrmp7mZtEkREOqtWJW1nzZrFkiVLvvK4uro6Hn30UZ599tmvG9dhwduOg8gAog1JW8fORe2yvoiIiIiIiHQ9Ff4I1YEIhmHw3SP64HK0nDpwb3gDe+UGLFcKgTHf6+AoRUS6tla1R5g5cyY/+tGPSEtL49hjj2XkyJF069YNt9tNTU0N69evZ+HChXz00UfMmDGDm266qb3j7hJ87djTFtij0nZBu6wvIiIi0tlVVFSQnZ3d4r41a9YwZMiQDo5IRCTxNpTVA9A704N7Pwlbw1+G58vZAARGXY7lyeqw+EREDgetStpecMEFnHXWWbz11lu89dZb/POf/6S2thaI94wZOHAg06dP58UXX2TAgAHtGnBX4nHGf/m1W9K221gsw4a9bge2umLM1B7tch4RERGRzuqMM87g7rvv5phjjmm2/e9//zsPPPAAy5YtS0xgIiIJtKHcD8CA3P0P8/It+StGNEAsZyjhwpkdFZqIyGGj1YPIXC4XZ511FmeddRYAtbW1BINBMjMzcTrV4PtQNA4ii8QsIjETp72NWwy7UojmDMNZtgLHzoWEB57etuuLiIiIdHKXXXYZP/rRjzj33HO5+eabqa6u5qabbmLt2rXcd999iQ5PRCQhNjZU2hbmtJy0dRR/gXP7p2AY+CdcA4bG5YiItLVD/smalpZGXl6eErZfQ2NPW2i/atuohpGJiIiI7NcVV1zBCy+8wMKFCznzzDM588wzcblcvPbaa5x44omJDk9EpMPFTItNTZW2vn0PiAbxLfozAKHB5xDLLOzI8EREDhv657AEctptOGwGAIGI2S7niChpKyIiInJAffr0YdCgQRQVFVFXV8epp55KXl5eosMSEUmIouog4ZiJx2GjIMOzz37Pyn9gqy/B9OUSGH5RAiIUETk8KGmbYI0tEgLh9h1G5ihdDtFgu5xDREREpLNqrLDdsmULr732Grfddht33nkn1157LdXV1Ye87qOPPsqQIUO4++67m7aVlpZy4403cuSRRzJ27FjOOecc3nnnnWavq6qq4vrrr2f8+PFMnDiRX/ziF9TX1x9yHCIiB6txCFlhbgo2w2i2zwhW4lnzEgCBcVeB09vh8YmIHC6UtE2wxhYJ/nZqj2Cm98X05mCY4XjiVkRERESaXHrppZx66qm88MILDBgwgAsuuIBXX32V4uJizjjjjENac9myZTz//PMMGTKk2faf/exnbNq0iUceeYTXX3+dE088kWuvvZaVK1c2HXPDDTewfv16nnjiCf7yl7+wYMECfvWrX32taxQRORgbDtDP1lmyGCyTWGZ/Ij2ndnRoIiKHFSVtE8zrjN+C9uppi2EQ6T4RUIsEERERkb09/vjj3HDDDc3mNPTp04d//OMffOMb3zjo9err67nxxhu56667yMjIaLZv8eLFXHzxxYwePZrevXvzwx/+kPT0dFasWAHAhg0b+Pjjj7nrrrsYM2YMEydO5Je//CVz5syhpKTk612oiEgrbTxAP1tHw2fKxic6RUSk/Rx00ra4uJidO3c2fb1s2TLuvvtuXnjhhTYN7HDRWGnbbklbINJ9PADOEiVtRURERPY0efLkFrfbbDauvvrqg17vjjvuYMaMGUybNm2ffePGjeOtt96iqqoK0zSZM2cOoVCoKYbFixeTnp7OqFGjml4zbdo0bDYby5YtO+hYREQOVjASo6g63lZvwN6VtpYVr7Rl98BrERFpP46DfcH111/PhRdeyNlnn01paSmXX345gwYN4vXXX6e0tJRrrrmmPeLsshp72vrbqact7P6F6iheCJYFe/UlEhERETmczJ49m2984xu43W5mz5693+MMw+A73/lOq9edM2cOK1eu5MUXX2xx//333891113HEUccgcPhwOPx8NBDD9G3b18AysrKyM7ObvYah8NBRkYGpaWlLa7pdNo7/K2dw2Hv2BNKu9G97Bra8j6ub6iyzUlx0S2z+RAyW+UGbKEqcLqx9RiJy67//bQ1/X+y69C97BoSfR8POmm7bt06Ro8eDcBbb73FoEGDeP755/nkk0/49a9/raTtQWqstA1GzHY7RyRvDJbNgd1fgq22CDO9V7udS0RERCTZPfnkk5xxxhm43W6efPLJ/R53MEnb4uJi7r77bh5//HHcbneLxzzwwAPU1NTw5JNPkpWVxXvvvce1117Ls88+u0//29aKtOPTWgcSbseCA+lYupddQ1vdxzU7a7Esi/7Zvn3WdG9bgGVBJHc04ZgdYvrfTnvQ/ye7Dt3LriGR9/Ggk7bRaBSXywXA3LlzOe644wAoLCzcbwWA7F97DyIDwOklmjsC566lOEsWElLSVkRERA5j77//fov//XWsWLGC8vJyzj333KZtsViML774gmeffZa3336bZ555hjfeeINBgwYBMHToUBYsWMCzzz7LHXfcQW5uLhUVFc3WjUajVFdXk5eX1yZxiogcSOMQsgG5LQ0hWwRAtKH9noiItK+D7mk7cOBAnn/+eRYsWMDcuXM5+uijAdi1axeZmZltHV+X5+uAnrawu1G8o3hBu55HREREpLOIRCKccMIJbNiw4WuvNWXKFF5//XVeffXVpj8jR47kjDPO4NVXXyUQCADxXrl7stvtWJYFxHve1tTUsHz58qb98+fPxzTNpifdRETa04byxqTtXkPIokEcpfGfTZF8JW1FRDrCQSdtb7jhBl544QW+853vcNpppzF06FAgXqWgN5MHz+OM34L2Tto29rVt/NdRERERkcOd0+kkFAq1yVqpqakMHjy42R+fz0dmZiaDBw+msLCQvn378qtf/Yply5axdetWHn/8cT799FNOOOEEAAYMGMBRRx3FrbfeyrJly1i4cCF33nknp512Gvn5+W0Sp4jI/lT6w1T6IxiGQb/s5klbR+lyMKOYvjzMND25KSLSEQ66PcIRRxzB/PnzqaurIyMjo2n7hRdeiNfrbdPgDgcdMYgMIJLfUGlbtgIiAXDqXomIiIhcdNFF/O1vf+Ouu+7C4Tjot8at5nQ6efTRR7nvvvv4wQ9+gN/vp0+fPvz2t79lxowZTcfde++93HnnnVx66aXYbDZOOukkfvnLX7ZbXCIijTaUxYeQ9czw4HE2H77TrDWCBluLiHSIg35nGgwGsSyrKWFbVFTEu+++21QZIAfH20HtEcy0nsRS8rHXl+AsXUqkYEq7nk9ERESkM/jyyy+ZN28en3zyCUOGDNmnCOGhhx465LWffvrpZl/369ePP/3pTwd8TWZmJvfdd98hn1NE5FBt3F9rBMC5cyGwuxhIRETa30EnbX/4wx9y4okn8q1vfYuamhouvPBCHA4HlZWV/PznP+fb3/52e8TZZe1O2prteyLDINp9AvYNb+LYuVBJWxEREREgPT2dk08+OdFhiIgkXGOl7YCc5kPIDH8ptppt8c+U+WMSEZqIyGHpoJO2K1as4OabbwbgnXfeIScnh1dffZV33nmHBx98UEnbg9RRg8gg/q+i7g1v4ixeSKDdzyYiIiKS/O65555EhyAiknCmZbGpodK2MLd50ta5M94aIZY9BMuV1uGxiYgcrg6pPUJKSvyH+CeffMJJJ52EzWZj7Nix7Nixo80D7Oq8HdTTFiDSYyIAzpKFYFnqRSQiIiKHLdM0eeyxx3j//feJRCJMnTqVa665Bo/Hk+jQREQ63I7qIMGoidtho1dm85+Djf1sI/njExGaiMhhy3awL+jTpw/vvfcexcXFfPLJJxx55JEAlJeXk5qa2uYBdnVeZ/wWdESlbTRvJJbNhS1Qjq1mS7ufT0RERCRZPfLII/zxj38kJSWF/Px8Zs+eze23357osEREEqKxNUK/bB+2PYt7LBNHyWIAIt2VtBUR6UgHnbS9+uqr+f3vf89xxx3H6NGjGTduHACffvopw4YNa/MAu7qOGkQGgN1NNG8kAM6dC9r/fCIiIiJJ6t///je//vWv+fvf/86f//xn/vKXv/D6669jmu08Z0BEpCOY0fifVto9hKx5awR7xTqMcB2W00cse0ibhigiIgd20O0RZs6cyYQJEygtLWXo0KFN26dOncoJJ5zQpsEdDnwd2B4BINJ9Is6SRTh3LiI05PwOOaeIiIhIstmxYwczZsxo+nratGkYhsGuXbvo3r17AiMTkfZk+Etx7viMaLexmOm9Eh1Om7NVb8G94U1cW/6L5UyhfvqviWUWfuXrNpQ1Jm19zbY7SxYCEM0fCzZ7m8crIiL7d9BJW4C8vDzy8vLYuXMnAN27d2f06NFtGtjhwutorLTtmKqOSPfxsBQcOxd2yPlEREREklEsFsPtdjfb5nA4iEQiCYpIRNqNZeIoXoB741s4iz+Pz/ew2QkOvYDgsG+A3f3VaySzWBjn1o9xb3gTR+nyps1GxE/q+zdSP/Vmog3zTVoSippsqwoCUJjTvNLWsVP9bEVEEuWgk7amafLnP/+ZJ554Ar8/3vcmJSWFyy+/nKuuugqb7aA7LhzWGgeRdUh7BGj6Ze0oXxV/zMWlPsQiIiJy+LEsi5///Oe4XK6mbeFwmNtuuw2v19u07aGHHkpEeCJykCzLojoYpaQmxM7aECW1IeqqdjHd/JyJgU+x+UubjjXTCrDV7sCz8nlcWz/EP/5qoknUrzUUNbEZ4LTv/7N1JGayZccOIiteoV/Z/+juDGAYBhgGkYIphPufiHvNKzhKvyT1k1/jH3814QGntrjW5go/lmWR4XWS7XPu3hGux1G+CiCpvj8iIoeLg07a/vGPf+TFF1/k+uuvZ/z4+A/uhQsX8tBDDxEOh7nuuuvaPMiuzNfQ0zZqWkRi5gF/MbcFM6U7sdSe2OuKcOxaSqTXke16PhEREZFkdM455+yz7cwzz0xAJCLyddSFojyzYDuLtlURjO5+enFYdBWXB5/CTZgar5OMjCzC/U4kVHgKZlpPnEVz8S7+C7a6YlI/+iXhPscQGHsFlicrgVcDRdUBbntrDeGYRbdUFwUZHnpleinI8JDtc7KxzM/W7ZvpVTSHI8JzcRIlBGz15ZA/4RxC/Wdi+XIBiORPwLfgAVxb3se38CHsdcUERl8ORvPPnE2tEXJS4onfBs7SpWBZmGkFmClqGyMi0tEOOmn7yiuvcNddd3H88cc3bRs6dCj5+fncfvvtStoeJK9z9y9MfzhGhrf9K5Uj3SdgX1+Ec+dCJW1FRETksHTPPfckOgQR+ZoWba/i8flbqQnGB24ZhkGOz8lxfMHMqucw3BYrIz15xpzBqGFncMyQHk2vjfQ6kkj+eLzLZ+Ne/xqurR/g3PkFdUf/hlj2oERdEq8tLyHUkHwuaagYXry9GoBuZgknhN/nwuhCbJjYDahL6c8/Y0ezxBjJFb4BHOnL3r2Y3Yl/8vWYqT3wrHgW95qXsPlLqJ98fbOWECt31gIwKE+tEUREkslBJ22rq6spLNy3kXlhYSHV1dVtEtThxGG34bQbRGIWgUiMDK/zq1/0NUW7T4D1r+HYuaDdzyUiIiIiItKW/OEYzy7YzscbywEoyPBw+eQ+FOZ4SVv9HJ6V/4IUJ+G+x7HWeSFfrCzjiy+K8Xk8TO67RyWt00tg3PcJ9z0O34IHsFdtxLfgfmpPeDAhQ7dK60LM31wJwI3HDcRmQFF1kKLqICnFn3LKrkdx2W14fXbM/PHYx3yb9PxxFK7cxaLFRTz12VYG5abQLW2PHr2GQXDERZgp3fEtuB/ntk9IMWPUH3krAMFIjJU76wAY0zN99+siAVxFcwG1RhARSZSDLuscOnQozz777D7bn332WYYOHdomQR1uGlskdNwwsgkAOHcuijfhFxERERER6QRWFNfwizdWNSVsTxmez52nDmVInoeMRffjWfkPAILDv4V/8vWcO643xw6Ktwv4y6ebWVFcs8+asexB1B19F5YrFXvVJtwb3ui4C9rDnBUlWJbFyB7pjCpIZ0SPdE4a2o3LJ3bne/Y36Z3pJWfQVIzT/gQn30us+3gwDM4Z04PBeakEoyZ//mQTUXPfz3jhfsdTd/RdYNhwFs3DURwv4Fmxs5aoaZKb4qJnhqfpeM/qf2IEqzBTexDJn9Bh3wMREdntoCttb7zxRr7//e8zd+5cxo4dC8CSJUsoLi7mb3/7W1vHd1jwOu1UB6P4O2oYWe5wLLsbW6gKe9VGYlkDOuS8IiIiIiIih+r9taU8+fk2ALqlurliWl+GdEuFiJ/UuXfjKFkMhoF/wo8IF84EwAAundybulCUL7ZW8cCHG/n5iYMozGneCsDyZBIYdRm+hQ/h+XI24V5HYXmz9w6h3VQFIny0oQKAM0bmN9vn3jAHW6Ac05dL3ZG/Arur2X67zeAH0/vxyzmr2Fju5+WlxVw4rmCfc0S7jSE06Ezca1/Ft+Sv1HQbw6KG1gvjemU09bO11ZfgWfsyAIExs8De/k+DiojIvg660nby5Mm8/fbbnHjiidTW1lJbW8uJJ57I22+/zcSJE9sjxi7P21BpG+ygpC12F5FuYwHUIkFERERERJJeaV2I5xYWAXDsoFzuOm1oPGEbi5D60a3xhK3DQ93025sSto1shsEPjuzH8O5pBKMm976/geKa4D7nCBfOJJY9GCMawLv0sQ65rkbvrNpF1DQZkJvC0G6pu3dEAnhWvQBAcPhF+yRsG+WmuJg1pQ8Ab6zYyYqGPrV7Cw7/NpY7A1ttEa71r7O0KJ60Hd8ro+kYz5dPQSxCNG8UkYKpbXF5IiJyCA5p6lV+fj7XXXcdf/rTn/jTn/7Eddddh2VZ3HrrrW0d32HB64onbf3hDkrasrsvkXPnwg47p4iIiIiIyMGyLIsnP9tGOGYyND+Vyyb3xtNQ+OJd/hSO8lVYrhRqj/kd0R4tFxI57TaunVFI/xwfdaEof5+/dd+DDBv+CdeAYeDa+gGOkiXteFW71Yej/HdtKRCvsm2seAXwrHsFI1SDmVZAuN8JB1xnUp8sjhm4uxVEbcOAtj1ZrlQCoy4FwFj6NKa/Eo/THk+AA/by1bi2fgCGQWDsFbBHLCIi0rEOKWnbkqqqKl588cW2Wu6w4nPGb0Ogoypt2bOvrZK2IiIiIiLSNkzLYs2uuhb7qh6qeZsr+bK4BofNxneP6NOU1HQUf4F7Tfwxfv+k64hlDzrgOh6nnZ/MKMRhM1i7q441JXX7HBPLGkhowGkA+Bb/GWKRNruO/fnvmjKCUZOeGR7G9txd8WqEanCveQmAwIjvtGo42kUTe1GQ4aE6EOGx+VuwWphhEu5/ErGsAQT9tZwRnsOoHuk47DawLLxL4i0Pw32PJ5Y1sI2uUEREDkWbJW3l0HmaBpF1fNLWXrEWI7RvM34REREREZGD9dLSYu7+z1reWbWr2Xb32ldJ/egWjHDLj+3vT10oyrMLtgNw1qh8uqfHh2UZ/jJSPrsXgNDAM4j0nNaq9bJ9Lo4akAPA6yt2tnhMcOQlWJ5MbDXbca995aDibUkkZlJUHWgxgRqKmryzOv69On1Ed2x7Vtmu/hdGJEAssz+R3ke16lxuh42rjuyHw2aweHs1a3btm5jGsOEfdxX+SIwp0c85OjM+1M25/WMc5avA4W6qxhURkcRR0jYJ+BqStv6I2WHntHx5xNL7YmDh3DG/w84rIiIiIiJdUzAS49018cf8V5XsTs7aarbjXfo3HDsX49ry/kGt+Y9FRdSGovTM8HDa8IYBXZZJyme/xwjXEsssjA/LOginDY+3IFi2o4bNFf599luuVAKj42t6Vz6Hrb7koNbf25OfbePm11fxu/+uZ2tloNm+jzaUUxuKkpviYkq/rKbtRqAc9/rXAQiMvBSM1n9075vta0pM//vLlhPTJZ4BzDXGYQBHlDwLsRDeZU8AEBxyPpY352AuUURE2oGStkmgsadtoAN72gKEGnoi+RY8AFbHJYxFRERERKTr+WhDedNw5T2Tod5lj0NDlamzaF6r11uxs5aPN8SrQL87pU/8EX7As/I5HKXLsRxe6qfevN/hXPvTLc3dlCB9fXnLCdlw3+OI5o2EWBjv4r8e1Pp7W9mQwF65s5Zb31zNE59tpToQIWpavLkyfv5Th+djt+1RZbvqeYiFieYMI9pj0kGf8/QR8cT0ip21bCyv32f/4qIaXnOdjs3pxVO5htSPbsVWX4LpzSE45NxDvFIREWlLjtYeeM011xxwf02NHrE/VN4EtEcA8E/4EZ5VL+DctRT3utcIDT67Q88vIiIiIiJdg2lZvLO6tOnrmmCUKn+E3PrV8Sf7DAMsC0fplxihGix3+gHXC0dNnvwsPizs+MF5DMqLD8py7FqKZ+U/APBPuAYzrechxXvGiHzmbargi62VFNf0oEdD24UmhoF//NWk/+dqnDvmY69YSyx78EGfpy4Upbw+DMCE3pks3FbF/9aVMW9TBaMK0imvD5PucXD0gN2Vrba6Ytwb3gIgOPqyQxoGlpfqZmq/LOZuquC1L0u49pjCZvsXb6+m2pZJcd9z6FPxKo7S5fHzjboMHN6DPp+IiLS9VlfapqWlHfBPz549Ofvss9sx1K4rEYPIACxfLoHxPwQgZf5vIRrs0POLiIiIiEjXsHh7NaV1IVJcdrqlugHYUlGHd+ljAIT7zySW2R8sC+eOz75yvX8v30lJbYhMr5MLxhYAYAQrSfns92BZhPufSKTvsYccb69ML+N6xYd+vbGi5WpbM6Mv4d5HA+Da9J9DOs+WhnYIealufjKjkFtOHEy/bB/BqMkXW6sAOHloN1yO3R/NPSueBcsk2n0c0bxRh3RegDNGxttJLNpexfaq3W0ZgpEYqxuqf9PHfxMzpTsQH8IW/hrfUxERaVutrrS955572i2IZ599lr///e+UlpYydOhQbr31VkaPHr3f49966y0eeOABioqK6NevHzfccAMzZsxo8dhf/epXvPDCC9x8881cdtll7XQFX09jpa2/g9sjAPjHXIFn+WzstdvxLnuCwPirOjwGERERERHp3N5uGDx27KA8yv1hdtWFiGz4AHvFOiyHl8DIi3FvmIO9ahPOonmE+5+437UWbqtiTkMi9ZJJvfG57Ngr1pIy77cYgUrM9N74x/3ga8d8xojuLN5ezacbKzhndA9yU/ZtsxDudwKurR/g2vYhgbFXHnQrhq2V8TYRfbPi1atD8lO57ZQhfLqxgheX7sBlt3H84Lz4wdEgntUv4tr6P6Chl+3X0DPDy8TemSzYVsXry3dy1fT+AHxZXEPUtMhPc9M9K436I27Au/I5AqO/e1C9c0VEpH0l/Cfym2++yT333MPVV1/NK6+8wtChQ5k1axbl5eUtHr9o0SKuv/56zj//fF599VWOP/54rr76atauXbvPse+++y5Lly6lW7du7X0ZX8vu9ggJ6Cvr9FI/5WcA+Bb+CSNQ0fExiIiIiIhIp7W53M+aXXXYDIMThuTSL9uLw4rQf0u8jUFo6HlYniwiPacB4CxZCNHAPutEYybPLtjOAx9uxLQsJvXJYmLvDNxrXibt/eux1e/ETOlG3bRb2uQR/oF5KQzvnoZpWby1suVq22j+WExfLka4/qD68TbaUhG/zr7Zu+O1GQZHDcjh/nNG8rszh+Nz2nBu/5T0t7+PZ+Vz8UriwpmH1I5hb2eOilfRzt9Sxc6a+JOVi7ZVAzCuVwaGYRDLHU7d0XcRyyzc7zoiItLxEp60feKJJ7jwwgs577zzGDhwILfffjsej4eXXnqpxeNnz57NUUcdxfe+9z0GDBjAtddey/Dhw3nmmWeaHVdSUsKdd97Jvffei9Pp7IhLOWRNg8g6uD1Co9Dgc4nkjsAWrsG34P6ExCAiIiIiIp3T26vjVbZH9M0k2+eib5aPoyKf4AqWYnmzCQ4+B4BYRn/MlHyIRXDuXNRsjdK6EHf9Zy3vNKw1c1g3fjgxk5RPbou3WDBjRHpNo/bEP2Gm92mz2M8YEW8h8L915VQHIvseYNgINwxwdm9+96DXb0za9sny7bu0YeCo2UrqR7eQMvdubP5STF8u9VN/gX/Cjw76XC3pl+1jdEE6lmUxZ2UJpmWxdEd8Hk1jewgREUlOCU3ahsNhVqxYwbRp05q22Ww2pk2bxuLFi1t8zZIlS5g6dWqzbdOnT2fJkiVNX5umyY033sisWbMYNGhQu8TelnyN7RESlLTFZqd+2q0AeJfPxl61MTFxiIiIiIhIp1LpDzN/cyUAJw+LP+HYNyXKyeH3iJoWlUMu2l0VaxhEesY/yzmL5jatsXBbFbe+uZqN5X58Ljs/mVHIJX0qyf7vj3AWfwF2J/7xP6R+6i1YrrQ2jX949zQKc3xETbPZILU9NSZtHSWLMfxlrV47HDXZ0VDdumelbSP36hdJ/8/VOEqWgN1JcPg3qZn5VyK9px/S8LH9OXNkvNr2k40VfL6lkrpQFJ/L3jTcTUREklNCk7aVlZXEYjFycnKabc/JyaGsrOVfhmVlZeTm5h7w+L/97W84HA4uueSStg+6HTS2RwgmKmkLRHpPJ9T3OAwzSsq89utfLCIiIiIiXcd7a8swLYvBeakU5qQAkLvhX6TZghTberA6bVqz45taJBR/DmaUfy3ZwQMfbsQfjlGY4+POU4dyhHsLqR/8HCNQgZnWk9rj/0h44OltmshsZBgGZzQkNd9bW0p9OLrPMWZqAdG8kWBZuDe/1+q1t1cHsCyLVLeDLG/zpz+NYCXeL58AyyRScAQ1J/+F4MhL2qTtw94Gd0tlSLdUYqbF4/O3AjCmIB2Hre2/nyIi0nZaPYiss1i+fDmzZ8/m5ZdfxmjlL3Wn094ev/8PyOGwN/13ui/+CzwQMXG57Pt7SbsLH/0rXM98gHvjW3hLFxLrOTlhsXQme95L6fx0P7sW3c+uRfeza9H9FOn8QlGT99fGq1NPHhYfpmWrK8a9/nXcdhuv2s9gXFWQ4T12P4YfzR2O5c7ACFVTvXkhry+PfxaaOawbF44twEEU38cPgWUR6TWN+snXt0sic0/jemXQM8NDUXWQTzZUNFUM7ync7wQcpctxbX6X4LBvtCqB3NTPNsu7z2dT585FYFnEMvtTP/3XbXMhB3DmyO784f31BKPxOSpqjSAikvwSmrTNysrCbrfvM3SsvLx8n2raRrm5uftU4e55/IIFCygvL+fYY49t2h+Lxfjd737H7Nmzef/99/dZM5KgCtdwOH5eZ8Pvb3842rQtIdIH4hj2Tbwrn8P94W1Unfdau/xrdleU0PsmbU73s2vR/exadD+7Ft1Pkc7t000V1Idj5Ka4mNA7E8wYvi/+CGaM6qxRrPYPJatir4Fjho1IwRG4Nv2HmrUfAicwLD+Nb0/oBYB71SvYaouwPJnUT7yu3RO2EB8MduygXJ5ZsJ3Pt1a2nLTtdRS+xX/BVleMvXwVsdzhX7nu1srGIWT79rN1lMR7+ka6T/ya0bfOyB5p9M/xsancj80wGFWQ3iHnFRGRQ5fQ9ggul4sRI0Ywb97uKZymaTJv3jzGjRvX4mvGjh3L/Pnzm22bO3cuY8eOBeCss87itdde49VXX236061bN2bNmsVjjz3WbtfydXicjYPIzARHAv7J12M5fDhLFuNe/0aiwxERERERkQ6yvSrAu2tKiZnWVx5rWhbvrIoPDTtpaDdshoFnxTM4SpdjObyUj/w+AFsr/Pu8trGvrW/nZxiWyeiGBKKtvgTvyn8AEBg9C1wpbXJdrTGxTyYA60rrqfCH9z3A6SXcazoA7k3/adWaWxqufZ9+tpaJc+dCAKI9OiZpaxgG547uAcCYnumkuLrcQ7ciIl1OQpO2AJdffjn//Oc/eeWVV9iwYQO33XYbgUCAc889F4CbbrqJ++67r+n4Sy65hI8//pjHH3+cDRs28Kc//Ynly5dz8cUXA/Hq3cGDBzf743Q6yc3NpbCwMCHX+FX2HERmWV/9Bqk9mSn5+MdfBUDK/HsgFkpoPCIiIiIi0v521Ya4+911PP3FNt5d03wglxGswghWNtu2tKiG4pogHoeNGQNzcBR/gWfVCwD4J/6Y7r0GArCjJkQo2rw4JZI/DtPuwR4sp7e5nTE940lb75JHIRYmmjeScN/j2utSW5TtczEwN54kXritusVjwv1PBMC57WOIBlo8ppFpWU2Vtn2ymidt7ZUbMEI1WA4v0eyhXzf0VhvTM4PfnD6Mq47s12HnFBGRQ5fwpO2pp57Kz372Mx588EHOOussVq1axWOPPdbU7qC4uJjS0t1vGsaPH8+9997LCy+8wFlnncU777zDww8/zODBgxN1CV+br6GPbcy0iMQSm7QF8I/9PjFfPvaarXi/fCrR4YiIiIiISDvyh2P83wcbqA/Fh3C9taqESCyeaDXCdaS/ezUZb1yKe93rYFlYlsVry3cCcNzgPHzhclI++wMAoYGnE+kzg0yfk3SPA8uy2Fa1V4LT7qI4bRQWMMW2kp4ZHhzFX+AsmgeGgX/81Qlp0zapbyYAn2+pbHF/NHckZkp3jGgA1/a5B1yrpDZEOGbitNvoke5ptq+pyjZ/LNidLby6/fTK9DY96SkiIsktKZ6JuPjii5sqZff29NNP77PtlFNO4ZRTTmn1+i31sU0me/7SDERiuBwJzqU7ffiPuJG0/92Ab8EDBIdegOXJSmxMIiIiIiLS5mKmxcMfb2JHdZBMrxMLqPRHmLupghkDc3GvexUjEE9iehc/gqNsOQt7f5cNZfU4bDZmDskidf4vMcJ1xLIGEhjzvaa1+2X7WLajhi0V/qYq1kYLjRGM4kOm2lZhmGF8ix4BIDT4HMyMvh12/Xua1DuTfywsYs2uOqoDETK8eyVUDYNw/xPwLH8G16b/EO53/H7XamyN0DvLi22vBLRj5wIAIt0ntO0FiIhIl5LwSlsBh83AZY//Ig8kaCja3oJDLyCaMxRbqBrfggcTHY6IiIiIiLSD5xZu58viGpx2G9cdM4BTGoZwvbGiBCtUi3vtqwBEeh8Nhg3nto/J+O+19IwVMWNgDj3WPYO9fDWW00f9tF+A3dW0duMAri17DyMD3qktxMRGD6sE3xcPYKvfieXNJjD8ova/6P3ITXXTPyce88JtVS0eE+p7AhgGjtIvsdUV73etxmvuu1drBCNch6N8FQDR7uPbIGoREemqlLRNEt49+tomBZudumm/BMD75ZPYqrckOCAREREREWlL763e1dS/9gdH9qV/jo/jBuWS4rJTUhti52f/wIj4iaX3oX7KTdQe9wfqHFl4AsVcH3iAS2IvNSV1/ZOvx0zp3mz9xoTllsrmw8h21gTZ5rex3jEIj9OOa+sH8TXGXgnOvYZ2dbDJfeJPGH6+tarF/VZKN6LdxgDg2vLf/a6zpaGfbWPiupFj11KwLMz0Xvt8v0RERPakpG2SaEzaBiLmVxzZcSJ9jiHcewaGGSFl/m8THY6IiIiIiLSRFcU1PD5/KwDnjylgUkOy0uO0c+KQPLyWvyEhaxEccREYNmI5w3gw4yZW2oeR6bLI2vYfAEJDziXSc+o+52hMWG6rDBA1d8/uWLajBoCy7ElNrQOi+WOJ9DqqvS631Sb2yQRgVUkdNcFIi8eE+sUHkrk3vg2RfauILctqao+wd6Wts6k1wsS2CllERLooJW2ThLdhGFkgnCSVtg3qpt2ChYFn/es4Ghrmi4iIiIhI57WrNsSfPt6EZcG0/tmcMTK/2f6Thnbj+OgnGFE/Fa6eRHodCcDWygDzi2M86plFdNwsMAyi3cYQGHVZi+fplurC67QTNS12VAebtjcmbd39p4PNATYH/nE/TMjwsb3lp7npk+XFsiwWbatu8ZhIryMxU/IxAhV4Vv1jn/1VgQi1oSiGYdA7c4+krWXhKFY/WxERaR0lbZOEL9naIzSI5Q4nOOxCAFI/vRMs6yteISIiIiIiyeyD9WX4wzEG5qUwa0ofjL2SpWlGkLPsnwLwIieAEf/Y+PrynQBM6peDZ9y3qTrrn9TNuDueeG2BYRj0aWyR0FB5Go6arNxZB8DQ/n2pPfZ31B53H2Z6r7a/0EPU2CLhi/20SMDuIjDu+wB41r6CrWZbs92N/WwL0t3NhkzbarZiC5SD3Uk0b2TbBy4iIl2KkrZJorHSNphkSVsA/+QbsBxenDsX4Nr4ZqLDERERERGRr2FjeTyBesygXJz2fT8Sute9Sq4rwk5bd+bUDmRdaR07a4J8tqUSgDNGNFTmulKaErr706+hRcLmhqTtqpJaoqZJls9JzwwPsZxhxLIHtdWltYnJfTMBWLGzlrpQtMVjIgVTiPSYBGYM3+JHmhW3bG3oZ9tnr362ja0RonmjwO5uh8hFRKQrUdI2SXgb/gXWn2TtEQDM1B74x8b/JTn93R+T/vaVuDbMgei+/ZtERERERCR57dlvtX+Ob5/9RrgW99pXsNtsbO97AZZh440VJby+ogSAsT0z9hmudSB9sxuHkcU/OzS2RhhTkLFPhW+y6J7uoVemF9OyWLS95RYJQLza1u7EUbIE5/ZPm7Zv3m8/23i7ObVGEBGR1lDSNkn4XMnZHqGRf9xVRLpPxIiFcG94k4y3v0/O4+NIe+8nuLa8D7GWm/SLiIiIiEjyKKsPUx+OYbcZ9N4rqQjgXvtvjEiAWEZfRk45BYDF26v5ZGMFwD79b79KY6Xt1go/pmU1JW1HF6R/nctod5MaBpLtt0UCYKYWEBxyAQDeJX9tGkrWWGnbLGkbDeAoXQ5oCJmIiLSOkrZJwutsbI9gJjiS/XClUHXuK1Rc+A7+cVcRS+2JLVKHZ81LZLxxCTlPjif1g5/jLJoLZnImnkVEREREDneNVaC9Mr37tEYwwrW4170CQHD4RfTI8DUlLy3LYlh+GoPyUg/qfD3SPThsNoJRky931FBSG8JmGIzokfb1L6YdNV738uKaAz4NGRx2AWZKPrZAOZ5V/8AfjrGrLgTQrCLZsetLMKOYKd0w05Knf6+IiCQvJW2ThDdJB5E1YxjE8kZQP+0WKi6ZR+W5rxIYdRmmNxdbsBLvimfIfPVCsmdPJuWT23DsXKTBZSIiIiIiSWRTebwKtF92C1W26xqrbPsR6TUNgDNGdG/af+ZBVtkCDRW9HoCmFguDu6U0ff5JVr0yvRRkeIiZFosP0CIBu7vZULJd29cBkO1zkerePaCtqZ9t/gRI0rYQIiKSXJS0TRKNg8gCSdjTtkWGjWiPidQdfRflly2g6sx/EBj2TUx3Bvb6EnxLHyPrpTPJ/OcpuNe8BLFwoiMWERERETnsNfWzbaEvrWvrBwAEh13YNGCsX46P70zqzTfG9WR490Orjm1skbB2Vx0Q72fbGTRW236+tfKAx+05lCxj2V/Bspp6+TZq6mfbQ/1sRUSkdZS0TRK+hn9pDiRzpe3+2BxEeh9F3XH3Un75IqpPfZzgoLOw7G6cZctJf+8nZD89Fe/ChzCCB37DIyIiIiIi7cOyLDY1DsnaK2lrBCqw1e4AwyC616CsE4fkcdqI/EMeHLb3uZK9n22jSX2yAPhyRy1V/gPP8GgcSpZWuYxvhV5gim0VRrgWAFvtDmx1xWDYiHQb295hi4hIF+H46kOkI3id8fx5p0za7snuJtz/JML9T6IuUIF3xTN4vnwSe30JqfN/S8qCBwgOu5DA6FnEMgsTHa2IiIiIyGGj3B+hLhTFZhj02WsImaP0SwBiGf2wXG3bb3bPgVxZPie9Mj1tun576Z3poU+Wl62VAe7/cAO/OHEwLkfLdU9magHBYd8g/OnfmBL7nPytS/CVPEIsoz+WO56kjuYOB+e+Fc4iIiItUaVtkugUPW0PkuXNxj/xx1RcMo+a4+8nmjMcIxrA++VTZD07g/Q3Z+HcMV99b0VEREREOsDm8sYhZJ59hpA5ypYDEM0b1ebn7Z3pbarSHV2QfsgVux3NMAyuOao/KS47G8v9/G3eFqwDfHapG/wN/uK6nE8dUzEyeoNlYa/aiKNkCQCR7hM7KHIREekKVGmbJHyNPW0jZoIjaQd2N6Gh5xMach7Oorl4lzyKe8t/cW96B/emd4jkjSIw5gpCA88AuzPR0YqIiIiIdEmb99MaAcCxK15p2x5JW5fDRp8sL1sq/Izr1Tn62Tbqnu7hxzMK+d176/lsSyUFGR7OGd2jxWOLakIssY9krXcMp50+mnCwAseuZThLv8QI1xAunNnB0YuISGempG2S8Dg72SCyQ2EYRHodSaTXkdgr1+Nd+hie1f/CWfolzvd+THThn6g6799Njw+JiIiIiEjbaUza9tu7n22oGnvNVgCieSPb5dzfn9aXTeV+xvXsXElbgGH5aVw2uTePf7aVV5YVU5Du4Yh+Wc2OKa8P89ryEgD6ZMUriy1vDpG+xxLpe2wiwhYRkU5O7RGShK8Ltkc4kFjWQOqO+S3ll35B/RE3YXqycVSuw/fZHxIdmoiIiIhIl2NZVlPStv9eSVtHabw1Qiy9D5a7fZKqvTK9HDUgp9O0RtjbMYNyOXloNwD+OncLG8vrAajwh5n9+TZu/PcKvtgaH7o8rV92wuIUEZGuQ5W2SaIxadvpB5EdpMa+t5H88WS+9k28y58iNOzCdnksS0RERETkcFUZiFATjGIYBr33M4Qs2k3vwQ/kWxN6srM2xNKiav74v41M6pPJB+vLiZrxFndD81M5d3QPhua37SA3ERE5PKnSNkl4nPFbcbglbRtFek8nOOgsDMsk9YOfg3l4fh9ERERERNpDY5VtQboHt2OvIWSl7dfPtiuxGQY/nN6PnhleqoMR3ltbStQ0GdwtlZ+fMIhfnDhYCVsREWkzStomiaZBZOHYASeSdmV1R/4a05WGc9dSPCufS3Q4IiIiIiJdxubyhtYIOc2rbI1wLfbqzYCStq3hddr56bGF9Mr0MqRbKj87fiC3nDiI4d2VrBURkbalpG2S8Da0R4hZEI4dnklbK6Ub9UfcBEDK/N9i+EsTHJGIiIiISNewuSIA7DuEzFG2AiwLM60nlierpZfKXvJS3fzm9GHcctJgRvRI77R9ekVEJLkpaZskGpO2cPi2SAAIjryESN4obKFqUufenehwRERERES6hE0N7RH2SdruamyNMLrDYxIREZH9U9I2SdhtRlNvqcM5aYvNTt2M32Bh4FnzIs6ieYmOSERERESkU6vyR6gORADos58hZJG8kR0el4iIiOyfkrZJpLHa1h8+jJO2QDR/HMERFwOQ+uEvIBZOcEQiIiIiIp1X0xCyDA+ePZ7wI1yPvWoDoH62IiIiyUZJ2yTidcZvR/BwrrRtUD/lZ5jeXByV6/Au/VuiwxERERER6bT21xrBXtrQzza1B5YvNxGhiYiIyH4oaZtEmiptlbTF8mRSd+QvAUj54n5sNdsTHJGIiIiISOe0eX9J213LAIiqNYKIiEjSUdI2ifhcje0RzARHkhxCg88jXDAFIxog9ZNfJzocEREREZFOaXfStnk/W7uGkImIiCQtJW2TSGN/KbVHaGAY8aFkNgfuTe/g2vRuoiMSEREREelUqgMRKv3xIWTNKm0jAWzlawFV2oqIiCQjJW2TiE/tEfYRyx5MYOyVAKR+fCtE/AmOSERERESk82issu2e3nwImaN8JVgmZko3zJT8RIUnIiIi+6GkbRJpHEQWUNK2mfqJ1xJL64W9djspCx5MdDgiIiIiIp3GlooAsG9rBEfpcgCiuaqyFRERSUZK2iaRxkFkStruxemj7qg7APAu+Sv2inUJDkhEREREpHPYtJ8hZI7ShiFk3dTPVkREJBkpaZtENIhs/8L9TyLU70QMM0LqR78Ay0p0SCIiIiIiSW9zS0nbWAhHhfrZioiIJDMlbZOIKm0PrO6oO7AcHlxF83CvfTnR4YiIiIiIJLXaYJTy+jDQPGnrKF8NZgzLl4uZ0iNR4YmIiMgBKGmbRJS0PTAzvTf1E68FIPXTOzGCVQmNR0REREQkmb27thSAggxP01N9AK5N/wEg1m0UGEZCYhMREZEDU9I2iShp+9UCY68kmjUQW6AM3+f3JTocEREREZGktKs2xBvLSwA4Z9TualpH6XJcW/4HhkFkyDmJCk9ERES+gpK2ScTnit8Of1hJ2/2yu6g76i4AvCuexVa3I8EBiYiIiIgkn2cXbidqmgzvnsbkvpnxjWYM76I/AxDuPxMzd0jiAhQREZEDUtI2ifgaKm2DqrQ9oEjv6YQLpmCYYXyLHk50OCIiIiIiSWXR9ioWb6/GZhh8Z1IvjIYWCO71r2Gv3ozlSiMw6tIERykiIiIHoqRtEvE0JG39ETPBkSQ//6TrAPCs+Ae2uuIERyMiIiIikhzCUZNnvtgOwMxh3eiZ4QXACJTjWf4MAIHRl2O50xMWo4iIiHw1JW2TiE89bVst0nMa4R5HYJjhpke8REREREQOd2+sLKGsPkyWz8nZo7o3bfcufQwjGiCWM4Rw/5MSGKGIiIi0hpK2ScTrUtK21QwD/+SfAuBd+Ry2+p0JDkhEREREJLH2HD727Qm9mp7kc5QswbX1w/h76PFXg6GPgSIiIslOv62TiLexPYIGkbVKpOc0Ij0mY8RCqrYVERERkcPeMwv2GD7WJzO+MRbBtzj+Xjk04DRiWQMTF6CIiIi0mpK2ScTnjN+OQCSGZVkJjqYTMAzqJzVU2654VtW2IiIiInLYWrS9iiVF1dhtBpdM6r17+Ni6f2Or2Y7lziA48pIERykiIiKtpaRtEmlsj2BaEI4padsakV5HEukxqaHa9pFEhyMiIiIi0uECkRhPNw4fG9qNggwPALb6Erwrn4sfM2YWlis1YTGKiIjIwVHSNol4HPam/w6oRULrGAb1k64DwLviGWz1JQkOSERERESkY83+fBvl9WFyU1yc1Th8zDLxff5/EA0SzRtBuO/xiQ1SREREDoqStknEbjNwO+K3xK9hZK0W6XUUke4T49W2i1VtKyIiIiKHj/mbK/h0UwWGYfCDI/s1DR9zr38dR+mX4HDjn3gdNLRLEBERkc5BSdsk42t4kxVQ0rb19qy2Xf40Rv2uBAckIiIiItL+yuvDPPn5NgDOGJHP4G7x9ge2mu14lz0OgH/0LMy0goTFKCIiIodGSdsk491jGJm0XqT30US6T8CIhfCp2lZEREREujjTsvjr3M34wzEKc3ycPbpHw44YKV/cB7EI0fxxhAeclthARURE5JAoaZtkGoeR+dXT9uA0622ralsRERFJrEcffZQhQ4Zw9913N9u+ePFiLrnkEsaOHcv48eO56KKLCAaDTfurqqq4/vrrGT9+PBMnTuQXv/gF9fX1HR2+dAJvrdzF6pI63A4bPziyHw5bvP2Be82L2MvXYDl91E+6Vm0RREREOiklbZPM7vYIZoIj6XwivWcQyR+HEQ3iW/yXRIcjIiIih6lly5bx/PPPM2TIkGbbFy9ezPe+9z2mT5/Ov/71L1588UUuuugibLbdb8lvuOEG1q9fzxNPPMFf/vIXFixYwK9+9auOvgRJcpvL/by4dAcAF03oRfd0DwD2qo14VzwDQGDcVVi+vITFKCIiIl+PkrZJxqOetofOMKif9FMAvCtmY/hLExyQiIiIHG7q6+u58cYbueuuu8jIyGi275577uE73/kOV155JYMGDaKwsJBTTz0Vl8sFwIYNG/j444+56667GDNmDBMnTuSXv/wlc+bMoaSkJBGXI0koFDV55NPNxEyLCb0zmTEwJ74jFsH3+X1gxoj0nEq473GJDVRERES+FiVtk0xjpa1fSdtDEulzDJFuY1VtKyIiIglxxx13MGPGDKZNm9Zse3l5OUuXLiUnJ4dvfvObTJs2jYsvvpgFCxY0HbN48WLS09MZNWpU07Zp06Zhs9lYtmxZh12DJLd/Li6iuCZIhtfJrCl9MBraH3hWPoe9ahOWOx3/hGvUFkFERKSTU9I2yTT2tA0qaXtoDAP/5IZq2+VPYfjLEhyQiIiIHC7mzJnDypUruf766/fZt23bNgAeeughLrjgAh577DGGDx/OZZddxubNmwEoKysjOzu72escDgcZGRmUluoJIoF1pXW8uyb+v4UrpvYl1e0AwF62Es/qfwLgn/AjLE9WwmIUERGRtuFIdADSnNcZz6NrENmhC/c5lki3MTh3LcW35C/UT/tlokMSERGRLq64uJi7776bxx9/HLfbvc9+04zPK/jGN77BeeedB8Dw4cOZN28eL730UouJ3tZwOu0dXlDpcNg79oQCQCRm8sTn2zAMgxmDcpjYryExG/HjW3AfBhbRwuMxCo/G1co1dS+7Bt3HrkP3suvQvewaEn0flbRNMl71tP36DAP/pJ+SMedSvF8+hX/sD7B8uYmOSkRERLqwFStWUF5ezrnnntu0LRaL8cUXX/Dss8/y9ttvAzBgwIBmrxswYAA7dsQHSuXm5lJRUdFsfzQapbq6mry8lgdKRRL0njGsAoMO9/LSHWyvDJDucXDhmIKme+Bb8CjUFBPz5VE7+gdwkPdG97Jr0H3sOnQvuw7dy64hkfdRSdsk42tK2poJjqRzC/c9bo9q279SP+2WRIckIiIiXdiUKVN4/fXXm227+eabKSws5IorrqB3795069aNTZs2NTtm8+bNHH300QCMGzeOmpoali9fzsiRIwGYP38+pmkyevTojrkQOWimZWFAU2/Z9rC9KsDrK+LD6L4zqXdTWwTnjs9wbXyroUXY9eBKabcYREREpGOpp22S8WoQWdswDPyTrgPA++VTGIHyBAckIiIiXVlqaiqDBw9u9sfn85GZmcngwYMxDINZs2bx9NNP8/bbb7Nlyxbuv/9+Nm7cyPnnnw/Eq26POuoobr31VpYtW8bChQu58847Oe2008jPz0/wFUpL1pfV871/LOUfi4qa74gEcG7/FKKBr30O07J4bP5WYqbFuF4ZTO6TCYARrMK34AEAQoPPIdpNiX0REZGuRJW2SaZxEFlAZfRfW7jv8UTyRuMsXRavtp36i0SHJCIiIoexyy67jHA4zD333EN1dTVDhw7l8ccfp0+fPk3H3Hvvvdx5551ceuml2Gw2TjrpJH75S/XnT1YvLy0mapq8s7qUGQNz6JnhBcsidd5dOHYuJpbZn/ojf4WZcuhJ93dXl7KxrB6P086lk3vHK3otC9/CP2EEq4hl9CUw8pI2vCoRERFJBkraJhmfetq2nYZq24w3L8e77ElMXz6hwlMw0woSHZmIiIgcBp5++ul9tl155ZVceeWV+31NZmYm9913X3uGJW1kc7mf5cU1AFiWxUtLivnxjEKcO+bj2LkYAHvVJtLeu5b6abcQzRt50OcorQvxryXxnsffHN+TbF98xJhr87s4i+aBzY7/iBvB3trRYyIiItJZqD1CkvE647dESdu2Ee53ApH88RhRP6mf/Jqc2ZPJ/NdpeBc+hL1yfaLDExEREZFO6o2V8R6zg/LifWQXbKti065KvEv+BkC48GRimYUYoWpSP/g5rg1vHtT6lmXxxGfbCMdMhnRL5ZiBOQDY6nfiXfxXAAIjLyWWWdhWlyQiIiJJREnbJNPYHsGv9ghtwzCoPuNp6o78NZEek7EwcO5aSur835L93DFkPXcsvvm/w7FrGVhWoqMVERERkU5gZ02QL7ZWAXDZ5D5M658NwKaPn8FWvxPLm41/zJXUHncvkd5HgWXiW/gQ3kUPgxlt1TkWbqtmeXENDpuNWVP6YGtsi/DF/RjRANG8EYSGnNtelygiIiIJpvYISaaxPUIwaiY4kq7DcmcQGHsFgbFXYPhLcW96B/fGt3Fu/xRH5TocC9eRsvBPxFJ7EiqcSbhwJpEek8FmT3ToIiIiIpKE3lq1C8uyGNMzg95ZXs4b04PVmzYxovR1gukG5qjLwekFoH7Kz/Fk9Mez4mnc6+fgKF9DJH8csYx+mBl9iaX1Brtzn3N8sL4MgJOH5tE93QPE2yI4di0Duwv/pJ+CoRocERGRrkpJ2yTjcarStj1ZvjyCIy4mOOJijFANri3/xb3xLVxb/oe9rgjfsr/jW/Z3wn2Oofr02XojLCIiIiLNVPkjfLyhHIDTR8QHjOWlurkm5X1cdWGWRwcyoM+xGI0vMAyCw79JLLMfvvl/wF65vnmbLsNGLK0X4X4nEBpyHhgGVYEIXxbXAjCjoS2CEazEu/QxAAIjL8ZM7dEh1ysiIiKJkRQZqWeffZbjjjuOUaNGccEFF7Bs2bIDHv/WW28xc+ZMRo0axRlnnMGHH37YtC8SifCHP/yBM844g7FjxzJ9+nRuuukmSkpK2vsy2oQGkXUcy51OaPA51Mx8lLJZy6g+9XGCQy/Asrtxbf0Az4rnEh2iiIiIiCSZt1fvImpaDM5LZUi3VADsZSsZF1qAgcGT1uks3lGzz+siBVOoPfnP+Mf/kNCAU4nmDsNy+sAysddsxbvscdxrXgRg/uZKLMuiMDelqcrWt/ivGOE6YlkDCA06p+MuWERERBIi4UnbN998k3vuuYerr76aV155haFDhzJr1izKy8tbPH7RokVcf/31nH/++bz66qscf/zxXH311axduxaAYDDIypUrueqqq3j55Zd56KGH2LRpE1dddVVHXtYh27OnraUeqx3H4SXc/yRqj/8j9VNvBiBl3m8w6nclODARERERSRZ1oSjvry0FdlfZYpn4lvwVu82goscxbLX34cUlxZgtvJc3U/IJDzydwIRrqDvuPqrP/hfVpz9FcOTFAHiXPYFr83/5ZGP8s9CRDb1yHcVf4Nz2ERgG/ok/URsvERGRw0DCk7ZPPPEEF154Ieeddx4DBw7k9ttvx+Px8NJLL7V4/OzZsznqqKP43ve+x4ABA7j22msZPnw4zzzzDABpaWk88cQTnHrqqRQWFjJ27FhuvfVWVqxYwY4dOzry0g5JY6WtBYTU1zYhAqMuJ5I3Glu4htRPbkt0OCIiIiKSJN5fW0YwatIzw8uYnukAuDa/h71iHZbDS/djfojXaWd7VYD5myu/ekHDiLfvGv7tpqFijvn34StdjN1mMKVvFkQC+BY+BEBo8DnEsga22/WJiIhI8kho0jYcDrNixQqmTZvWtM1mszFt2jQWL17c4muWLFnC1KlTm22bPn06S5Ys2e956urqMAyD9PT0Nom7PXmcu2+JWiQkiM1O3bG/wzJseNa/hmvL+4mOSEREREQSLBw1eWd1/Cms00fmYxgGRrgW75dPAhAc8S18GXmcNjxegfvy0mIq/GHCrSzECIz+LuE+M6gLhvlu8EmOz6kkzePAu3w2Nn8pZko+gREXtcu1iYiISPJJ6CCyyspKYrEYOTk5zbbn5OSwcePGFl9TVlZGbm7uPseXlZW1eHwoFOLee+/ltNNOIzU1tcVjnE47htHirnbjcOz/kSaP00YwYhIBXC49+pQQPccSHncF7kV/Je2jW6i95ANw+lo89ED3Ujof3c+uRfeza9H97Fp0P6Wz+WhDObWhKLkpLqb0zcIIVpL60S8xglWYaQWEBp4FwElD8/jPml3sqgtx7cvLAXDabaS67aS4HAzKS+HbE3rhduxVP2PYqJt4LV+u2kAf1nJx1SM4tzlwr38NAP+Ea8Dh7dBrFhERkcRJaNK2vUUiEX7yk59gWRa33377AY5LTEVrONzyeX1OO8GISY0/Qtjn6uCopFF4wk/JXvsG9pptOD+9l/ppt+z/2P3cS+mcdD+7Ft3PrkX3s2vR/ZTOIhIzeXNlfLDxqcPzcfqLSf3wl9jqd2J5Mqmf+guwOwHwOO1cPLEXzy4ooiYUxbIsIjGTSr9JpT/C9qoADpvBdyb13uc8q0pDPOy4lOtjD9PPqMSY91sAwn2PJdp9QsddsIiIiCRcQpO2WVlZ2O32fYaOlZeX71NN2yg3N3efqtqWjo9EIlx77bXs2LGDp556ar9VtsnI47QDEQL6IJNYrhTqZtxNxpzL8C55lODgc4jlDk90VCIiIiLSWtEgzqJ5OIs/x/TlEelzDLHMwoNe5p+Ld1BWHybD4+S4nGrS3v9VvMI2pTt1M+7CTC1odvyUftlM6ZeNaVkEIyb14Sh1oRibK/w88dlW3l1TyrheGYzs0bx92ycbKwgaXhYP/RmTqv4Pw1+K5UolMOaKr/VtEBERkc4noT1tXS4XI0aMYN68eU3bTNNk3rx5jBs3rsXXjB07lvnz5zfbNnfuXMaOHdv0dWPCdsuWLTz55JNkZWW1S/ztpXEYmV89bRMu3O8EQgNOxbBipH3wMzB1T0RERESSmmXiKFmC7/P/I+O1i0j57A+4tn6IZ/WLpP3nGtLeuQr3qn9iqy9p9hrDX4ajdDmuze/h2jAHe9lKiAb5ckdNUy/bnwytI+vjn2EEq4hl9qf2uHv3SdjuyWYY+Fx28lLd9M/xceygXE4YnAfA3+ZtoS4UbTo2GImxYFsVABOGDKDu6LsJ9zmG+mm/xPJktvm3SURERJJbwtsjXH755fzsZz9j5MiRjB49mqeeeopAIMC558anp950003k5+dz/fXXA3DJJZfwne98h8cff5wZM2bw5ptvsnz5cu644w4gnrD98Y9/zMqVK/nrX/9KLBajtLQUgIyMDFyu5G834G1I2gaVtE0KddNvx7n1I5wli/GseIbgqEsTHZKIiIiI7M2ycK99Cfe617D5dz+ZZ6bkE+4zA3vtdpw7PsdevQXvl0/i/fJJYlkDMaKBeALXjO6zZMwy8Nal8x2rgLzufZi45n2IRYjmjaD+yF9juQ7+ab4LxxXwZXENJbUhnlmwnR8c2Q+AhduqCUVNuqW6GZibgmmk4p9y0yF/O0RERKRzS3jS9tRTT6WiooIHH3yQ0tJShg0bxmOPPdbU7qC4uBibbXdB8Pjx47n33nu5//77+b//+z/69evHww8/zODBgwEoKSnh/fffB+Css85qdq7Zs2dzxBFHdNCVHTqvM369qrRNDmZqD+qn/py0j35JyvzfEi48GTOle6LDEhEREZFGloV3yaO41/07/qXTR6T3DEL9jieWM4zGqcNGuBbn9k9xbfkfjrLl2CvX717DMDB9+Zip3bEMO47K9ZSX7SInUk8P204K6leCYRApOIL6qT8Hu/uQQvU47Xx/Wj/u/M9a5m6qYHyvDCb3zeKTjfGWcdMKszE6ekqyiIiIJB3Dsiwr0UEkWmlpbYef0+Wy73f4xo3/XsEH68u5+YSBnDtm/49bSQcyY2S+fDbOksWEBpxGzcy/Nu060L2Uzkf3s2vR/exadD+7lra4n3l5aW0UTeeVbO9jO5plWeyqDcEXj5C7dQ6hqMn8vAsZPuPbdM9KP+BrDX8ZjrIVWO4MzNTumN48sNmb9n+4vox/zV1OP2s7PxgWIT+yHTO1gMCoy5odd6j+tWQHry/fSYrbwU3HDeS2t9dgWRb3njWCbmmHlhA+WMl0L+XQ6T52HbqXXYfuZdfQnvexNe9jE15pK/tqbI8QiJgJjkSa2OzUHvM7sv55Cu4Nc3Btfo9wvxMSHZWIiIjIYWldaR1vrChhQ2kdx9e8xDGRj6gBXnBfwNy6yTje2sg5o7tzyvB8HLaWq1ajnhx2ZB5BbooLp735qI+dNUGeWbCdkC2dYeNOJHVEPvVtfA3njOrO0qJqtlYG+O1767Asi0F5KR2WsBUREZHkpqRtEvJqEFlSiuUOJzD2CnyL/0Lqh7dQUTAVXCmJDktERETksFJaF+IP728gGI5yTvjfHBv5CJfDxrI+32XUoFOp3VjBl8U1/GvJDj7bUsn3pvalX7YPiFfmbijzM3dTBZ9tqaQ2FMVptzEoL4Xh+WkM655Knywfj3y6mVDUZGh+KqcM79Yu1+Gw2/jBkf341ZtrCDS87z+yMKddziUiIiKdj5K2Saip0lal9EmnftJPca9/A3vtdlK++D/qj7w10SGJiIiIdG2xEFgW2F1ELYM/f7KZYDjKFc63OMn+Ga40L4GJP2ZK4SkATOuXxdxNlTyzYBtbKwP8+q01nDKsG067wbxNleyqCzUtbTMMIjGTlTtrWbmzFpbGt5mWhc8V7z1ra8f+sr0yvZw/tgfPLyrCYTOY3Cez3c4lIiIinYuStknI54o/nhVQpW3ycfqom/EbMt64BO/SxwgNPgd6jmn96y0TMJqGYYiIiIhIXG0witdlb9bOwLntY1Lm/zaetAUqAjG+H7DA5mCg08ThsOOfcA3hhoQtgGEYHFmYzcgeaTy9YDufb6nkzZUlTftddhsT+mQyrV8WI7qnsbM2xKqSOlbtrGXVrjrqQ1EALp/ch5wUV7tf98xh3YiZFvlpblLd+ngmIiIicXpXkIR297RV0jYZhfseR3DgGXjWv07qBz/D/605LR9oWdjqduAoWYxz15KGv78kllZA1dn/wvLldWzgIiIiIklqZ02QX7yxmpwUJz8+upDeWV4wY3i/fLIpYRuMxqgOhHAD3XzgsDvxj7+a8IBTW1wzw+vkmqP6s7BfFm+sKCHFZWda/2zG98rA49w9SKxXppdemV5OHJKHaVlsrwoSNU0KczqmDZbNMDhjZPcOOZeIiIh0HkraJqHdPW01iCxZ1U+/DdfWD3HuWopr6ZOER1yGEarGsWspzpIlOEqW4CxZjC1Qus9rHZXryXjzu1Sd/U9weBMQvYiIiEhy+WB9OVHTpKQ2xO1vr+G7U/pwjG0JtrpiLHc6xcc+zB3/WUe9z8+RfdP59tg8qt3pWJ6sr1x7Qu9MJvTObFUcNsOgT5ben4mIiEjiKWmbhHwuVdomOzMln/qpN5P24c14Pv0NziVP4KjasM9xls1BNGcY0W5jieSPxUwtIP2dq3CWLCb9vWupOfkRMGwtnEFERETk8GBaFnM3VQCQn+ampDbEXz/ZyFDHk/S3WwQHncWji6rZEXTRPTOds6cNwdyjUlZERESkK1LSNgl5NIisUwiOuAjPmhdx7lzYlLCNpfclkj+WaP44It3GEs0bsU81bc2pfyfj39/CvWEOKfN/S/3UXyQifBEREZGksGpnLVWBCCkuO3efNox/L9/JliX/wajfyhZnCh+HJrNoexUOm8EPp/dr1tpAREREpKtS0jYJ+Zzxyku/Km2Tm2GjeubfSNn0GuHU/kTyx2F5s7/yZZGCI6g97l7S3/sxvkV/Jpbel+CIizogYBEREZHk8/HGeJXtEX2zcDlsXDCmB5Et8/DvhLeZypwV1QBcOK4n/bJ9iQxVREREpMMoaZuEGnvaBpW0TXpWSjfC479P+CCrokNDzqW+Zgspn99H6oe/IJbWi0ifGe0UpYiIiEhyCkZiLNxWBcCRhfF//HbsXEhmaBvhrAzWek6GGhhdkM7JQzXEVURERA4fStomIQ0iOzz4J16LvXoznjUvkf7296k671ViOUMTHZaIiIhIh1m4rZpQ1CQ/zc3A3BSwLDyr/gGANeQMbhoxgdUltQzvnoZhGAmOVkRERKTjaAJSEmoaRKaetl2bYVB77O8JF0zBFqkj441LsdWXJDoqERERkQ7zycZyAKb1z8YwDBxly3GUrQK7k+Dgc3E7bIzpmYHTro8tIiIicnjRu58k1FhpG4jEsCwrwdFIu7K7qTnlb0QzC7HXFZH+5nch4k90VCIiIiLtrsIfZsXOWgCO7B9vjeBZ+TwAoX4ntmpWgIiIiEhXpaRtEmpM2lpAKKoWCV2d5cmi+vTZmJ5snLuWkv7uj8BUlbWIiIh0bfM2VQIwOC+Vbmlu7OVrcJQsBsNGaOj5CY5OREREJLGUtE1CHufu2+LXMLLDgpnRj+pT/45ld+Pe9A4pc+9OdEgiIiIi7cayLD7ZWAHAtIYBZJ5V8SrbcN/jMFO6Jyw2ERERkWSgpG0SshkG3obEbUBJ28NGtMckao//IwC+pY/i+fKpBEckIiIi0j62VgYoqg7gsNmY3CsFz/LZOHd8BoZBcOiFiQ5PREREJOGUtE1STX1tw2qPcDgJDTqTuik/ByD141txbf5vgiMSERERaXufbopX2Z6YW0mPj67f3ct20NmY6b0SGZqIiIhIUlDSNkk1Jm3VHuHwExh/NYFh38CwTNL+88N4bzcRERGRLiJmWny2cRenht7i0tLfYa/ejOXOoH7qLwiMvSLR4YmIiIgkBSVtk5TP1VBpq6Tt4ccwqJvxW8K9pmOL1JP58rl4lzwKlqquRUREpPPbuG4ZV1b+gVOj7+J1GkR6T6fm5EeI9J6e6NBEREREkoaStknK42hsj6Ck7WHJ7qRm5qOE+p+MYUZI/fQOMl7/Drb6kkRHlnD2inU4t3+a6DBERETkEBhlqyiYezMFZjEOXyb+qb+gfuovsDyZiQ5NREREJKkoaZukfK74rVF7hMOX5U6n5pTHqD3mt1gOD65tH5L1/Im4Nr+X6NASxlG6nKx/nULmv7+BZ/kziQ5HREREWikYifHpwgXseuUGwiE/6+wDKT3+YSK9j0p0aCIiIiJJSUnbJNXY0zaopO3hzTAIjriYygveIpozHFuwgow5l5H60S0QDSQ6ug5lBMpJf3MWRjQIQOpHt+Dc+kFigxIREZEDKqsL8dzC7dz+r//Re8HtOGL1bHf2p2rqrfQt6Jno8ERERESSlpK2Saqxp60/oj6mArHsQVRe8Dr+MfHhHN4vnyLrX6djL1+V4Mg6SCxC+js/wF5XRDSjH8FBZ2FYMdLf/sHh8z0QERHpJCzLYs2uOv700Uau//dK5q1YyxW1D5Nt1OHOHcCQb93PSSP7JjpMERERkaTmSHQA0rLGSlv1tJUmdjf1039NuM8M0t+7DkfFGrL+dTp1024hOOpyMIxER9huUj69A1fRPExnCjWnPk4sox82/y5cRfPIeONSqs5/HTMlP9FhioiIHNYiMZPPt1TxzupdbK7wA5Bq1XGz9Rj9U/24sgqpO+5eLE9GgiMVERERSX6qtE1STUlbtUeQvUT6HEPFN98l1Pd4jFiItI9/RfqcSzH8ZYkOrV24V72A78snAKg94UFi2YPB7qJm5qNEMwdgr9tB+pzLIeJPcKQiIiKHp2AkxivLirnuleX8de5mNlf4cdhsnNDfy1+zn2e4twp3ejfqZ/wGy5OV6HBFREREOgUlbZOUz9nYHkFJW9mX5cul5rQnqT3qTiy7G/eW98l+/kRcm94Fq+u01HDsXEjaBzcDUD/5esKFJzftszxZVJ/+FKYnG2fpMtLf/RGY+v+LiIhIR9peFeC2t9fwyrJiaoJRsnxOzh9bwAPnjuQq2yuk1W/GcmdQN+M3eipGRERE5CCoPUKS8jjj+XRV2sp+GQbB0ZcT6TmF9P9cg6NiDRlvXk4sJZ9w/5MJFc4kUjAV7M5ER3pIbPU7SX/rSgwzTKhwJv6JP9nnGDOjH9WnPk7mv7+Be9M7pMy9i/rpv05AtCIiIocXy7L4aEMFs7/YRiRmkul18q0JPZnUJwuHzcBevgbntk/AMKg76nbM9N6JDllERESkU1GlbZJqHEQW0CAy+QqxnGFUXvAG/jFXYDpTsNeX4F0+m8zXvk3OE2NJe/fHuDbM6VztA2Ih0t+6Eru/hGj2EGqPvx+Mln9cRXtMpPb4PwLgW/o3PF8+2XFxioiIHIaCkRiPzt3C3+dvIRIzGdUjnbtOG8rUftk4bPEe+97lTwEQ7ntcvLWRiIiIiBwUVdomKQ0ik4Pi8FI//dfUT/05rm2f4Nr0Nu5N/8EWKMez9mU8a1/GsrsJ955BqHAm4X4nYHmzEx11yyyL1A9vwVmyCNOdQfUpj2G5Ug/4ktCgM6mr2Urq/N+S+vGvMNN6E+53fAcFLCIicvjYXhXgz59uZntlAMMwOG9MD04fkY9tj4GojpLFOEqWgM1OcMRFiQtWREREpBNT0jZJedXTVg6F3U243/GE+x1P3Yzf4ti5EPfGt3Fveht7zVbcm/+De/N/sAwbkYIjCA06m+Cgs8GVkujIm3iWP4V31fNYho2ak/6Mmdm/Va8LjL8ae/UmvKteIO0/P6TqnJeJ5Y1o52hFREQOH/5wjLv+s5ZAJN4O4erp/RmSv9c/rFoW3mXxAaKhAadhpnRPQKQiIiIinZ+StkmqcRCZetrKIbPZiRZMJlowmfojb8VeviqewN34No7ylbiK5uEqmkfKp3cSGnwOgREXJzzJ6SyaR+ontwFQP/UXRPrMaP2LDYO6Gb/FXluEa/snZMy5lKrzX8dM7dE+wYqIiBxmXHaDnhkeclLdXDyhJ+meffvmO7d/ir1yPTg8BId9IwFRioiIiHQNStomKa9LSVtpQ4ZBLHc4/tzh+Cf/FFvNVtzr5+BZ+RyO6k14VzyNd8XTRPLHERhxMaGBZ4LT26Eh2mq2k/729zHMKMHB5xAY+/2DX8TupGbmX8l86WwcletIn3MZVee8nFSVxCIiIp2Vw27j1pOH4HLZCbfUwsuMNfWyDQ4+B8uT1cERioiIiHQdStomKa8zPnTJr5620g7M9D4Exl9FYNwPcBbNxbPiGdwb38ZZshhnyWLMT24nOOQ8giMuJpYzpP0DigRIf+t72IIVRPJGUXvs72GP3ngHw3JnUH36U2S9eCbOshWk/+eH1Jz6d7BiGJEARiwIDX83fm1EgxANYESDOGwWGB5w+jCdqVjOFCynD8sV/28c3kOOTUREpCtzbX4PW20RliuN4OBzEx2OiIiISKempG2SauxpG4yYCY5EujTDINLrSCK9jqTOX4pn1Qt4Vz6HvWYrvi+fwPflE0R6TIpX3w44DRyeto/Bskj73w04y5ZjenOoOeWxeGL0azDT+1B96uNkvnoB7i3/Je+Rfm0TK2BhNCRy48nc0KAz8R9xY5utLyIi0inFwnhWPAMQb4ugp1xEREREvhYlbZOUb4/2CKZlNZvIK9IeLF8egQnXEBj/Q5zbPsa74mlcm97FWfwFzuIvMD+8hVj2YGKZ/Yll9I//nVlILKM/liv1q09gRrFXb8FeuQ575XocDX/bK9dji9Rj2RzUzPwrZlrPNrmeaPfx1Jz4J9Lf+wlGNLD7Og07lsMLDg+Ww4Pl8GI5PNDwt2G3Y4X8GJH6hj97/Hc8ZYsRqYNIHQCOBQ8Q7nsc0e4T2iRuERGRzsi9/g1sgXJMbw6hgacnOhwRERGRTk9J2yTVWGlrAaGo2fS1SLszbET6zCDSZwa2+p14Vj6PZ+Vz2Ot2YCtZhLNk0T4vMb15xDL7E90joWvEwruTsxXrsVdvwjAjLZ7SsrupnfEbIgVT2vRSwgNOpbz30RDxg9OLZfeAfd+hKXvab58+y4RocHcCN1yPb/Gf8az7N6lz76bqnJfUNkFERA5P4Xo8q14AIDjiYrC7EhyQiIiISOenpG2ScjtsGMSTtv5wTElbSQgzpTv+Sdfin/Aj7BVrsFdtxF69GUfVRuzVm7BXbcIWKMMWKMUWKMVZ/PkB17McXqJZA4llDSSWNYho1gBiWYOIZfRrtw94lisVWlMJ/FUMGzh98f625AFQP+2WeC/g4s9xbX6XcP+Tvv55REREOhn3lvcxwrWYaT0J9zsh0eGIiIiIdAlK2iYpm2HgddrxR2IEIhpGJglmsxPLHU4sd/g+u4xQDfbqzQ0J3Xgi1169CWzOhgTtoKa/zbSCePKzizBTCwiMuQLfoodImfcbwn2PA5t+rIqIyOHFXrEagHDfY8GmQgMRERGRtqDsQhLzOG1K2krSs9zpRLuNJtptdKJDSQj/+B/iWfksjsr1eFa9QHDERYkOSUREpEM5KtcBEM0alOBIRERERLqOrlPy1gU1DiPzt9RfU0SSguVOxz/xJwD4Pr8v3j9XRETkcBEJYKstAiCWNTDBwYiIiIh0HUraJrHGPrbBiJngSETkQAIjv0MsvQ92/y58S/+W6HBEREQ6jKNqPVgWpi8Xy5OV6HBEREREugwlbZNYY9LWr/YIIsnN7qZ+ys8A8C56BMNfluCAREREOoa9It4aIabWCCIiIiJtSknbJOZrSNqqp61I8gsNPINI3mhskTpSFtyf6HBEREQ6hL1SSVsRERGR9qCkbRLzupS0Fek0DBv1024BwLPiGWxVmxIckIiISPtrGkKWraStiIiISFtS0jaJeZ3x26NBZCKdQ6TXkYT6HIthRkmZ/7tEhyMiItKujHAdttodgIaQiYiIiLQ1JW2TmFftEUQ6nfppv8DCwLPhDRw7FyU6HBERkXZjr1wPgJmSj+XOSHA0IiIiIl2LkrZJbHdPWzPBkYhIa8VyhhEaegEAKfPuBstKcEQiIiLtozFpqypbERERkbanpG0SU6WtSOdUP/kGLLsb147PcG35b6LDERERaRe7+9kOTnAkIiIiIl2PkrZJrHEQmXrainQuZloBgTGzAEiZ+xswowmOSEREpO3ZK+JJW1XaioiIiLQ9JW2TmK9hEJkqbUU6H//4qzHdmTgq1+JZ/a9EhyMiItKmjHAttvqdgJK2IiIiIu3BkegAZP8aK22VtBXpfCx3Bv6JPyH109vxfX4vwUFng9PbdieI+HFUrsNesRZH+WrsNVuJZRYS7jmNSI9J4PS13bkOB5aFo2wFls1JLKMvODyJjkhEJKk1VtmaqT2wXGkJjkZERESk61HSNol5HY3tETSITKQzCoy6BO+yx7HXbsO39DH8E3908ItEAzgq12OvWIOjYm08SVuxFlvNNgz2HXLmW/Qwls1JNH9cPIHbaxqR/PGHnoS0LIxwDZYrHQzj0NbYDyNQTsr832Gv3oKZ1pNYakH877SemKnxr9s00b2fGDyr/oln5XM4qjcBYGFgpvUilllILLM/0cxCYhn9iWUWYqb1Apu9XWMSEekM7JWNrREGJTgSERERka5JSdsk1lhpG4yq0lakU7K7qZ9yE+nv/gjvoocJjPg2ljen5WMtC1t9MY7SFTjKVuAoW469fDX26i0tJmcBTG8O0ezBxLIHE0vvi6N8Fc7tn2Kv24Gz+HOcxZ/Dgvux7G4i3ScS6TWNcM9pRLuNAbsrvkg0gL2uGFvtDmx1Rdhrixr+3oGtbgf2uiKMaJBo9hBqj/kt0R6T2uRb49r8Hmnv34AtUHbA40xPFrHUnnskdXsR7TaaSP5YcBxiQtcycW6fi2fls7g3vo1hRuKbHT4smx1buBZ77Tbstdtg24fNX2pzEcvo25DQLSSaM4xo7nBimQPA7jy0eEREOqHdQ8jUGkFERESkPShpm8R8Tg0iE+nsQoPOIrLkUZylX+Jb8AD1R90BZgx71UYcZcvjCdqGRK0tWNHiGqYnqyE5O6QpSRvNHtJyAtiysNVswVU0F+f2T3EWzcPu34Wr6FNcRZ+SAlgOL7GM/tj8JdgC5a26DkfFGrJePofAyEuon/JzLHf6oX1DwvWkfnoH3pXPAhDNHkJgzCxs/jJstUXY64qw1RVjq92OLVKPLViJLVgJZcubX6bNRTR/DJEeRxApmEyk+8SvjMnwl+JZ/U+8K57DXrOlaXuk2xiCIy4iOPAscPowAuXx+1O1EXv1RuxVG7FXbcJevRkjFsJRua4pWdEsnuzBRHNHEMuNJ3KjOcOxPJmH9n0SEUly9sr1AMSyBic4EhEREZGuSUnbJOZ1qqetSKdn2KifeguZr30T7/KncZYsxlG+CiMa3OdQy7ATyxpING8k0dyR8SrOnCFY3tzWtyYwDMyMfgQz+hEc/m2wLOxVG3Bu/zSeyC2ahy1YgaN85e7zOrzE0nphphXEq1lTG1sUFBBL6wkOL77Pfo931Qt4l8/Gtekd6o6+m3DhzIP6Vjh2LiT93R83JUz9Y66kfspNLbduaGjLEE/kNlT91hZhr96Eo3gBdv8unMVf4Cz+AhaBZdiI5o4g0mMykYIjiPSYjOXLjVfVbvsI74pncW16B8OMAmA6UwkNOZfg8G8TzRvZ/NS+XKK+XKIFk5vHZMaw1RU3JXIdletwlK3CXrYSW6QOZ9lynHsll2OpPeMJ3IZqXDO1B7HUHpgp3dU3V0Q6r2AVtvpdAEQ1hExERESkXRiWZbX83O1hpLS0tsPP6XLZCX9FBW1RdYCzH/sCr9PGRz+e3kGRycFqzb2UzqO97mfG6xfh2rr7UXvL4W1I5o2I/8kbSTR7SPsn8iwz3nahbgexlB6YaQVY7sxWJYWd2z8l9YOf4ajeDECo8BTqjr4znoA8kFgE34L78S38E4ZlEkstoPb4PxLpdeQhXoOFrXozrh2fxdtA7PisWeVso2jWQGyxMLaarU3bIvnjCYy4iNDAM9puWJtlYqvZhqN8ZbxqunwVjrKV8fYKB2B6c+L3ILVgdzI3tXs8WZ5agJneBwxb28TYRejnbdfSFvczL08DsBLxPtZbtgj3+7/ETCug5pTHOvz80nb0c7Vr0H3sOnQvuw7dy66hPe9ja97HqtI2ifmaKm1NTMvC1sZDgESk49Qcfz+eVS/Ee7LmjSSW0T8xA60MG7Hc4fx/e3ceHUWVtgH8qeolO0lIwhICIYDpGENCAvNhsP/3wQAAI+hJREFUMJoBOQwOouA6jIoyCHoGdRQQcAEhgCCKh6DIIssgihxEUFk9Iui4gDgCBgGRRQgISFZC1u5U3e+P7q50ZRmWLL34/M7pdNWt6u5b/VZ3V95++5YSmXjVN7XF3ISiv32GoO+zEbB/EfxObIXpzDcoS38elTf8vd4Eo6HoGEI+ewqmvBwAQGX8XSi9ZTqEX2gjtkGCGhaHyrA4VCb+DQAgl57TErims9/BWHgERsdPd1VzK1RZ7kJF4t+vabsv3x8ZamgsrKGxsHa5raa56iKMBfZKXGP+IRhKcu2VumXnIFVXQq4osA9PUas610n1C0V12x6wte0JW/teqG6byjO0E5FHkAsd49lyaAQiIiKiZsOkrQdzDo8AAJU2FYFmnrGcyFuJwChU9HzC3d1oPGMAytInofK6OxCy81mYLvyIkC8nwe+XDSjt+woU589khQr/AysR/O0MSEoVVL9QlGbORtV1g5ulW2pwe1RddyeqrrsTACBVFsF0dg+MsoryDn8GTNd40rJGEH6hsEXfCFv0jbUWCEhVxfYEbuk5+xi+Zeccw0DY5w2XzkCuughz7pdahbaABKV1PGztesLWrieq2/WEEtaF1bhE1OIMBb8AAJTW17m5J0RERES+i0lbD+ZnlCEBELCPa8ukLRF5CiUyEcV3f4KAAysQtHsOzOe+Q/iaASjv9SQqLXcj5IvnYD5tTzZaO2biUr/XoAa3b7H+Cf9wWLv8BTAbAE/7WZIkQfiHQ/EPb7jyV7HZh1k4/wNM53+A6fe9MJTk2iuIC48g4NBqAPZqXFvbNCjhXQHI2v3X95iOCXulsn8E1OB2juEZ2kENagsY/Jp8U1uUEDBc/BXmUztgPrUTpnPfAYoVkAz2xLYkQWjTLhfIELIMYQqCEn4dqltboEQ4TvoX1hUwmN29ZUQex1lpq4QzaUtERETUXDimLTx3TFsA+PMb36DMqmD6XxPw524R8DcxcetpOFaNb2E8r55ccgbB/3kefqd26NqF0R+lfV5EZdLDV34itSbmS/GUyi7A9PtemM7/AOP5vTBd2A9JqWqy+7ePsdsOalA7qI6TpdnH2e0AJbwL1KD2boujU514VlfA/NsuLVFb39jGjSFkI5TQOHsit3U8qiMsUFpboIR2tieDbeWQK4sgVxVDqiyGXFlkr6KuLHZcF0GqLAZENWzR6bB27m+vRnfH8ygEYCuHVF3ewAr1J/uFX1izDeXCMW2bRksfx0qVRQjb+AAEJBQPWeeWXzJQ0/Glz8k/MsbRdzCWvoOx9A3uHtOWSVt4dtJ26LI9OFNsP8u8UZbQvX0IenUKQ69OYUhq1wpmI38W6258M/YtjOc1EgJ+xz5B8FcvQa7Ih61NCi71z64ZLsFNfDqeihXG/EMwnf8Bcvnv9jYhYP99hnPahXNeKJAr8iGXnYeh9DzksvNXlPxVTUFQwrvZL2HdUN3afq2EdgYMpvpv5BgKwnDxFAwlpyGX2K8NJbkwlORCqsiHCIh0JIej7SdhC3Fc13OiPLPZgOq841qS1vzbt7q+C9kEW/v/gzW2L6ydMiH8WwNCsW+7UAGhQBKqbh6OebmyEMbCIzAU/qJdy9b6jw+EbAYgIKm2yz5vtSmtYlHV+VZYO/eHLbp34yqcbRUwlJyEXF4AubIQUmUh5IpC+7TjWq5wtFcWXVOSX8gmKK06QmkVCzU0FkqrWCjadSfAeO0JOyZtm0ZLH8caz+5ByDdToYR0RMnAxS362NT0fPpz8g+EcfQdjKXvYCx9A5O2AN577z0sW7YMeXl5SEhIwOTJk5GcnNzg+lu3bkV2djZ+++03dO7cGePHj0dmZqa2XAiB+fPn44MPPkBJSQnS0tIwdepUdO7cud778+Sk7YGzJVifcw7f5xbj90v6f7b8jDJSolvZk7gdw3B9uxAYZZ6srKXxzdi3MJ6NI1UWw3hhP2wdbmo4kdeCGM8rUHuM3bJzkB3JXEPZOcglp2G4eAqSqP95tFejdoYS1tWepFdsMJQ4k7S5kG2ljeueMUBL6hpKz8JQfEK3XAluD2unfrDG9oUtJgPCHNyox6t5YGEfa7jgCIxaItc+LVVX1Kwmm6H6h0P4h0H1C7Nf+4dB+IVp7VJ1Jcy5X8B05ltIqlW7rWoKgq3jLajq3B/W2H4QgVH1dkWqughD0TEYC4/CUGS/GIuOQS45DQlXfxgnHFW113Lb2pSgtlBadYYaGgtbmxRUJv79il/7TNo2jZY+jvU/+C4CDq1GVae+KO/9bIs+NjU9fk76BsbRdzCWvoOx9A1/+KTtli1bMGHCBEybNg0pKSlYuXIltm3bhm3btiEiIqLO+nv37sWDDz6IsWPHom/fvti4cSOWLl2K9evXIz7efgbbJUuWYMmSJZg9ezZiYmKQnZ2NX375BVu2bIGfX92KFk9O2joJIfDbxUp8n1uMH04X4/vcYhSW6yt8gswG9OgQinat/GA2yDAbZfg5rs1GGWaDBLNBhp9R1pabDFJN8ZX2BxAQ2r9yQmjNMEiAySDDKEswGmSYZEmbNxnqtkkSIEkSJNgLpezXvpVY5puxb2E8fQvj2UQUq71atugojEXH7YnD4uMwFB2DbCu7/M0D20IN7QQlpCOUVp2gtOoENbQT1IAoe9Vv6VnIpWftJ2O75HJitoqCOvclZCNs7f+kJWqV1paWHW5AqJAvnQUkGap/mL3S9Eof31oG85mvYT61HeaTn8NQfkG32NamB6yd+0P1D4ex6CgMRcdgKDwKg7OSuh6qXxjUoLb2BHFAa6j+raEGRED4hzumW0P4t9amr6q/qmJP5pecguHiScf1KcgXT8FQcqreSuTioevqnnyvAUzaNo2WPo4N+noqzOf2oLzHY9rJH8l78XPSNzCOvoOx9B2MpW/4wydt7733XnTv3h1TpkwBAKiqiszMTDz00EMYPXp0nfWffvppVFRUYPHimp9j3XfffUhISEBWVhaEELj55psxYsQIjBw5EgBw6dIl9OnTB7Nnz8agQYPq3Kc3JG1rE0Lg18Jy/De3GP89fRE/nC5GSWV1E/aweUkAZEcm15nQlSUJsuPaINvbDbKka5dlCQaXaaNjucHRbnCdlyUYHNOypE8+C6FPSgOORHWtV4M90Sxp0679dyajZVmCqtbcsPYLqvZLTMDZF/vjuU6rjg7VrANtu4yyrNsuo8E+bXTdXtnluXIkzBuel3QjGDb0P7wzyV47TpLrNezt2nLZ5XltYFudP+IWQui+OKh5uoTL7fXPrfM51e5HCP20tp5+22SX/c3Zf327BJNRhqKo2pcM2j4Kl/1BqpnX9bHWvuTyQ/U6cXXts+qyPa7TkgQYnV+SOC8G+75g0qbt884vSa6UIgRsioBNUWFVBKoVFVbdtH2Z/SIgSYBJlmse0/EFjbHWFzcGxzoGx3Pl3Cca3Hecr00hoGjXQnsuVBVQ4bgWAqpwib/z+XWdd3l+AcBolAFV1Lx/1H6vcL5HONpr3099cWtw33L5kkp22X5nu0a4Trq8d4h6V9G73Ce2pLvSvYe5XjnbJZfbub6v6d7vXO+jTn8ETOXn4FdyAv4Xj8Ov5ARUgx+swTGoCu6IqqAYWINiIIz+um2svRmujym57jtKFUxl52CuOA9T2TlIAa1QHPF/UM0h9n3B5b1F1cVKaK8h3X4I6PZJe6xqpu2vR/0+prq+R9XaD2q/P9buv2ssXLfb3mcF/gWHEPrbDoT+thOBhT/V/xw7WAPboqpVN1SFdUNlaFdUhXZDVWhXqAGR//N2tV3LYV99X75KEDBUFcF8KRfmS7kwXToFo8EIa89/stK2hbX0cWzoJw9AripCSd/XGj6ZInkNJhV8A+PoOxhL38FY+gZ3J22NzfLIV8hqteLgwYN47LHHtDZZltGnTx/s27ev3tvs378fjzzyiK4tIyMD27dvBwCcOXMGeXl56NOnj7Y8JCQEKSkp2LdvX71JW28kSRK6RAShS0QQ7kvtAFUIHL1Qhn2/XURJpQ1V1c5kjIqqahXWamdCxj7tuvx/JSadj+WcV4RAtSJgU1XHtT3BU60KLblzJf8OCgCKPkOHy2cjiIjIM5kBXO+4uCpyXBpLBtDBMX24Ce7Pk6QDSEcbFKGvYT/+LO+HCdU4JjrYL2oHHBfRuFQZCBTWvu1xx8Xd2gBogyCzASu72RDb2v1Do1DzkCqLIFUWAbIMJayLu7tDRERE5NPcmrQtKiqCoih1hkGIiIjAiRMn6r1Nfn4+IiMj66yfn58PAMjLy9PaGlrHF8mSBEvbYFjaNtFYfo2gOBK41arQVT9B2CvmnFV1zpyts7JQFTWVdKpaU22nCKFrVx2VeKpqX6Y421R7pZ6iCu321Y5p1VFy5ayYBOpWTeraoK+8baiKEgAMBntlZn0aKnyUHeVKdarxoK8EBezPVbVqvyiuF8c2117mrBJzVqEpteLgnFdcEuau1aC6+ZomXZyc9++sQHPet2ucaj+/zmo25/PiWunqrOKqiYH+GZRqxUhb6qzYdCxoqCLWtbLVWc2s1qp4dT5fkiQ5nqN6qnldnhPXSj57T6U6X3rUX7Xo0mdILpVrdavZBIBqRWhfilS7xNverurifzUkAGajvULWbLAPlWIyyDAZ7EOpGB3XzipaALp+2Gr3q1a7c98QqLVP1rpWhdBV3hq0a311rrNS1lnFCtTen2rtBy7ziqKiWqvUremf8/VS89qpeQ5rx6L2/bq+Pp3VmXX2K+hfL67vB7Wrol0rcevb12vHrj6u34O5VoPif7WjZn/WrVdP25UQ9fS/vi8FXefrrcrX+i102+W8ney4ce33UNeqed1rHzXvV/qq3Jr9UaBu3PXz+vfqhp4z1/67boPrfoNaz5MECaWIxCapPzahv7aCEICQ7ffpV899Oh+roX3iaveh+rg+jus+Xh+zwf6LELJbsmQJ5s6di+HDh+OFF17QLRNCYNSoUfjqq6+wYMEC9O/fX1t29uxZTJ06Fd999x0CAwMxZMgQjBs3DkajWw/bAQDCFGg/QWBUIuCooCciIiKi5uH+oz8PYDIZWnQ4PAAwGg0t+4At7NrPJe19jEYDqqv5swdfwXj6FsbTtzCensX1C0IhaoYduVK+fCyUk5ODNWvWwGKx1Lt85cqV9Y7xrygKHnvsMURGRmLNmjW4cOECJk6cCJPJhLFjxzZ3ty/P4IeSgW/D7GcE+JNPIiIiombl1qRteHg4DAYDCgr0JxopKCioU03rFBkZWadi1nX9qKgora1Nmza6dRISEuq9T5vNPQedHN/EdzCWvoXx9C2Mp29hPD1XtXL1wxz5YjzLysrw7LPPYsaMGVi4cGGd5YcPH8by5cvx4YcfIiMjQ7fs66+/xrFjx7BixQpERkbi+uuvx7/+9S+89tpreOKJJ2A2m1tqMxrW0pUORERERH9Qsjsf3Gw244YbbsCuXbu0NlVVsWvXLqSmptZ7mx49emD37t26tm+//RY9evQAAMTExCAqKkp3n6Wlpfjxxx8bvE8iIiIioqaQlZWFzMxM3fkVnCoqKjBu3DhMmTJFKzRwtX//fsTHx+uKFzIyMlBaWopjx441a7+JiIiIyLO4fXiEESNGYOLEiUhKSkJycjJWrlyJiooK3HXXXQCACRMmoG3bthg3bhwAYPjw4XjooYewfPlyZGZmYsuWLfjpp5+QlZUFwD5e3PDhw7Fw4ULExsYiJiYG2dnZaNOmjW68MCIiIiKiprR582YcOnQI69atq3f5rFmzkJqa2uAxaX3nbnDOO8/bUBuH+aLGYCx9A+PoOxhL38FY+gZ3x9HtSdu//vWvKCwsxPz585GXl4frr78eS5cu1Q5Qz507B1muKQhOS0vDa6+9hnnz5uH1119H586dsWDBAsTHx2vrjBo1ChUVFZgyZQpKSkrQs2dPLF26FH5+fnUen4iIiIiosc6dO4eZM2di+fLl9R5zfv7559i9ezc2bNjQpI/LYb6osRhL38A4+g7G0ncwlr7BnXGUhLia80L7pry8Sy3+mGazgS9gH8FY+hbG07cwnr6F8fQtTRHPqKiQJupN423fvh1jxoyBwVBTkaEoCiRJgizLGDZsGN577z1dMYKiKJBlGb169cKqVauQnZ2NHTt24OOPP9bWOX36NPr3748NGzYgMTGxzuPyOJYag7H0DYyj72AsfQdj6RuaM45Xchzr9kpbIiIiIiJvd+ONN2Ljxo26tueeew5dunTBqFGjEB4ejvvvv1+3fPDgwXjuuefQt29fAPZzNyxatAgFBQWIiIgAYD93Q3BwMLp169YyG0JEREREHoFJWyIiIiKiRgoODtYN1wUAgYGBCAsL09rrO/lYdHQ0OnbsCMB+0rFu3bphwoQJePbZZ5GXl4d58+bhgQcegNlsbv6NICIiIiKPIV9+FSIiIiIiam4GgwGLFi2CLMu4//778eyzz2LIkCF46qmn3N01IiIiImphHNMWHAuMGoex9C2Mp29hPH0L4+lbfG1MW3fhcSw1BmPpGxhH38FY+g7G0je4e0xbVtoSEREREREREREReRAmbYmIiIiIiIiIiIg8CJO2RERERERERERERB6ESVsiIiIiIiIiIiIiD8KkLREREREREREREZEHYdKWiIiIiIiIiIiIyIMwaUtERERERERERETkQZi0JSIiIiIiIiIiIvIgkhBCuLsTRERERERERERERGTHSlsiIiIiIiIiIiIiD8KkLREREREREREREZEHYdKWiIiIiIiIiIiIyIMwaUtERERERERERETkQZi0bWHvvfce+vXrh+7du+Pee+9FTk6Ou7tEV+D777/H448/joyMDFgsFmzfvl23XAiB7OxsZGRkIDk5GY888ghOnjzpns7SZS1evBh33303UlNTkZ6ejn/+8584ceKEbp2qqipMmzYNvXv3RmpqKp588knk5+e7qcfUkNWrV2Pw4MFIS0tDWloa7r//fnz55ZfacsbRuy1ZsgQWiwUzZ87U2hhT7/HGG2/AYrHoLgMHDtSWM5beh8ex3ofHPL6Jn4/e7ffff8f48ePRu3dvJCcnY/DgwThw4IC2nP9begdFUTBv3jz069cPycnJ6N+/PxYsWAAhhLYOY+mZmiK/U1xcjHHjxiEtLQ29evXC888/j7KysibvK5O2LWjLli2YNWsWxowZgw0bNiAhIQEjR45EQUGBu7tGl1FeXg6LxYKXXnqp3uVvv/02Vq1ahalTp2Lt2rUICAjAyJEjUVVV1cI9pSuxZ88ePPDAA1i7di1WrFiB6upqjBw5EuXl5do6L7/8Mnbu3Il58+Zh1apVuHDhAp544gk39prq065dO4wfPx7r16/Hhx9+iBtvvBFjxozB0aNHATCO3iwnJwdr1qyBxWLRtTOm3uW6667D119/rV1Wr16tLWMsvQuPY70Tj3l8Dz8fvdvFixcxbNgwmEwmvP3229i8eTMmTpyI0NBQbR3+b+kd3n77bbz//vuYMmUKtmzZgvHjx2Pp0qVYtWqVbh3G0vM0RX5n/PjxOHbsGFasWIFFixbhv//9L6ZMmdL0nRXUYu655x4xbdo0bV5RFJGRkSEWL17sxl7R1YqPjxefffaZNq+qqrjpppvE0qVLtbaSkhKRlJQkNm3a5I4u0lUqKCgQ8fHxYs+ePUIIe/xuuOEGsXXrVm2dY8eOifj4eLFv3z439ZKu1J/+9Cexdu1axtGLlZaWigEDBohvvvlGPPjgg2LGjBlCCL42vc38+fPFHXfcUe8yxtL78DjWN/CYx7vx89H7vfrqq2LYsGENLuf/lt5j9OjR4rnnntO1PfHEE2LcuHFCCMbSW1xLfsf5/pqTk6Ot8+WXXwqLxSLOnz/fpP1jpW0LsVqtOHjwIPr06aO1ybKMPn36YN++fW7sGTXWmTNnkJeXp4ttSEgIUlJSGFsvcenSJQDQvuH+6aefYLPZdDHt2rUroqOjsX//fnd0ka6AoijYvHkzysvLkZqayjh6saysLGRmZupiB/C16Y1OnTqFjIwM3HrrrRg3bhzOnj0LgLH0NjyO9R085vFu/Hz0fjt27EBSUhKeeuoppKenY8iQIVi7dq22nP9beo/U1FTs3r0bv/76KwDg559/xg8//IBbbrkFAGPpra4kbvv27UOrVq3QvXt3bZ0+ffpAluUmHzrK2KT3Rg0qKiqCoiiIiIjQtUdERNQZV4q8S15eHgDUG1uOI+X5VFXFyy+/jLS0NMTHxwMA8vPzYTKZ0KpVK926ERERWrzJcxw5cgR/+9vfUFVVhcDAQCxYsADdunXD4cOHGUcvtHnzZhw6dAjr1q2rs4yvTe+SnJyMWbNmIS4uDnl5eViwYAEeeOABbNy4kbH0MjyO9Q085vFu/Hz0DadPn8b777+PESNG4PHHH8eBAwcwY8YMmEwmDB06lP9bepHRo0ejtLQUt912GwwGAxRFwTPPPIM77rgDAPME3upK4pafn4/WrVvrlhuNRoSGhjb5ey6TtkT0hzZt2jQcPXpUN84ieZe4uDh89NFHuHTpEj799FNMnDgR7777rru7Rdfg3LlzmDlzJpYvXw4/Pz93d4caKTMzU5tOSEhASkoK+vbti61bt8Lf39+NPSP6Y+Ixj/fi56PvEEIgKSkJY8eOBQAkJibi6NGjWLNmDYYOHerm3tHV2Lp1KzZu3Ii5c+dqBSOzZs1CmzZtGEtqMhweoYWEh4fDYDDUOVlDQUEBIiMj3dQragpRUVEAwNh6oaysLHzxxRdYuXIl2rVrp7VHRkbCZrOhpKREt35BQYEWb/IcZrMZsbGxSEpKwrhx45CQkIB33nmHcfRCBw8eREFBAe666y4kJiYiMTERe/bswapVq5CYmMiYerlWrVqhc+fOyM3NZSy9DI9jvR+PebwbPx99R1RUFLp27apr69KlizZ8EP+39B5z5szB6NGjMWjQIFgsFgwZMgQPP/wwFi9eDICx9FZXErfIyEgUFhbqlldXV+PixYtN/p7LpG0LMZvNuOGGG7Br1y6tTVVV7Nq1C6mpqW7sGTVWTEwMoqKidLEtLS3Fjz/+yNh6KCEEsrKy8Nlnn2HlypXo2LGjbnlSUhJMJpMupidOnMDZs2fRo0ePFu4tXS1VVWG1WhlHL3TjjTdi48aN+Oijj7RLUlISBg8erE0zpt6rrKwMp0+fRlRUFGPpZXgc6714zOMb+PnoO9LS0rQxUJ1OnjyJDh06AOD/lt6ksrISkiTp2gwGA4QQABhLb3UlcUtNTUVJSQl++uknbZ3du3dDVVUkJyc3aX84PEILGjFiBCZOnIikpCQkJydj5cqVqKiowF133eXurtFllJWVITc3V5s/c+YMDh8+jNDQUERHR2P48OFYuHAhYmNjERMTg+zsbLRp0wb9+/d3Y6+pIdOmTcOmTZvw1ltvISgoSBt3JiQkBP7+/ggJCcHdd9+N2bNnIzQ0FMHBwZgxYwZSU1N54Oth5s6di1tuuQXt27dHWVkZNm3ahD179mDZsmWMoxcKDg7Wxll0CgwMRFhYmNbOmHqPV155BX379kV0dDQuXLiAN954A7Is4/bbb+fr0wvxONY78ZjHN/Dz0Xc8/PDDGDZsGBYtWoTbbrsNOTk5WLt2LbKysgAAkiTxf0sv0bdvXyxatAjR0dHa8AgrVqzA3XffDYCx9GSNze907doVN998MyZPnoxp06bBZrNh+vTpGDRoENq2bdukfZWE82sAahHvvvsuli1bhry8PFx//fV48cUXkZKS4u5u0WV89913GD58eJ32oUOHYvbs2RBCYP78+Vi7di1KSkrQs2dPvPTSS4iLi3NDb+lyLBZLve2zZs3S/vmsqqrC7NmzsXnzZlitVmRkZOCll17iT8w8zPPPP4/du3fjwoULCAkJgcViwahRo3DTTTcBYBx9wUMPPYSEhAS88MILABhTb/LMM8/g+++/R3FxMVq3bo2ePXvimWeeQadOnQAwlt6Ix7Heh8c8voufj95r586deP3113Hy5EnExMRgxIgRuO+++7Tl/N/SO5SWliI7Oxvbt29HQUEB2rRpg0GDBmHMmDEwm80AGEtP1RT5neLiYkyfPh07duyALMsYMGAAXnzxRQQFBTVpX5m0JSIiIiIiIiIiIvIgHNOWiIiIiIiIiIiIyIMwaUtERERERERERETkQZi0JSIiIiIiIiIiIvIgTNoSEREREREREREReRAmbYmIiIiIiIiIiIg8CJO2RERERERERERERB6ESVsiIiIiIiIiIiIiD8KkLREREREREREREZEHYdKWiIjqsFgs2L59u7u7QURERERERPSHZHR3B4iISG/SpEnYsGFDnfaMjAwsW7bMDT0iIiIiImq8SZMmoaSkBG+99Za7u0JE5PGYtCUi8kA333wzZs2apWszm81u6g0RERERkeezWq08ZiYin8HhEYiIPJDZbEZUVJTuEhoaCsA+dMHq1avx6KOPIjk5Gbfeeiu2bdumu/2RI0cwfPhwJCcno3fv3pg8eTLKysp066xbtw6DBg1CUlISMjIykJWVpVteVFSEMWPGICUlBQMGDMDnn3/evBtNRERERH8YVqsVM2bMQHp6Orp3745hw4YhJydHW75+/Xr06tVLd5vt27fDYrFo82+88QbuvPNOfPDBB+jXrx+Sk5NbrP9ERM2NSVsiIi+UnZ2Nv/zlL/j4448xePBgjB07FsePHwcAlJeXY+TIkQgNDcW6deswb948fPvtt5g+fbp2+9WrVyMrKwv33XcfNm7ciLfeegudOnXSPcabb76J2267DZ988gluueUWjB8/HsXFxS25mURERETko+bMmYNPP/0Us2fPxoYNGxAbG4tHH330qo83c3Nz8emnn+LNN9/ERx991Cx9JSJyByZtiYg80BdffIHU1FTdZdGiRdrygQMH4t5770VcXByefvppJCUlYdWqVQCATZs2wWq14pVXXkF8fDzS09MxZcoUfPzxx8jPzwcALFy4ECNGjMDDDz+MuLg4JCcn45FHHtH1YejQobj99tsRGxuLsWPHory8XFf9QERERER0LcrLy7FmzRpMmDABmZmZ6NatG6ZPnw4/Pz+sW7fuqu7LZrNhzpw5SExMREJCQjP1mIio5XFMWyIiD9S7d29MnTpV1+YcHgEAUlNTdct69OiBw4cPAwCOHz8Oi8WCwMBAbXlaWhpUVcWvv/4KSZJw4cIFpKen/88+uP70LDAwEMHBwSgsLLzWTSIiIiIiAmCvjrXZbEhLS9PaTCYTkpOTtV+PXano6Gi0bt26qbtIROR2TNoSEXmggIAAxMbGNst9+/n5XdF6JpNJNy9JElRVbY4uERERERHpyLIMIYSuzWaz1VkvICCgpbpERNSiODwCEZEX2r9/v27+xx9/RNeuXQEAXbt2xZEjR1BeXq4t37t3L2RZRlxcHIKDg9GhQwfs2rWrJbtMRERERAQA6NSpE0wmE/bu3au12Ww2HDhwAN26dQMAhIeHo6ysTHdM+/PPP7d4X4mI3IVJWyIiD2S1WpGXl6e7uA5NsG3bNqxbtw6//vor5s+fj5ycHDz44IMAgMGDB8NsNmPSpEn45ZdfsHv3bkyfPh133nknIiMjAQBPPvkkVqxYgXfeeQcnT57EwYMHtTFxiYiIiIiaU2BgIIYNG4Y5c+bgP//5D44dO4bJkyejsrIS99xzDwAgJSUFAQEBeP3115Gbm4uNGzdi/fr1bu45EVHL4fAIREQe6KuvvkJGRoauLS4uDtu2bQNgT7pu2bIF06ZNQ1RUFObOnatVJQQEBGDZsmWYOXMm7rnnHgQEBGDAgAGYNGmSdl9Dhw5FVVUV/v3vf2POnDkICwvDwIEDW24DiYiIiOgPR1VVGI32NMT48eMhhMCECRNQVlaGpKQkLF26VDuPQ1hYGF599VXMmTMHH3zwAdLT0/Hkk09i8uTJ7twEIqIWI4nag8QQEZFHs1gsWLBgAfr37+/urhARERERXbGRI0ciNjYWU6ZMcXdXiIg8HodHICIiIiIiIqJmc/HiRezcuRN79uxBnz593N0dIiKvwOERiIiIiIiIiKjZPP/88zhw4AD+8Y9/4NZbb3V3d4iIvAKHRyAiIiIiIiIiIiLyIBwegYiIiIiIiIiIiMiDMGlLRERERERERERE5EGYtCUiIiIiIiIiIiLyIEzaEhEREREREREREXkQJm2JiIiIiIiIiIiIPAiTtkREREREREREREQehElbIiIiIiIiIiIiIg/CpC0RERERERERERGRB2HSloiIiIiIiIiIiMiD/D/6+dZrp0HdXwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1400x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -708,12 +616,11 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.savefig('lstm_results.png', dpi=150, bbox_inches='tight')\n",
-    "plt.show()\n",
+    "plt.close(fig)\n",
     "print(\"Graphique sauvegardé.\")"
    ]
   },
   {
-   "cell_id": "cell-19",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -723,17 +630,9 @@
    ]
   },
   {
-   "cell_id": "cell-20",
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:13:03.825603Z",
-     "iopub.status.busy": "2026-07-28T23:13:03.825365Z",
-     "iopub.status.idle": "2026-07-28T23:13:03.838162Z",
-     "shell.execute_reply": "2026-07-28T23:13:03.836869Z"
-    }
-   },
+   "execution_count": 23,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -746,7 +645,7 @@
       "  Max DD: -1.7%\n",
       "\n",
       "Buy & Hold SPY (Test set):\n",
-      "  CAGR:   21.9%\n"
+      "  CAGR:   23.5%\n"
      ]
     }
    ],
@@ -815,7 +714,6 @@
    ]
   },
   {
-   "cell_id": "cell-21",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -823,35 +721,37 @@
    ]
   },
   {
-   "cell_id": "cell-22",
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-28T23:13:03.840022Z",
-     "iopub.status.busy": "2026-07-28T23:13:03.839843Z",
-     "iopub.status.idle": "2026-07-28T23:13:03.909975Z",
-     "shell.execute_reply": "2026-07-28T23:13:03.908521Z"
-    }
-   },
+   "execution_count": 24,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Modèle sauvegardé dans ObjectStore: lstm_spy_model\n",
+      "  - seed: 42\n",
+      "  - data_sha256: 897a5cb445127e6b1af3b69799235cd56da745fb45c4ddac624d37041d732f49\n",
+      "  - model_sha256: 38e8b5e2e529219ee25c50e1b5b206389afe9f656f83606574a8f41e1822ad2a\n",
       "  - hidden_size: 50\n",
       "  - num_layers: 2\n",
       "  - seq_length: 20\n",
-      "  - scaler range: [165.46, 477.71]\n",
-      "  - direction accuracy: 53.1%\n",
-      "  - MAE: $6.88\n"
+      "  - scaler range: [154.29, 449.49]\n",
+      "  - direction accuracy: 53.3%\n",
+      "  - MAE: $10.15\n"
      ]
     }
    ],
    "source": [
     "# Sauvegarder le modèle\n",
     "MODEL_KEY = \"lstm_spy_model\"\n",
+    "\n",
+    "# Empreinte stable des paramètres entraînés pour comparer deux exécutions.\n",
+    "model_hasher = hashlib.sha256()\n",
+    "for name, tensor in sorted(model.state_dict().items()):\n",
+    "    model_hasher.update(name.encode(\"utf-8\"))\n",
+    "    model_hasher.update(tensor.detach().cpu().contiguous().numpy().tobytes())\n",
+    "model_sha256 = model_hasher.hexdigest()\n",
     "\n",
     "# Créer le checkpoint\n",
     "checkpoint = {\n",
@@ -862,7 +762,10 @@
     "    'scaler_min': float(scaler_min),\n",
     "    'scaler_max': float(scaler_max),\n",
     "    'direction_accuracy': float(direction_accuracy),\n",
-    "    'mae': float(mae)\n",
+    "    'mae': float(mae),\n",
+    "    'seed': SEED,\n",
+    "    'data_sha256': data_sha256,\n",
+    "    'model_sha256': model_sha256,\n",
     "}\n",
     "\n",
     "# Sauvegarder dans ObjectStore\n",
@@ -871,6 +774,9 @@
     "qb.object_store.save_bytes(MODEL_KEY, buffer.getvalue())\n",
     "\n",
     "print(f\"Modèle sauvegardé dans ObjectStore: {MODEL_KEY}\")\n",
+    "print(f\"  - seed: {checkpoint['seed']}\")\n",
+    "print(f\"  - data_sha256: {checkpoint['data_sha256']}\")\n",
+    "print(f\"  - model_sha256: {checkpoint['model_sha256']}\")\n",
     "print(f\"  - hidden_size: {checkpoint['hidden_size']}\")\n",
     "print(f\"  - num_layers: {checkpoint['num_layers']}\")\n",
     "print(f\"  - seq_length: {checkpoint['seq_length']}\")\n",
@@ -880,7 +786,6 @@
    ]
   },
   {
-   "cell_id": "cell-23",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -912,7 +817,7 @@
  "metadata": {
   "cost": {
    "api_provider": "none",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 60,
    "external_account": "quantconnect-organization",
    "free_alternative": null,
@@ -927,7 +832,7 @@
    "vram_tier": "T4-or-better"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Foundation-Py-Default",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -631,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -722,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2025:CoursIA — prev: MED/qc #15098

## Résumé

- initialise explicitement les RNG Python, NumPy et PyTorch avec `SEED = 42`, active les algorithmes PyTorch déterministes et configure cuBLAS avant l'import de Torch ;
- fournit au `DataLoader(shuffle=True)` son propre `torch.Generator` seedé, afin que l'ordre des minibatches ne dépende plus du RNG global ;
- enregistre une empreinte des données et une empreinte byte-level des paramètres entraînés dans le checkpoint ObjectStore ;
- remplace l'affichage distant temporaire de la figure par `plt.close(fig)` après `savefig`, puis conserve les sorties d'une nouvelle exécution QC Cloud complète.

See #9768

## Diagnostic dérive

- **Cause : (e) stochasticité non-seedée.** Le notebook publiait les métriques d'un entraînement gouverné par l'initialisation PyTorch et un `DataLoader(shuffle=True)` sans générateur seedé.
- **Verdict : `CAUSE_FIXED`.** Deux exécutions Research consécutives sur `Foundation-Py-Default` ont produit le même dataset, les mêmes pertes aux epochs 10/20/30/40/50, les mêmes métriques finales et la même empreinte byte-level du modèle.
- La variation des prix/scalers par rapport au snapshot historique vient des données QC reprovisionnées ; l'empreinte des données permet désormais de distinguer cette dérive de la stochasticité du modèle.

## Preuve d'exécution Research QC Cloud

Deux `Run All` consécutifs ont reproduit :

- période : 2015-01-02 à 2025-12-31, 2 766 lignes ;
- pertes epoch 50 : train `0.000209`, test `0.001946` ;
- MSE `161.8630`, MAE `$10.15`, MAPE `1.71 %`, direction accuracy `53.3 %` ;
- métriques simplifiées du notebook : Sharpe `0.133`, CAGR `4.0 %`, MaxDD `-1.7 %` ;
- empreintes des données et du modèle identiques entre les deux exécutions QC Cloud.

Ces deux runs consécutifs établissent le déterminisme. Un run supplémentaire, lancé après redémarrage explicite du kernel, a produit le snapshot distant committé et sauvegardé sans édition manuelle des sorties :

- 27 cellules, dont 12 cellules code ;
- compteurs séquentiels `1` à `12` après redémarrage explicite du kernel ;
- 12/12 cellules code avec sorties `stream` ;
- zéro sortie `error`, zéro `display_data`, zéro URL dans les outputs ;
- `plt.close(fig)` présent, `plt.show()` absent.

## Déploiement et backtest QC Cloud

Les métriques ci-dessous viennent du backtest OOS déployé via `main.py` et sont distinctes des métriques simplifiées calculées dans le QuantBook.

- trainers déterministes : `2a66bc62a63f85cb40b6ede81721a9c0` et `2a2b42893f010118540915686e9592f6`, tous deux `Completed`, `progress=1` ;
- backtest OOS après le second trainer : `378ebc0fec97be01e68f4ad897f6a78b`, `Completed`, 554 dates et 2 ordres ;
- validation finale après sauvegarde du notebook : compile `2898f8f1e3d022fd5df56abe0ea55b22-3abe6202acdf773b752218df06f89ae2` (`BuildSuccess`) puis backtest `9e04e5f4ad5b2bc9cf95a6ca5471c44f` (`Completed`, `progress=1`) ;
- Sharpe `-0.444`, CAGR `3.736 %`, MaxDD `2.900 %`, profit net `8.445 %` (`$8,445.15`).

Le backtest final reproduit exactement le backtest OOS initial et celui lancé après le second trainer. Dans le notebook, les métriques de stratégie arrondies restent elles aussi identiques à l'ancien snapshot (`0.133`, `4.0 %`, `-1.7 %`) malgré la variation du Buy & Hold et des métriques d'apprentissage ; la séquence d'exécution et les dépendances croisées sont cohérentes, mais ce maintien à la précision affichée ne constitue pas une preuve d'identité de la série de positions.

## Validation

- `python scripts/notebook_tools/validate_pr_notebooks.py origin/main MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb --json` : PASS, 12 cellules code ;
- `python scripts/notebook_tools/check_exec_ratchet.py origin/main` : PASS, `CLEAN→CLEAN`, zéro régression ;
- `python scripts/notebook_tools/check_output_failure_text.py origin/main --json` : PASS, `TOOL_FAILURE 0→0`, `MACHINE_PATH 0→0` ;
- parsing syntaxique de chacune des 12 cellules : PASS ;
- C.1 : aucun `raise NotImplementedError`, `assert False` ou `1/0` ;
- C.2/H.1/H.3 : exécution complète QC Cloud, compteurs non nuls et séquentiels, sorties réelles, zéro erreur ;
- scan de contenu : aucune URL pré-signée, aucun marqueur de signature temporaire, aucun chemin machine ;
- `git diff --check` : PASS ; diff limité au QuantBook attendu.

## Hors périmètre observé

La mention markdown préexistante de `BTCUSD` et la table finale `(à remplir)` ne sont pas modifiées dans ce grain de déterminisme. Les corriger exigerait un sous-grain pédagogique séparé et une nouvelle exécution complète ; aucune valeur n'a été recopiée manuellement dans la prose.

## Verdict SOTA

`SOTA-OK` — le vrai QuantBook a été exécuté sur QC Cloud, puis le projet a été compilé et backtesté avec les outils QuantConnect réels. Aucun substitut local ni output fabriqué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
