### PR TITLE
docs(harness,#15486): ratifier la convention d'accrétion des twins intra-série (même identifiant + suffixe)

### DIFF
--- a/.claude/rules/notebook-accretion-numbering.md
+++ b/.claude/rules/notebook-accretion-numbering.md
@@ -95,10 +95,17 @@ Le sweep n'est pas « chercher l'ancien nom ». Six surfaces cassent, et cinq on
 
 Deux residus supplementaires se traitent dans la meme tranche : les cles orphelines de `pedagogy_density_baseline.json` (#13815) et la liste de rendu Quarto (#13931).
 
-## 7. Ce que la regle ne couvre pas
+## 7. Twins C#/Python d'une meme serie — meme identifiant, suffixe de langage seul
+
+Deux notebooks jumeaux **d'une meme serie** (meme concept, deux implementations) portent le **meme identifiant** `Prefixe-num(lettre)` ; seul le suffixe de langage les distingue (`-Csharp`). La variante C# ni ne decremente ni ne decale l'accretion : elle partage le slot de son jumeau Python. Des fichiers qui s'echangent leurs corrections (campagnes de parite #12208, retroportage #15461) ne peuvent pas porter deux accretions differentes.
+
+Ratifie par #15486 (origine : review user de #15437). La convention etait deja dominante partout (GameTheory `02`-`17`, Search `02b`/`03b`-`03d`, SocialChoice) ; l'unique deviation mesuree — `GameTheory-02d-...-Csharp` — a ete corrigee par renommage avant merge (#15437, commit f74fd9864c : `02d` -> `02c`).
+
+Le volet **inter-series** (meme concept dans deux series *differentes* partageant un identifiant) reste le chantier **#12933**, hors de la presente regle.
+
+## 8. Ce que la regle ne couvre pas
 
 - **Le padding zero** (`Search-3` vs `GameTheory-03`, ordre lexicographique casse) — chantier propre, **#14545**.
-- **Le suffixe de langage** des twins C#/Python — **#12933**.
 - **La numerotation des en-tetes markdown *dans* un notebook** (`## 3.`) — [notebook-conventions.md](notebook-conventions.md).
 
 ## Voir aussi


### PR DESCRIPTION
Grain: MED/harness — lane myia-po-2023:CoursIA — prev: MED/docs #15526

## Résumé

Action 2 de #15486 : **ratification écrite** de la convention d'accrétion des twins C#/Python intra-série, dans `.claude/rules/notebook-accretion-numbering.md`.

L'action 1 (renommage `GameTheory-02d-…-Csharp` → `02c`) était déjà livrée dans #15437 (commit f74fd9864c, MERGED — paire `02c`/`02c-Csharp` vérifiée sur `origin/main` ce cycle).

Le changement :
- **Nouvelle section 7** « Twins C#/Python d'une même série — même identifiant, suffixe de langage seul » : jumeaux d'une même série portent le même identifiant `Prefixe-num(lettre)` ; seul le suffixe `-Csharp` les distingue ; l'accrétion est partagée (des fichiers qui s'échangent leurs corrections — #12208, #15461 — ne peuvent pas porter deux accrétions). Cite la ratification #15486, l'origine user (review #15437), l'inventaire où la convention était déjà dominante, et la correction de l'unique déviation. Le volet **inter-séries** reste explicitement #12933.
- L'ancienne section 7 (« Ce que la règle ne couvre pas ») devient **section 8**, et son bullet « suffixe de langage — #12933 » est retiré (couvert).
- +9/−2, un seul fichier. Aucune autre référence à « section 7 » de cette règle dans le dépôt (grep vérifié). Détecteur paragraph-length : clean.

Closes #15486 (action 1 déjà mergée dans #15437 + action 2 = cette PR = acceptance complète)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
