### PR TITLE
fix(guard,#15566): retirer l'echappatoire rebase inerte du crible SHA

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -2751,11 +2751,25 @@ def _resolve_absent_sha_state(data: dict, cap: int = 5) -> dict[str, dict]:
 #
 # Le predicat se rattache donc au contenu : une levee citant un SHA
 # rembobine reste VALIDE si l'arbre du SHA rembobine est identique a
-# l'arbre de la tete (wake-commit, amend de message), ou si aucun fichier
-# de la PR n'est touche par la difference (rebase sans conflit). En cas
-# d'incertitude (arbre inconnu, pagination suspecte) : comportement
-# anterieur, le refus -- l'organe ne devient jamais permissif sur un
-# doute, c'est le cas que B.0 existe pour attraper.
+# l'arbre de la tete (wake-commit, amend de message). En cas
+# d'incertitude (arbre inconnu) : comportement anterieur, le refus --
+# l'organe ne devient jamais permissif sur un doute, c'est le cas que
+# B.0 existe pour attraper.
+#
+# #15566 -- l'echappatoire « rebase sans conflit » (aucun fichier de la PR
+# touche par la difference) est RETIREE, pas corrigee. Mesure sur une
+# vraie paire de rebase (39846a7a3 -> 9296031c6 : meme patch pose sur
+# deux bases) : `compare/{sha}...{head}` est une comparaison TROIS-POINTS
+# -- `merge_base_commit` rend d3107fce, pas le SHA cite -- et les fichiers
+# de la PR sont dans `changed` par construction, donc l'intersection
+# n'etait jamais vide et la marque n'a jamais pu etre posee sur une PR
+# non vide. Le code etait mort. Le corriger « en comparant merge_base
+# explicitement » serait un no-op (trois-points EST merge_base..head), et
+# l'API ne sert pas la forme deux-points (`..` rend 404, mesure sur une
+# paire parent/enfant). Une version exacte demanderait une comparaison de
+# blobs par chemin -- 3 appels API par SHA contre 1 -- et rouvrirait une
+# surface fail-open sur un organe de merge-gate. Le critere d'arbre suffit
+# au remede demontre (#15492) ; le rebase retombe sur le refus conservateur.
 
 
 def _pr_head_oid(data: dict) -> str:
@@ -2771,82 +2785,12 @@ def _pr_head_oid(data: dict) -> str:
     return ""
 
 
-def _pr_file_paths(data: dict, page_cap: int = 100) -> set[str] | None:
-    """Chemins des fichiers de la PR, bornes incluses.
-
-    None = determination impossible (PR sans numero, erreur reseau, ou
-    liste tronquee a la pagination) : l'appelant doit alors rester sur le
-    comportement strict -- ne JAMAIS deduire « fichiers inchanges » d'une
-    liste incomplete.
-    """
-    number = data.get("number")
-    if number is None:
-        return None
-    try:
-        files = gh_json(
-            ["api", f"repos/{REPO}/pulls/{number}/files?per_page={page_cap}"])
-    except subprocess.CalledProcessError:
-        return None
-    if not isinstance(files, list) or len(files) >= page_cap:
-        return None  # pagination potentiellement tronquee -> fail-safe
-    return {f.get("filename") for f in files if f.get("filename")}
-
-
-def _rewind_pr_files_untouched(data: dict, state: dict[str, dict],
-                               head_oid: str, head_tree: str,
-                               cap: int = 3) -> dict[str, bool]:
-    """SHAs rembobines rattaches a la PR dont AUCUN fichier de la PR n'a
-    bouge entre le SHA rembobine et la tete (cas rebase, #15556).
-
-    Compare cote serveur `{sha}...{head_oid}` : si aucun des fichiers
-    touches par la comparaison n'est un fichier de la PR, le livrable est
-    inchange et la levee reste valide. Fail-safe systematique : compare
-    irrecuperable, plus de `cap` candidats, fichiers de la PR inconnus ou
-    liste de compare au plafond (troncature silencieuse de l'API a 300)
-    -> le SHA n'est PAS marque untouched (le refus survit).
-    """
-    if not head_oid or not head_tree:
-        return {}
-    pr_refs: set[str] = set()
-    if data.get("number") is not None:
-        pr_refs.add(str(data["number"]))
-    for m in re.finditer(r"#(\d+)", (data.get("title") or "")
-                         + "\n" + (data.get("body") or "")):
-        pr_refs.add(m.group(1))
-    pr_refs.discard("")
-    rattachable = sorted(
-        s for s, v in state.items()
-        if v.get("message") and _message_refs_pr(v["message"], pr_refs)
-        and not (v.get("tree") and v["tree"] == head_tree))
-    if not rattachable:
-        return {}
-    pr_files = _pr_file_paths(data)
-    if pr_files is None:
-        return {}
-    untouched: dict[str, bool] = {}
-    for sha in rattachable[:cap]:
-        try:
-            compare = gh_json(
-                ["api", f"repos/{REPO}/compare/{sha}...{head_oid}"])
-        except subprocess.CalledProcessError:
-            continue
-        files = compare.get("files") or []
-        if len(files) >= 300:
-            continue  # troncature suspecte -> fail-safe
-        changed = {f.get("filename") for f in files}
-        if not (changed & pr_files):
-            untouched[sha] = True
-    return untouched
-
-
 def _attach_absent_sha_context(data: dict) -> None:
     """Resolution serveur du contexte SHA, AVANT analyse (qui reste pure).
 
-    Assemble les trois vues que `analyse` consulte : messages (rattachement
-    #13639), arbres des commits rembobines et arbre de la tete (#15556),
-    puis la comparaison fichiers pour les seuls candidats rattaches dont
-    l'arbre differe -- un seul appel reseau par SHA, un par PR pour la
-    tete et les fichiers.
+    Assemble les deux vues que `analyse` consulte : messages (rattachement
+    #13639) et arbres des commits rembobines plus arbre de la tete
+    (#15556) -- un appel reseau par SHA, plus un pour la tete.
     """
     state = _resolve_absent_sha_state(data)
     data["_absent_sha_messages"] = {s: v["message"] for s, v in state.items()
@@ -2863,8 +2807,6 @@ def _attach_absent_sha_context(data: dict) -> None:
         except subprocess.CalledProcessError:
             head_tree = ""
     data["_head_tree"] = head_tree
-    data["_rewind_pr_files_untouched"] = _rewind_pr_files_untouched(
-        data, state, head_oid, head_tree)
 
 
 def can_lift(comment: dict) -> bool:
@@ -3418,7 +3360,6 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
         resolved = pr_data.get("_absent_sha_messages") or {}
         rewound_trees = pr_data.get("_absent_sha_trees") or {}
         head_tree = pr_data.get("_head_tree")
-        untouched = pr_data.get("_rewind_pr_files_untouched") or {}
         kept_lifts = []
         for (t, lifter, lift_body) in explicit_lifts:
             refused = None
@@ -3435,14 +3376,9 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                     # rembobine ET rattache. #15556 : avant de desnuer la
                     # levee, verifier que le push a reellement change le
                     # livrable -- wake-commit et amend de message poussent
-                    # un arbre IDENTIQUE, rebase sans conflit ne touche
-                    # aucun fichier de la PR. Sans donnees d'arbre (audit
+                    # un arbre IDENTIQUE. Sans donnees d'arbre (audit
                     # retro, resolution serveur impossible) : refus, le
                     # comportement anterieur n'est jamais assoupli.
-                    if untouched.get(sha):
-                        if artifact is None:
-                            artifact = (sha, "pr_files_untouched")
-                        continue
                     tree = rewound_trees.get(sha)
                     if tree and head_tree and tree == head_tree:
                         if artifact is None:

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3507,7 +3507,13 @@ def test_15556_controle_negatif_commit_de_contenu_invalide_toujours():
     posee avant un commit de CONTENU -- l'arbre cite differant de l'arbre
     de la tete -- reste invalide. Le remede ne rend pas l'organe
     permissif : c'est exactement le cas que B.0 existe pour attraper
-    (« un push muet est indiscernable d'un push qui repond »)."""
+    (« un push muet est indiscernable d'un push qui repond »).
+
+    #15566 : ce chemin est aussi celui d'un REBASE -- un rebase fait
+    differer l'arbre, donc il retombe ici, sur le refus conservateur.
+    L'echappatoire qui pretendait l'absoudre a ete retiree (mesuree
+    inerte, cf le bloc #15566 dans `check_unaddressed_nits.py`) : c'est ce
+    test qui pinne le comportement retenu."""
     res = run([USER_NIT, lift_citant_sha()],
               commits=[{"oid": NIT_OID, "committedDate": at(19)}],
               _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"},
@@ -3529,22 +3535,6 @@ def test_15556_sans_donnees_arbre_refus_conservateur():
     assert res["blocked"] is True
     assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
     assert res["voided_lifts"][0]["tree_differs"] is False
-
-
-def test_15556_rebase_sans_fichier_de_la_pr_touche_conserve():
-    """Cas rebase sans conflit : l'arbre global differant (main a avance)
-    mais AUCUN fichier de la PR n'est touche par la difference -- le
-    livrable est inchangé, la levee reste valide."""
-    res = run([USER_NIT, lift_citant_sha()],
-              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
-              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"},
-              _absent_sha_trees={"2d6e4c3642": TREE_B},
-              _head_tree=TREE_A,
-              _rewind_pr_files_untouched={"2d6e4c3642": True})
-    assert res["blocked"] is False
-    assert res["voided_lifts"] == []
-    assert [(a["sha"], a["reason"]) for a in res["rewind_artifacts"]] == \
-        [("2d6e4c3642", "pr_files_untouched")]
 
 
 def test_15556_artefact_ne_masque_pas_un_vrai_refus():
@@ -3576,87 +3566,6 @@ def test_15556_headrefoid_prefere_au_dernier_oid():
     assert mod._pr_head_oid(data) == "f" * 40
     assert mod._pr_head_oid({"commits": [{"oid": "e" * 40}]}) == "e" * 40
     assert mod._pr_head_oid({"commits": [{"committedDate": at(19)}]}) == ""
-
-
-def test_15556_file_paths_tronques_renvent_none(monkeypatch):
-    """Fail-safe de `_pr_file_paths` : une liste de fichiers au plafond de
-    pagination (troncature potentielle) est une NON-determination, jamais
-    une liste complete -- en deduire « fichiers inchanges » serait le
-    faux negatif que l'acceptance 3 interdit."""
-    monkeypatch.setattr(mod, "gh_json",
-                        lambda args: [{"filename": f"f{i}.py"} for i in range(100)])
-    assert mod._pr_file_paths({"number": 7}) is None
-    monkeypatch.setattr(mod, "gh_json", lambda args: [])
-    assert mod._pr_file_paths({"number": 7}) == set()
-    assert mod._pr_file_paths({}) is None
-
-
-def test_15556_compare_hors_fichiers_pr_marque_untouched(monkeypatch):
-    """`_rewind_pr_files_untouched` : la difference SHA rembobine -> tete
-    ne touche que des fichiers HORS de la PR (rebase sur main) : le SHA
-    est marque untouched. Elle touche un fichier de la PR : pas de
-    marque, le refus survit."""
-    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_B}}
-    head_oid, head_tree = "f" * 40, TREE_A
-    data = {"number": 7, "title": "t", "body": ""}
-
-    def fake_gh_json(args):
-        url = args[-1]
-        if "/pulls/7/files" in url:
-            return [{"filename": "src/livrable.py"}]
-        if "/compare/" in url:
-            return {"files": [{"filename": "README.md"}]}  # hors PR
-        raise AssertionError(f"appel inattendu: {url}")
-
-    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
-    assert mod._rewind_pr_files_untouched(data, state, head_oid,
-                                          head_tree) == {"111aaaa111": True}
-
-    def fake_gh_json_touche(args):
-        url = args[-1]
-        if "/pulls/7/files" in url:
-            return [{"filename": "src/livrable.py"}]
-        if "/compare/" in url:
-            return {"files": [{"filename": "src/livrable.py"}]}  # DANS la PR
-        raise AssertionError(f"appel inattendu: {url}")
-
-    monkeypatch.setattr(mod, "gh_json", fake_gh_json_touche)
-    assert mod._rewind_pr_files_untouched(data, state, head_oid,
-                                          head_tree) == {}
-
-
-def test_15556_compare_au_plafond_fail_safe(monkeypatch):
-    """L'API compare tronque silencieusement a 300 fichiers : une liste au
-    plafond ne prouve RIEN sur les fichiers restants -- pas de marque."""
-    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_B}}
-
-    def fake_gh_json(args):
-        url = args[-1]
-        if "/pulls/7/files" in url:
-            return [{"filename": "src/livrable.py"}]
-        if "/compare/" in url:
-            return {"files": [{"filename": f"f{i}.py"} for i in range(300)]}
-        raise AssertionError(f"appel inattendu: {url}")
-
-    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
-    assert mod._rewind_pr_files_untouched(
-        {"number": 7, "title": "t", "body": ""}, state, "f" * 40,
-        TREE_A) == {}
-
-
-def test_15556_meme_arbre_pas_de_compare_ni_de_files(monkeypatch):
-    """Un SHA rembobine d'arbre IDENTIQUE a la tete est deja un artefact :
-    ni l'appel compare ni l'appel fichiers de la PR ne sont dus pour lui
-    (le gate paie un appel par PR, pas par SHA, quand tout est muet)."""
-    state = {"111aaaa111": {"message": "fix(x,#7): typo", "tree": TREE_A}}
-
-    def fake_gh_json(args):
-        raise AssertionError("aucun appel reseau attendu ici")
-
-    monkeypatch.setattr(mod, "gh_json", fake_gh_json)
-    assert mod._rewind_pr_files_untouched(
-        {"number": 7, "title": "t", "body": ""}, state, "f" * 40,
-        TREE_A) == {}
 
 
 def test_13641_ref_par_prefixe_ne_compte_pas():


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/tooling #15557

Closes #15566

## Mesure avant décision (acceptance 1)

`_rewind_pr_files_untouched` se présentait comme l'échappatoire du **rebase** : « la comparaison serveur `{sha}...{head}` ne touche aucun fichier de la PR ». Mesuré sur une **vraie paire de rebase** — pas une fixture — `39846a7a3` (tête de branche pré-rebase de #15557, parent sur un `main` ancien) et `9296031c6` (le même patch posé sur un `main` postérieur) :

| Appel | `merge_base_commit` | fichiers | fichiers de la PR dans `changed` |
|---|---|---|---|
| `compare/39846a7a3...9296031c6` (ce que le code faisait) | `d3107fce` ≠ sha cité | 17 | **les 2** (`check_unaddressed_nits.py` + son test) |

`A...B` est donc bien **trois-points** : le diff part de `merge_base(A,B)`, et les fichiers de la PR y sont **par construction** (la tête les porte). L'intersection `changed & pr_files` n'était jamais vide → la marque n'a jamais pu être posée sur une PR non vide → **le code était mort**. Le point 1 de l'issue est confirmé.

## Ce qui rend la correction non rentable (mesuré, pas supposé)

Les corrections suggérées par l'issue ne tiennent pas à la mesure :

1. **« comparer `{merge_base}` explicitement »** → **no-op** : trois-points *est* déjà `merge_base..head`. L'appel explicite redonne le même diff, fichiers de la PR inclus.
2. **forme deux-points `{sha}..{head}`** → l'API ne la sert pas : `compare/{A}..{B}` rend **404**, y compris sur une paire parent/enfant (`58c14e975..9296031c6`). Il n'y a donc pas de correction « un caractère ».
3. Reste la comparaison **blob par chemin** (`compare/M...X` vs `compare/M...head`), exacte et couvrant le point 2 — mais **3 appels API par SHA contre 1** sur un organe de merge-gate, et elle rouvre une surface **fail-open** (elle fait *accepter* là où l'organe refuse aujourd'hui).

## Décision : retrait

L'échappatoire était **inerte** : la retirer ne change **aucun comportement observable**, supprime une promesse que le code ne tenait pas, et referme d'un coup le trou du point 2 (le chemin qui l'ouvrait disparaît). Le remède démontré (#15492 : wake-commit, amend de message) repose sur l'**égalité d'arbre**, intacte. Un rebase retombe sur le refus conservateur — soit exactement ce que l'organe faisait déjà — et le test de contrôle négatif le pinne désormais nommément.

## Périmètre : 2 fichiers, −185/+30

- `scripts/check_unaddressed_nits.py` : fonction `_rewind_pr_files_untouched`, helper `_pr_file_paths` (client unique), appel dans `_attach_absent_sha_context`, branche de consommation (`pr_files_untouched`), prose du bloc #15556.
- `scripts/tests/test_check_unaddressed_nits.py` : les 5 tests des fonctions retirées (377 → 372 fonctions) ; le contrôle négatif existant documente désormais le cas rebase.

## Validation

- **494 tests verts** (suite nits éclatée) ; **685 verts** en ajoutant les suites `pick_*` qui partagent `analyse_pr` ; 0 échec.
- Comparaison base/après : 377 → 372 fonctions de test = exactement les 5 retirées, aucune autre perdue.
- `python -m py_compile` OK ; hooks pré-commit (gitleaks, `text=True`/`encoding=`) verts.
- **Contrôle négatif préservé** (acceptance 4) : les tests du cas retenu (`test_15556_push_muet_arbre_identique_conserve_la_levee`, `..._controle_negatif_...`, `..._sans_donnees_arbre_refus_conservateur`, `..._artefact_ne_masque_pas_un_vrai_refus`) injectent des données d'arbre — **aucun ne monkeypatche la réponse de `compare`**.

## Note de traçabilité

Le corps de #15557 (mergée) décrit encore l'échappatoire. Je n'ai **pas** réécrit ce corps — il est le compte rendu de la décision de merge à sa date. J'y ajouterai un **addendum append-only** pointant ce retrait, pour qu'un lecteur qui atterrit dessus ne soit pas induit en erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
