### PR TITLE
fix(docs,#15516): sweep mermaid fill-sans-color — famille racine/Notebooks/ML/SymbolicAI (4 READMEs, 18 règles)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -356,12 +356,13 @@ flowchart LR
     NB4 -. "PAC ⇓ uniform_concentration" .-> L3
     NB5 -. "vote ≅ préférences agrégées" .-> L5
     NB6 -. "échantillon i.i.d. + Hoeffding" .-> L3
-    style L1 fill:#e8f5e9,stroke:#2e7d32
-    style L2 fill:#e8f5e9,stroke:#2e7d32
-    style L3 fill:#e8f5e9,stroke:#2e7d32
-    style L4 fill:#e8f5e9,stroke:#2e7d32
-    style L5 fill:#e8f5e9,stroke:#2e7d32
-    style L6 fill:#e8f5e9,stroke:#2e7d32
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style L1 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style L2 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style L3 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style L4 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style L5 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style L6 fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
 ```
 
 Lecture : chaque nœud **SIM** représente un notebook ML dont le résultat empirique (marge, ERM, ensemble, PAC) est *prouvé* par au moins un nœud **LEAN** via une flèche pointillée. Le **vert pâle** sur les nœuds Lean rappelle que la *preuve* est l'engagement de véracité du notebook — pas une décoration. Voir l'EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) et le hub central [P0](../README.md#lean) pour la cartographie complète (PR #5049). Cross-réf hubs voisins déjà livrés : [QuantConnect (PR #5047)](../QuantConnect/README.md), [GameTheory (PR #5050)](../GameTheory/README.md), [Probas (PR #5053)](../Probas/README.md), [SymbolicAI Lean (#5043 MERGED)](../SymbolicAI/Lean/README.md).

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -323,12 +323,13 @@ flowchart LR
     N4 -. "fraction risquée f" .-> L4
     N5 -. "invariant réentrance" .-> L5
     N6 -. "impossibilité" .-> L6
-    style L1 fill:#e8f5e9
-    style L2 fill:#e8f5e9
-    style L3 fill:#e8f5e9
-    style L4 fill:#e8f5e9
-    style L5 fill:#e8f5e9
-    style L6 fill:#e8f5e9
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style L1 fill:#e8f5e9,color:#1b5e20
+    style L2 fill:#e8f5e9,color:#1b5e20
+    style L3 fill:#e8f5e9,color:#1b5e20
+    style L4 fill:#e8f5e9,color:#1b5e20
+    style L5 fill:#e8f5e9,color:#1b5e20
+    style L6 fill:#e8f5e9,color:#1b5e20
 ```
 
 Le pipeline complet relie les **notebooks** (qui motivent) aux **lakes** (qui prouvent) et inversement : un notebook Tweety illustre un AF-Dung et cite `argumentation_lean` comme source de l'extension prouvée ; un cours QuantConnect cite `kelly_lean` comme justification formelle de la fraction risquée optimale. Sans la couche Lean, ces résultats seraient des formules réputées « standard » mais jamais démontrées. Avec elle, la justification est formellement garantie — pas seulement empiriquement ajustée.

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -46,9 +46,10 @@ flowchart TD
     LEAN -.->|"sensitivity_lean (Huang 2019)"| SC
     TW -.->|"induction logique (FOIL)"| SL
 
-    classDef found fill:#e8f0fe,stroke:#1a73e8
-    classDef app fill:#e6f4ea,stroke:#188038
-    classDef bridge fill:#fef7e0,stroke:#f9ab00
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    classDef found fill:#e8f0fe,stroke:#1a73e8,color:#174ea6
+    classDef app fill:#e6f4ea,stroke:#188038,color:#137333
+    classDef bridge fill:#fef7e0,stroke:#f9ab00,color:#856404
     class TW,SW,LEAN found
     class SMT,PL,SC app
     class AA,SL bridge

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ flowchart LR
     GameTheory --> RL
     SymbolicAI(["SymbolicAI<br/>logique, planners, SMT, Lean"]) --> CaseStudies(["CaseStudies<br/>systèmes hybrides"])
 
-    classDef track fill:#f5f5f5,stroke:#333,stroke-width:1px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    classDef track fill:#f5f5f5,stroke:#333,stroke-width:1px,color:#333;
     class Search,Sudoku,ML,RL,Probas,GameTheory,SymbolicAI,CaseStudies,GenAI,QuantConnect track;
 ```
 
@@ -79,8 +80,9 @@ flowchart LR
     A4 -.-> AP
     A5 -.-> AP
 
-    classDef stage fill:#f5f5f5,stroke:#333,stroke-width:1px;
-    classDef learn fill:#eef4ff,stroke:#333,stroke-width:1px,stroke-dasharray:4 3;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    classDef stage fill:#f5f5f5,stroke:#333,stroke-width:1px,color:#333;
+    classDef learn fill:#eef4ff,stroke:#333,stroke-width:1px,stroke-dasharray:4 3,color:#333;
     class A1,A2,A3,A4,A5 stage;
     class AP learn;
 ```


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: LIGHT/readme #15550

`See #15516` (contribution partielle : famille racine/Notebooks/ML/SymbolicAI sur 25 fichiers — tranches famille déjà livrées : QuantConnect #15550 ; résiduel : GameTheory+SMT+Tweety, Z3-Linq2Z3, slides, Probas gelé tant que #15502 ouvert).

## Summary

Sweep mermaid `fill:` sans `color:` (#15516, résiduel #15022) — **famille racine + MyIA.AI.Notebooks + ML + SymbolicAI** : 4 READMEs (dont le README racine du dépôt), 18 règles fautives. Pattern du pilote #15502 : **ajout de `color:` uniquement** (aucune couleur pédagogique retirée, aucun `fill:` modifié), garde `%%` anti-harmonisation sur chacun des 5 blocs touchés. Tranche fournée #15516 consécutive à #15550 (même découpage par famille prescrit par le body de l'issue).

**Périmètre : 4 fichiers**

- `README.md` (3 règles classDef, 2 blocs)
- `MyIA.AI.Notebooks/README.md` (6 règles style, 1 bloc)
- `MyIA.AI.Notebooks/ML/README.md` (6 règles style, 1 bloc)
- `MyIA.AI.Notebooks/SymbolicAI/README.md` (3 règles classDef, 1 bloc)

## Palette (contrastes WCAG calculés)

| fill | color retenu | ratio | stroke d'origine en couleur de texte |
|---|---|---|---|
| `#f5f5f5` / `#eef4ff` | `#333` (= stroke, harmonisation légitime) | 11.44–11.59:1 | `#333` = 11.4+ (OK) |
| `#e8f5e9` | `#1b5e20` | 7.00:1 | — |
| `#e8f0fe` | `#174ea6` | 6.85:1 | `#1a73e8` = 3.93 (échoue AA) |
| `#e6f4ea` | `#137333` | 5.24:1 | `#188038` = 4.42 (échoue AA) |
| `#fef7e0` | `#856404` | 5.13:1 | `#f9ab00` = 1.81 (échoue AA) |

Les trois strokes SymbolicAI échouent AA comme couleur de texte — le ton retenu est **délibérément plus foncé**, c'est exactement le cas couvert par la garde `%%` « ne pas harmoniser ».

## Validation

```
$ python scripts/notebook_tools/detect_mermaid_fill_without_color.py --check <chacun des 4 fichiers>
No fill-without-color rule detected (vs #15022). — EXIT=0 (x4)
```

Diff strictement additif sur les règles mermaid : aucune prose, liste, compteur ou arborescence modifiés (§E : rien à réconcilier hors blocs style ; marqueurs CATALOG-STATUS non touchés).

## QA visuel (acceptance #15516)

Calcul-verifié (WCAG ≥ AA sur les 5 fills) ; confirmation visuelle thème sombre au merge-gate par lane vision (CoursIA-2/MiniMax ou ai-01), conformément au routing de l'acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
