### PR TITLE
fix(ci): refetch unreadable fast-lane merge base (#15553)

### DIFF
--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -84,17 +84,65 @@ def guard_applies(guard: Guard, changed: list[str]) -> bool:
     return any(path_matches(f, p) for f in changed for p in guard.paths)
 
 
-def changed_files(base_ref: str) -> list[str]:
-    out = subprocess.run(
+def _run_diff(base_ref: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
         ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
-        cwd=REPO_ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
     )
-    if out.returncode != 0:
-        raise SystemExit(
-            "[fast-lane] impossible de calculer le diff contre "
-            f"{base_ref} : {out.stderr.strip()}"
+
+
+def _refetch_base(base_ref: str) -> subprocess.CompletedProcess:
+    """Refetch a remote branch into the exact remote-tracking ref used by diff."""
+    prefix = "origin/"
+    if not base_ref.startswith(prefix) or base_ref == prefix:
+        return subprocess.CompletedProcess(
+            args=[], returncode=2, stdout="",
+            stderr=f"base ref non refetchable: {base_ref!r}",
         )
-    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+    branch = base_ref[len(prefix):]
+    refspec = f"+refs/heads/{branch}:refs/remotes/origin/{branch}"
+    return subprocess.run(
+        ["git", "fetch", "--refetch", "--filter=blob:none", "origin",
+         refspec],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+
+
+def changed_files(base_ref: str) -> list[str]:
+    first = _run_diff(base_ref)
+    if first.returncode == 0:
+        return [line.strip() for line in first.stdout.splitlines()
+                if line.strip()]
+
+    print(
+        "[fast-lane][infrastructure] diff initial illisible contre "
+        f"{base_ref}; refetch cible de la branche de base",
+        file=sys.stderr,
+    )
+    fetched = _refetch_base(base_ref)
+    second = _run_diff(base_ref) if fetched.returncode == 0 else None
+    if second is not None and second.returncode == 0:
+        print(
+            "[fast-lane][infrastructure] base reparee; diff relu apres "
+            "refetch cible",
+            file=sys.stderr,
+        )
+        return [line.strip() for line in second.stdout.splitlines()
+                if line.strip()]
+
+    fetch_error = fetched.stderr.strip() or f"exit {fetched.returncode}"
+    retry_error = (
+        second.stderr.strip() if second is not None
+        else "diff non retente car le refetch a echoue"
+    )
+    raise SystemExit(
+        "[fast-lane][infrastructure][fail-closed] diff illisible; aucun "
+        "verdict de garde n'a ete calcule. "
+        f"base={base_ref}; erreur initiale={first.stderr.strip()}; "
+        f"refetch={fetch_error}; nouvelle lecture={retry_error}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_fast_lane_merge_base.py
+++ b/scripts/tests/test_fast_lane_merge_base.py
@@ -1,0 +1,107 @@
+"""Regression tests for unreadable fast-lane merge bases (#15553)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CI_DIR = Path(__file__).resolve().parents[1] / "ci"
+sys.path.insert(0, str(CI_DIR))
+
+import fast_lane  # noqa: E402
+from fast_lane_registry import Guard  # noqa: E402
+
+
+def _completed(args, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+def test_unreadable_diff_refetches_exact_remote_tracking_ref(monkeypatch):
+    calls = []
+    results = iter([
+        _completed([], 128, stderr="fatal: no merge base"),
+        _completed([], 0),
+        _completed([], 0, stdout="scripts/bad.py\n"),
+    ])
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return next(results)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert fast_lane.changed_files("origin/main") == ["scripts/bad.py"]
+    assert calls == [
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        ["git", "fetch", "--refetch", "--filter=blob:none", "origin",
+         "+refs/heads/main:refs/remotes/origin/main"],
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+    ]
+
+
+def test_unreadable_diff_stays_fail_closed_with_infrastructure_cause(monkeypatch):
+    results = iter([
+        _completed([], 128, stderr="fatal: no merge base"),
+        _completed([], 0),
+        _completed([], 128, stderr="error: Could not read deadbeef"),
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: next(results))
+
+    with pytest.raises(SystemExit) as exc:
+        fast_lane.changed_files("origin/main")
+
+    message = str(exc.value)
+    assert "[infrastructure][fail-closed]" in message
+    assert "aucun verdict de garde n'a ete calcule" in message
+    assert "Could not read deadbeef" in message
+
+
+def test_readable_real_guard_failure_remains_blocking(
+        monkeypatch, tmp_path, capsys):
+    """Negative control: a readable diff and failing guard must stay red."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t"],
+                   check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"],
+                   check=True)
+    target = tmp_path / "measured.txt"
+    target.write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "measured.txt"],
+                   check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "base"],
+                   check=True)
+    base_sha = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    ).stdout.strip()
+    target.write_text("real defect\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qam", "defect"],
+                   check=True)
+
+    guard = Guard(
+        name="negative-control",
+        argv=[sys.executable, "-c", "raise SystemExit(1)"],
+        source="test",
+        paths=["*.txt"],
+        blocking=True,
+    )
+    monkeypatch.setattr(fast_lane, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(fast_lane, "PILOT", [guard])
+
+    rc = fast_lane.main([
+        "--base-ref", base_sha,
+        "--head-sha", "beef" * 10,
+        "--repo", "jsboige/CoursIA",
+        "--only", "negative-control",
+        "--no-shadow",
+        "--dry-run",
+    ])
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "negative-control' -> failure" in output
+    assert "au moins un bloquant en echec" in output


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #15498

## Problème mesuré

Le moteur fast-lane pouvait échouer avant toute mesure sur `git diff origin/main...HEAD` lorsqu’un clone partiel du runner ne résolvait plus le merge-base. Le log mélangeait alors panne d’entrée et verdict de garde.

## Correctif

- Première lecture inchangée : `git diff --name-only <base>...HEAD`.
- Sur échec seulement, refetch ciblé et forcé du graphe atteignable par la branche de base :
  `git fetch --refetch --filter=blob:none origin +refs/heads/<base>:refs/remotes/origin/<base>`.
- Nouvelle lecture du diff après refetch.
- Si elle échoue encore : arrêt fail-closed avec marqueur explicite `[fast-lane][infrastructure][fail-closed]`, erreur initiale, erreur de fetch et erreur de seconde lecture. Aucun verdict de garde n’est calculé depuis une entrée illisible.

Le workflow partagé n’est pas modifié : #15538 touche actuellement `always-on-guards.yml`. Le repair reste donc collision-free et borné au moteur + tests.

## Contrôles

- happy path : le premier diff échoue, le refspec exact est refetché, le second diff est consommé ;
- panne persistante : `SystemExit` fail-closed et cause infrastructure visible ;
- **contrôle négatif demandé** : dépôt Git réel, diff lisible, garde bloquante réellement fautive → code retour 1 et check-run `failure`. Le retry d’infrastructure ne blanchit donc pas un défaut mesuré.

## Validation

```text
python -m pytest scripts/tests/test_fast_lane_merge_base.py scripts/tests/test_fast_lane.py -q
75 passed
python -m py_compile scripts/ci/fast_lane.py scripts/tests/test_fast_lane_merge_base.py
PASS
git diff --check
PASS
```

Closes #15553

🤖 Generated with [Claude Code](https://claude.com/claude-code)