### PR TITLE
fix(ci,#15387): un graphe d'objets incomplet sur le runner ne rougit plus un gate requis

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -134,6 +134,38 @@ jobs:
       IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
     steps:
+      # ------------------------------------------------------------------
+      # HEAL (#15387) : le pool self-hosted REUTILISE le work dir entre jobs.
+      # Un job a profondeur par defaut y laisse un clone SHALLOW ; le
+      # `fetch-depth: 0` ci-dessous declenche alors un `fetch --unshallow`
+      # dont l'echec est AVALE par actions/checkout -- mesure firsthand sur
+      # #15492 (run 34542167016, job 103087137418) : `error: Could not read
+      # 0102d652b3...` emis PENDANT le fetch, etape rendue verte malgre tout.
+      # Le depot reste alors ni shallow ni complet, et tout `git log --raw` /
+      # `git rev-list` ulterieur casse -- ce qui fait rougir un check REQUIS
+      # sur une panne d'infrastructure, jamais sur du fond. On repart d'un
+      # clone neuf des que l'etat est shallow ou le graphe troue.
+      # ------------------------------------------------------------------
+      - name: "Purger un work dir reutilise au graphe incomplet (#15387)"
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE" || exit 0
+          if [ ! -d .git ]; then
+            echo "[heal] aucun work dir preexistant -- checkout fera un clone neuf"
+            exit 0
+          fi
+          if [ -f .git/shallow ]; then
+            echo "::notice::[heal] work dir SHALLOW reutilise -- purge avant unshallow"
+            rm -rf .git
+            exit 0
+          fi
+          if ! git rev-list --all --count >/dev/null 2>&1; then
+            echo "::notice::[heal] graphe d'objets incomplet -- purge du work dir"
+            rm -rf .git
+            exit 0
+          fi
+          echo "[heal] work dir complet -- reutilisation"
+
       # fetch-depth: 0 + blob:none : requis par le fast-lane (les gardes
       # delta comparent HEAD a la base) et SUFFISANT pour les organes
       # metadata (leur sparse-checkout d'origine est un sous-ensemble de

--- a/.github/workflows/always-on-metadata-guards.yml
+++ b/.github/workflows/always-on-metadata-guards.yml
@@ -86,6 +86,38 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # ------------------------------------------------------------------
+      # HEAL (#15387) : le pool self-hosted REUTILISE le work dir entre jobs.
+      # Un job a profondeur par defaut y laisse un clone SHALLOW ; le
+      # `fetch-depth: 0` ci-dessous declenche alors un `fetch --unshallow`
+      # dont l'echec est AVALE par actions/checkout -- mesure firsthand sur
+      # #15492 (run 34542167016, job 103087137418) : `error: Could not read
+      # 0102d652b3...` emis PENDANT le fetch, etape rendue verte malgre tout.
+      # Le depot reste alors ni shallow ni complet, et tout `git log --raw` /
+      # `git rev-list` ulterieur casse -- ce qui fait rougir un check REQUIS
+      # sur une panne d'infrastructure, jamais sur du fond. On repart d'un
+      # clone neuf des que l'etat est shallow ou le graphe troue.
+      # ------------------------------------------------------------------
+      - name: "Purger un work dir reutilise au graphe incomplet (#15387)"
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE" || exit 0
+          if [ ! -d .git ]; then
+            echo "[heal] aucun work dir preexistant -- checkout fera un clone neuf"
+            exit 0
+          fi
+          if [ -f .git/shallow ]; then
+            echo "::notice::[heal] work dir SHALLOW reutilise -- purge avant unshallow"
+            rm -rf .git
+            exit 0
+          fi
+          if ! git rev-list --all --count >/dev/null 2>&1; then
+            echo "::notice::[heal] graphe d'objets incomplet -- purge du work dir"
+            rm -rf .git
+            exit 0
+          fi
+          echo "[heal] work dir complet -- reutilisation"
+
       # Checkout UNION des trois organes : fetch-depth 0 + blob:none (le
       # graphe complet est requis par l'organe stale-base -- rev-list BASE..main
       # et dates de commits, cf #11835 ; les blobs restent paresseux) ;
@@ -118,6 +150,14 @@ jobs:
       # ------------------------------------------------------------------
       - name: "Organe base-not-main : signaler une base != main (advisory)"
         if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main'
+        # ADVISORY : ne doit JAMAIS faire rougir ce check REQUIS (contrat
+        # documente en tete de fichier -- patron #13384 : seul l'organe
+        # BLOQUANT `conj` rougit, via l'etape AGREGAT). Sans ce marqueur,
+        # une affectation `VAR=$(git ...)` en echec sous `bash -e` avortait
+        # l'etape et rougissait le job (#15387 : graphe d'objets incomplet
+        # sur un work dir self-hosted reutilise -> #15366, #15447, #15483,
+        # #15496 bloquees sur une panne d'infrastructure).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/base_not_main.py --pr "${{ github.event.pull_request.number }}"
@@ -130,6 +170,14 @@ jobs:
       # ------------------------------------------------------------------
       - name: "Organe stale-base : avertissement base >14j (advisory)"
         if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        # ADVISORY : ne doit JAMAIS faire rougir ce check REQUIS (contrat
+        # documente en tete de fichier -- patron #13384 : seul l'organe
+        # BLOQUANT `conj` rougit, via l'etape AGREGAT). Sans ce marqueur,
+        # une affectation `VAR=$(git ...)` en echec sous `bash -e` avortait
+        # l'etape et rougissait le job (#15387 : graphe d'objets incomplet
+        # sur un work dir self-hosted reutilise -> #15366, #15447, #15483,
+        # #15496 bloquees sur une panne d'infrastructure).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -128,6 +128,38 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      # ------------------------------------------------------------------
+      # HEAL (#15387) : le pool self-hosted REUTILISE le work dir entre jobs.
+      # Un job a profondeur par defaut y laisse un clone SHALLOW ; le
+      # `fetch-depth: 0` ci-dessous declenche alors un `fetch --unshallow`
+      # dont l'echec est AVALE par actions/checkout -- mesure firsthand sur
+      # #15492 (run 34542167016, job 103087137418) : `error: Could not read
+      # 0102d652b3...` emis PENDANT le fetch, etape rendue verte malgre tout.
+      # Le depot reste alors ni shallow ni complet, et tout `git log --raw` /
+      # `git rev-list` ulterieur casse -- ce qui fait rougir un check REQUIS
+      # sur une panne d'infrastructure, jamais sur du fond. On repart d'un
+      # clone neuf des que l'etat est shallow ou le graphe troue.
+      # ------------------------------------------------------------------
+      - name: "Purger un work dir reutilise au graphe incomplet (#15387)"
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE" || exit 0
+          if [ ! -d .git ]; then
+            echo "[heal] aucun work dir preexistant -- checkout fera un clone neuf"
+            exit 0
+          fi
+          if [ -f .git/shallow ]; then
+            echo "::notice::[heal] work dir SHALLOW reutilise -- purge avant unshallow"
+            rm -rf .git
+            exit 0
+          fi
+          if ! git rev-list --all --count >/dev/null 2>&1; then
+            echo "::notice::[heal] graphe d'objets incomplet -- purge du work dir"
+            rm -rf .git
+            exit 0
+          fi
+          echo "[heal] work dir complet -- reutilisation"
+
       - uses: actions/checkout@v4
         with:
           # Full history required by test_twin_registry_integrity.py::

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -398,6 +398,18 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
+# Signatures par lesquelles git nomme LUI-MEME un graphe d'objets incomplet
+# (#15387). Le pool self-hosted reutilise son work dir : un job a profondeur
+# par defaut y laisse un clone shallow, le job suivant en `fetch-depth: 0`
+# tente un `fetch --unshallow`, et l'echec de ce fetch est avale par
+# actions/checkout (mesure #15492, run 34542167016). Volontairement ETROIT :
+# toute AUTRE sortie non nulle du walk reste un `RuntimeError`.
+_GRAPH_INCOMPLETE_SIGNATURES = (
+    "Could not read ",
+    "Failed to traverse parents of commit ",
+)
+
+
 def _build_blob_history(repo_root: Path) -> tuple[dict, dict]:
     """Map ``(path_blobs, blob_paths)`` pour tous les fichiers, ancetres de HEAD.
 
@@ -447,6 +459,23 @@ def _build_blob_history(repo_root: Path) -> tuple[dict, dict]:
     if proc.returncode != 0:
         proc = _walk()
     if proc.returncode != 0:
+        # Un `RuntimeError` EST un echec de test ordinaire : le rollup ne le
+        # distingue pas d'un verdict de fond, si bien qu'une panne de runner
+        # faisait rougir un check REQUIS sur toute la flotte (#15492, #15513,
+        # #15517, #15523). Quand git NOMME lui-meme le graphe troue, on rend
+        # un SKIP -- c'est le « verdict d'infrastructure distinct » que #15387
+        # demandait, et que lever une exception ne pouvait pas produire. Le
+        # garde ne s'affaiblit pas : il cesse seulement de parler de FOND
+        # quand il n'a pas pu mesurer, et toute autre sortie non nulle leve.
+        stderr = proc.stderr.strip()
+        if any(sig in stderr for sig in _GRAPH_INCOMPLETE_SIGNATURES):
+            pytest.skip(
+                "HISTORY_WALK_INCOMPLETE (#15387) : graphe d'objets incomplet "
+                "sur le runner (work dir reutilise, unshallow avorte) -- panne "
+                "d'infrastructure, PAS un verdict de fond. La couverture de "
+                "test_audit_shas_exist_in_file_history est perdue pour ce run "
+                "seulement. stderr=" + stderr[:300]
+            )
         raise RuntimeError(
             "HISTORY_WALK_INCOMPLETE (#15387) : git log -m --raw a terminé "
             f"avec le code {proc.returncode} ; l'historique parcouru est "
@@ -714,6 +743,57 @@ def test_walk_en_echec_avorte_avec_verdict_infrastructure(monkeypatch):
     with pytest.raises(RuntimeError, match="HISTORY_WALK_INCOMPLETE"):
         _build_blob_history(Path("."))
     assert len(calls) == 2, "1 essai + 1 retry avant l'abort"
+
+
+@pytest.mark.parametrize(
+    "stderr_git",
+    [
+        # Les deux moities de la signature mesuree sur #15492 (run 34542167016).
+        "error: Could not read 0102d652b3e7e328f7e9d710e99e0098745bc4cd",
+        "fatal: Failed to traverse parents of commit bb02b3d1cf2e09a4e438260601e38b8e105f50f3",
+    ],
+)
+def test_graphe_incomplet_rend_un_skip_pas_un_echec_de_fond(monkeypatch, stderr_git):
+    """git NOMME le graphe troue -> SKIP (verdict d'infrastructure #15387).
+
+    Un `RuntimeError` ici est indiscernable d'un verdict de fond dans le
+    rollup : c'est ce qui bloquait #15492/#15513/#15517/#15523 sur une panne
+    de runner. Le retry reste du, le skip ne vient qu'apres.
+    """
+    import subprocess
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 128,
+            stdout=_fake_raw_line("f" * 40, "e" * 40, "A/X.ipynb") + "\n",
+            stderr=stderr_git,
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(pytest.skip.Exception, match="HISTORY_WALK_INCOMPLETE"):
+        _build_blob_history(Path("."))
+    assert len(calls) == 2, "1 essai + 1 retry avant le verdict d'infrastructure"
+
+
+def test_signature_inconnue_leve_toujours(monkeypatch):
+    """Le skip est ETROIT : une sortie non nulle non nommee reste un echec.
+
+    Contre-controle du test ci-dessus -- sans lui, elargir accidentellement
+    ``_GRAPH_INCOMPLETE_SIGNATURES`` transformerait le garde en no-op muet.
+    """
+    import subprocess
+
+    def fake_run(cmd, **kw):
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="fatal: not a git repository",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="HISTORY_WALK_INCOMPLETE"):
+        _build_blob_history(Path("."))
 
 
 def test_walk_transitoire_retraye_puis_parse(monkeypatch):


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/docs #15500

## Ce qui bloquait, et pourquoi ce n'etait pas du fond

Vingt-quatre PRs de la flotte portaient un required gate rouge sous trois noms differents. Les trois sont la meme panne, et aucune n'est un verdict de contenu.

Le pool self-hosted **reutilise son work dir entre jobs**. Un job a profondeur par defaut y laisse un clone **shallow** ; le job suivant, en `fetch-depth: 0`, tente alors un `fetch --unshallow` — et l'echec de ce fetch est **avale** par `actions/checkout`.

Mesure firsthand, PR #15492, [run 34542167016 / job 103087137418](https://github.com/jsboige/CoursIA/actions/runs/34542167016/job/103087137418) :

```
[command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules \
  --filter=blob:none --unshallow origin +refs/heads/*:refs/remotes/origin/* ...
##[error]error: Could not read 0102d652b3e7e328f7e9d710e99e0098745bc4cd
```

L'etape est rendue **verte** malgre cette erreur. Le depot reste alors ni shallow ni complet, et tout `git log --raw` / `git rev-list` ulterieur casse :

```
fatal: Failed to traverse parents of commit bb02b3d1cf2e09a4e438260601e38b8e105f50f3
```

Les trois objets cites (`0102d652b3…`, `bb02b3d1cf…`, `3b02058dd5…`) **existent** dans le depot — `git cat-file -t` rend `commit` pour chacun. Ce n'est pas une perte d'objets : c'est le clone du runner qui est troue.

Corollaire mesure : `filter: blob:none` n'est **pas** en cause. L'objet manquant est un **commit**, que ce filtre n'omet jamais. C'est le `--unshallow` avorte qui creuse le trou.

### Portee

Les trois jobs partagent le meme pool `[self-hosted, coursia-ephemeral, coursia-linux]` et le meme checkout `fetch-depth: 0` + `filter: blob:none`.

| Gate requis | PRs bloquees |
|---|---|
| `Always-on guards -- 12 organes` | #15518, #15506, #15483, #15465, #15464, #15463, #15455, #15454, #15448, #15447, #15446, #15443, #15442, #15303, #15280, #15214 |
| `Always-on metadata guards -- 3 organes` | #15496, #15483, #15447, #15366 |
| `Scripts Tests (CPU)` | #15523, #15517, #15513, #15492 |

## Les trois volets

### 1. HEAL avant checkout — la cause, traitee la ou elle est

Une etape ajoutee en tete des trois jobs concernes : on repart d'un clone neuf des que le work dir est shallow (`.git/shallow` present) ou que `git rev-list --all --count` ne boucle pas.

Une action composite locale ne pouvait pas porter ce geste : `uses: ./.github/actions/...` exige que le depot soit **deja** checkout. D'ou trois etapes `run:` inline.

### 2. Les advisories ne peuvent plus rougir (`always-on-metadata-guards.yml`)

Le fichier **documente en tete** (l. 47-52) que seul l'organe bloquant `conj` rougit, via l'etape `Agregat`, et que « les deux advisories tournent EN PREMIER (elles ne peuvent pas rougir) ». Le code contredisait ce contrat : ni `Organe base-not-main` ni `Organe stale-base` ne portaient `continue-on-error: true`. Sous `shell: /usr/bin/bash -e`, une affectation `BEHIND=$(git rev-list "$BASE_SHA..origin/main" --count)` en echec avorte l'etape — et un organe **declare advisory** rougissait un check **requis**.

Ce volet vaut independamment du volet 1 : un advisory qui peut rougir un gate requis est un defaut en soi.

### 3. Un verdict d'infrastructure distinct, et etroitement borne (`test_twin_registry_integrity.py`)

#15387 demandait explicitement, en commentaire dans le code, un « verdict d'infrastructure distinct -- jamais un verdict de fond ». L'implementation levait un `RuntimeError` — or **un `RuntimeError` dans un test est un echec de test ordinaire** : le rollup ne le distingue pas d'un verdict de contenu, donc une panne de runner rougissait un gate requis sur toute la flotte. L'intention etait juste, l'organe ne la produisait pas.

`_build_blob_history` rend desormais un `pytest.skip` **quand git nomme lui-meme le graphe troue**, borne a deux signatures :

```python
_GRAPH_INCOMPLETE_SIGNATURES = (
    "Could not read ",
    "Failed to traverse parents of commit ",
)
```

Toute **autre** sortie non nulle continue de lever. Le garde ne s'affaiblit pas : il cesse seulement de parler de fond quand il n'a pas pu mesurer.

Deux verrous de test encadrent la bornure — sans le second, elargir accidentellement le tuple transformerait le garde en no-op muet :

- `test_graphe_incomplet_rend_un_skip_pas_un_echec_de_fond` (parametre sur les deux moities de la signature mesuree) ;
- `test_signature_inconnue_leve_toujours` — contre-controle.

Le verrou existant `test_walk_en_echec_avorte_avec_verdict_infrastructure` passe **inchange** : son stderr (`fatal: promisor fetch failure`) ne matche aucune signature, donc il leve toujours.

## Validation

```
$ python -m pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py -q
46 passed, 1 warning in 16.68s
```

`test_audit_shas_exist_in_file_history` s'execute **reellement** ici — le graphe local est complet, donc aucun skip — et emet toujours son avertissement de blobs orphelins par squash. Le garde garde, la ou il peut mesurer.

## Ce que cette PR ne fait pas

- Elle ne retire pas `filter: blob:none` : la mesure ci-dessus disqualifie cette piste (objet manquant = commit).
- Elle ne traite pas les autres rouges du balayage (#15508 ratchets notebook, #15440 Lean CI inacheve, #15390, #15370, #15210), qui ont des causes distinctes.
- Le label `coursia-ephemeral` decrit mal un pool qui reutilise son work dir. Le renommer ou rendre le pool reellement ephemere est un grain a part.

See #15387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
