### PR TITLE
fix(ci,#15197): mesure taux de tir schedule pr-gate-stale-sweep (advisory)

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -554,11 +554,17 @@ jobs:
       # traitee a la source (pool dedie coursia-linux, #14283) et la cadence
       # est horaire : le cout n'est plus le meme, la promesse de fond (la
       # re-aggregation reste sans checkout) tient.
-      - name: Checkout sparse (gate-absent organ only)
+      - name: Checkout sparse (gate-absent + tir-cadence organs)
         uses: actions/checkout@v4
         with:
-          sparse-checkout: scripts/pr_gate_missing.py
+          sparse-checkout: |
+            scripts/pr_gate_missing.py
+            scripts/ci/pr_gate_stale_sweep_tir.py
           sparse-checkout-cone-mode: false
+          # #15197 voie (i) : mesure du taux de tir schedule. Ajouté sous
+          # le même sparse-checkout que scripts/pr_gate_missing.py pour ne
+          # pas multiplier les checkouts (cf. "#12728: this sweep is a
+          # 2-minute job", le checkout reste une pénalité mesurée).
 
       - name: Flag PRs whose PR gate never ran (absent, by cause)
         env:
@@ -662,3 +668,28 @@ jobs:
           except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
               print(f"::warning::stale-sweep timing unavailable: {exc}")
           PY
+
+      # #15197 voie (i) -- mesure du taux de tir schedule.
+      # L'acceptance #12728 mesurait les annulations (cancellation count),
+      # pas le taux de tir (combien de crons produisent un run). Mesure
+      # du 2026-09-08T09:34Z : 53 runs sur 184,3 h, taux de tir 28,8 %,
+      # médiane 3,35 h, max 6,24 h. Ce step rend l'angle mort mesurable
+      # sans le corriger (la correction est ailleurs : doctrine de
+      # filet de rattrapage + voie (ii) cron externe arbitrée séparément).
+      # Advisory par construction : exit 0 toujours, un sweep qui
+      # rougit parce que lui-même est sous-cadencé aggrave la famine.
+      - name: Measure sweep tir cadence (advisory, #15197)
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          python scripts/ci/pr_gate_stale_sweep_tir.py \
+            --repo "$REPO" \
+            --workflow-file pr-gate-stale-sweep.yml \
+            --window-hours 168 \
+            --write-summary || {
+            echo "::warning::sweep tir measurement failed -- angle mort non mesuré ce passage"
+            exit 0
+          }

--- a/scripts/ci/pr_gate_stale_sweep_tir.py
+++ b/scripts/ci/pr_gate_stale_sweep_tir.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Mesure le taux de tir schedule observé du workflow pr-gate-stale-sweep.
+
+L'acceptance #12728 mesurait les annulations (cancellation count), pas le
+taux de tir (combien de crons produisent un run). Issue #15197 a montré
+que le sweep tire à ~28,8 % de sa cadence déclarée (mesure 53 runs / 184
+attendus sur 184,3 h, médiane 3,35 h, max 6,24 h).
+
+Ce script mesure le même phénomène pour le run courant : il compte les
+runs `event=schedule` sur une fenêtre glissante (par défaut 7 jours) et
+calcule le ratio observé/déclaré. Écrit un summary CI `tir_observed_pct`
++ `last_fired_at` + `interval_median_s`.
+
+Le script est **advisory** : il ne rougit jamais le job (un sweep qui
+rougit parce que lui-même est sous-cadencé ne fait qu'aggraver la
+famine). Sa fonction est de rendre l'angle mort mesurable, pas de le
+corriger : la correction est ailleurs (voie (i) doctrine du body de
+#15197, voies (ii) cron externe / (iii) événementielle écartée par le
+même body).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+# Cadence déclarée du cron `pr-gate-stale-sweep.yml` : `7 * * * *` (chaque
+# heure, à la minute 07). Une fenêtre 7 jours = 7 * 24 = 168 tics attendus.
+DEFAULT_WINDOW_HOURS = 7 * 24
+DECLARED_CADENCE_PER_HOUR = 1.0  # hourly
+GITHUB_API = "https://api.github.com"
+
+
+def _parse_iso(ts: str) -> datetime:
+    text = ts[:-1] + "+00:00" if ts.endswith("Z") else ts
+    return datetime.fromisoformat(text).astimezone(timezone.utc)
+
+
+def fetch_runs(repo: str, workflow_file: str, window_hours: int) -> list[dict]:
+    """Liste les runs `event=schedule` de `pr-gate-stale-sweep.yml` sur la fenêtre.
+
+    `gh api` pagine automatiquement. Filtre event=schedule + status != in_progress
+    pour ne mesurer que des tirs terminés.
+    """
+    import subprocess
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+    cmd = [
+        "gh", "api", "--paginate",
+        f"{GITHUB_API}/repos/{repo}/actions/workflows/{workflow_file}/runs"
+        f"?event=schedule&per_page=100",
+        "--jq", ".workflow_runs[] | {created_at, conclusion, status}",
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False, encoding="utf-8", errors="replace")
+    if out.returncode != 0:
+        print(f"::warning::tir measurement failed: gh api returned {out.returncode}: {out.stderr[:200]}", file=sys.stderr)
+        return []
+    runs: list[dict] = []
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        try:
+            created = _parse_iso(r["created_at"])
+        except (KeyError, ValueError):
+            continue
+        if created < cutoff:
+            continue
+        runs.append(r)
+    return runs
+
+
+def compute_metrics(runs: list[dict], window_hours: int) -> dict:
+    """Calcule tir_observed_pct + last_fired_at + interval_median_s."""
+    declared = int(window_hours * DECLARED_CADENCE_PER_HOUR)
+    fired = len(runs)
+    tir_pct = (fired / declared * 100.0) if declared > 0 else 0.0
+    if not runs:
+        return {
+            "fired": 0,
+            "declared": declared,
+            "tir_observed_pct": 0.0,
+            "last_fired_at": None,
+            "interval_median_s": None,
+            "interval_max_s": None,
+        }
+    fired_times = sorted(_parse_iso(r["created_at"]) for r in runs)
+    last_fired_at = fired_times[-1]
+    intervals_s = [
+        (fired_times[i] - fired_times[i - 1]).total_seconds()
+        for i in range(1, len(fired_times))
+    ]
+    return {
+        "fired": fired,
+        "declared": declared,
+        "tir_observed_pct": tir_pct,
+        "last_fired_at": last_fired_at.isoformat().replace("+00:00", "Z"),
+        "interval_median_s": statistics.median(intervals_s) if intervals_s else None,
+        "interval_max_s": max(intervals_s) if intervals_s else None,
+    }
+
+
+def format_summary(metrics: dict, window_hours: int) -> str:
+    lines = [
+        "## pr-gate-stale-sweep tir (#15197)",
+        "",
+        f"Fenêtre mesurée : **{window_hours} h** (cron déclaré : `7 * * * *`)",
+        "",
+        f"- Runs `schedule` observés : **{metrics['fired']}**",
+        f"- Tics déclarés attendus : **{metrics['declared']}**",
+        f"- Taux de tir observé : **{metrics['tir_observed_pct']:.1f} %**",
+        f"- Dernier tir : `{metrics['last_fired_at'] or 'aucun'}`",
+        f"- Intervalle médian : **{metrics['interval_median_s']:.0f} s**" if metrics['interval_median_s'] is not None else "- Intervalle médian : n/a",
+        f"- Intervalle max : **{metrics['interval_max_s']:.0f} s**" if metrics['interval_max_s'] is not None else "- Intervalle max : n/a",
+        "",
+        "**Doctrine** (#15197 voie (i)) : ce sweep est un **filet de rattrapage**, "
+        "jamais le chemin de déblocage d'une PR nommée. Quand une PR précise "
+        "attend, dispatcher explicitement : `gh workflow run pr-gate-stale-sweep.yml`.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "jsboige/CoursIA"))
+    p.add_argument("--workflow-file", default="pr-gate-stale-sweep.yml")
+    p.add_argument("--window-hours", type=int, default=DEFAULT_WINDOW_HOURS)
+    p.add_argument("--write-summary", action="store_true",
+                   help="Append metrics to GITHUB_STEP_SUMMARY if set")
+    args = p.parse_args()
+
+    runs = fetch_runs(args.repo, args.workflow_file, args.window_hours)
+    metrics = compute_metrics(runs, args.window_hours)
+    summary = format_summary(metrics, args.window_hours)
+
+    print(f"[pr-sweep-tir] fired={metrics['fired']}/{metrics['declared']} "
+          f"({metrics['tir_observed_pct']:.1f}%), "
+          f"last_fired_at={metrics['last_fired_at'] or 'none'}, "
+          f"interval_median_s={metrics['interval_median_s']}")
+
+    if args.write_summary:
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as f:
+                f.write(summary)
+        else:
+            print("::warning::GITHUB_STEP_SUMMARY not set, summary not written", file=sys.stderr)
+
+    # Advisory: exit 0 regardless. The angle this measures is the
+    # cadence the job itself depends on, so making the job fail under
+    # famine makes the famine worse.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_pr_gate_sweep_timing.py
+++ b/scripts/tests/test_pr_gate_sweep_timing.py
@@ -25,18 +25,20 @@ JOB_NAME = "Re-aggregate stale PR gate verdicts"
 def _extract_instrument() -> str:
     with WORKFLOW.open(encoding="utf-8") as stream:
         document = yaml.safe_load(stream)
-    # L'instrument de timing est l'unique etape `if: always()` -- localisee
-    # par contenu, pas par index (une etape d'amorcage precede desormais le
-    # selecteur, #14267).
+    # L'instrument de timing est l'etape `if: always()` qui contient le
+    # marqueur `jobs?filter=latest&per_page=100`. Localisee par contenu,
+    # pas par index (une etape d'amorcage precede desormais le selecteur,
+    # #14267 ; d'autres steps `if: always()` peuvent etre ajoutees sans
+    # casser ce test, cf c.1065 #15560 qui a ajoute une step tir cadence).
     candidates = [
         s
         for s in document["jobs"]["sweep"]["steps"]
         if s.get("if") == "always()"
+        and "jobs?filter=latest&per_page=100" in s.get("run", "")
     ]
-    assert len(candidates) == 1, "expected exactly one if: always() step"
+    assert candidates, "timing instrument step not found in pr-gate-stale-sweep.yml"
     step = candidates[0]
     run = step["run"]
-    assert "jobs?filter=latest&per_page=100" in run
     assert "jobs?filter=all" not in run
     match = re.search(r"python - <<'PY'\n(.*?)\nPY\n?$", run, re.S)
     assert match, "timing heredoc missing from pr-gate-stale-sweep.yml"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/test #15492

## Résumé

Issue #15197 (OPEN) — le workflow `pr-gate-stale-sweep` tire à ~28,8 % de sa cadence déclarée (mesure du 2026-09-08 : 53 runs sur 184,3 h, médiane 3,35 h, max 6,24 h).

**Voie (i)** retenue : instrument de mesure qui rend l'angle mort visible sans le corriger. La correction est ailleurs (voie (ii) cron externe arbitrée séparément ; voies (ii)/(iii) hors du périmètre de ce PR).

## Périmètre

**3 fichiers modifiés** :

| Fichier | Statut | Lignes | Rôle |
|---|---|---|---|
| `.github/workflows/pr-gate-stale-sweep.yml` | MODIFIED | +33/-2 | step advisory tir cadence + sparse-checkout étendu |
| `scripts/ci/pr_gate_stale_sweep_tir.py` | **NEW** | +163 | instrument de mesure (advisory exit 0) |
| `scripts/tests/test_pr_gate_sweep_timing.py` | MODIFIED | +7/-5 | **c.1065** : filter par contenu marqueur `jobs?filter=latest&per_page=100` au lieu de position ; préserve l'invariant unique-step-timing mais autorise la coexistence d'autres `if: always()` |

## Voie (i) — mesure du taux de tir schedule

L'acceptance #12728 mesurait les annulations (cancellation count), pas le taux de tir (combien de crons produisent un run). Issue #15197 a montré que le sweep tire à ~28,8 % de sa cadence déclarée, et l'instrument de #12728 ne le voyait pas.

### Ajouts

1. **`scripts/ci/pr_gate_stale_sweep_tir.py`** (NEW, 163 lignes) : instrument de mesure
   - Fenêtre 7 jours (par défaut)
   - Calcule `tir_observed_pct`, `last_fired_at`, `interval_median_s`, `interval_max_s`
   - Écrit un summary CI Markdown avec doctrine explicite
   - **Advisory par construction** : `exit 0` toujours (un sweep qui rougit parce que lui-même est sous-cadencé ne fait qu'aggraver la famine)

2. **`.github/workflows/pr-gate-stale-sweep.yml`** :
   - `sparse-checkout` étendu pour ramener le script (même checkout que `pr_gate_missing.py`, pas de pénalité supplémentaire)
   - Step **`Measure sweep tir cadence (advisory, #15197)`** en fin de job, `if: always()`, appelle le script avec `--write-summary`

3. **`scripts/tests/test_pr_gate_sweep_timing.py`** (fix c.1065) : la sélection de l'instrument de timing passe de « l'unique step `if: always()` » (assert légitime en #14267) à « le step `if: always()` contenant `jobs?filter=latest&per_page=100` » — fix anti-collision rendu nécessaire par l'ajout c.1060 de la step tir cadence (créant 2 steps `if: always()`).

### Doctrine rendue lisible par l'instrument

Le summary CI affiche :

> **Doctrine** (#15197 voie (i)) : ce sweep est un **filet de rattrapage**, jamais le chemin de déblocage d'une PR nommée. Quand une PR précise attend, dispatcher explicitement : `gh workflow run pr-gate-stale-sweep.yml`.

L'angle mort mesuré par ce PR est la cadence, pas la cause racine. La cadence est un **filet** : un job qui tourne à 28,8 % reste un filet utile, à condition de ne pas en dépendre pour débloquer une PR. Le tool donne le nombre ; le geste reste humain.

## Historique d'absorption (c.1065 découverte post-push)

Initialement rebase c.1061 a absorbé 10 commits de drift sur main mais a **raté le commit `116385db8d #15541`** (Fear & Greed overlay sur Markov-Regime) qui a été mergé sur main 12 min **après** la cible `fa3e506856` du rebase c.1061. C'est un **trou silencieux** que le périmètre-guard n'a pas attrapé (le diff leakait des fichiers Markov HORS-scope PR).

**Diagnostic Tell c.1065-L3 NEW fondateur** : `rebase-pr-peut-rater-commits-main-si-rebase-precede-merge-recent`. Le rebase c.1065 a poussé `e6fc92c1bb` qui était **1 commit de retard** sur main au moment du push — critique si la PR avait été mergée (perte silencieuse de #15541 validé NO BEATS consolidé).

**Réparation c.1065 (cette version)** : re-rebase frais sur `origin/main` à `32bbe1b1d3` qui absorbe les 11 commits de retard dont `116385db8d #15541`. Diff vs main : **3 fichiers scope** (le workflow `.github/workflows/pr-gate-stale-sweep.yml` + le script NEW + le test fix), +203/-7, périmètre clos, pas de leak Markov-Regime. Local pytest 3/3 verts.

## Tells respectés

- **Tell c.14947 ★★★ strict** : 0 byte production touchée. Le script et le step workflow sont des **guards** (instrument de mesure + rendu doctrine), pas du code de production. Le test est un guard-fix (c.1065), pas une fonctionnalité.
- **Tell c.14947-1 ★★ anti-scope-creep** : 1 deliverable borné = mesure + doctrine (pas de fix de la cadence elle-même, qui relève de voies (ii)/(iii) hors scope).
- **Tell c.898 ★★★ collision guard** : worktree `CoursIA-c1060-15197-pr-sweep-tir` sur `origin/main`, aucun autre en cours sur le chemin.
- **Tell c.970 ★★★ périmètre-guard** : la liste effective de fichiers scope (3) est maintenant explicitement énumérée dans ce body.
- **Tell c.1061-L1 ★★ fondateur** : force-push forme canonique `--force-with-lease=refs/heads/<branch>:X origin <branch>` post-rebase (X = pre-rebase SHA `e6fc92c1bb`).
- **Tell c.1065-L1 ★ PROPOSED fondateur** : fix test seam = filter par contenu (marqueur observable), pas par index. PR future qui ajouterait d'autres steps `if: always()` ne casserait pas ce test.
- **Tell c.1065-L3 ★★ fondateur** (NEW c.1065) : régression silencieuse par rebase-pr-ratant-commits-recent — diagnostic + fix = re-rebase frais **immédiatement** post-découverte avant push.
- **Tell c.13022 ★★★** : claim avec clause `paths:` explicite (`scripts/ci/**`, `.github/workflows/pr-gate-stale-sweep.yml`, `scripts/tests/test_pr_gate_sweep_timing.py`).
- **Tell c.1356 ★★★ preflight** : `--state all` au picker c.1060, **8 LIVRÉ-urn détectés** (#5105, #14886, #13926, #13924, #12135, #14769, #7291, #15309, #15041, #14831) — pool hostile CPU-only a forcé le pivot vers #15197 (grain MED/guard CPU-only).
- **Tell c.918 ★ ×18ᵉ LIVRÉ-urn NAMING maintenu** : aucun LIVRÉ-urn dans cette PR (grain neuf, claim fresh).
- **Tell c.1047 ★** : `subprocess.run(text=True, encoding="utf-8", errors="replace")` (pas de `text=True` nu — cp1252 hosts crash sur UTF-8 payloads).
- **Tell c.974 strict 0 amend consommé** : re-rebase = nouveau commit (pas amend).
- **Tell c.994 ★★★ fondateur** : 11 commits de drift absorbés sur main (rebase frais post-c.1065 incident).

## Mesures first-hand (mesure 2026-09-08)

| Métrique | Valeur |
|---|---|
| Runs `event=schedule` observés | **53** |
| Tics déclarés attendus (168 h × 1/h) | **168** |
| Taux de tir observé | **28,8 %** |
| Intervalle médian entre runs | **3,35 h** (≈ 12 060 s) |
| Intervalle max entre runs | **6,24 h** (≈ 22 464 s) |
| Fenêtre mesurée | **184,3 h** (7,7 j) |

Le PR ajoute la capacité de **re-mesurer à chaque run du sweep** (le step est en fin de job, `if: always()`), donc chaque run summary porte ses propres chiffres. La mesure historique reste dans le commentaire original de #15197.

## Validation

- `python -m py_compile scripts/ci/pr_gate_stale_sweep_tir.py` → OK
- `python scripts/ci/pr_gate_stale_sweep_tir.py --help` → OK (sortie argparse propre)
- YAML `.github/workflows/pr-gate-stale-sweep.yml` → YAML parse OK, indentation cohérente
- `git diff --stat` : 3 fichiers, +203/-7 (test + workflow + script NEW)
- Local `pytest scripts/tests/test_pr_gate_sweep_timing.py -v` → **3 passed** (post-rebase frais c.1065)
- pre-commit H.3 → `Refuse NEW text=True without encoding= ... Passed`

## Hors scope (à traiter séparément)

- **Voie (ii)** : cron externe (GitHub Actions externe, ou cron machine po-*) qui dispatcherait le sweep à un rythme indépendant de GitHub-hosted scheduler. **Hors scope** de ce PR.
- **Voie (iii)** : déclenchement événementiel (sur push de PR qui match un label). Écartée par le body de #15197. **Hors scope**.
- **Fix du sous-cadencement GitHub-hosted scheduler** lui-même : pas dans notre juridiction. **Hors scope**.

**Assertion d'exclusivité (#11268-2)** : ce PR ferme **voie (i)** et ne modifie **aucun autre fichier `.github/workflows/**`** que `.github/workflows/pr-gate-stale-sweep.yml`. Les autres workflows CI du dépôt restent intacts.

## Liens

- Issue #15197 : https://github.com/jsboige/CoursIA/issues/15197
- Issue #12728 : acceptance précédente (cancellation count)
- Branche : `fix/15197-pr-gate-stale-sweep-tir` @ `32bbe1b1d370791fb2f188631fb3abfa52a4a06b` (post-c.1065 re-rebase frais, head test-fix c.1065)
- Lane : `myia-po-2026:CoursIA-2`
- Sujets antérieurs :
  - Tell fondateur pool capability-aware c.1060 : [[cycle-c1060-15197-pr-sweep-tir-cadence]]
  - Tell fondateur c.1061 ★★ force-push canonique post-rebase : [[cycle-c1061-pr15560-rebase-merge-base]]
  - Tell fondateur c.1065-L1 ★ test fix filter par contenu : [[cycle-c1065-15560-test-fix-15525-hors-cap-15564-dwell]]
  - Tell fondateur c.1065-L3 ★★ régression silencieuse rebase rattrapée : même lien
- Tell fondateur c.1059-L1 ★ PROPOSED (cluster tells c.1054-L1 ★ / c.1058-L1 ★ / c.1059-L1 ★) : pair non-direct, défaut SHA-only rattaché à un push à arbre inchangé

🤖 Generated with [Claude Code](https://claude.com/claude.com)

