### PR TITLE
fix(docs,#15516): sweep mermaid fill-sans-color — famille Probas (5 READMEs, 5 règles)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
@@ -43,7 +43,8 @@ flowchart TD
     BAY -->|"posterior = input"| A
     A --> B --> C --> D --> E
     E -.->|"formalisation"| LAKE
-    classDef lean fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ne pas harmoniser le ton avec le stroke (libelle sinon illisible)
+    classDef lean fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
     class LAKE lean;
 ```
 

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
@@ -75,7 +75,8 @@ flowchart TD
     BAY -->|"posterior = input"| A
     A --> B --> C --> D --> E
     D -.->|"formalisation"| LAKE
-    classDef lake fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ne pas harmoniser le ton avec le stroke (libelle sinon illisible)
+    classDef lake fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
     class LAKE lake;
 ```
 

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/README.md
@@ -48,7 +48,8 @@ flowchart TD
     F --> S --> R --> B --> C
     B -.->|"formalisation"| LAKE
     F -.->|"formalisation"| LAKE
-    classDef lean fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ne pas harmoniser le ton avec le stroke (libelle sinon illisible)
+    classDef lean fill:#fff3cd,stroke:#856404,stroke-width:2px,color:#856404;
     class LAKE lean;
 ```
 

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -173,7 +173,8 @@ flowchart TD
     P5 -.->|"diagnostics<br/>à tout moment"| P2
     P5 -.-> P4
     P8 -.->|"décision séquentielle,<br/>Thompson, Gittins"| DT
-    classDef decision fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ne pas harmoniser le ton avec le stroke (libelle sinon illisible)
+    classDef decision fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
     class DT decision;
 ```
 

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -158,7 +158,8 @@ flowchart TD
     P4 --> P6
     P5 -.->|"diagnostics<br/>à tout moment"| P2
     P5 -.-> P4
-    classDef causal fill:#d1ecf1,stroke:#0c5460,stroke-width:2px;
+    %% color: explicite -- sans lui, libelle clair sur fond clair en mode sombre GitHub (#15022) ; ne pas harmoniser le ton avec le stroke (libelle sinon illisible)
+    classDef causal fill:#d1ecf1,stroke:#0c5460,stroke-width:2px,color:#0c5460;
     class P6 causal;
 ```
 


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: MED/tooling #15557

## Quoi

Dernière tranche du découpage #15516 (mermaid `fill:` sans `color:`), déblocée par le merge du pilote **#15502** (README racine Probas, mêmes fichiers racine — plus de collision). **5 READMEs de sous-séries Probas, 1 règle `classDef` chacun** :

| Fichier | Règle corrigée |
|---|---|
| `Probas/DecisionTheory/DecInfer/README.md` | `lean` : `fill:#fff3cd` + `color:#856404` |
| `Probas/DecisionTheory/PyMC/README.md` | `lake` : `fill:#fff3cd` + `color:#856404` |
| `Probas/DecisionTheory/README.md` | `lean` : `fill:#fff3cd` + `color:#856404` |
| `Probas/Infer/README.md` | `decision` : `fill:#d1ecf1` + `color:#0c5460` |
| `Probas/PyMC/README.md` | `causal` : `fill:#d1ecf1` + `color:#0c5460` |

## Pattern (identique au pilote #15502, pairings repris verbatim)

- `color:` **uniquement ajouté** aux règles `fill:` existantes (aucun autre changement de style)
- Pairings Bootstrap-alert du pilote : `#fff3cd → #856404` (warning) et `#d1ecf1 → #0c5460` (info) — contrastes WCAG AA déjà mesurés dans #15502 (fonds clairs GitHub, mode sombre : le libellé reste lisible car `color:` explicite)
- Garde `%%` anti-harmonisation **une par bloc** avant chaque `classDef` touché

## Validation

- Détecteur `detect_mermaid_fill_without_color.py --check` : **exit 0 sur les 5 fichiers** (1 règle fautive chacun avant, 0 après)
- Markdown-only (READMEs) — aucun notebook touché, exception C.2 sans objet
- Catalogue byte-identical à main

See #15516 — **tranche finale du découpage par familles**. Après merge de #15550 / #15551 / #15552 / #15555 + celle-ci, l'inventaire #15516 est couvert à 100 % (pilote #15502 déjà mergé) : clôture de l'issue à l'arbitrage d'ai-01 (ce PR porte `See` et non `Closes` car il ne porte qu'une tranche — la clôture doit suivre la vérification corpus entier du détecteur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)