### PR TITLE
fix(ci,#15545): arm positive control in slides-composition-advisory — dead scanner now fails

### DIFF
--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -16,20 +16,27 @@ name: Slides Composition Advisory
 #
 # ADVISORY, jamais bloquant sur les constats : les findings sortent en
 # ::warning file=,line= (annotations de PR), exit 0. Exit 1 uniquement sur
-# META-défaillance du gate lui-même — trois causes, même classe (#8807 trap 1,
+# META-défaillance du gate lui-même — quatre causes, même classe (#8807 trap 1,
 # « un gate qui énumère zéro cible est vert et muet ») :
 #   (a) zéro deck découvert alors que slides/ a changé ;
 #   (b) binaire slidev introuvable — aucun deck n'est mesurable ;
-#   (c) deck découvert mais serveur jamais prêt — ce deck n'est PAS mesuré.
+#   (c) deck découvert mais serveur jamais prêt — ce deck n'est PAS mesuré ;
+#   (d) contrôle positif NON signalé — la fixture dédiée doit rougir, sinon
+#       l'instrument est mort et « 0 constat » sur les decks ne prouve rien
+#       (#15545 : un scanner mort rendait le même vert, ex glyphBBox v1
+#       sur #15381 — branche image jamais atteinte, signal à 0 à vie).
 # (b) et (c) sont ajoutées après coup (#12147) : le gate a rendu trois verts
 # les 20-21/08 sans mesurer une seule slide — chemin node_modules faux d'un
 # niveau, puis warning + continue + exit 0. Un vert qui n'a rien mesuré est
-# indiscernable d'un vert qui n'a rien trouvé : c'est ce que ces trois causes
+# indiscernable d'un vert qui n'a rien trouvé : c'est ce que ces causes
 # séparent.
 #
-# Le contrôle positif (slide 5 S3-acculturation @ 6cabc826b DOIT être
-# signalée) vit côté tests locaux : run_composition_control.py — nécessite
-# l'objet git 6cabc826b, hors d'un checkout shallow CI.
+# Le contrôle positif CI s'appuie sur la fixture committée
+# slides/_composition-control (défaut HORS_CANVAS déterministe slide 2,
+# indépendant des fontes) — aucun objet git requis. Le contrôle local
+# historique (slide 5 S3-acculturation @ 6cabc826b via
+# run_composition_control.py) reste valable : il vérifie en plus le rendu
+# du thème réel sur un deck de production au commit fondateur.
 
 on:
   schedule:
@@ -130,24 +137,18 @@ jobs:
           # ---- decks touchés : le deck dont le dir a changé, ou TOUS si infra partagée ----
           CHANGED=$(git diff --name-only "$BASE...$HEAD" -- slides/ || true)
           if grep -qE 'slides/(theme-ia101|package(-lock)?\.json)' <<< "$CHANGED"; then
-            MAPS=$(find slides -name slides.md -not -path '*/node_modules/*' -not -path '*/archive/*')
+            # _composition-control est la fixture du contrôle positif (#15545) :
+            # son défaut est DÉLIBÉRÉ — la scanner comme un deck réel ne produirait
+            # que du bruit.
+            MAPS=$(find slides -name slides.md -not -path '*/node_modules/*' -not -path '*/archive/*' -not -path '*/_composition-control/*')
           else
             # Découverte par DIR (intention du commentaire ci-dessus) : un diff qui
             # touche slides/<dir>/ via son jumeau Marp (slides.marp.md), analysis/
             # ou images/ impacte le deck Slidev du dir même si slides.md lui-même
             # n'est pas dans le diff. L'ancien grep fichier-exact faisait sortir
             # trap 1 (meta-failure) sur ces diffs dir-seulement.
-            DIRS=$(grep -oE '^slides/[^/]+/' <<< "$CHANGED" | sort -u || true)
+            DIRS=$(grep -oE '^slides/[^/]+/' <<< "$CHANGED" | grep -v '^slides/_composition-control/' | sort -u || true)
             MAPS=$(for d in $DIRS; do [ -f "${d}slides.md" ] && printf '%s\n' "${d}slides.md"; done)
-          fi
-
-          if [ -z "$MAPS" ]; then
-            if [ -n "$CHANGED" ]; then
-              echo "::error title=Composition gate meta-failure::slides/ a changé mais aucun deck slides.md découvert dans le diff — gate muet, à investiguer (#8807 trap 1)"
-              exit 1
-            fi
-            echo "Aucun deck impacté." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
           fi
 
           # Le binaire vit dans slides/node_modules : npm ci tourne avec
@@ -178,6 +179,78 @@ jobs:
           WAIT_PERIOD=3
           TOTAL_WAIT_BUDGET_S=$((WAIT_MAX_ITER * WAIT_PERIOD))
           echo "Budget d'attente par deck : ${TOTAL_WAIT_BUDGET_S}s (mesuré ~70-90s sur runner ubuntu-24.04)." >> "$GITHUB_STEP_SUMMARY"
+
+          # ---- Contrôle positif : la fixture DOIT rougir (#15545) ----
+          # Avant de mesurer les vrais decks, on prouve que l'instrument
+          # mesure : la slide 2 de slides/_composition-control porte un
+          # défaut HORS_CANVAS déterministe (p en absolu top:600px sur
+          # canvas 552px — indépendant des fontes et du thème). Un scanner
+          # mort (chemin de flagging cassé, ex glyphBBox v1 sur #15381)
+          # rendrait « 0 constat » partout : indistinguable d'un vert honnête.
+          # C'est la seule condition où un advisory a le droit d'être
+          # bruyant : elle ne dit rien des decks, tout de l'instrument.
+          CTRL_DIR=slides/_composition-control
+          CTRL_PORT=8899
+          cp "$CTRL_DIR/slides.md" "$CTRL_DIR/dev.md"
+          (cd "$CTRL_DIR" && "$SLIDEV_BIN" dev.md --port "$CTRL_PORT" --open false \
+             > /tmp/slidev_$CTRL_PORT.log 2>&1) &
+          CTRL_PID=$!
+          CTRL_READY=0
+          for i in $(seq 1 "$WAIT_MAX_ITER"); do
+            curl -sf "http://localhost:$CTRL_PORT/" > /dev/null && CTRL_READY=1 && break
+            sleep "$WAIT_PERIOD"
+          done
+          CTRL_SCAN_EXIT=99
+          if [ "$CTRL_READY" -ne 1 ]; then
+            echo "::error title=Composition gate meta-failure::contrôle positif : serveur slidev de la fixture jamais prêt en ${TOTAL_WAIT_BUDGET_S}s -- instrument NON VALIDÉ, aucun deck mesuré"
+            echo "Contrôle positif : fixture jamais servie -- instrument non validé." >> "$GITHUB_STEP_SUMMARY"
+            tail -40 "/tmp/slidev_$CTRL_PORT.log" 2>/dev/null || true
+          else
+            python scripts/notebook_tools/scan_slidev_composition.py \
+              --url "http://localhost:$CTRL_PORT/" \
+              --slides-md "$CTRL_DIR/slides.md" \
+              --baseline-slide 2 --baseline-commit fixture \
+              --out "$COMP_OUT_DIR/_positive_control.json" > /tmp/scan_$CTRL_PORT.log 2>&1
+            CTRL_SCAN_EXIT=$?
+            # PASS attendu : exit 1 (constats présents) ET controle_positif=true.
+            # exit 2 = baseline NON signalée (scanner mort) ; exit 0 = rien
+            # mesuré du tout ; autre = crash.
+            CTRL_OK=$(python - "$COMP_OUT_DIR/_positive_control.json" <<'PYEOF'
+          import json, sys
+          try:
+              d = json.load(open(sys.argv[1], encoding="utf-8"))
+          except Exception:
+              print("unreadable"); sys.exit(0)
+          print("ok" if d.get("controle_positif_ok") is True else "ko")
+          PYEOF
+          )
+            if [ "$CTRL_SCAN_EXIT" -eq 1 ] && [ "$CTRL_OK" = "ok" ]; then
+              echo "Contrôle positif PASS : la slide baseline de la fixture est signalée (HORS_CANVAS déterministe)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error title=Composition gate meta-failure::contrôle positif NON signalé (scanner exit $CTRL_SCAN_EXIT, controle_positif=$CTRL_OK) -- instrument suspect, la mesure des decks qui suit est SANS GARANTIE (#8807 trap 1)"
+              echo "Contrôle positif FAIL : instrument suspect (exit $CTRL_SCAN_EXIT, controle_positif=$CTRL_OK)." >> "$GITHUB_STEP_SUMMARY"
+              tail -40 "/tmp/scan_$CTRL_PORT.log" 2>/dev/null || true
+              META_FAIL=1
+            fi
+          fi
+          rm -f "$CTRL_DIR/dev.md"
+          kill "$CTRL_PID" 2>/dev/null || true
+
+          if [ -z "$MAPS" ]; then
+            if [ -n "$CHANGED" ]; then
+              echo "::error title=Composition gate meta-failure::slides/ a changé mais aucun deck slides.md découvert dans le diff — gate muet, à investiguer (#8807 trap 1)"
+              exit 1
+            fi
+            echo "Aucun deck impacté." >> "$GITHUB_STEP_SUMMARY"
+            # #15545 — même sans deck à mesurer, un instrument mort doit se
+            # voir : le contrôle positif a tourné ci-dessus ; s'il a failé on
+            # rougit malgré l'absence de decks.
+            if [ "$META_FAIL" -ne 0 ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
           for MD in $MAPS; do
             DIR=$(dirname "$MD")
             PORT=$((PORT+1))

--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -202,9 +202,10 @@ jobs:
           done
           CTRL_SCAN_EXIT=99
           if [ "$CTRL_READY" -ne 1 ]; then
-            echo "::error title=Composition gate meta-failure::contrôle positif : serveur slidev de la fixture jamais prêt en ${TOTAL_WAIT_BUDGET_S}s -- instrument NON VALIDÉ, aucun deck mesuré"
+            echo "::error title=Composition gate meta-failure::contrôle positif : serveur slidev de la fixture jamais prêt en ${TOTAL_WAIT_BUDGET_S}s -- instrument NON VALIDÉ, mesure des decks éventuels SANS GARANTIE"
             echo "Contrôle positif : fixture jamais servie -- instrument non validé." >> "$GITHUB_STEP_SUMMARY"
             tail -40 "/tmp/slidev_$CTRL_PORT.log" 2>/dev/null || true
+            META_FAIL=1
           else
             python scripts/notebook_tools/scan_slidev_composition.py \
               --url "http://localhost:$CTRL_PORT/" \

--- a/scripts/notebook_tools/tests/test_scan_slidev_composition.py
+++ b/scripts/notebook_tools/tests/test_scan_slidev_composition.py
@@ -267,7 +267,7 @@ def test_controle_positif_warning_when_baseline_omitted():
             "canvas_w": 980, "canvas_h": 552,
             "BORNE": "ADVISORY",
             "ctrl_positif_ok": None, "ctrl_positif_msg": None,
-            "n_total": 0, "n_hors": 0, "n_chev": 0, "n_occ": 0,
+            "n_total": 0, "n_hors": 0, "n_chev": 0, "n_rec": 0, "n_occ": 0,
         }
         exec(block, ns)
         return ns["report"]
@@ -280,3 +280,39 @@ def test_controle_positif_warning_when_baseline_omitted():
     rpt2 = _build(7)
     assert rpt2["controle_positif_armed"] is True
     assert rpt2["controle_positif_warning"] is None
+
+
+# ---- Fixture du contrôle positif CI (#15545) -------------------------------
+# La fixture slides/_composition-control/slides.md est le contrat entre le
+# workflow slides-composition-advisory.yml (--baseline-slide 2) et le
+# scanner : si quelqu'un réordonne ses slides ou édite le défaut délibéré,
+# le contrôle CI casse de façon opaque (baseline absente / non signalée).
+# Ce test verrouille les invariants AVANT que la CI ne les lise.
+
+FIXTURE = Path(__file__).resolve().parents[3] / "slides" / "_composition-control" / "slides.md"
+
+
+def test_positive_control_fixture_exists_and_counts():
+    assert FIXTURE.exists(), f"fixture contrôle positif absente : {FIXTURE}"
+    slides = split_slides_source(FIXTURE.read_text(encoding="utf-8"))
+    assert len(slides) == 2, "la fixture doit compter exactement 2 slides (baseline = 2)"
+
+
+def test_positive_control_fixture_baseline_defect_deterministic():
+    src = FIXTURE.read_text(encoding="utf-8")
+    slides = split_slides_source(src)
+    baseline = slides[1]["source"] if "source" in slides[1] else None
+    # fallback : le texte de la slide 2 par lignes
+    if baseline is None:
+        lines = src.split("\n")
+        start, end = slides[1]["start_line"] - 1, (slides[1 + 1]["start_line"] - 1) if len(slides) > 2 else len(lines)
+        baseline = "\n".join(lines[start:end])
+    # défaut déterministe : p en absolu AU-DELÀ du canvas par défaut (552 px)
+    assert "top:600px" in baseline, "le défaut HORS_CANVAS délibéré (top:600px) doit rester sur la slide 2"
+    assert "<p" in baseline, "le tag débordant doit rester un P (content_overflow ne compte que CONTENT_TAGS)"
+
+
+def test_positive_control_fixture_canvas_default():
+    # le contrôle CI suppose le canvas par défaut 980×552 : top:600px déborde
+    # de 48 px. Un canvasHeight headmatter > 600 casserait la garantie.
+    assert parse_headmatter_canvas(FIXTURE) == (980, 552)

--- a/slides/_composition-control/slides.md
+++ b/slides/_composition-control/slides.md
@@ -1,0 +1,19 @@
+---
+theme: ../theme-ia101
+title: "Contrôle positif composition (fixture CI #15545)"
+---
+
+# Fixture de contrôle positif — slide propre
+
+Cette slide ne porte aucun défaut. Elle existe pour que le défaut
+délibéré porte un numéro de slide stable : **2**.
+
+---
+
+# Slide baseline — défaut HORS_CANVAS déterministe
+
+Le paragraphe ci-dessous est positionné en absolu à 600 px du haut du
+canvas (552 px) : il déborde par le bas quelle que soit la fonte ou le
+thème. Un scanner vivant DOIT le signaler (HORS_CANVAS, tag P).
+
+<p style="position:absolute; top:600px; left:0; width:240px; height:40px;">élément contrôle hors canvas</p>


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: LIGHT/readme #15559

## Quoi

L'appel CI de `scan_slidev_composition.py` n'armait jamais `--baseline-slide` : **« 0 constat » était indistinguable d'un chemin de flagging mort**. Ce n'était pas théorique — le signal CHEVAUCHEMENT v1 (`glyphBBox` ouvrant sur `if (!el.firstChild) return null;`, `<img>` void element) a rendu `0` pendant toute sa vie, et le vert a été lu comme une absence de défaut (#15381, OBS 1).

## Le fix (3 pièces)

1. **Fixture deck committée** `slides/_composition-control/slides.md` — 2 slides ; la slide 2 porte un défaut HORS_CANVAS **déterministe** : `<p>` en absolu `top:600px` sur canvas 552 px (indépendant des fontes et du thème — aucune métrique textuelle en jeu, la bbox est `[0, 600, 240, 640]` par construction). Contrairement au contrôle local historique (`run_composition_control.py`, objet git `6cabc826b`), la fixture ne requiert **aucun objet git** → utilisable dans le checkout blobless CI.

2. **Câblage workflow** : le contrôle tourne **inconditionnellement** après le check du binaire slidev, AVANT l'early-exit « aucun deck impacté » (un instrument mort doit se voir même les nuits sans deck — ~90 s sur runner public, le prix de l'honnêteté). PASS = scanner exit 1 (constats présents) ET `controle_positif_ok: true`. Tout le reste (exit 2 = baseline non signalée, serveur fixture jamais prêt, rapport illisible) = **4e cause de méta-défaillance** `::error` + exit 1, même classe que « zéro deck découvert » (#8807 trap 1). La fixture est exclue de la découverte des decks réels (branches `find` et `DIRS`).

3. **Tests d'intégrité de la fixture** (3 nouveaux, `test_scan_slidev_composition.py`) : 2 slides exactement, `top:600px` + tag `<p>` sur la slide 2, canvas par défaut 980×552 — le contrat `--baseline-slide 2` entre workflow et scanner ne peut pas dériver silencieusement.

## Validation réelle (pas seulement unitaire)

E2E local exécuté : fixture servie via `slidev dev` (binaire de l'arbre principal, pattern junction du contrôleur local), scannée avec `--baseline-slide 2 --baseline-commit fixture-local-e2e` :

```
n_slides: 2 | n_hors_canvas: 1 | controle_positif_ok: True
slide2 hors_canvas: [{'tag': 'P', 'cls': '', 'bbox': [0, 600, 240, 640]}]
scanner exit 1  (= signature PASS attendue par le workflow)
```

Tests : **15/15 verts** (dont réparation d'un test rouge préexistant sur main, même fichier, 1 ligne : le namespace exec manquait `n_rec` ajouté par #15351 — vérifié rouge sur main propre avant fix). YAML workflow validé.

## Scope

- Scanner inchangé (le support `--baseline-slide` existait déjà : exit 2 déjà codé — c'est le câblage CI qui manquait).
- Contrôle local historique conservé (il vérifie en plus le rendu du thème réel au commit fondateur).

Closes #15545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
