### PR TITLE
fix(docs,#15516): sweep mermaid fill-sans-color — GameTheory/SMT/Tweety/slides (4 fichiers, 11 règles)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -476,12 +476,13 @@ flowchart LR
     N4 -. "balanced ⟹ Core non-vide" .-> L4
     N5 -. "optimalité proposant" .-> L5
     N6 -. "stabilité sous menace" .-> L6
-    style L1 fill:#e8f5e9
-    style L2 fill:#e8f5e9
-    style L3 fill:#e8f5e9
-    style L4 fill:#e8f5e9
-    style L5 fill:#e8f5e9
-    style L6 fill:#e8f5e9
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    style L1 fill:#e8f5e9,color:#1b5e20
+    style L2 fill:#e8f5e9,color:#1b5e20
+    style L3 fill:#e8f5e9,color:#1b5e20
+    style L4 fill:#e8f5e9,color:#1b5e20
+    style L5 fill:#e8f5e9,color:#1b5e20
+    style L6 fill:#e8f5e9,color:#1b5e20
 ```
 
 Le pipeline complet relie les **notebooks** (qui motivent — Lemke-Howson, Axelrod, Folk Theorem, Gale-Shapley via `game_theory_lean`) aux **lakes** (qui prouvent — Arrow résolu 0 sorry, Bondareva-Shapley résolu 0 sorry #3954, von Neumann/Sion, Vickrey, Gale-Shapley existence et optimalité côté proposant, grim-trigger). Sans la couche Lean, ces résultats seraient des théorèmes réputés « standard » mais jamais démontrés ; avec elle, la justification est **formellement garantie** — pas seulement admise. La spécificité GameTheory : la simulation (Lemke-Howson numérique, OpenSpiel CFR, Axelrod tournois) précède la preuve, mais les deux faces du même raisonnement sont également outillées.

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -36,8 +36,9 @@ flowchart LR
     TH4 --> V
     V -->|"sat"| M["modèle<br/>(solution)"]
     V -->|"unsat"| U["impossibilité<br/>prouvée"]
-    classDef sat fill:#fff3cd,stroke:#856404,stroke-width:2px;
-    classDef smt fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    classDef sat fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
+    classDef smt fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
     class SAT sat;
     class SMT smt;
 ```

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -81,7 +81,8 @@ flowchart LR
     P4["<b>Phase 4</b><br/>Frameworks avancés<br/>ADF, WAF, ranking, probabiliste<br/>NB 7a-7b"]
     P5["<b>Phase 5</b><br/>Applications<br/>dialogues, vote, préférences<br/>NB 8-9"]
     P1 --> P2 --> P3 --> P4 --> P5
-    classDef core fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+    classDef core fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
     class P3 core;
 ```
 

--- a/slides/02-resolution-problemes/analysis/vision-compare-s17.md
+++ b/slides/02-resolution-problemes/analysis/vision-compare-s17.md
@@ -91,8 +91,9 @@ graph TD
   Timisoara --> Lugoj:::frontier
   Zerind --> Arad4[Arad]:::frontier
   Zerind --> Oradea2[Oradea]:::frontier
-  classDef root fill:#ccc,stroke:#333
-  classDef frontier fill:#fff,stroke:#00aa00,stroke-dasharray:5
+  %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ton parfois plus fonce que le stroke (le stroke en couleur de texte rendrait infer illisible) : ne pas harmoniser
+  classDef root fill:#ccc,stroke:#333,color:#333
+  classDef frontier fill:#fff,stroke:#00aa00,stroke-dasharray:5,color:#006600
 ```
 
 Cela reproduit fidèlement le codage couleur du PPTX (nœuds frontière en vert pointillé).


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: LIGHT/readme #15551

`See #15516` (contribution partielle : 2e moitié du groupe « le reste » du découpage prescrit par le body — tranches livrées : QuantConnect #15550, racine/Notebooks/ML/SymbolicAI #15551, ce PR GameTheory/SMT/Tweety/slides. Résiduel : Z3-Linq2Z3 9 notebooks/29 règles + Probas gelé tant que #15502 ouvert).

## Summary

Sweep mermaid `fill:` sans `color:` (#15516, résiduel #15022) — **GameTheory + SMT + Tweety + slides** : 4 fichiers, 11 règles. Pattern du pilote #15502 : **ajout de `color:` uniquement**, garde `%%` anti-harmonisation sur chacun des 4 blocs touchés. SMT et Tweety portent exactement les classDefs Bootstrap du pilote Probas avant sa correction — mêmes pairings repris.

**Périmètre : 4 fichiers**

- `MyIA.AI.Notebooks/GameTheory/README.md` (6 règles style, 1 bloc)
- `MyIA.AI.Notebooks/SymbolicAI/SMT/README.md` (2 règles classDef, 1 bloc)
- `MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md` (1 règle classDef, 1 bloc — les classDefs l.305-306 ont déjà `color:`)
- `slides/02-resolution-problemes/analysis/vision-compare-s17.md` (2 règles classDef, 1 bloc)

## Palette (contrastes WCAG calculés)

| fill | color retenu | ratio | note |
|---|---|---|---|
| `#e8f5e9` | `#1b5e20` | 7.00:1 | pattern #15502 |
| `#fff3cd` | `#856404` | 4.96:1 | pairing exact du pilote #15502 |
| `#d1ecf1` | `#0c5460` | 6.92:1 | pairing exact du pilote #15502 |
| `#ccc` | `#333` (= stroke) | 7.87:1 | harmonisation légitime |
| `#fff` | `#006600` | 7.24:1 | stroke `#00aa00` échoue AA (3.11) — ton plus foncé **délibéré**, garde `%%` posée |

## Validation

```
$ python scripts/notebook_tools/detect_mermaid_fill_without_color.py --check <chacun des 4 fichiers>
No fill-without-color rule detected (vs #15022). — EXIT=0 (x4)
```

Diff strictement additif sur les règles mermaid (aucune prose/compteur modifié). Le fichier slides est un document d'analyse figé (comparatif PPTX/Slidev S17) — seules les 2 règles classDef changent, le codage couleur décrit en prose l.98 est préservé (frontière = vert, root = gris).

## QA visuel (acceptance #15516)

Calcul-verifié (WCAG ≥ AA sur les 5 fills) ; confirmation visuelle thème sombre au merge-gate par lane vision (CoursIA-2/MiniMax ou ai-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
