### PR TITLE
fix(guard,#15556): identite d'arbre dans le crible SHA rembobine — un push muet n'invalide plus une levee

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -2704,15 +2704,20 @@ def _message_refs_pr(message: str, pr_refs: set[str]) -> bool:
     return bool(cited & pr_refs)
 
 
-def _resolve_absent_sha_messages(data: dict, cap: int = 5) -> dict[str, str]:
+def _resolve_absent_sha_state(data: dict, cap: int = 5) -> dict[str, dict]:
     """Resoudre cote serveur les SHAs cites mais absents des commits de la PR.
 
     S'execute UNIQUEMENT dans le chemin `gate` (reseau) : `analyse` reste
-    pur et lit le resultat via `data["_absent_sha_messages"]`. Sans entree
-    resolue, `analyse` reste en mode avertissement -- l'audit retro, qui
-    n'appelle jamais ceci, ne peut donc pas produire de faux blocage.
-    Capped a `cap` appels : plus de 5 SHAs absents cites sur une seule PR
-    est extraordinaire, et chaque appel paie un aller-retour API.
+    pur et lit le resultat via `data["_absent_sha_messages"]` (le message)
+    et `data["_absent_sha_trees"]` (l'arbre du commit rembobine, #15556).
+    Sans entree resolue, `analyse` reste en mode avertissement -- l'audit
+    retro, qui n'appelle jamais ceci, ne peut donc pas produire de faux
+    blocage. Capped a `cap` appels : plus de 5 SHAs absents cites sur une
+    seule PR est extraordinaire, et chaque appel paie un aller-retour API.
+
+    #15556 : le MEME appel porte deja l'arbre du commit (`commit.tree.sha`)
+    -- le capter ici evite un second aller-retour par SHA au moment de
+    distinguer push muet (arbre identique) et push de contenu.
     """
     oids = {(c.get("oid") or "").lower() for c in (data.get("commits") or [])}
     oids.discard("")
@@ -2722,16 +2727,144 @@ def _resolve_absent_sha_messages(data: dict, cap: int = 5) -> dict[str, str]:
     for c in (data.get("comments") or []) + (data.get("reviews") or []):
         cited |= _cited_shas(c.get("body") or "")
     absent = sorted(s for s in cited if not any(o.startswith(s) for o in oids))
-    messages: dict[str, str] = {}
+    state: dict[str, dict] = {}
     for sha in absent[:cap]:
         try:
             commit = gh_json(["api", f"repos/{REPO}/commits/{sha}"])
         except subprocess.CalledProcessError:
             continue  # non resoluble -> analyse restera en mode avertissement
         head = ((commit.get("commit") or {}).get("message") or "").split("\n")[0]
-        if head:
-            messages[sha] = head
-    return messages
+        tree = ((commit.get("commit") or {}).get("tree") or {}).get("sha")
+        if head or tree:
+            state[sha] = {"message": head or "", "tree": tree}
+    return state
+
+
+# --- #15556 : identite de CONTENU, pas de SHA ------------------------------
+#
+# Sur #15492, sept rounds de reparation ont ete consommes par une boucle :
+# pousser un wake-commit (le remede canonique aux checks qui ne s'arment
+# pas) rembobine la tete, rembobiner invalide les levees qui citaient
+# l'ancienne tete, invalider oblige a relever, relever oblige a re-pousser.
+# Deux levees valides ont ete detruites par un push qui n'avait pas bouge
+# UN BYTE du livrable -- l'arbre etait identique, seul le SHA avait change.
+#
+# Le predicat se rattache donc au contenu : une levee citant un SHA
+# rembobine reste VALIDE si l'arbre du SHA rembobine est identique a
+# l'arbre de la tete (wake-commit, amend de message), ou si aucun fichier
+# de la PR n'est touche par la difference (rebase sans conflit). En cas
+# d'incertitude (arbre inconnu, pagination suspecte) : comportement
+# anterieur, le refus -- l'organe ne devient jamais permissif sur un
+# doute, c'est le cas que B.0 existe pour attraper.
+
+
+def _pr_head_oid(data: dict) -> str:
+    """OID de la tete de la PR : `headRefOid` si present, sinon le dernier
+    commit portant un `oid` (le plus recent de la liste chronologique)."""
+    head = (data.get("headRefOid") or "").lower()
+    if head:
+        return head
+    for c in reversed(data.get("commits") or []):
+        oid = (c.get("oid") or "").lower()
+        if oid:
+            return oid
+    return ""
+
+
+def _pr_file_paths(data: dict, page_cap: int = 100) -> set[str] | None:
+    """Chemins des fichiers de la PR, bornes incluses.
+
+    None = determination impossible (PR sans numero, erreur reseau, ou
+    liste tronquee a la pagination) : l'appelant doit alors rester sur le
+    comportement strict -- ne JAMAIS deduire « fichiers inchanges » d'une
+    liste incomplete.
+    """
+    number = data.get("number")
+    if number is None:
+        return None
+    try:
+        files = gh_json(
+            ["api", f"repos/{REPO}/pulls/{number}/files?per_page={page_cap}"])
+    except subprocess.CalledProcessError:
+        return None
+    if not isinstance(files, list) or len(files) >= page_cap:
+        return None  # pagination potentiellement tronquee -> fail-safe
+    return {f.get("filename") for f in files if f.get("filename")}
+
+
+def _rewind_pr_files_untouched(data: dict, state: dict[str, dict],
+                               head_oid: str, head_tree: str,
+                               cap: int = 3) -> dict[str, bool]:
+    """SHAs rembobines rattaches a la PR dont AUCUN fichier de la PR n'a
+    bouge entre le SHA rembobine et la tete (cas rebase, #15556).
+
+    Compare cote serveur `{sha}...{head_oid}` : si aucun des fichiers
+    touches par la comparaison n'est un fichier de la PR, le livrable est
+    inchange et la levee reste valide. Fail-safe systematique : compare
+    irrecuperable, plus de `cap` candidats, fichiers de la PR inconnus ou
+    liste de compare au plafond (troncature silencieuse de l'API a 300)
+    -> le SHA n'est PAS marque untouched (le refus survit).
+    """
+    if not head_oid or not head_tree:
+        return {}
+    pr_refs: set[str] = set()
+    if data.get("number") is not None:
+        pr_refs.add(str(data["number"]))
+    for m in re.finditer(r"#(\d+)", (data.get("title") or "")
+                         + "\n" + (data.get("body") or "")):
+        pr_refs.add(m.group(1))
+    pr_refs.discard("")
+    rattachable = sorted(
+        s for s, v in state.items()
+        if v.get("message") and _message_refs_pr(v["message"], pr_refs)
+        and not (v.get("tree") and v["tree"] == head_tree))
+    if not rattachable:
+        return {}
+    pr_files = _pr_file_paths(data)
+    if pr_files is None:
+        return {}
+    untouched: dict[str, bool] = {}
+    for sha in rattachable[:cap]:
+        try:
+            compare = gh_json(
+                ["api", f"repos/{REPO}/compare/{sha}...{head_oid}"])
+        except subprocess.CalledProcessError:
+            continue
+        files = compare.get("files") or []
+        if len(files) >= 300:
+            continue  # troncature suspecte -> fail-safe
+        changed = {f.get("filename") for f in files}
+        if not (changed & pr_files):
+            untouched[sha] = True
+    return untouched
+
+
+def _attach_absent_sha_context(data: dict) -> None:
+    """Resolution serveur du contexte SHA, AVANT analyse (qui reste pure).
+
+    Assemble les trois vues que `analyse` consulte : messages (rattachement
+    #13639), arbres des commits rembobines et arbre de la tete (#15556),
+    puis la comparaison fichiers pour les seuls candidats rattaches dont
+    l'arbre differe -- un seul appel reseau par SHA, un par PR pour la
+    tete et les fichiers.
+    """
+    state = _resolve_absent_sha_state(data)
+    data["_absent_sha_messages"] = {s: v["message"] for s, v in state.items()
+                                    if v.get("message")}
+    data["_absent_sha_trees"] = {s: v["tree"] for s, v in state.items()
+                                 if v.get("tree")}
+    head_oid = _pr_head_oid(data)
+    head_tree = ""
+    if head_oid:
+        try:
+            commit = gh_json(["api", f"repos/{REPO}/commits/{head_oid}"])
+            head_tree = ((commit.get("commit") or {}).get("tree")
+                         or {}).get("sha") or ""
+        except subprocess.CalledProcessError:
+            head_tree = ""
+    data["_head_tree"] = head_tree
+    data["_rewind_pr_files_untouched"] = _rewind_pr_files_untouched(
+        data, state, head_oid, head_tree)
 
 
 def can_lift(comment: dict) -> bool:
@@ -3260,7 +3393,10 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
     followup_lifts = collect_followup_lifts(pr_data, cutoff, issue_info)
 
     # #13639 -- passer les levees au crible du SHA rembobine (voir
-    # _SHA_CITED ci-dessus pour le pourquoi et l'etroitesse). Inerte sans
+    # _SHA_CITED ci-dessus pour le pourquoi et l'etroitesse). #15556 : le
+    # refus se rattache desormais a l'identite de CONTENU -- un push muet
+    # (wake-commit, amend de message, rebase sans fichier de la PR touche)
+    # ne desnue plus la levee ; cf _attach_absent_sha_context. Inerte sans
     # OIDs connus : le pre-filtre d'audit (sans `commits`) et les fixtures
     # sans `oid` sautent ce passage -- comportement inchange. Limite assumee
     # : ce pre-filtre d'audit ne verra donc jamais cette classe de defaut
@@ -3270,6 +3406,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                    for c in (pr_data.get("commits") or []) if c.get("oid")]
     voided_lifts: list[dict] = []
     absent_sha_warnings: list[dict] = []
+    rewind_artifacts: list[dict] = []
     if commit_oids:
         pr_refs: set[str] = set()
         if pr_data.get("number") is not None:
@@ -3279,10 +3416,15 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
             pr_refs.add(m.group(1))
         pr_refs.discard("")
         resolved = pr_data.get("_absent_sha_messages") or {}
+        rewound_trees = pr_data.get("_absent_sha_trees") or {}
+        head_tree = pr_data.get("_head_tree")
+        untouched = pr_data.get("_rewind_pr_files_untouched") or {}
         kept_lifts = []
         for (t, lifter, lift_body) in explicit_lifts:
             refused = None
+            refused_known_change = False
             warned = None
+            artifact = None
             for sha in sorted(_cited_shas(lift_body)):
                 if any(oid.startswith(sha) for oid in commit_oids):
                     continue  # present dans la PR : preuve valide
@@ -3290,15 +3432,38 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                     continue  # citation de contexte : ni refus, ni signalement
                 message = resolved.get(sha)
                 if message and _message_refs_pr(message, pr_refs):
-                    refused = sha  # rembobine ET rattache : la levee est nue
+                    # rembobine ET rattache. #15556 : avant de desnuer la
+                    # levee, verifier que le push a reellement change le
+                    # livrable -- wake-commit et amend de message poussent
+                    # un arbre IDENTIQUE, rebase sans conflit ne touche
+                    # aucun fichier de la PR. Sans donnees d'arbre (audit
+                    # retro, resolution serveur impossible) : refus, le
+                    # comportement anterieur n'est jamais assoupli.
+                    if untouched.get(sha):
+                        if artifact is None:
+                            artifact = (sha, "pr_files_untouched")
+                        continue
+                    tree = rewound_trees.get(sha)
+                    if tree and head_tree and tree == head_tree:
+                        if artifact is None:
+                            artifact = (sha, "same_tree")
+                        continue
+                    refused = sha
+                    if tree and head_tree:
+                        refused_known_change = True
                     break
                 warned = sha  # non resoluble ou sans rapport : avertir
             if refused:
                 voided_lifts.append(
-                    {"author": lifter, "at": t.isoformat(), "sha": refused})
+                    {"author": lifter, "at": t.isoformat(), "sha": refused,
+                     "tree_differs": refused_known_change})
             else:
                 kept_lifts.append((t, lifter, lift_body))
-                if warned:
+                if artifact:
+                    rewind_artifacts.append(
+                        {"author": lifter, "at": t.isoformat(),
+                         "sha": artifact[0], "reason": artifact[1]})
+                elif warned:
                     absent_sha_warnings.append(
                         {"author": lifter, "at": t.isoformat(), "sha": warned})
         explicit_lifts = kept_lifts
@@ -3639,12 +3804,14 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         "ignored_overrides": ignored_overrides,
         "voided_lifts": voided_lifts,
         "absent_sha_warnings": absent_sha_warnings,
+        "rewind_artifacts": rewind_artifacts,
         "unevaluated": to_read,
         "unevaluated_total": len(unevaluated),
     }
 
 
-FIELDS = "number,title,body,mergedAt,author,comments,reviews,commits,url,state"
+FIELDS = ("number,title,body,mergedAt,author,comments,reviews,commits,url,"
+          "state,headRefOid")
 
 # `commits` porte une connection `authors` par commit : sur un `gh pr list` large,
 # GraphQL depasse son plafond de 500 000 noeuds. L'audit retro liste donc SANS
@@ -3689,11 +3856,27 @@ def _print_unevaluated(result: dict) -> None:
 
 
 def _print_sha_notes(result: dict) -> None:
-    """#13639 : nommer les levees dont la preuve citee manque de la PR."""
+    """#13639 : nommer les levees dont la preuve citee manque de la PR.
+
+    #15556 : distinguer l'ARTEFACT du vrai defaut -- un push muet
+    (wake-commit, amend de message) ne change pas l'arbre, la preuve citee
+    reste byte-pour-byte vraie ; seul le SHA a change. Les deux cas ne
+    demandent pas le meme geste au lecteur, et l'artefact ne bloque pas.
+    """
+    for a in result.get("rewind_artifacts") or []:
+        why = ("arbre identique à la tête"
+               if a["reason"] == "same_tree"
+               else "fichiers de la PR inchangés")
+        print(f"  [i] levee de {a['author']} à {a['at']} cite {a['sha']} "
+              f"rembobiné par un push muet ({why}) — preuve conservée, "
+              f"non bloquant")
     for v in result.get("voided_lifts") or []:
+        detail = (" — l'arbre DIFFÈRE de la tête : vraie réserve à reposer"
+                  if v.get("tree_differs")
+                  else " — arbre non comparable, refus conservateur")
         print(f"  [!] NON LEVE — levee de {v['author']} à {v['at']} : cite "
               f"{v['sha']}, absent des commits de la PR (résolu côté serveur, "
-              f"mais rembobiné par un push ultérieur)")
+              f"mais rembobiné par un push ultérieur){detail}")
     for w in result.get("absent_sha_warnings") or ():
         print(f"  [i] levee de {w['author']} à {w['at']} cite {w['sha']} "
               f"(absent des commits, non rattaché à cette PR) — non bloquant")
@@ -3714,9 +3897,9 @@ def analyse_pr(pr: int) -> dict:
     visible immediatement.
     """
     data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
-    # #13639 : resolution serveur des SHAs cites-absents, AVANT analyse
-    # (qui reste pure). Sans ceci, la classe #13557 serait invisible.
-    data["_absent_sha_messages"] = _resolve_absent_sha_messages(data)
+    # #13639 + #15556 : resolution serveur du contexte SHA (messages,
+    # arbres rembobines, arbre de tete), AVANT analyse (qui reste pure).
+    _attach_absent_sha_context(data)
     return analyse(data, review_threads(pr), datetime.now(timezone.utc),
                    issue_info=gh_issue_info,
                    dismissed_improperly=improper_dismissals(pr))
@@ -3724,9 +3907,9 @@ def analyse_pr(pr: int) -> dict:
 
 def gate(pr: int, as_json: bool) -> int:
     data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
-    # #13639 : resolution serveur des SHAs cites-absents, AVANT analyse
-    # (qui reste pure). Sans ceci, la classe #13557 serait invisible.
-    data["_absent_sha_messages"] = _resolve_absent_sha_messages(data)
+    # #13639 + #15556 : resolution serveur du contexte SHA (messages,
+    # arbres rembobines, arbre de tete), AVANT analyse (qui reste pure).
+    _attach_absent_sha_context(data)
     merged = ts(data.get("mergedAt"))
     cutoff = merged or datetime.now(timezone.utc)
     result = analyse(data, review_threads(pr), cutoff,

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3479,6 +3479,186 @@ def test_13639_sha_distant_du_marqueur_est_contexte():
     assert res["absent_sha_warnings"] == []
 
 
+# --- #15556 : un push qui ne change pas l'arbre n'invalide pas la levee ---
+
+TREE_A = "t" + "a" * 39   # arbre du commit rembobine ET de la tete
+TREE_B = "t" + "b" * 39   # arbre d'un vrai commit de contenu
+
+
+def test_15556_push_muet_arbre_identique_conserve_la_levee():
+    """Instance fondatrice (#15492) : wake-commit / amend de message
+    rembobinent la tete SANS toucher un byte du livrable -- l'arbre du SHA
+    cite est identique a l'arbre de la tete. La preuve avancee par la
+    phrase reste vraie : la levee est conservée, signalee comme artefact
+    non bloquant."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"},
+              _absent_sha_trees={"2d6e4c3642": TREE_A},
+              _head_tree=TREE_A)
+    assert res["blocked"] is False
+    assert res["voided_lifts"] == []
+    assert [(a["sha"], a["reason"]) for a in res["rewind_artifacts"]] == \
+        [("2d6e4c3642", "same_tree")]
+
+
+def test_15556_controle_negatif_commit_de_contenu_invalide_toujours():
+    """Controle negatif OBLIGATOIRE (acceptance 3 de l'issue) : une levee
+    posee avant un commit de CONTENU -- l'arbre cite differant de l'arbre
+    de la tete -- reste invalide. Le remede ne rend pas l'organe
+    permissif : c'est exactement le cas que B.0 existe pour attraper
+    (« un push muet est indiscernable d'un push qui repond »)."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"},
+              _absent_sha_trees={"2d6e4c3642": TREE_B},
+              _head_tree=TREE_A)
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
+    assert res["voided_lifts"][0]["tree_differs"] is True
+    assert res["rewind_artifacts"] == []
+
+
+def test_15556_sans_donnees_arbre_refus_conservateur():
+    """Audit retro / resolution serveur sans arbre : comportement
+    anterieur integralement preserve (refus). L'incertitude n'assouplit
+    jamais l'organe."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"})
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
+    assert res["voided_lifts"][0]["tree_differs"] is False
+
+
+def test_15556_rebase_sans_fichier_de_la_pr_touche_conserve():
+    """Cas rebase sans conflit : l'arbre global differant (main a avance)
+    mais AUCUN fichier de la PR n'est touche par la difference -- le
+    livrable est inchangé, la levee reste valide."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"},
+              _absent_sha_trees={"2d6e4c3642": TREE_B},
+              _head_tree=TREE_A,
+              _rewind_pr_files_untouched={"2d6e4c3642": True})
+    assert res["blocked"] is False
+    assert res["voided_lifts"] == []
+    assert [(a["sha"], a["reason"]) for a in res["rewind_artifacts"]] == \
+        [("2d6e4c3642", "pr_files_untouched")]
+
+
+def test_15556_artefact_ne_masque_pas_un_vrai_refus():
+    """Une meme levee cite deux SHAs : l'un rembobine par push muet
+    (arbre identique), l'autre par un vrai commit de contenu. Le refus
+    gagne -- un artefact parmi les preuves ne sauve pas une levee dont
+    une autre preuve est morte."""
+    body = ("Les 2 nits sont adresses dans les commits 111aaaa111 et "
+            "222bbbb222.")
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12), "body": body}
+    res = run([USER_NIT, reply],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"111aaaa111": "fix(x,#0): typo",
+                                    "222bbbb222": "fix(y,#0): autre"},
+              _absent_sha_trees={"111aaaa111": TREE_A, "222bbbb222": TREE_B},
+              _head_tree=TREE_A)
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["222bbbb222"]
+    assert res["rewind_artifacts"] == []
+
+
+def test_15556_headrefoid_prefere_au_dernier_oid():
+    """`_pr_head_oid` : headRefOid (present depuis #15556 dans FIELDS)
+    prime sur le dernier commit portant un oid -- sur une PR a plus de
+    commits que le plafond de la liste, le dernier affiche n'est pas
+    garanti etre la tete."""
+    data = {"headRefOid": "f" * 40,
+            "commits": [{"oid": "e" * 40}, {"oid": "d" * 40}]}
+    assert mod._pr_head_oid(data) == "f" * 40
+    assert mod._pr_head_oid({"commits": [{"oid": "e" * 40}]}) == "e" * 40
+    assert mod._pr_head_oid({"commits": [{"committedDate": at(19)}]}) == ""
+
+
+def test_15556_file_paths_tronques_renvent_none(monkeypatch):
+    """Fail-safe de `_pr_file_paths` : une liste de fichiers au plafond de
+    pagination (troncature potentielle) est une NON-determination, jamais
+    une liste complete -- en deduire « fichiers inchanges » serait le
+    faux negatif que l'acceptance 3 interdit."""
+    monkeypatch.setattr(mod, "gh_json",
+                        lambda args: [{"filename": f"f{i}.py"} for i in range(100)])
+    assert mod._pr_file_paths({"number": 7}) is None
+    monkeypatch.setattr(mod, "gh_json", lambda args: [])
+    assert mod._pr_file_paths({"number": 7}) == set()
+    assert mod._pr_file_paths({}) is None
+
+
+def test_15556_compare_hors_fichiers_pr_marque_untouched(monkeypatch):
+    """`_rewind_pr_files_untouched` : la difference SHA rembobine -> tete
+    ne touche que des fichiers HORS de la PR (rebase sur main) : le SHA
+    est marque untouched. Elle touche un fichier de la PR : pas de
+    marque, le refus survit."""
+    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_B}}
+    head_oid, head_tree = "f" * 40, TREE_A
+    data = {"number": 7, "title": "t", "body": ""}
+
+    def fake_gh_json(args):
+        url = args[-1]
+        if "/pulls/7/files" in url:
+            return [{"filename": "src/livrable.py"}]
+        if "/compare/" in url:
+            return {"files": [{"filename": "README.md"}]}  # hors PR
+        raise AssertionError(f"appel inattendu: {url}")
+
+    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
+    assert mod._rewind_pr_files_untouched(data, state, head_oid,
+                                          head_tree) == {"111aaaa111": True}
+
+    def fake_gh_json_touche(args):
+        url = args[-1]
+        if "/pulls/7/files" in url:
+            return [{"filename": "src/livrable.py"}]
+        if "/compare/" in url:
+            return {"files": [{"filename": "src/livrable.py"}]}  # DANS la PR
+        raise AssertionError(f"appel inattendu: {url}")
+
+    monkeypatch.setattr(mod, "gh_json", fake_gh_json_touche)
+    assert mod._rewind_pr_files_untouched(data, state, head_oid,
+                                          head_tree) == {}
+
+
+def test_15556_compare_au_plafond_fail_safe(monkeypatch):
+    """L'API compare tronque silencieusement a 300 fichiers : une liste au
+    plafond ne prouve RIEN sur les fichiers restants -- pas de marque."""
+    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_B}}
+
+    def fake_gh_json(args):
+        url = args[-1]
+        if "/pulls/7/files" in url:
+            return [{"filename": "src/livrable.py"}]
+        if "/compare/" in url:
+            return {"files": [{"filename": f"f{i}.py"} for i in range(300)]}
+        raise AssertionError(f"appel inattendu: {url}")
+
+    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
+    assert mod._rewind_pr_files_untouched(
+        {"number": 7, "title": "t", "body": ""}, state, "f" * 40,
+        TREE_A) == {}
+
+
+def test_15556_meme_arbre_pas_de_compare_ni_de_files(monkeypatch):
+    """Un SHA rembobine d'arbre IDENTIQUE a la tete est deja un artefact :
+    ni l'appel compare ni l'appel fichiers de la PR ne sont dus pour lui
+    (le gate paie un appel par PR, pas par SHA, quand tout est muet)."""
+    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_A}}
+
+    def fake_gh_json(args):
+        raise AssertionError("aucun appel reseau attendu ici")
+
+    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
+    assert mod._rewind_pr_files_untouched(
+        {"number": 7, "title": "t", "body": ""}, state, "f" * 40,
+        TREE_A) == {}
+
+
 def test_13641_ref_par_prefixe_ne_compte_pas():
     """NanoClaw c.702 sur #13641 : le substring check `any(f"#{n}" in message)`
     matchait `#13639` dans un message contenant `#136390` (ticket adjacent
@@ -5538,8 +5718,9 @@ def test_analyse_pr_assemble_comme_gate(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(mod, "gh_json", lambda args: dict(payload))
-    monkeypatch.setattr(mod, "_resolve_absent_sha_messages",
-                        lambda data, cap=5: {"abc123": "corps du message"})
+    monkeypatch.setattr(mod, "_resolve_absent_sha_state",
+                        lambda data, cap=5: {"abc123": {"message": "corps du message",
+                                                         "tree": None}})
     monkeypatch.setattr(mod, "review_threads", lambda pr: [])
     monkeypatch.setattr(mod, "improper_dismissals", lambda pr: [])
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: LIGHT/notebook #15555

Closes #15556

## Summary

`check_unaddressed_nits.py` rattachait une levée au **SHA** qu'elle cite. Un push qui rembobine la tête sans toucher un byte du livrable (wake-commit, amend de message, rebase sans fichier de la PR touché) invalidait donc des levées valides — l'engrenage mesuré sur #15492 : pousser → rembobiner → invalider → relever → re-pousser. Le prédicat se rattache désormais à l'**identité de contenu** : une levée citant un SHA rembobiné reste valide si l'arbre du SHA est identique à l'arbre de la tête, ou si aucun fichier de la PR n'est touché par la différence. En cas d'incertitude (arbre inconnu, pagination tronquée) : refus conservateur — l'organe ne devient jamais permissif sur un doute.

**Périmètre : 2 fichiers**

- `scripts/check_unaddressed_nits.py`
- `scripts/tests/test_check_unaddressed_nits.py`

## Changements

1. **`_resolve_absent_sha_state`** (ex-`_resolve_absent_sha_messages`, même aller-retour API) capte en plus l'arbre du commit rembobiné (`commit.tree.sha`) — zéro appel réseau supplémentaire par SHA.
2. **`_attach_absent_sha_context`** : greffon unique assemblant messages (#13639), arbres rembobinés, arbre de la tête (`headRefOid` ajouté à `FIELDS`, fallback dernier OID) et comparaison fichiers. `analyse()` reste pure ; l'audit rétro (qui n'attache jamais le contexte) garde son comportement antérieur à l'identique.
3. **Boucle `analyse()`** : avant de desnuer une levée rattachée, deux échappatoires de contenu — `_rewind_pr_files_untouched` (rebase : la comparaison serveur `{sha}...{head}` ne touche aucun fichier de la PR) puis égalité d'arbre (push muet). Un artefact ne masque jamais un vrai refus : si un autre SHA cité est mort pour de bon, la levée reste invalidée.
4. **`_rewind_pr_files_untouched`** : fail-safe systématique — compare irrecuperable, fichiers de la PR au plafond de pagination (100), liste de compare au plafond de troncature silencieuse (300), plus de 3 candidats → PAS de marque, le refus survit.
5. **Messages distingués** (acceptance 2) : l'artefact est `[i]` non bloquant (« rembobiné par un push muet (arbre identique à la tête / fichiers de la PR inchangés) — preuve conservée ») ; le vrai refus `[!]` porte désormais « l'arbre DIFFÈRE de la tête : vraie réserve à reposer » quand l'arbre est connu, « arbre non comparable, refus conservateur » sinon.

## Validation

```
$ python -m pytest scripts/tests/test_check_unaddressed_nits.py \
    scripts/tests/test_check_unaddressed_nits_{dismissal,followup,hold,mention,unevaluated}.py -q
499 passed in 11.01s

$ python -m pytest scripts/tests/test_pick_*.py -q
191 passed in 2.03s
```

Le picker (`pick_idle_grain.py` → `analyse_pr`) consomme le même point d'entrée que le merge-gate : les deux voient le même contexte SHA (exigence « Portée » de l'issue).

**Re-mesure #15492 (acceptance 4, tête au moment du run)** :

```
$ python scripts/check_unaddressed_nits.py 15492
OK  PR #15492 — aucun nit non leve.
  [i] levee de clusterManager-Myia à 2026-09-11T03:37:19 ... cite 0d71ce2dca rembobiné par un push muet
      (arbre identique à la tête) — preuve conservée, non bloquant
  [i] levee de jsboige à 2026-09-11T03:37:35 ... (idem)
  [i] levee de myia-ai-01 à 2026-09-11T03:54:50 ... (idem)
RC=0
```

rc=0 **sans aucune phrase nouvelle écrite** — les trois levées détruites par le wake-commit (celles nommées dans l'issue) sont reconnues artefacts. Contrôle de non-régression : `#15548` reste `OK rc=0`.

**Contrôle négatif (acceptance 3)** : `test_15556_controle_negatif_commit_de_contenu_invalide_toujours` — levée posée avant un commit de contenu (arbres différents) reste invalidée, `tree_differs: True`. Compléments : sans données d'arbre (audit rétro) → refus conservateur intégral ; artefact + vrai refus dans la même levée → le refus gagne ; plafonds de pagination → fail-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Post-merge — #15566 (2026-09-11)** : l'échappatoire `_rewind_pr_files_untouched` décrite ci-dessus (« rebase : la comparaison serveur `{sha}...{head}` ne touche aucun fichier de la PR ») s'est révélée **inerte** et a été **retirée** par #15569. `compare/A...B` est une comparaison **trois-points** : sur une vraie paire de rebase (`39846a7a3` → `9296031c6`, même patch sur deux bases), `merge_base_commit` rend `d3107fce` — pas le SHA cité — et les fichiers de la PR sont dans `changed` par construction, donc l'intersection n'était jamais vide et la marque n'a jamais pu être posée. Le critère d'**égalité d'arbre** (wake-commit, amend de message), qui est le remède réellement démontré sur #15492, reste seul et intact ; un rebase retombe sur le refus conservateur. Mesures et tactiques d'adaptation tentées : #15566 / #15569.
