### PR TITLE
docs(genai,#15457): aérer la liste des onze notebooks 03-Functional — tranche 7 (4461 c)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/03-Functional/README.md
@@ -27,22 +27,26 @@ reprend la question laissée ouverte par la précédente.
 1. [`presenter-ai-engine-par-son-api.ipynb`](03-5-Multi-Provider/presenter-ai-engine-par-son-api.ipynb)
    pose le socle : instance, catalogue des routes `mwai/v1`, première
    completion réelle avec compte de tokens.
+
 2. [`configurer-chatbots-par-l-api.ipynb`](03-1-Chatbots/configurer-chatbots-par-l-api.ipynb)
    traite les chatbots comme des **documents JSON** — lecture,
    duplication, écriture read-modify-write — puis mesure honnêtement ce
    que les instructions d'un persona changent, et ce qu'elles ne changent
    pas.
+
 3. [`administrer-les-formulaires-par-l-api.ipynb`](03-2-Forms/administrer-les-formulaires-par-l-api.ipynb)
    montre l'autre style d'API du plugin : le formulaire est un
    **contenu** WordPress (custom post type `mwai_form`, CRUD unitaire,
    corps Gutenberg, rendu public par shortcode) — et mesure la frontière
    gratuite/Pro (du contenu rendu, pas encore des champs).
+
 4. [`piloter-wordpress-par-mcp.ipynb`](03-4-MCP-Server/piloter-wordpress-par-mcp.ipynb)
    ouvre la seconde face du plugin : **WordPress comme serveur MCP** —
    endpoint JSON-RPC `mcp/v1/http`, handshake avec négociation de
    version, catalogue de 43 outils à JSON Schema, et de vrais
    `tools/call` en lecture puis en écriture — la frontière
    d'authentification mesurée à 401 sur chaque méthode.
+
 5. [`brancher-plusieurs-providers-par-l-api.ipynb`](03-5-Multi-Provider/brancher-plusieurs-providers-par-l-api.ipynb)
    ouvre la régie des **environnements** : la matrice
    `ai_<usage>_default_env` lue et écrite par l'API, l'interrogation
@@ -50,12 +54,14 @@ reprend la question laissée ouverte par la précédente.
    mesuré par accident : `settings/update` **ne met pas à jour, il
    remplace**. La matrice croisée laisse des cases vides, dont la case
    json.
+
 6. [`parler-au-chatbot-en-visiteur-par-l-api.ipynb`](03-1-Chatbots/parler-au-chatbot-en-visiteur-par-l-api.ipynb)
    ouvre la troisième face, celle du **navigateur d'un visiteur
    anonyme** (namespace `mwai-ui/v1`) : la page publique n'embarque
    aucun jeton, l'amorçage passe par `start_session`, la conversation
    par `chats/submit` au `X-WP-Nonce` — et la nuance : un nonce est un
    anti-CSRF, pas une authentification.
+
 7. [`obtenir-des-donnees-structurees-par-l-api.ipynb`](03-1-Chatbots/obtenir-des-donnees-structurees-par-l-api.ipynb)
    ferme la dernière veine « non prouvée » : la route `/ai/json`, qui
    ignore `envId`/`model` et lit **la case json de la matrice d'usages**
@@ -63,12 +69,14 @@ reprend la question laissée ouverte par la précédente.
    remplit la case par read-modify-write, obtient du JSON réellement
    exploitable, puis mesure honnêtement la promesse : le **null
    silencieux** du parser PHP et la nature de la contrainte de format.
+
 8. [`autour-du-consent-oauth-du-serveur-mcp.ipynb`](03-4-MCP-Server/autour-du-consent-oauth-du-serveur-mcp.ipynb)
    reprend la question laissée ouverte par l'étape 4 : comment un client
    tiers se connecte-t-il **sans les clés de l'admin** ? Serveur
    d'autorisation OAuth 2.0 embarqué, enregistrement dynamique, PKCE,
    consentement réservé aux administrateurs, code → token → appel MCP
    réel au bearer délégué — puis révocation mesurée.
+
 9. [`interroger-lassistant-de-lediteur-par-l-api.ipynb`](03-1-Chatbots/interroger-lassistant-de-lediteur-par-l-api.ipynb)
    complète le tour des **quatre faces** du plugin — admin, agent,
    visiteur, éditeur — par celle de celui qui écrit : la route
@@ -76,12 +84,14 @@ reprend la question laissée ouverte par la précédente.
    refus, et où la frontière gratuite/Pro est inscrite dans la réponse
    elle-même. La route est stateless : le tour isolé oublie, le tour qui
    re-apporte `messages` souvient.
+
 10. [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](03-1-Chatbots/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb)
     ouvre la cinquième surface : la famille `mwai-ui/v1/files/*`, celle
     des **pièces jointes** — éphémères par architecture (TTL d'une heure
     prouvé par soustraction), partitionnées par utilisateur, avec le
     miroir admin `mwai/v1/openai/files/*`. Le stockage est fait ; la
     question devient son usage.
+
 11. [`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](03-1-Chatbots/joindre-un-fichier-au-chatbot-par-l-api.ipynb)
     ferme le dossier pièces jointes par la question qui suit le
     stockage : **comment un fichier téléversé entre-t-il dans une


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: MED/docs #15524

## Résumé

Tranche 7 de #15457 : le README de `AI-Engine-WordPress/03-Functional` présentait **un bloque de 4 461 c** (l.27-90) — la liste ordonnée des onze notebooks de la série (lien + description enveloppée par élément) formait un seul paragraphe continu.

Solución de curación: **lista flexible** — una línea vacía entre cada elemento (el más largo ≈ 450 c). Los números de la lista se mantienen continuos (CommonMark conserva el primer número de cada segmento).

## Preuves

- Détecteur (seuil 2000 c, pattern #15454/#15455) : `1 finding -> 0`.
- **+10/−0** : 10 lignes vides insérées, aucun octet de contenu modifié — préservation triviale.
- Preflight : pas de `[CLAIMED]` sur ce fichier dans les commentaires de #15457, **aucune PR sœur du sweep ouverte le couvrant** (énumération `15457 in:title` complète passée ce cycle — tranches #1-#6 et #8 déjà couvertes par #15473/#15487/#15466/#15515/#15524/#15501/#15494).

See #15457 (tranche 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
