### PR TITLE
fix(twin,#15345): renumber 3 index collisions bloquant Scripts Tests (CPU)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process/0009-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process/0009-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
 python_sha: 8af07ff52418817a2aca960def7ab03d697c491c
-csharp_sha: 3ba21c169e6c85cfbd5185acb5444d3a57d5cbcf
+csharp_sha: b63c8ee46ab248579a443740f138cfe6d5568f46
 content_python_sha: 78589a5bc09ba1f74b9d0f57b0585dd56b3e0f67002bc47813a3a131f352ba50
-content_csharp_sha: c06adb667122f19581de02736f25c0a67ea4c39ab6c9138614847edd6f11b586
+content_csharp_sha: f2efe1cdfe7d5cc3e9e9a0498dfd66511bd28c87df67bea1ea20450e41374290

--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process/0010-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process/0010-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
 python_sha: 8af07ff52418817a2aca960def7ab03d697c491c
-csharp_sha: b63c8ee46ab248579a443740f138cfe6d5568f46
+csharp_sha: 3ba21c169e6c85cfbd5185acb5444d3a57d5cbcf
 content_python_sha: 78589a5bc09ba1f74b9d0f57b0585dd56b3e0f67002bc47813a3a131f352ba50
-content_csharp_sha: f2efe1cdfe7d5cc3e9e9a0498dfd66511bd28c87df67bea1ea20450e41374290
+content_csharp_sha: c06adb667122f19581de02736f25c0a67ea4c39ab6c9138614847edd6f11b586

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics/0006-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics/0006-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
-python_sha: ffb1dcb9662376112b0f3889e2ec02d68316cbbf
+python_sha: e72d31df25ab9ea17a7705f124de4852daf8e509
 csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
-content_python_sha: 502e22d84930e75b9716ce37080de094034cb2d0ad8ea4cbf61d0ee9420c05d2
+content_python_sha: 8ec84220dafa1c0bc753b2c49621447a29fd3cdfc3b887480981c546b2b13859
 content_csharp_sha: d2471f19c3459505386a13bb7974735deed73ae2b9c4684db8da68111c197c5d

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics/0007-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics/0007-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
-python_sha: e72d31df25ab9ea17a7705f124de4852daf8e509
+python_sha: ffb1dcb9662376112b0f3889e2ec02d68316cbbf
 csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
-content_python_sha: 8ec84220dafa1c0bc753b2c49621447a29fd3cdfc3b887480981c546b2b13859
+content_python_sha: 502e22d84930e75b9716ce37080de094034cb2d0ad8ea4cbf61d0ee9420c05d2
 content_csharp_sha: d2471f19c3459505386a13bb7974735deed73ae2b9c4684db8da68111c197c5d

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl/0007-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl/0007-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
-python_sha: 37f10f7b3be91ad79f7491dad2834f7849e257e3
+python_sha: 3ae67b8df05a719616ce38af49258a3d8cd22cbd
 csharp_sha: f772b4048c0c6227986c830cf89946d10d7aaccd
-content_python_sha: 3eec3895e2617c4cb7e2af7fc1552f365040762bbe7b541c55fab950b30e62c7
+content_python_sha: 2657c67eb3d77bbcd2bed49b0d1e01e9f44725333dbcb5eb8f4aaed38549ed7d
 content_csharp_sha: e0fa1a57976b5801ece24c4b48560865c905d8755c9821ddea113ccd7fc6da18

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl/0008-2026-09-10-myia-po-2023-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl/0008-2026-09-10-myia-po-2023-CoursIA.yaml
@@ -1,6 +1,6 @@
 date: '2026-09-10'
 by: myia-po-2023:CoursIA
-python_sha: 3ae67b8df05a719616ce38af49258a3d8cd22cbd
+python_sha: 37f10f7b3be91ad79f7491dad2834f7849e257e3
 csharp_sha: f772b4048c0c6227986c830cf89946d10d7aaccd
-content_python_sha: 2657c67eb3d77bbcd2bed49b0d1e01e9f44725333dbcb5eb8f4aaed38549ed7d
+content_python_sha: 3eec3895e2617c4cb7e2af7fc1552f365040762bbe7b541c55fab950b30e62c7
 content_csharp_sha: e0fa1a57976b5801ece24c4b48560865c905d8755c9821ddea113ccd7fc6da18


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/lean #15563

## Problème

`Scripts Tests (CPU)` est **ROUGE sur `main`** depuis le `2026-09-11T09:08:28Z` (run `34582678134`, SHA `342189d5b4`) :

```
FAILED scripts/notebook_tools/tests/test_twin_registry_integrity.py::test_audit_index_unique_and_no_identical_duplicates_per_pair
AssertionError: prefixe NNNN duplique dans une paire (l'index est la cle de tri du journal, #14911/#15345)
```

`Scripts Tests (CPU)` est un check **requis** : tant qu'il est rouge sur `main`, le `PR gate` bloque **toute** PR de la flotte. Ce n'est pas un rouge de lane, c'est un rouge de base.

## Mesure (firsthand, sur `origin/main` = `6defc69cc5`)

Scan des 158 paires de `scripts/notebook_tools/twin_pairs.d/` : **3 collisions d'index**, et exactement 3.

| Paire | Index | Fichiers en collision |
|---|---|---|
| `probas-16-sparse-gaussian-process` | `0008` | `0008-2026-09-08-myia-po-2024-CoursIA-2.yaml` · `0008-2026-09-10-myia-po-2023-CoursIA.yaml` |
| `sw-2-rdf-basics` | `0005` | `0005-2026-09-08-myia-po-2024-CoursIA-2.yaml` · `0005-2026-09-10-myia-po-2023-CoursIA.yaml` |
| `sw-7-owl` | `0006` | `0006-2026-09-08-myia-po-2024-CoursIA-2.yaml` · `0006-2026-09-10-myia-po-2023-CoursIA.yaml` |

Le second invariant de la garde (attestations byte-identiques intra-paire) est **déjà satisfait** : 0 doublon de blob. Seul l'index est à réparer.

## Cause racine

`_audit_filename` alloue l'index via `len(glob("*.yaml")) + 1` (`scripts/notebook_tools/check_twin_parity.py:1429`). Le motif est identique dans les trois paires : une entrée `po-2024:CoursIA-2` du **2026-09-08** détient l'index `N`, puis deux entrées `po-2023:CoursIA` du **2026-09-10** se sont vu attribuer `N` (collision) et `N+1`.

Deux lanes dont le checkout ne voit pas encore le fichier de l'autre calculent le **même** index ; comme les noms diffèrent par la date et le slug de lane, **les deux fichiers mergent proprement** — la collision n'apparaît qu'à l'arrivée de la garde #15345. C'est la classe décrite par #14911/#15345, dont c'est une **récurrence** sur des entrées postérieures à la garde.

## Réparation

Les deux entrées `po-2023` remontent d'un cran (`N → N+1`, `N+1 → N+2`). L'entrée `po-2024:CoursIA-2` du 09-08 (antérieure) **conserve** son index.

Le choix d'un double renommage plutôt que d'un déplacement simple est délibéré : l'index est la clé de tri du journal (`sorted(glob)`, #14911) et `_latest_audit` lit `audits[-1]`. Déplacer la seule entrée en collision à la fin aurait **promu l'audit antérieur du 09-10 au rang d'attestation courante**. En décalant les deux, l'ordre d'append relatif des deux audits du 09-10 est préservé.

## Vérification

**Multiset de blobs identique avant/après** sur les trois paires (`git hash-object` sur le worktree vs `git ls-tree origin/main`) — aucun contenu perdu ni altéré, seuls les préfixes bougent :

| Paire | Avant | Après |
|---|---|---|
| `probas-16` | `49a3f10e`@0008, `ec2a2dda`@0009 | `49a3f10e`@**0009**, `ec2a2dda`@**0010** |
| `sw-2` | `2af52082`@0005, `95670aec`@0006 | `2af52082`@**0006**, `95670aec`@**0007** |
| `sw-7-owl` | `0cef017e`@0006, `d199c650`@0007 | `0cef017e`@**0007**, `d199c650`@**0008** |

Garde réelle relancée localement :

```
python -m pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py -q
46 passed, 1 warning in 79.87s
```

(le warning est le signalement pré-existant de blobs orphelins par squash — légitime, non bloquant.)

## Deux signalements qui ne sont pas dans cette PR

1. **Le re-cassage imminent de #15146.** La branche `chore/14209-normalize-residue` est en retard sur `main` (elle *ajoute* `gametheory-6-evolutiontrust/0008-2026-08-24-CoursIA-2-DRIFT-INTRO-ESS.yaml` alors que `0008-2026-08-24-myia-po-2027-CoursIA-2.yaml` existe déjà) — mesuré : **1 collision d'index** sur son arbre. Elle est `DIRTY`, donc elle devra être résolue de toute façon ; mais si elle est résolue sans regarder, elle re-casse la garde que cette PR répare. Traité à part, pas ici (un sujet par PR).
2. **`len(glob("*.yaml")) + 1` n'est pas gap-safe.** Sur un répertoire à trous (ex. `0001`, `0003`), `len+1 = 3` **collisionne avec l'existant `0003`** — situation atteignable puisqu'un dédoublonnage (ou ce renommage) peut retirer un fichier du milieu. Non corrigé ici pour garder la PR atomique (la réparation de données et le durcissement de l'allocateur sont deux sujets, le second demandant son propre test).

## Portée

6 fichiers renommés, **0 changement de contenu** (`git diff --cached --stat` : 12 insertions / 12 deletions, uniquement des préfixes d'index dans des entrées YAML).

See #15345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
