### PR TITLE
tooling(#15022): mermaid fill-without-color detector + advisory workflow (mechanical guard for #15502)

### DIFF
--- a/.github/workflows/mermaid-fill-color-advisory.yml
+++ b/.github/workflows/mermaid-fill-color-advisory.yml
@@ -124,19 +124,10 @@ jobs:
 
           # Aggregate findings across the diff: a single fill-without-color
           # rule in ANY modified file flags the PR. Unmeasured = JSON
-          # unparseable (script died or produced nothing).
-          FINDINGS=$(python -c "
-import json, sys
-findings = -1
-unmeasured = 0
-try:
-    payload = json.load(open('payload.json'))
-    findings = payload.get('total_hits', -1)
-    unmeasured = payload.get('error_count', 0)
-except Exception:
-    unmeasured = 1
-print(f'{findings} {unmeasured}')
-")
+          # unparseable (script died or produced nothing) -> FIND stays -1,
+          # caught by the guard below (one-liner python -c : un bloc python
+          # multi-lignes en colonne 0 terminerait le scalaire litteral YAML).
+          FINDINGS=$(python -c "import json; d = json.load(open('payload.json')); print(d.get('total_hits', -1), d.get('error_count', 0))" 2>/dev/null || echo "-1 1")
           FIND=$(echo "$FINDINGS" | awk '{print $1}')
           UNM=$(echo "$FINDINGS" | awk '{print $2}')
           echo "fill-without-color rules across modified files: $FIND"

--- a/.github/workflows/mermaid-fill-color-advisory.yml
+++ b/.github/workflows/mermaid-fill-color-advisory.yml
@@ -1,0 +1,191 @@
+name: Mermaid Fill Color Advisory
+
+# Organ for the "mermaid fill: without color:" convention (issue #15022 founding
+# incident -- user reported light-on-light labels in dark theme; fix PR #15502
+# verified the rule BY HAND, review NanoClaw asked for a mechanical guard so
+# the class cannot return on the 25 corpus files that still carry it).
+#
+# ADVISORY, never blocking (same posture decision as
+# paragraph-length-advisory.yml #15513 and consecutive-code-cells-advisory.yml
+# #12797): the job ALWAYS exits 0. The actionable payload is the
+# `mermaid-fill-color` LABEL, never the green conclusion of the job. Promoting
+# to a blocking gate is a separate decision, to revisit only once the residual
+# corpus (25 files / 90 rules measured on main 2026-09-11, follow-up issue in
+# the PR body) is swept and stable.
+#
+# Per-PR scope: runs detect_mermaid_fill_without_color.py ONLY on the *.md and
+# *.ipynb modified by the PR (3-point diff merge-base...HEAD), NOT a repo-wide
+# scan on every push -- the residual is pre-existing on main, a per-PR scan
+# would flag every PR touching an already-defective file (#8829 posture).
+#
+# Self-cover (#8822): a paths-filtered label-poser must list its own file,
+# else it cannot re-run (so cannot remove its own label) once the matching
+# paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
+#
+# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
+# benevolent review applies, no internal content criterion runs against them.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '**/*.ipynb'
+      # Self-cover (#8822) -- the script, its tests + fixture, and the
+      # workflow itself.
+      - 'scripts/notebook_tools/detect_mermaid_fill_without_color.py'
+      - 'scripts/notebook_tools/tests/test_detect_mermaid_fill_without_color.py'
+      - 'scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color.md'
+      - '.github/workflows/mermaid-fill-color-advisory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: mermaid-fill-color-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mermaid-fill-color-advisory:
+    name: "Mermaid fill-without-color advisory (label, non-blocking)"
+    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
+    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
+    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
+    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
+    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
+    # under student-pr-reviews.md -- benevolent review, no content gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Need base..head history for `git diff` of changed files.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Self-test detector (proves it can fire)
+        # A detector that cannot be shown firing is indistinguishable from a
+        # disconnected one (lecon #11685). Run --self-test FIRST so a broken
+        # install is loud before any measurement happens.
+        run: |
+          python scripts/notebook_tools/detect_mermaid_fill_without_color.py --self-test
+
+      - name: Advisory check on modified .md / .ipynb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Without a git context GH_REPO, `gh pr edit` / `gh label create`
+          # cannot infer the target repo and fail silently (variation-tag-guard
+          # documented this trap firsthand after #8765).
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          LABEL_FINDING: mermaid-fill-color
+          LABEL_UNMEASURED: mermaid-fill-color-unmeasured
+        run: |
+          set -uo pipefail
+
+          # Added/modified .md + .ipynb in the PR (deletions excluded -- a
+          # deleted file has nothing to measure). 3-point diff (#10403) :
+          # merge-base...HEAD -- strictly this PR's apport.
+          git diff --name-only --diff-filter=d "$BASE...$HEAD" -- '*.md' '*.ipynb' \
+            | grep -v $'\r$' > changed_files.txt || true
+          COUNT=$(wc -l < changed_files.txt | tr -d ' ')
+          echo "Modified .md / .ipynb in this PR: $COUNT"
+
+          # Helper: ensure a label exists (idempotent), then add/remove it.
+          ensure_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No modified files to check."
+            unset_label "$LABEL_FINDING"; unset_label "$LABEL_UNMEASURED"
+            exit 0
+          fi
+
+          # Advisory: ALWAYS exit 0. The job never fails; the actionable signal
+          # is the pair of LABELS decided from the JSON payload below.
+          python scripts/notebook_tools/detect_mermaid_fill_without_color.py \
+            --json --stdin --root . < changed_files.txt > payload.json
+          cat payload.json
+
+          # Aggregate findings across the diff: a single fill-without-color
+          # rule in ANY modified file flags the PR. Unmeasured = JSON
+          # unparseable (script died or produced nothing).
+          FINDINGS=$(python -c "
+import json, sys
+findings = -1
+unmeasured = 0
+try:
+    payload = json.load(open('payload.json'))
+    findings = payload.get('total_hits', -1)
+    unmeasured = payload.get('error_count', 0)
+except Exception:
+    unmeasured = 1
+print(f'{findings} {unmeasured}')
+")
+          FIND=$(echo "$FINDINGS" | awk '{print $1}')
+          UNM=$(echo "$FINDINGS" | awk '{print $2}')
+          echo "fill-without-color rules across modified files: $FIND"
+          echo "Unmeasured (parse errors / illisibles): $UNM"
+
+          # Issue #8819 applied: TWO distinct labels. "Could not measure" and
+          # "measured, carries the defect" call for different reactions, so
+          # they never collapse into one. Each label is raised when its count
+          # is > 0 and cleared otherwise (a stale label from an earlier push
+          # must not stick).
+          ensure_label "$LABEL_FINDING" \
+            "A modified .md or .ipynb carries a mermaid style/classDef rule with fill: but no color: -- light-on-light label risk in dark theme (#15022 founding incident, #15502 fix + guard)" "E99695"
+          ensure_label "$LABEL_UNMEASURED" \
+            "A modified .md or .ipynb could not be measured by the mermaid fill-color detector -- NOT verified (#8819)" "BFD4F2"
+
+          # The #8819 guard: if the detector died, FIND/UNM are not integers
+          # (FIND defaults to -1 on unreadable payload). With only `set -uo
+          # pipefail` (no -e), each comparison falls into the wrong branch if
+          # unchecked. NOT measured => NOT verified: pose the unmeasured label
+          # and a loud ::error::, never a green claim.
+          if ! [ "${FIND:-}" -eq "${FIND:-}" ] 2>/dev/null \
+             || ! [ "${UNM:-}" -eq "${UNM:-}" ] 2>/dev/null \
+             || [ "${FIND:-}" -lt 0 ] 2>/dev/null; then
+            echo "::error::mermaid fill-color payload illisible (detector produced no usable JSON) -- the advisory measured NOTHING; conformity neither claimed nor denied."
+            set_label "$LABEL_UNMEASURED"
+            exit 0
+          fi
+
+          if [ "$FIND" -gt 0 ]; then
+            echo "::notice::$FIND fill-without-color mermaid rule(s) in modified file(s) (#15022 founding incident). See the '$LABEL_FINDING' label."
+            set_label "$LABEL_FINDING"
+          else
+            unset_label "$LABEL_FINDING"
+          fi
+
+          if [ "$UNM" -gt 0 ]; then
+            echo "::warning::$UNM modified file(s) could not be measured -- NOT verified by the mermaid fill-color advisory (#8819). See the '$LABEL_UNMEASURED' label."
+            set_label "$LABEL_UNMEASURED"
+          else
+            unset_label "$LABEL_UNMEASURED"
+          fi
+
+          # The closing line asserts ONLY what was measured (issue #8819). The
+          # job never claims "all conform" while unmeasured > 0.
+          if [ "$UNM" -gt 0 ]; then
+            echo "RESULT: $UNM file(s) NOT measured -- conformity neither claimed nor denied."
+          elif [ "$FIND" -gt 0 ]; then
+            echo "RESULT: $FIND fill-without-color rule(s) in modified file(s) -- labelled."
+          else
+            echo "RESULT: no modified file carries a fill-without-color mermaid rule (verified)."
+          fi
+          exit 0

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -185,6 +185,7 @@ SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "leaky-fixture-sweep.yml",
     "machine-dep-timing-advisory.yml",
     "machine-dep-timing-inventory.yml",
+    "mermaid-fill-color-advisory.yml",
     "orphan-branch-scan.yml",
     "outputs-text-fragmentation-advisory.yml",
     "pedagogy-density-advisory.yml",

--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -15,7 +15,7 @@ complement. L'inventaire ci-dessous remplace la lecture en aveugle de
 
 | Categorie | Scripts | Role |
 |-----------|---------|------|
-| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_fabricated_outputs.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_link_target_regression.py`, `detect_solution_leaks.py`, `detect_cjk_residue.py`, `detect_paragraph_length.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 (axe-1 texte + **axe-3 link-targets** triade) / #3801 / #4970 / **#6927** (SVG inline rollout) / **#6891 axe-2 fabrication textuelle** (sibling detector) / **#8428** (CJK LLM-translation residue, regression-guard post-fleet-sweep) / **#15405** (paragraphes markdown > 2000 c, wall-of-text guard) |
+| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_fabricated_outputs.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_link_target_regression.py`, `detect_solution_leaks.py`, `detect_cjk_residue.py`, `detect_paragraph_length.py`, `detect_mermaid_fill_without_color.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 (axe-1 texte + **axe-3 link-targets** triade) / #3801 / #4970 / **#6927** (SVG inline rollout) / **#6891 axe-2 fabrication textuelle** (sibling detector) / **#8428** (CJK LLM-translation residue, regression-guard post-fleet-sweep) / **#15405** (paragraphes markdown > 2000 c, wall-of-text guard) / **#15022** (mermaid fill sans color, clair-sur-clair theme sombre) |
 | **Validateurs CI** | `validate_pr_notebooks.py`, `check_c2_compliance.py`, `check_notebook_navlinks.py`, `check_plotly_static_risk.py` | Gates pre-merge, `--check` exit-code CI-ready |
 | **Scanners structurels** | `scan_cell_ordering.py`, `scan_md_hierarchy.py`, `scan_figure_visual_signature.py` | Audit hierarchie markdown + ordre cellules pedagogiques + **signature visuelle des figures PNG (consolidation L777-L1/L778-L1/L2/L779-L1/L2/L780-L1/L2/L3/L781-L1/L2/L3 du rollout MANIFEST c.754-c.781, EPIC #5780)** |
 | **Execution kernels** | `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py`, `batch_reexecute.py`, `wsl_papermill.py` | .NET Interactive + Python Papermill via WSL |
@@ -286,6 +286,30 @@ fichiers pre-existants soit a zero.
 
 **Owner** : partition-mienne pour les PRs docs (relecture fichier-entier
 README series), cluster-manager pour la bascule bloquante.
+### `detect_mermaid_fill_without_color.py` (#15022, PR #15502)
+
+Regression-guard du defect **#15022** (signale par le user) : une regle mermaid
+`style`/`classDef` portant `fill:` sans `color:` force un fond clair en
+laissant le libelle heriter la couleur de texte du theme — clair-sur-clair en
+mode sombre GitHub. Le fix #15502 avait verifie les 10 regles du README Probas
+**a la main** ; ce detecteur mecanise la verification (demande review
+NanoClaw : « le motif peut revenir, sur ce fichier comme sur les 24 autres »).
+Scanne les `.md` trackes + cellules markdown des `.ipynb`, fence `mermaid`
+seulement, commentaires `%%` exclus. Cable en advisory par
+`.github/workflows/mermaid-fill-color-advisory.yml` (labels
+`mermaid-fill-color` / `mermaid-fill-color-unmeasured`, jamais bloquant).
+
+```bash
+python scripts/notebook_tools/detect_mermaid_fill_without_color.py --self-test  # prouve qu'il tire
+python scripts/notebook_tools/detect_mermaid_fill_without_color.py README.md    # un fichier
+python scripts/notebook_tools/detect_mermaid_fill_without_color.py --check      # exit 1 si finding
+```
+
+Baseline fleet (origin/main, 2026-09-11) : **25 fichiers / 90 regles fautives**
+sur 204 regles `fill:` — le README Probas porte exactement les 10 regles du
+fix #15502 (ground truth retrouve). Le residuel pre-existant fait l'objet
+d'une issue de suivi (sweep par familles) ; l'advisory ne flague que les
+fichiers modifies par une PR.
 
 ---
 

--- a/scripts/notebook_tools/detect_mermaid_fill_without_color.py
+++ b/scripts/notebook_tools/detect_mermaid_fill_without_color.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Detecte les regles mermaid `style`/`classDef` portant `fill:` sans `color:` (#15022).
+
+Pourquoi cet outil existe
+-------------------------
+Defect fondateur #15022 (signale par le user, fix PR #15502) : dans un bloc
+mermaid, une regle `style`/`classDef` qui force un `fill:` clair SANS `color:`
+explicite laisse le libelle heriter la couleur de TEXTE du theme. En mode
+sombre GitHub, texte clair du theme sur fond clair force = illisible
+(clair-sur-clair). Le README Probas portait 10 regles dans cet etat sur 3
+blocs ; la verification « 0 regle fill: sans color: » avait ete faite A LA MAIN
+dans #15502 -- rien n'empechait la recidive (review NanoClaw : « le motif peut
+revenir, sur ce fichier comme sur les 24 autres .md du depot »).
+
+Ce detecteur formalise cette verification : une ligne `style <id> ...` ou
+`classDef <name> ...` a l'interieur d'une fence ```mermaid est un FINDING si
+elle porte `fill:` mais pas `color:`. La correction est l'ajout d'un `color:`
+explicite (ton fonce, cf. la garde `%%` posee par #15502 : le ton peut
+deliberement s'ecarter du `stroke` -- ne pas harmoniser aveuglement).
+
+Scope : fichiers `.md` trackes + cellules markdown des `.ipynb` (le defect vit
+dans les README de series ; les notebooks peuvent porter les memes blocs).
+Il DETECTE, il ne CORRIGE PAS.
+
+Mesure fleet sur origin/main (2026-09-11) : **25 fichiers / 90 regles fautives**
+sur 204 regles `fill:` totales (114 avec `color:`). Ground truth : le README
+Probas porte exactement les 10 regles recomptees a la main par la review
+NanoClaw sur #15502 -- le detecteur les retrouve toutes (precision et rappel
+prouves sur ce cas). Le residuel fait l'objet d'une issue de suivi nommee dans
+le body PR (advisory = pas de cascade sur le pre-existant).
+
+Usage
+-----
+    python detect_mermaid_fill_without_color.py                  # fleet (git ls-files *.md + notebooks)
+    python detect_mermaid_fill_without_color.py README.md        # un fichier
+    python detect_mermaid_fill_without_color.py --json           # sortie machine
+    python detect_mermaid_fill_without_color.py --check          # exit 1 si finding (CI-ready)
+    python detect_mermaid_fill_without_color.py --self-test      # prouve que le detecteur tire
+    git diff --name-only ... | python detect_mermaid_fill_without_color.py --stdin --json
+
+Exit codes
+----------
+    0 -- aucun finding (ou mode non --check)
+    1 -- un ou plusieurs findings (--check seulement)
+    2 -- erreur (fichier illisible / introuvable)
+
+Voir aussi
+----------
+- `.github/workflows/mermaid-fill-color-advisory.yml` -- cablage advisory (label)
+- `detect_cjk_residue.py` (#8428), `detect_paragraph_length.py` (#15405) -- pattern detect_*
+- #15022 (defect fondateur), #15502 (fix + garde %%), issue de suivi sweep corpus
+
+See #15022, #15502.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Ouverture de fence code (``` ou ~~~), avec tag de langage optionnel.
+_FENCE_OPEN_RE = re.compile(r"^\s*(`{3,}|~{3,})\s*(\S*)")
+
+# Ligne de regle de style mermaid : `style <id> <props>` ou `classDef <name> <props>`.
+# On ne juge QUE ces deux formes : ce sont les seules qui portent un `fill:` de
+# fond dans la grammaire mermaid (les `class x foo` appliquent, ne definissent pas).
+_STYLE_LINE_RE = re.compile(r"^\s*(style|classDef)\s+\S+\s+\S")
+
+_FILL_RE = re.compile(r"\bfill\s*:")
+_COLOR_RE = re.compile(r"\bcolor\s*:")
+
+# Allowlist : chemins (substring) ou le pattern est un FIXTURE DE TEST positif --
+# le detecteur doit pouvoir prouver qu'il tire sur un cas volontaire.
+ALLOWED: dict[str, str] = {
+    "scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color":
+        "fixture de test positif (pattern volontaire pour piner le contrat)",
+}
+
+
+def classify_mermaid_fill_rules(text: str) -> tuple[list[dict], int, int]:
+    """Return ``(findings, n_style_rules, n_with_color)`` for ``text`` (markdown).
+
+    Un finding = ligne ``style``/``classDef`` d'une fence mermaid portant
+    ``fill:`` sans ``color:``. ``n_style_rules`` compte les regles style/
+    classDef avec ``fill:`` (denominateur), ``n_with_color`` celles qui portent
+    aussi ``color:`` -- la paire documente l'etat du fichier sans finding.
+    """
+    findings: list[dict] = []
+    n_style_rules = 0
+    n_with_color = 0
+    in_fence = False
+    fence_is_mermaid = False
+    fence_marker = ""
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        m = _FENCE_OPEN_RE.match(line)
+        if m:
+            marker, tag = m.group(1), (m.group(2) or "").lower()
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker[0] * 3
+                fence_is_mermaid = tag == "mermaid"
+            elif line.strip().startswith(fence_marker) and not tag:
+                # Fermeture : meme famille de marqueur, pas de tag de langage.
+                in_fence = False
+                fence_is_mermaid = False
+            continue
+        if not (in_fence and fence_is_mermaid):
+            continue
+        if not _STYLE_LINE_RE.match(line):
+            continue
+        stripped = line.strip()
+        if stripped.startswith("%%"):
+            continue  # commentaire mermaid, pas une regle
+        if not _FILL_RE.search(line):
+            continue
+        n_style_rules += 1
+        if _COLOR_RE.search(line):
+            n_with_color += 1
+            continue
+        rule_type = stripped.split()[0]
+        target = stripped.split()[1] if len(stripped.split()) > 1 else "?"
+        findings.append({
+            "lineno": lineno,
+            "rule": rule_type,
+            "target": target,
+            "context": stripped[:90],
+            "reason": "fill: sans color: -- libelle herite la couleur de texte du theme (clair-sur-clair en mode sombre, #15022)",
+        })
+    return findings, n_style_rules, n_with_color
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        return "".join(src)
+    return src or ""
+
+
+def _is_allowed(rel_path: str) -> str | None:
+    for needle, reason in ALLOWED.items():
+        if needle in rel_path:
+            return reason
+    return None
+
+
+def scan_markdown_file(path: Path, root: Path) -> dict:
+    """Scan un .md : findings par ligne (lineno dans le fichier)."""
+    try:
+        rel = str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        rel = str(path).replace("\\", "/")
+    allowed_reason = _is_allowed(rel)
+    if allowed_reason:
+        return {"path": rel, "allowed": allowed_reason, "hits": [], "stats": None, "error": None}
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return {"path": rel, "allowed": None, "hits": [], "stats": None, "error": str(exc)}
+    findings, n_rules, n_color = classify_mermaid_fill_rules(text)
+    return {
+        "path": rel, "allowed": None, "hits": findings,
+        "stats": {"fill_rules": n_rules, "with_color": n_color},
+        "error": None,
+    }
+
+
+def scan_notebook(path: Path, root: Path) -> dict:
+    """Scan un .ipynb : findings par cellule markdown (cell_index)."""
+    try:
+        rel = str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        rel = str(path).replace("\\", "/")
+    allowed_reason = _is_allowed(rel)
+    if allowed_reason:
+        return {"path": rel, "allowed": allowed_reason, "hits": [], "stats": None, "error": None}
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": rel, "allowed": None, "hits": [], "stats": None, "error": str(exc)}
+    hits: list[dict] = []
+    n_rules = n_color = 0
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        findings, r, c = classify_mermaid_fill_rules(_cell_source(cell))
+        n_rules += r
+        n_color += c
+        for fd in findings:
+            hits.append({"cell_index": ci, "cell_type": "markdown", **fd})
+    return {
+        "path": rel, "allowed": None, "hits": hits,
+        "stats": {"fill_rules": n_rules, "with_color": n_color},
+        "error": None,
+    }
+
+
+# Marcheur + SKIP_DIRS canonique centralises dans notebook_walk (#8650).
+from notebook_walk import SKIP_DIRS, iter_notebooks  # noqa: E402
+
+
+def _iter_tracked_md(root: Path) -> list[Path]:
+    """Fichiers .md trackes (git ls-files = source de verite, drop gitignore
+    et contenu de submodules), hors SKIP_DIRS."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", "*.md"],
+            cwd=str(root), capture_output=True, text=False, timeout=180,
+        )
+    except (FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    out: list[Path] = []
+    for e in result.stdout.decode("utf-8", "replace").strip("\x00").split("\x00"):
+        if not e:
+            continue
+        rel = e.replace("\\", "/")
+        if any(part in SKIP_DIRS for part in rel.split("/")):
+            continue
+        out.append(root / rel)
+    return out
+
+
+def _scan_one(path: Path, root: Path) -> dict:
+    if path.suffix == ".ipynb":
+        return scan_notebook(path, root)
+    return scan_markdown_file(path, root)
+
+
+def _human_report(results: list[dict]) -> str:
+    scanned = [r for r in results if r["allowed"] is None and r["error"] is None]
+    allowed = [r for r in results if r["allowed"]]
+    errors = [r for r in results if r["error"]]
+    affected = [r for r in scanned if r["hits"]]
+    total_hits = sum(len(r["hits"]) for r in scanned)
+    total_rules = sum((r["stats"] or {}).get("fill_rules", 0) for r in scanned)
+    total_color = sum((r["stats"] or {}).get("with_color", 0) for r in scanned)
+    lines = [
+        f"Files scanned : {len(scanned)}",
+        f"Mermaid fill: rules : {total_rules} (with color: {total_color})",
+        f"Findings (fill: sans color:) : {total_hits} in {len(affected)} file(s)",
+        f"Allowed (skipped) : {len(allowed)}",
+        "",
+    ]
+    if errors:
+        lines.append(f"Read errors : {len(errors)}")
+        for r in errors:
+            lines.append(f"  - {r['path']}: {r['error']}")
+        lines.append("")
+    if not affected:
+        lines.append("No fill-without-color rule detected (vs #15022).")
+        return "\n".join(lines)
+    for r in affected:
+        lines.append(f"## {r['path']}")
+        for h in r["hits"]:
+            loc = (f"cell [{h['cell_index']}]" if "cell_index" in h
+                   else f"line {h['lineno']}")
+            lines.append(f"  - {loc}: {h['rule']} {h['target']} | {h['context']}")
+        lines.append("")
+    lines.append(
+        "NOTE: corriger en ajoutant un `color:` explicite (ton fonce ; peut\n"
+        "s'ecarter deliberement du `stroke` -- cf garde %% #15502, ne pas\n"
+        "harmoniser aveuglement). Verifier chaque finding firsthand."
+    )
+    return "\n".join(lines)
+
+
+def _self_test() -> int:
+    """Prouve que le detecteur tire : un bloc fautif DOIT produire un finding,
+    son corrige (color: ajoute) DOIT n'en produire aucun."""
+    bad = (
+        "```mermaid\n"
+        "flowchart LR\n"
+        "    A --> B\n"
+        "    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;\n"
+        "    class A,B dist;\n"
+        "```\n"
+    )
+    good = (
+        "```mermaid\n"
+        "flowchart LR\n"
+        "    A --> B\n"
+        "    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;\n"
+        "    class A,B dist;\n"
+        "```\n"
+    )
+    outside = (
+        "```\n"
+        "classDef dist fill:#d1ecf1,stroke:#0c5460;\n"  # fence non-mermaid : ignore
+        "```\n"
+    )
+    f_bad, n_bad, c_bad = classify_mermaid_fill_rules(bad)
+    f_good, n_good, c_good = classify_mermaid_fill_rules(good)
+    f_out, _, _ = classify_mermaid_fill_rules(outside)
+    assert len(f_bad) == 1 and f_bad[0]["rule"] == "classDef", f"self-test FAIL: bad={f_bad}"
+    assert n_bad == 1 and c_bad == 0, f"self-test FAIL: stats bad=({n_bad},{c_bad})"
+    assert f_good == [] and n_good == 1 and c_good == 1, f"self-test FAIL: good={f_good}"
+    assert f_out == [], f"self-test FAIL: non-mermaid fence judged: {f_out}"
+    print("self-test: 3/3 pass (finding on fill-without-color, clean on color:, ignore non-mermaid fence)")
+    return 0
+
+
+_SCANNABLE_EXT = {".ipynb", ".md"}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("target", nargs="?", help="Fichier .md ou .ipynb a scanner (defaut: fleet)")
+    parser.add_argument("--root", default=".", help="Repo root (defaut: cwd)")
+    parser.add_argument("--json", action="store_true", help="Sortie machine JSON")
+    parser.add_argument("--check", action="store_true", help="Exit 1 si finding (CI-ready)")
+    parser.add_argument("--self-test", action="store_true", help="Prouve que le detecteur tire")
+    parser.add_argument(
+        "--stdin", action="store_true",
+        help="Lire les chemins a scanner sur stdin (un par ligne, sortie de "
+             "`git diff --name-only`) : verdict sur exactement les fichiers "
+             "touches par la PR, pas la fleet entiere.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    root = Path(args.root).resolve()
+    if args.stdin:
+        results = []
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            p = Path(line)
+            if not p.is_absolute():
+                p = root / p
+            if p.suffix not in _SCANNABLE_EXT or not p.exists():
+                continue
+            try:
+                rel_parts = p.relative_to(root).parts
+            except ValueError:
+                rel_parts = p.parts
+            if any(part in SKIP_DIRS for part in rel_parts):
+                continue
+            results.append(_scan_one(p, root))
+    elif args.target:
+        p = Path(args.target)
+        if not p.is_absolute():
+            p = root / p
+        if not p.exists():
+            print(f"error: target not found: {p}", file=sys.stderr)
+            return 2
+        results = [_scan_one(p, root)]
+    else:
+        nb_paths = list(iter_notebooks(root / "MyIA.AI.Notebooks"))
+        md_paths = _iter_tracked_md(root)
+        results = [scan_notebook(p, root) for p in nb_paths] + [
+            scan_markdown_file(p, root) for p in md_paths
+        ]
+
+    scanned = [r for r in results if r["allowed"] is None and r["error"] is None]
+    errors = [r for r in results if r["error"]]
+    total_hits = sum(len(r["hits"]) for r in scanned)
+
+    if args.json:
+        payload = {
+            "scanned": len(scanned),
+            "flagged_count": len([r for r in scanned if r["hits"]]),
+            "total_hits": total_hits,
+            "error_count": len(errors),
+            "results": results,
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color.md
+++ b/scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color.md
@@ -1,0 +1,49 @@
+# Fixture : blocs mermaid `fill:` sans `color:` (pattern #15022)
+
+Fixture de test POSITIF du detecteur `detect_mermaid_fill_without_color.py`.
+Ce fichier porte volontairement les formes fautives pour piner le contrat —
+il est allowlisté par chemin dans le detecteur (`ALLOWED`), un scan fleet ne
+doit donc jamais le remonter comme finding.
+
+## Bloc fautif (classDef sans color:)
+
+```mermaid
+flowchart LR
+    A --> B
+    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    class A,B dist;
+```
+
+## Bloc corrige (classDef avec color:)
+
+```mermaid
+flowchart LR
+    A --> B
+    classDef dist fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
+    class A,B dist;
+```
+
+## Forme style (fautive)
+
+```mermaid
+flowchart TD
+    X --> Y
+    style X fill:#fff3cd,stroke:#856404;
+    style Y fill:#fff3cd,stroke:#856404,color:#856404;
+```
+
+## Fence NON mermaid (doit etre ignoree)
+
+```
+classDef dist fill:#d1ecf1,stroke:#0c5460;
+style X fill:#fff3cd;
+```
+
+## Commentaire %% portant le mot fill (doit etre ignore)
+
+```mermaid
+flowchart LR
+    A --> B
+    %% color: explicite -- une regle fill: sans color: serait un finding
+    classDef ok fill:#d1ecf1,color:#0c5460;
+```

--- a/scripts/notebook_tools/tests/test_detect_mermaid_fill_without_color.py
+++ b/scripts/notebook_tools/tests/test_detect_mermaid_fill_without_color.py
@@ -1,0 +1,171 @@
+"""Tests for scripts/notebook_tools/detect_mermaid_fill_without_color.py (#15022).
+
+Pourquoi ce fichier de tests existe
+-----------------------------------
+`detect_mermaid_fill_without_color.py` est le detecteur DETECTION du defect
+#15022 (regles mermaid `style`/`classDef` avec `fill:` sans `color:` = libelle
+clair-sur-clair en theme sombre). La verification etait faite a la main dans
+le fix #15502 ; la review NanoClaw a demande la garde mecanique. Ces tests
+pinent le contrat pour qu'une regression (faux positif massif ou forme
+manquee) soit attrapee avant de polluer l'advisory.
+
+Clusters :
+
+  1. TestClassify       -- regle unitaire : finding fill-sans-color, clean
+                           fill-avec-color, fence non-mermaid ignoree,
+                           commentaire %% ignore, forme style ET classDef.
+  2. TestScanMarkdown   -- fichier .md : findings par ligne + stats pairees.
+  3. TestScanNotebook   -- cellule markdown .ipynb : finding par cell_index,
+                           cellule code ignoree.
+  4. TestAllowlist      -- fixture positive allowlistee par chemin.
+  5. TestMainExitCodes  -- contrat de sortie : --check 1 sur finding, 0 clean,
+                           --self-test 0.
+
+Ground truth : la mesure fleet sur origin/main (2026-09-11) = 25 fichiers /
+90 regles fautives / 204 regles fill: totales ; le README Probas porte
+exactement 10 findings pre-fix (retrouves par le detecteur -- les memes 10
+que le recompte manuel de la review NanoClaw sur #15502).
+"""
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from detect_mermaid_fill_without_color import (  # noqa: E402
+    ALLOWED,
+    classify_mermaid_fill_rules,
+    main,
+    scan_markdown_file,
+    scan_notebook,
+)
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "mermaid_fill_no_color.md"
+
+
+class TestClassify:
+    def test_classdef_fill_without_color_is_finding(self):
+        text = "```mermaid\nflowchart LR\nA-->B\nclassDef d fill:#d1ecf1,stroke:#0c5460;\nclass A,B d;\n```\n"
+        findings, n_rules, n_color = classify_mermaid_fill_rules(text)
+        assert len(findings) == 1
+        assert findings[0]["rule"] == "classDef" and findings[0]["target"] == "d"
+        assert (n_rules, n_color) == (1, 0)
+
+    def test_classdef_fill_with_color_is_clean(self):
+        text = "```mermaid\nclassDef d fill:#d1ecf1,color:#0c5460;\n```\n"
+        findings, n_rules, n_color = classify_mermaid_fill_rules(text)
+        assert findings == []
+        assert (n_rules, n_color) == (1, 1)
+
+    def test_style_form_is_judged_too(self):
+        text = "```mermaid\nflowchart TD\nX-->Y\nstyle X fill:#fff3cd,stroke:#856404;\n```\n"
+        findings, _, _ = classify_mermaid_fill_rules(text)
+        assert len(findings) == 1 and findings[0]["rule"] == "style"
+
+    def test_non_mermaid_fence_ignored(self):
+        text = "```\nclassDef d fill:#d1ecf1;\nstyle X fill:#fff3cd;\n```\n"
+        findings, n_rules, _ = classify_mermaid_fill_rules(text)
+        assert findings == [] and n_rules == 0
+
+    def test_mermaid_comment_line_ignored(self):
+        # Un %% porte les mots fill:/color: en prose -- pas une regle.
+        text = "```mermaid\n%% fill: sans color: serait un finding\nclassDef ok fill:#d1ecf1,color:#000;\n```\n"
+        findings, n_rules, n_color = classify_mermaid_fill_rules(text)
+        assert findings == [] and (n_rules, n_color) == (1, 1)
+
+    def test_rule_without_fill_ignored(self):
+        # classDef sans fill: (fond herite du theme) : rien a verifier.
+        text = "```mermaid\nclassDef d stroke:#333,stroke-width:2px;\n```\n"
+        findings, n_rules, _ = classify_mermaid_fill_rules(text)
+        assert findings == [] and n_rules == 0
+
+    def test_tilde_fence_supported(self):
+        text = "~~~mermaid\nclassDef d fill:#d1ecf1;\n~~~\n"
+        findings, _, _ = classify_mermaid_fill_rules(text)
+        assert len(findings) == 1
+
+    def test_fixture_contract_counts(self):
+        """Le fixture porte exactement 2 findings (classDef dist, style X) et
+        5 regles fill: dont 3 avec color:."""
+        findings, n_rules, n_color = classify_mermaid_fill_rules(FIXTURE.read_text(encoding="utf-8"))
+        rules = sorted((f["rule"], f["target"]) for f in findings)
+        assert rules == [("classDef", "dist"), ("style", "X")]
+        assert (n_rules, n_color) == (5, 3)
+
+
+class TestScanMarkdown:
+    def test_scan_marks_line_numbers(self):
+        result = scan_markdown_file(FIXTURE, FIXTURE.parents[3])
+        assert result["error"] is None and result["allowed"] is None
+        linenos = sorted(h["lineno"] for h in result["hits"])
+        assert len(linenos) == 2
+        assert result["stats"] == {"fill_rules": 5, "with_color": 3}
+
+    def test_scan_unreadable_file_reports_error(self, tmp_path):
+        missing = tmp_path / "nope.md"
+        missing.write_text("x", encoding="utf-8")
+        result = scan_markdown_file(missing, tmp_path)
+        # Lisible mais sans mermaid : clean, pas d'erreur.
+        assert result["hits"] == [] and result["error"] is None
+
+
+class TestScanNotebook:
+    def _nb(self, tmp_path, cell_source):
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": cell_source},
+                {"cell_type": "code", "source": "classDef d fill:#d1ecf1;"},
+            ],
+            "metadata": {},
+            "nbformat": 4,
+        }
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        return p
+
+    def test_markdown_cell_flagged_code_cell_ignored(self, tmp_path):
+        src = "```mermaid\nclassDef d fill:#d1ecf1;\n```\n"
+        result = scan_notebook(self._nb(tmp_path, src), tmp_path)
+        assert len(result["hits"]) == 1
+        assert result["hits"][0]["cell_index"] == 0
+        assert result["stats"]["fill_rules"] == 1
+
+
+class TestAllowlist:
+    def test_fixture_path_is_allowed(self):
+        rel = "scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color.md"
+        assert any(needle in rel for needle in ALLOWED)
+        result = scan_markdown_file(FIXTURE, FIXTURE.parents[4])
+        # Le resolve() du root reel peut differe ; on teste via _is_allowed
+        # indirectement : le chemin fixture doit matcher une cle ALLOWED.
+        matched = [needle for needle in ALLOWED if needle in str(FIXTURE).replace("\\", "/")]
+        assert matched, "fixture positive doit etre allowlistee par chemin"
+
+
+class TestMainExitCodes:
+    def test_self_test_exits_zero(self, capsys):
+        assert main(["--self-test"]) == 0
+
+    def test_check_on_finding_exits_one(self, tmp_path):
+        bad = tmp_path / "bad.md"
+        bad.write_text("```mermaid\nclassDef d fill:#d1ecf1;\n```\n", encoding="utf-8")
+        assert main(["--check", "--root", str(tmp_path), str(bad)]) == 1
+
+    def test_check_on_clean_exits_zero(self, tmp_path):
+        good = tmp_path / "good.md"
+        good.write_text("```mermaid\nclassDef d fill:#d1ecf1,color:#000;\n```\n", encoding="utf-8")
+        assert main(["--check", "--root", str(tmp_path), str(good)]) == 0
+
+    def test_stdin_json_payload_fields(self, tmp_path, capsys, monkeypatch):
+        bad = tmp_path / "bad.md"
+        bad.write_text("```mermaid\nstyle X fill:#fff3cd;\n```\n", encoding="utf-8")
+        monkeypatch.setattr("sys.stdin", io.StringIO(f"{bad}\n"))
+        rc = main(["--json", "--stdin", "--root", str(tmp_path)])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["total_hits"] == 1 and out["flagged_count"] == 1
+        assert out["error_count"] == 0
+        # Champs consommes par le workflow advisory.
+        assert {"scanned", "flagged_count", "total_hits", "error_count"} <= set(out)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/notebook-dotnet #15462

See #15022 (garde mecanique demandee par la review NanoClaw sur #15502, concern 1 : « le motif peut revenir, sur ce fichier comme sur les 24 autres »). Sweep du residuel tracke par #15516.

**Périmètre : 6 fichiers** — `.github/workflows/mermaid-fill-color-advisory.yml`, `scripts/notebook_tools/detect_mermaid_fill_without_color.py`, `scripts/notebook_tools/tests/test_detect_mermaid_fill_without_color.py`, `scripts/notebook_tools/tests/fixtures/mermaid_fill_no_color.md`, `scripts/notebook_tools/README.md`, `scripts/ci/check_self_hosted_runner_policy.py`.

## Summary

- `scripts/notebook_tools/detect_mermaid_fill_without_color.py` (NEW, 367 l.) : detecte les regles mermaid `style`/`classDef` avec `fill:` sans `color:` dans les fences ```mermaid des `.md` trackes + cellules markdown des `.ipynb`. Convention `detect_*` : stdlib only, `--json`/`--check`/`--stdin` (mode diff PR)/`--self-test`, allowlist par chemin pour la fixture positive. Commentaires `%%` et fences non-mermaid exclus.
- `.github/workflows/mermaid-fill-color-advisory.yml` (NEW) : cablage advisory per-PR (pattern paragraph-length-advisory #15513 / cjk-residue-advisory #8826) — labels `mermaid-fill-color` / `mermaid-fill-color-unmeasured` (#8819 : mesure vs non-mesure jamais confondus), job TOUJOURS exit 0 (decision user pour ce type d'organe), self-cover #8822, anti-fork (student-pr-reviews), runner self-hosted statique (politique #14283).
- Tests `test_detect_mermaid_fill_without_color.py` : **16/16 pass** (classification, fixture contract, notebook cells, allowlist, codes de sortie, payload JSON consomme par le workflow).
- Entree `scripts/notebook_tools/README.md` (table + section dediee).
- `scripts/ci/check_self_hosted_runner_policy.py` (commit 80711f7df) : entree `mermaid-fill-color-advisory.yml` dans `SELF_HOSTED_WORKFLOW_ALLOWLIST` — la politique est fail-closed, le workflow self-hosted devait etre explicitement liste des son introduction (pattern #14283, meme tranche que chaque advisory label-poser). Verif locale : 58/58 tests policy verts.

## Mesure fleet (calibration, origin/main bb02b3d1c, 2026-09-11)

Sortie de `detect_mermaid_fill_without_color.py --json` (constat fleet de calibration, hors du perimetre livre declare ci-dessus) :

```text
scanned=2511 fichiers, flagged=25 fichiers, faulty_rules=90,
fill_rules_total=204, fill_rules_with_color=114, read_errors=0
```

**Ground truth** : le README Probas porte exactement les 10 regles recomptees a la main par la review NanoClaw sur #15502 — le detecteur les retrouve toutes (le meme `--json` sur ce fichier seul : `flagged_count: 1, total_hits: 10`). Residuel pre-existant -> issue de suivi **#15516** (sweep par familles), PAS dans cette PR (advisory = pas de cascade).

## Pourquoi advisory et pas bloquant

Meme posture que #15513/#12797 (decision user) : le residuel pre-existant au niveau fleet (cf. mesure ci-dessus) ferait echouer toute PR les touchant ; l'advisory labelise les APPORTS neufs, le sweep residuel se fait par familles (#15516). La promotion en gate bloquante est une decision separee, a revisiter quand le residuel sera a 0.

## Validation

- `python -m pytest tests/test_detect_mermaid_fill_without_color.py -q` : **16 passed**
- `python detect_mermaid_fill_without_color.py --self-test` : 3/3 pass
- Fleet scan : cf. mesure ci-dessus (0 erreur de lecture ; hors scope PR)
- Aucun `.ipynb` modifie ; exclusivite tooling + docs only, y compris le workflow `.github/workflows/mermaid-fill-color-advisory.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
