### PR TITLE
fix(docs,#15516): sweep mermaid fill-sans-color — famille QuantConnect (2 READMEs, 17 règles)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -101,9 +101,10 @@ flowchart TD
     VERD --> CKPT["Checkpoint<br/>model.pt + metadata.json"]
     VERD -.-> NO["NO BEATS<br/>(documente honnetement)"]
     CKPT --> REG["REGISTRY.md"]
-    style VERD fill:#fff3e0
-    style CKPT fill:#e8f5e9
-    style NO fill:#ffebee
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style VERD fill:#fff3e0,color:#bf360c
+    style CKPT fill:#e8f5e9,color:#1b5e20
+    style NO fill:#ffebee,color:#721c24
 ```
 
 Ci-dessous, l'arborescence des scripts qui implémente ce pipeline.
@@ -516,10 +517,11 @@ flowchart LR
     TH --> TR2["Trading differe"]
     TR1 --> RES1["L4 DT : 24/26 panel @10bps<br/>(OOT temporel réel 04/09 : NO-BEATS)"]
     TR2 --> RES2["PatchTST : 0/26 seeds BEATS<br/>Signal noye dans le bruit"]
-    style P1 fill:#e8f5e9
-    style P2 fill:#ffebee
-    style RES1 fill:#c8e6c9
-    style RES2 fill:#ffcdd2
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style P1 fill:#e8f5e9,color:#1b5e20
+    style P2 fill:#ffebee,color:#721c24
+    style RES1 fill:#c8e6c9,color:#1b5e20
+    style RES2 fill:#ffcdd2,color:#721c24
 ```
 
 L'écart de performance n'est pas un hasard : un classifieur d'action capture la **non-linéarité directionnelle** qu'un régresseur de rendement lisse et perd dans le seuillage. D'où le verdict consolidé — un seul BEATS (DT action-based, **panel @10bps** ; non confirmé hors-échantillon en temps, OOT réel 04/09 NO-BEATS), tout le reste NO BEATS (rendement/forecast).

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -119,9 +119,10 @@ flowchart LR
     PC --> RM["Risk Management<br/>quels filtres ?"]
     RM --> E["Execution<br/>quels ordres ?"]
     RM -. "ajustement temps reel" .-> U
-    style A fill:#e1f5ff
-    style PC fill:#e8f5e9
-    style RM fill:#fff3e0
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style A fill:#e1f5ff,color:#004085
+    style PC fill:#e8f5e9,color:#1b5e20
+    style RM fill:#fff3e0,color:#bf360c
 ```
 
 Le flux de données traverse cinq modules Découplables : l'**Universe** sélectionne les actifs, l'**Alpha** produit les signaux directionnels, la **Portfolio Construction** transforme les signaux en tailles cibles, le **Risk Management** filtre/ajuste ces cibles en continu, et l'**Execution** route les ordres. Chaque module est remplaçable indépendamment — c'est ce qui permet de composer une stratégie complexe sans réécrire l'ensemble.
@@ -494,11 +495,12 @@ flowchart TD
     FEES --> VERD{"Sharpe net<br/>survit aux frais ?"}
     VERD -->|"oui"| KEEP["Strategie robuste"]
     VERD -->|"non"| DROP["Edge evapore"]
-    style PSR fill:#fff3e0
-    style VERD fill:#fff3e0
-    style KEEP fill:#e8f5e9
-    style ART fill:#ffebee
-    style DROP fill:#ffebee
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style PSR fill:#fff3e0,color:#bf360c
+    style VERD fill:#fff3e0,color:#bf360c
+    style KEEP fill:#e8f5e9,color:#1b5e20
+    style ART fill:#ffebee,color:#721c24
+    style DROP fill:#ffebee,color:#721c24
 ```
 
 Le **fil rouge** de la série : un Sharpe spectaculaire en backtest court est presque toujours un artefact. La validation ci-dessus — walk-forward, OOS strict aligné, multi-seed, PSR > 50%, puis test des frais réels — est ce qui sépare une stratégie robuste d'une illusion statistique. Les stratégies du tableau Top 5 ci-dessous sont celles qui ont survécu à ce pipeline.
@@ -554,8 +556,9 @@ flowchart LR
     QC -. "fréquence risquée f" .-> KELLY
     KELLY -. "théorème-prouve f*" .-> ML
     ML --> BACKTEST
-    style KELLY fill:#e8f5e9
-    style BACKTEST fill:#e1f5ff
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style KELLY fill:#e8f5e9,color:#1b5e20
+    style BACKTEST fill:#e1f5ff,color:#004085
 ```
 
 Le pipeline complet relie donc trois familles du dépôt : la **théorie** (Lean prouve `kelly_optimal` + `kelly_unique`), la **pratique** (ML-Training-Pipeline dimensionne Kelly HMM-regime, fee-aware, multi-asset, cap-relaxed — voir `ML-Training-Pipeline/docs/M11*`), et la **validation empirique** (backtests QC Cloud walk-forward + multi-seed, comparatif dans [`docs/qc/qc-comparative-backtests.md`](../../docs/qc/qc-comparative-backtests.md)). Sans la couche Lean, la pratique risquerait de s'appuyer sur une formule réputée « standard » mais jamais démontrée. Avec elle, la justification du fractionnement du capital est formellement garantie — pas seulement empiriquement ajustée.


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: DEEP/ml #15548

`See #15516` (contribution partielle : famille QuantConnect sur 25 fichiers — le résiduel reste ouvert, découpage par famille conforme au body de l'issue).

## Summary

Sweep mermaid `fill:` sans `color:` (#15516, résiduel #15022) — **famille QuantConnect** : les 2 READMEs de la famille (racine QuantConnect + ML-Training-Pipeline), 17 règles fautives sur les 90 de l'inventaire. Pattern du pilote #15502 : **ajout de `color:` uniquement** (aucune couleur pédagogique retirée, aucun `fill:` modifié), garde `%%` anti-harmonisation posée sur chacun des 5 blocs touchés.

**Périmètre : 2 fichiers**

- `MyIA.AI.Notebooks/QuantConnect/README.md` (10 règles, 3 blocs)
- `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md` (7 règles, 2 blocs)

## Palette (langage du pilote #15502, Bootstrap-alert tones)

| fill | color retenu | ratio WCAG min mesuré |
|---|---|---|
| `#e1f5ff` (bleu clair) | `#004085` | 9.03:1 |
| `#e8f5e9` / `#c8e6c9` (verts) | `#1b5e20` | 5.85:1 (sur #c8e6c9) |
| `#fff3e0` (orange) | `#bf360c` | 5.11:1 |
| `#ffebee` / `#ffcdd2` (rouges/roses) | `#721c24` | 7.82:1 (sur #ffcdd2) |

Toutes les paires ≥ 4.5:1 (AA) — calcul Python WCAG-relatif, mêmes formules que la review NanoClaw du pilote.

## Validation

```
$ python scripts/notebook_tools/detect_mermaid_fill_without_color.py --check MyIA.AI.Notebooks/QuantConnect/README.md
Mermaid fill: rules : 10 (with color: 10) / Findings : 0 — EXIT=0
$ python scripts/notebook_tools/detect_mermaid_fill_without_color.py --check MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
Mermaid fill: rules : 7 (with color: 7) / Findings : 0 — EXIT=0
```

(le détecteur vit sur la branche #15517 — exécuté depuis son checkout, cible = worktree frais origin/main 2f4b2bb96.)

Diff strictement additif sur les règles mermaid : aucune prose, liste, compteur ou arborescence modifiés (§E : rien à réconcilier — le fichier n'est pas touché hors des blocs style).

## QA visuel (acceptance #15516)

L'acceptance exige le QA visuel thème sombre par une lane vision (CoursIA-2/MiniMax ou ai-01) — ce grain est calcul-verifié (WCAG ≥ AA), la confirmation visuelle reste au merge-gate conformément au routing capability-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
