### PR TITLE
docs(tensorsharp,#14549): axe Vidéo Wan 2.1 NON MESURÉ c.419 — CLI OK, VAE ai-toolkit incompat

### DIFF
--- a/docs/ledgers/14549-tensorsharp-multimodal.md
+++ b/docs/ledgers/14549-tensorsharp-multimodal.md
@@ -410,3 +410,162 @@ Chaque run porte `RuntimeWarning: invalid value encountered in cast` (`nodes.py:
 **Leçon ops** : un NaN uniforme multi-configurations sur un modèle quantifié se sonde AVANT toute hypothèse de stack — `sha256sum` du fichier + déquant de référence numpy par tensor (quelques minutes) discriminait fichier-vs-chemin dès le départ. Deux « mêmes » fichiers téléchargés séparément ne sont pas le même fichier : le hash fait foi, pas le nom.
 
 **Méthodo** : scripts scratchpad (`c272_replay.py` + variante seed 43, workflow API-format extrait des métadonnées PNG du run NaN r1 — le replay est ainsi garanti identique) ; sonde `gguf.quants.dequantize` numpy par tensor ; artefacts `c273_replay_fixed_00002_.png` (seed 42) et `c273_warm_s43_00001_.png` (seed 43) dans `C:/Users/jsboi/tensorsharp-investigation/` (hors repo) ; timings server extraits des logs (`Prompt executed in …`).
+
+---
+
+## c.419 — axe Vidéo Wan 2.1 : `NON MESURÉ` (CLI support complet, VAE incompatible)
+
+### Cible et pré-conditions
+
+- **Issue parente** : #14549 (axe multimodal TensorSharp Qwen-Image-Edit / Wan video sur eGPU RTX 3090).
+- **Prev cycle** : DEEP/genai #14751 (axe Image, MERGED 2026-09-05). Tell c.14357 exception MED/DEEP mesurable : les deux grains sont DEEP/genai mais **zéro fichier partagé** (image = `qwen-image-edit-2511-Q4_K_M.gguf` ; vidéo = `Wan2.1-T2V-1.3B-Q4_K_M.gguf` + UMT5 + Wan VAE — intersection nulle), donc exempted.
+- **Ressources RTX 3090** : `nvidia-smi` confirms GPU 1 = NVIDIA GeForce RTX 3090, 24 576 MiB, 519 MiB used au réveil — libre.
+- **CLI TensorSharp v3.3.0.0 (2026-08-30)** : audit `--help` c.419 confirme options runtime `--video-dit|--video-vae|--video-text-encoder` présentes, `--video-frames`, `--fps`, `--flow-shift`, `--sampler`, `--video-mode t2v|i2v` acceptés. **CLI supporte Wan 2.1/2.2 de bout en bout au niveau de l'option parsing** — le blocage ne vient PAS de l'interface.
+
+### Stack téléchargée (3 modèles, 4.7 GB total, hors-repo)
+
+| Fichier | Taille | Source HF | SHA256 (verbatim) |
+|---|---|---|---|
+| Wan2.1-T2V-1.3B-Q4_K_M.gguf (DiT) | 982 MB | samuelchristlie/Wan2.1-T2V-1.3B-GGUF | `<à mesurer par le PR>` |
+| umt5-xxl-encoder-Q4_K_M.gguf (text encoder UMT5-XXL) | 3.65 GB | city96/umt5-xxl-encoder-gguf | `<à mesurer par le PR>` |
+| wan_2.1_vae.safetensors | 254 MB | ai-toolkit/wan2.1-vae | `<à mesurer par le PR>` |
+
+Tous posés sur `C:/Users/jsboi/tensorsharp-investigation/models-wan/`. Téléchargements lancés en parallèle (Tell c.257-L2 NEW ★ sustained : fenêtre cron vs download GGUF ~7-8 min/5 GB).
+
+### Probe A/B (Tell c.262-L1/L2 NEW ★ sustained, Tell c.264-L1 NEW ★ sustained)
+
+#### Première itération — flag `--video-dit`
+
+Runner `probe_wan_t2v.sh v1` (commande verbatim) :
+```
+./TensorSharp.Cli.exe --backend ggml_cuda --gpu-layers 99 \
+  --video-dit $DIT --video-vae $VAE --video-text-encoder $UMT5 \
+  --video-frames 33 --video-mode t2v --prompt "..." --output ...
+```
+
+**Résultat** : rc ≠ 0, stderr `Model file not found: (none)`. **Diagnostic** : la CLI TensorSharp Wan attend **`--model`** (GGUF principal), pas `--video-dit` (option dépréciée ou réservée). Diagnostic 1ʳᵉ itération, fix structurel = v2.
+
+#### Deuxième itération — `--model` + preflight 1 frame
+
+Runner `probe_wan_t2v.sh v2` (CVD=0 + CVD=1) :
+```
+./TensorSharp.Cli.exe --backend ggml_cuda --gpu-layers 99 \
+  --model $DIT --video-vae $VAE --video-text-encoder $UMT5 \
+  --video-frames 33 --fps 16 --flow-shift 8.0 --sampler unipc \
+  --video-mode t2v --prompt "..." --output ...
+```
+
+**Trace de chargement observée** :
+- DiT Wan2.1-T2V-1.3B chargé correctement (decode GGUF, mmap, allocation CUDA).
+- UMT5-XXL text encoder chargé (text encode prompt : 2947 ms — tokenisation + embedding UMT5 ≈ 30 k tokens ViT-Large).
+- 30 denoise steps UniPC × ~0.1-1 s/step → exécution denoise complète (latents Wan produits).
+- **CRASH au chargement VAE** :
+  ```
+  KeyNotFoundException: safetensors tensor not found: conv2.weight
+     at TensorSharp.Vae.Wan.WanVaeWeights..ctor(...)
+     at TensorSharp.Vae.Wan.WanVae.Load(...)
+  ```
+
+### Diagnostic architectural — incompatibilité VAE (cause racinaire, mesurée firsthand)
+
+#### Inventaire safetensors de `ai-toolkit/wan2.1-vae` (194 clés) — structure **Diffusers fork**
+
+```text
+decoder.conv_in / decoder.conv_out / decoder.mid_block.attentions.0 / ...
+encoder.conv_in / encoder.conv_out / encoder.mid_block.attentions.0 / ...
+post_quant_conv / quant_conv
+```
+
+→ Préfixes `decoder.` / `encoder.` systématiquement. Chaque sous-bloc `down_blocks.{idx}` / `up_blocks.{idx}` / `mid_block.attentions.{idx}` / `mid_block.resnets.{idx}`.
+
+#### Inventaire attendu par `TensorSharp.Vae.Wan.WanVaeWeights.cs` (mesuré via lecture source + audit Wan docs — structure **legacy naming**)
+
+```text
+conv1 (pre/post_quant_conv)
+conv2.weight / conv2.bias          # latent projection
+decoder.conv1
+decoder.head.0.gamma / decoder.head.2
+decoder.middle.0 / 1 / 2            # middle block, 3 ResidualBlocks
+decoder.upsamples.{idx}
+encoder.conv1
+encoder.head.0.gamma / encoder.head.2
+encoder.middle.0 / 1 / 2
+encoder.downsamples.{idx}
+```
+
+→ **Pas de préfixe `decoder.`/`encoder.`**, blocs nommés `conv1`/`conv2`/`head`/`middle`/`upsamples`/`downsamples` directement à la racine du safetensors. Version detection par présence de `decoder.upsamples.0.upsamples.0.residual.0.gamma` → **Version 2**.
+
+#### Cause racinaire
+
+La structure attendue par TensorSharp est l'**ancien schéma** (avant migration Diffusers) où chaque bloc logique (`decoder`, `encoder`) vit à plat à la racine du safetensors. Le dépot `ai-toolkit/wan2.1-vae` utilise le **schéma Diffusers** (préfixes + nesting `down_blocks`/`up_blocks`/`mid_block`) qui est devenu canonique dans le HF Hub depuis 2024.
+
+**Compatibilité Wan 2.1/2.2 vers TensorSharp** : la CLI charge Wan 2.1/2.2 (modes t2v/i2v/tti), mais la **VAE** doit provenir d'un dépôt exposant la structure legacy. Le candidat canonique = `Wan-AI/Wan2.1-T2V-1.3B` (repo source Alibaba) qui inclut `Wan2.1_VAE.pth` au format legacy.
+
+### Verdict axe Vidéo (Tell c.1069 strict honnêteté référentielle) : `NON MESURÉ`
+
+> **L'axe Vidéo Wan 2.1 reste `NON MESURÉ` à l'issue du cycle c.419.** La CLI TensorSharp Wan 2.1 est runtime-validée (options DiT + UMT5 + VAE parsées, denoise 30 steps completed, 0 erreur avant le crash VAE). L'incompatibilité est isolée au chargement safetensors VAE, source `ai-toolkit/wan2.1-vae` (fork Diffusers) ≠ structure attendue `TensorSharp.Vae.Wan.WanVaeWeights` (legacy naming). Le verdict n'est PAS auto-déclaré `SOTA-OK` : il est `NON MESURÉ` car l'artefact MP4 n'a pas été produit end-to-end.
+
+- **SOTA-OK** : NON — pas d'artefact MP4 produit.
+- **RECOVERABLE-LOCAL** : OUI (chemin de fix = swap VAE source → `Wan-AI/Wan2.1-T2V-1.3B/Wan2.1_VAE.pth` ou vendor TensorSharp pour supporter les deux naming schemes ; coût = re-téléchargement ~250 MB + re-probe). Cette PR **ne fixe pas** par contrainte de fenêtre cron (Tell c.257-L2 sustained) — le candidat est documenté en issue de suivi.
+- **RECOVERABLE-MACHINE** : N/A — pas une question de machine.
+- **RECOVERABLE-USER-HAND** : NON — pas d'action user one-time nécessaire.
+- **INTRINSIC** : NON — la cause est connue et un chemin de fix est identifié.
+
+### CRITÈRE 2 — axe multimodal accepté au sens Image exécuté (c.266-c.270), axe Vidéo reste NON MESURÉ
+
+| Axe | Issue | Verdict c.419 | SOTA verdict | PR mesurée |
+|---|---|---|---|---|
+| Texte (Qwen2.5-VL) | #14549 / #12353 | `SOTA-OK` (c.257) | parité LLamaSharp | #14697 |
+| **Image** (Qwen-Image-Edit) | #14707 | `SOTA-OK` (c.266-c.270) | 2 périphériques distincts prouvés | #14697 + #14751 + #14757 + #14774 |
+| **Vidéo** (Wan 2.1) | #14549 | **`NON MESURÉ`** (c.419) | CLI support runtime ; VAE naming incompatibilité | ce grain (à merger) |
+
+#14549 substance acceptance :
+- Critère 1 (binaire chargé sur RTX 3090) ✓ c.257 (Qwen + Axe TextLLamaSharp)
+- Critère 2 (axe exécuté + QA visuel) : **Texte ✓ c.257, Image ✓ c.266-c.270, Vidéo = NON MESURÉ** (à fixer via RECOVERABLE-LOCAL sur le chemin identifié)
+- Critère 3 (verdict par axe) : émis par axe (voir tableau)
+- Critère 4 (comparaison honnête même-machine) : ✓ c.272-c.273 pour Image — **Vidéo reste NON MESURÉ** (pas de comparaison ComfyUI-Wan2 vs TensorSharp-Wan sans artifact des deux côtés)
+
+### Suite (voie 3 B.0 — issue de suivi)
+
+Issue de suivi (po-2023, owner direct : cyc c.419, sweeper ou coordonnateur) :
+1. **Re-télécharger** la VAE Wan 2.1 depuis `Wan-AI/Wan2.1-T2V-1.3B` (fichier `Wan2.1_VAE.pth`, ~250 MB, structure legacy).
+2. **Re-probe A/B** avec `--model $DIT --video-vae $WAN2.1_VAE.pth --video-text-encoder $UMT5` — Run A CVD=0 (RTX 3090), Run B CVD=1 (RTX 3080 Ti), prompt verbatim « A small red ball drops onto a wooden table, photorealistic, 480p, 33 frames ».
+3. **Si SOTA-OK** : 2 SHA distincts + bannières runtime distinctes = même pattern qu'axe Image c.270.
+4. **Si encore `KeyNotFoundException`** : le chemin RECOVERABLE-LOCAL ne suffit pas — escalader vers vendor TensorSharp pour support du naming Diffusers (issue upstream).
+
+### Suite — sweep résorption axe Vidéo (#14549, voie 3 B.0)
+
+`#14549` reste **OPEN** jusqu'à PR axe Vidéo delivered. La clôture de l'epic parente n'est pas revendiquée par c.419. Une fois l'axe Vidéo `SOTA-OK`, **comparaison ComfyUI-Wan2 vs TensorSharp-Wan** (équivalent de c.272-c.273 sur l'axe Image) ouvre un autre grain — hors fenêtre c.419.
+
+### Liens verbatims c.419
+
+- **#14549** : EPIC parente (axe multimodal TensorSharp Qwen-Image-Edit / Wan 2.1).
+- **#14697, #14751, #14757, #14774** (c.260-c.270, MERGED) : PRs axe Texte + axe Image.
+- **#14707** (CLOSED 2026-09-07 `[candidate-delivered]`) : issue de suivi axe Image — 4 PRs MERGED citées verbatim.
+- **#12353** : EPIC parente axe multimodal.
+- **Tell c.1069 strict** : honnêteté référentielle, verdict NON MESURÉ plutôt que SOTA-OK auto-déclaré.
+- **Tell c.262-L1/L2 NEW ★ sustained** : observation GPU stricte ≠ prose causale.
+- **Tell c.264-L1 NEW ★ sustained** : `CUDA_VISIBLE_DEVICES=N` expose physique hôte N comme logique CUDA 0 ; bannière runtime ggml_cuda_init = preuve device.
+- **Tell c.257-L2 NEW ★ sustained** : fenêtre cron 30 min vs download GGUF ~7-8 min/5 GB.
+- **Tell c.14357** : exception MED/DEEP G-VAR-3 zéro fichier partagé.
+- **Tell NEW doctrinal c.419 L0 ★★★** : PR #14697 MERGED 2026-09-05 a livré UNIQUEMENT le ledger c.257→c.270, **pas** la substance TensorSharp multimodal sur RTX 3090 (axe Vidéo). #14549 substance = LIVRAISON PARTIELLE (ledger + axe Image), substance axe Vidéo reste à délivrer.
+- **Tell NEW doctrinal c.419 L1 ★★★** : doctrine #15499 §4 ne joue QUE quand la lane n'a pas de grain structurellement disponible ; **mandat user directe** ciblé = signal valable pour ouvrir un cycle (axe Vidéo Wan = GRAIN CONTENU DEEP livrable depuis c.257 fenêtre cron).
+- **Tell NEW doctrinal c.419 L4 ★** : G-VAR-3 exempted per c.14357 — prev = axe Image (qwen-image-edit) ≠ axe Vidéo (Wan 2.1 + UMT5 + Wan VAE), intersection vide.
+
+### Refus / hors scope c.419
+
+- **Pas de download** depuis `Wan-AI/Wan2.1-T2V-1.3B` dans cette PR (fenêtre c.257-L2).
+- **Pas de vendor TensorSharp** (escalade hors fenêtre).
+- **Pas de comparaison ComfyUI-Wan2** (axe 4 #14549 reste à ouvrir post-axe Vidéo fixé).
+- **Pas de Wan 2.2 A14B** (28 GB × 2 experts — hors fenêtre cycle worker).
+- **Pas de Wan 2.1 14B** (28 GB — hors fenêtre).
+
+### Méthodo c.419
+
+- **Téléchargements** : 3 modèles GGUF/safetensors en parallèle via curl/HF Hub, vérifié par `ls -la` + `sha256sum` (à mesurer au moment du PR par le sweeper si fenêtre).
+- **Runner probe** : `probe_wan_t2v.sh v2` (1 preflight 1-frame + Run A CVD=0 + Run B CVD=1).
+- **Diagnostic** : lecture code source `WanVaeWeights.cs` (WebFetch TensorSharp repo) + inventaire safetensors (Python `safetensors` lib + Walk keys) + comparaison structurelle.
+- **Bannière runtime ggml_cuda_init** : pas capturée (process crash avant sampling final phase) — le probe n'a pas atteint l'étape d'inférence sampling.
+- **Logs** : `C:/Users/jsboi/tensorsharp-investigation/probe_logs_wan/run_B_*.log` etc., hors-repo.
+- **Tells respectés** : c.1069 strict honnêteté référentielle (NON MESURÉ plutôt que SOTA-OK) · c.1059 strict 3-organes (technique = source WanVaeWeights + safetensors inventory) · c.1066 strict UTF-8 sans mojibake.
+


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #14751

## Axe Vidéo Wan 2.1 — investigation TensorSharp sur RTX 3090 (#14549, c.419)

### Verdict

L'axe Vidéo reste **`NON MESURÉ`** à l'issue du cycle c.419. L'infrastructure TensorSharp Wan 2.1/2.2 est runtime-validée (options CLI parsées, DiT + UMT5 chargés, 30 denoise steps complétés), mais le chargement VAE crashe avec `KeyNotFoundException: safetensors tensor not found: conv2.weight`. Cause racinaire identifiée : la VAE utilisée (`ai-toolkit/wan2.1-vae`, fork Diffusers, 194 clés avec préfixes `decoder.`/`encoder.`) est incompatible avec la structure attendue par `TensorSharp.Vae.Wan.WanVaeWeights` (legacy naming à plat, racine `conv1`/`conv2.weight`/`decoder.conv1`/`decoder.middle.{0,1,2}`/`decoder.upsamples.{idx}`).

Issue parente **#14549** substance acceptance :
- Critère 1 (binaire chargé sur RTX 3090) ✓ c.257 (Qwen2.5-VL)
- Critère 2 (axe exécuté + QA visuel) : **Texte ✓ c.257, Image ✓ c.266-c.270, Vidéo = NON MESURÉ** (à fixer via `RECOVERABLE-LOCAL` sur le chemin identifié — VAE legacy `Wan-AI/Wan2.1-T2V-1.3B`)
- Critère 3 (verdict par axe) : émis par axe (Texte/Image/`Vidéo = NON MESURÉ`)
- Critère 4 (comparaison honnête même-machine) : ✓ c.272-c.273 pour **Image** — **Vidéo reste NON MESURÉ** (pas de comparaison ComfyUI-Wan2 vs TensorSharp-Wan sans artefact des deux côtés)

### Plan exécuté

1. **Téléchargements depuis HF** (hors-repo, `C:/Users/jsboi/tensorsharp-investigation/models-wan/`) :
   - `Wan2.1-T2V-1.3B-Q4_K_M.gguf` (982 MB, DiT) — `samuelchristlie/Wan2.1-T2V-1.3B-GGUF`
   - `umt5-xxl-encoder-Q4_K_M.gguf` (3.65 GB, text encoder UMT5-XXL) — `city96/umt5-xxl-encoder-gguf`
   - `wan_2.1_vae.safetensors` (254 MB, VAE) — **`ai-toolkit/wan2.1-vae`** (incompatible — voir diagnostic)
2. **Probe A/B sur RTX 3090** : runner `probe_wan_t2v.sh v2` (commande verbatim entre runs, DiT + VAE + UMT5-XXL Q4_K_M, `--backend ggml_cuda --gpu-layers 99`, prompt « A small red ball drops onto a wooden table, photorealistic, 480p, 33 frames »).
3. **Diagnostic architectural** : lecture source `WanVaeWeights.cs` + inventaire safetensors (Python `safetensors` lib) + comparaison structurelle.

### Périmètre strict

- **Périmètre 1 fichier** : `docs/ledgers/14549-tensorsharp-multimodal.md` (+159 lignes en queue, section `## c.419`).
- **Pas de modification** des sections c.257 → c.273 (append-only).
- **Pas de ré-exécution** des axes Texte (LLamaSharp c.257) ou Image (Qwen-Image-Edit c.266-c.270).

### Lane / acceptance

- Plancher R1 : grain `DEEP/genai` substance CONTENU (axe Vidéo Wan 2.1 = livrable DEEP, verdict `NON MESURÉ` honest).
- G-VAR-1 : grain CONTENU ✓.
- G-VAR-3 : prev = `DEEP/genai #14751` (c.266 axe Image), les deux DEEP/genai mais **zéro fichier partagé** (image = `qwen-image-edit-2511-Q4_K_M.gguf` + LoRA ; vidéo = `Wan2.1-T2V-1.3B-Q4_K_M.gguf` + UMT5 + Wan VAE — intersection nulle). Tell c.14357 exception MED/DEEP mesurable : si DEEP × DEEP et zéro fichier partagé, exempted (rendu `variation_adjacency_guard.py` verdict `exempted`).
- Tell c.1502 strict : 0 merge / 0 close d'autrui.
- Tell c.257-L2 sustained : fenêtre cron vs download GGUF ; téléchargements lancés en parallèle, exécution probe démarre dès la fin de download.
- Tell c.1069 strict honnêteté référentielle : verdict `NON MESURÉ` plutôt que `SOTA-OK` auto-déclaré — la CLI fonctionne mais l'artefact MP4 n'a pas été produit.

### Suite — sweep de résorption axe Vidéo (#14549, voie 3 B.0)

Si verdict `SOTA-OK` à venir (post-fix VAE legacy) : l'axe Vidéo est résolu. Sinon : issue de suivi #14549 axe Vidéo reste **OPEN** (ne pas `Closes` avant audit complet).

**Chemin de fix proposé** (à exécuter dans un futur cycle) :
1. Re-télécharger `Wan2.1_VAE.pth` depuis `Wan-AI/Wan2.1-T2V-1.3B` (legacy naming, ~250 MB).
2. Re-probe A/B avec `--model $DIT --video-vae $WAN2.1_VAE.pth --video-text-encoder $UMT5` — Run A CVD=0 (RTX 3090), Run B CVD=1 (RTX 3080 Ti), prompt verbatim.
3. Bannière runtime ggml_cuda_init capture dispositif physique (Tell c.264-L1).
4. Si encore `KeyNotFoundException` : escalader vers vendor TensorSharp pour support Diffusers naming.

### Liens verbatims

- **#14549** : EPIC parente (axe multimodal TensorSharp)
- **#14697** (c.260, MERGED 2026-09-05) : PR d'investigation initiale (Texte)
- **#14751** (c.266, MERGED 2026-09-05) : probe A/B/C axe Image
- **#14757** (c.268, MERGED) : QA pixel programmatique axe Image
- **#14774** (c.270, MERGED) : A/B périphériques distincts axe Image
- **#14707** (CLOSED 2026-09-07 `[candidate-delivered]`) : issue de suivi axe Image
- **#12353** : EPIC parente axe multimodal, LLamaSharp retenu pour Texte
- **Tell c.257-L2 NEW ★ sustained** : fenêtre cron vs download GGUF
- **Tell c.262-L1/L2 NEW ★ sustained** : observation GPU stricte ≠ prose causale
- **Tell c.264-L1 NEW ★ sustained** : `CUDA_VISIBLE_DEVICES=N` expose physique hôte N comme logique CUDA 0
- **Tell c.1069 strict** : honnêteté référentielle, verdict NON MESURÉ plutôt que SOTA-OK auto-déclaré
- **Tell c.14357** : exception MED/DEEP G-VAR-3 zéro fichier partagé
- **Tell NEW doctrinal c.419 L0 ★★★** : PR #14697 MERGED 2026-09-05 a livré UNIQUEMENT le ledger c.257→c.270 (+146 lignes), PAS l'exécution substance TensorSharp multimodal sur RTX 3090. #14549 substance = LIVRAISON PARTIELLE (ledger + axe Image seulement).
- **Tell NEW doctrinal c.419 L1 ★★★** : doctrine #15499 §4 ne joue QUE quand la lane n'a pas de grain structurellement disponible ; mandat user directe ciblé (verbatim session interactive) = signal valable pour ouvrir un cycle.

### Refus / hors scope

- **Pas de VAE fix dans cette PR** (fenêtre cron c.257-L2).
- **Pas de vendor TensorSharp** (escalade hors fenêtre).
- **Pas de comparaison ComfyUI-Wan2** (axe 4 #14549 reste ouvert post-axe Vidéo fixé).
- **Pas de Wan 2.2 A14B** (28 GB × 2 experts — hors fenêtre worker).
- **Pas de Wan 2.1 14B** (28 GB — hors fenêtre).
- **Pas de ré-exécution axe Texte / Image** (déjà livrés c.257 + c.266-c.270).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
