### PR TITLE
feat(qc,#11601): cellule d'interpretation sur 6 runs de code consecutifs (QC-Py-23b/19/07)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -235,6 +235,26 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+    "**Interpretation** : cette cellule est un cas d'ecole de l'**effet de levier**, et les trois nombres qu'elle imprime se deduisent l'un de l'autre — ils ne sont pas trois reglages independants.\n",
+    "\n",
+    "La valeur du contrat vient du **produit**, pas d'un choix : `5000 points x 50 $/point = 250 000 $`. Le trader ne decide ni du multiplicateur ni du prix ; il decide du **nombre de contrats**. C'est cette taille de notionnel, fixee par le produit, qui rend un seul contrat E-mini hors de portee pour un compte de quelques dizaines de milliers de dollars.\n",
+    "\n",
+    "Le levier, lui, est **derive** : avec une marge initiale a 5 % (`12 500 $`), le rapport `250 000 / 12 500` vaut **20:1**. Autrement dit, la marge n'est pas un frais mais un **depot de garantie**, et le levier n'est pas choisi par le trader mais impose par le pourcentage de marge du courtier.\n",
+    "\n",
+    "C'est ce qui donne son sens au couple `initial 12 500 / maintenance 10 000` : les deux seuils ne sont pas deux variantes du meme nombre, ils delimitent trois zones.\n",
+    "\n",
+    "| Mouvement adverse du prix | Perte sur le contrat | Effet sur la marge |\n",
+    "|---|---|---|\n",
+    "| `-4 %` (200 points) | `-10 000 $` | atteint la **maintenance** -> appel de marge |\n",
+    "| `-5 %` (250 points) | `-12 500 $` | **consomme la totalite** de la marge initiale |\n",
+    "\n",
+    "Le resultat a retenir est l'identite qui saute aux yeux dans ce tableau : **un pourcentage de marge de 5 % signifie qu'un mouvement adverse de 5 % efface le depot**. Le levier annonce (`20:1`) et le seuil de ruine (`-5 %`) sont le meme nombre vu de deux cotes — c'est la raison pour laquelle le dimensionnement de position, et non la prediction, est le premier facteur de survie sur les Futures."
+    ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -372,6 +372,20 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "id": "0211c396",
+    "source": [
+    "**Interpretation** : cette cellule ne charge aucune donnee de marche — elle **fabrique** un jeu de demonstration, et le commentaire de tete le dit sans detour (« en production, utiliser le pipeline de QC-Py-18 »). En tirer des conclusions de trading serait donc une erreur de lecture ; ce qu'elle installe, c'est un **terrain d'essai controle** pour toute la suite du notebook.\n",
+    "\n",
+    "La structure du signal genere est volontairement composite, pour que les modeles aient quelque chose a apprendre : une **tendance** lineaire (`linspace(100, 130)`), un **cycle** de periode longue (`15 * sin` sur `6*pi`, soit trois oscillations pleines), et un **bruit cumule** (`cumsum` de tirages gaussiens, donc une marche aleatoire et non un bruit blanc). C'est ce troisieme terme qui rend la prevision non triviale : la part impredictible du signal n'est pas stationnaire.\n",
+    "\n",
+    "Les features derivees reprennent la grammaire de QC-Py-18 : rendements sur **quatre horizons** (`1`, `5`, `10`, `20` jours, soit de l'intra-semaine au mensuel) et une volatilite realisee sur `20` jours. Les labels sont construits sur un rendement futur — c'est precisement le point ou un decoupage temporel mal fait introduirait un biais de lookahead, challenge tabule en §1.1.\n",
+    "\n",
+    "Le tirage porte sur **600 jours ouvres** (`freq='B'`), du **2022-01-03 au 2024-04-19** : la periode couvre un bear market (2022), un rebond (2023) et une phase haussiere (2024), donc plusieurs regimes — ce qui evite qu'un modele naif paraisse bon pour la seule raison que le marche allait dans un sens."
+    ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "cell-c4982d23",
@@ -738,6 +752,23 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "id": "04112495",
+    "source": [
+    "**Interpretation** : cette cellule **configure** le classifieur sans l'entrainer — aucune mesure n'est produite ici, et c'est delibere : chaque hyperparametre est un choix qu'on doit pouvoir lire avant de voir le score, sinon le score devient son propre justificatif.\n",
+    "\n",
+    "Quatre reglages portent l'essentiel :\n",
+    "\n",
+    "1. **`n_estimators=100`** — cent arbres. Le bagging tire son benefice de la **moyenne** ; en dessous d'une centaine, la variance de l'agregation est encore visible.\n",
+    "2. **`max_depth=5` et `min_samples_leaf=10`** — les deux freins a l'overfitting. Un arbre profond memorise le bruit de la marche aleatoire ; la profondeur 5 borne la capacite, et exiger 10 echantillons par feuille empeche les feuilles-singletons, qui sont exactement les memorisations d'un evenement unique.\n",
+    "3. **`max_features='sqrt'`** — chaque split ne considere que `sqrt(n_features)` colonnes. C'est le levier de **decorrelation** des arbres : sans lui, tous les arbres verraient la meme feature dominante et voteraient de la meme facon, ce qui annulerait le benefice de l'agregation (le commentaire de la cellule precedente decrit ce mecanisme).\n",
+    "4. **`class_weight='balanced'`** — repond directement au challenge « Class Imbalance » tabule en §1.1 : les poids compensent la proportion inegale de hausses et de baisses, de sorte qu'un modele ne puisse pas obtenir une accuracy flatteuse en predisant toujours la classe majoritaire.\n",
+    "\n",
+    "`random_state=42` fixe les tirages, donc la comparaison RF / XGBoost qui suit portera sur le meme decoupage. L'entrainement lui-meme a lieu plus loin, dans la validation croisee `TimeSeriesSplit`."
+    ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "cell-b9dc6e94",
@@ -943,6 +974,22 @@
     "except:\n",
     "    pass"
    ]
+  },
+  {
+    "cell_type": "markdown",
+    "metadata": {},
+    "id": "48f2013d",
+    "source": [
+    "**Interpretation** : ces cinq mesures sont celles du Random Forest sur le **jeu de test**, apres entrainement sur tout le train. Elles se lisent ensemble, jamais isolement.\n",
+    "\n",
+    "**Precision `0.7705` et rappel `0.7833` sont proches.** C'est le resultat attendu du `class_weight='balanced'` configure plus haut : le modele ne s'est pas replie sur la classe majoritaire. Un ecart fort entre les deux (precision haute, rappel bas) aurait signale exactement cette degenerescence.\n",
+    "\n",
+    "**`ROC AUC 0.8529` depasse l'accuracy `0.8354`.** L'aire sous la courbe mesure la qualite du **classement** des probabilites, l'accuracy la decision apres seuil a `0.5`. L'ecart indique que le modele ordonne mieux les observations qu'il ne les classe : une part des erreurs vient du **seuil**, pas du score — ce qui est actionnable (calibrer le seuil), contrairement a un modele qui ne saurait pas ordonner.\n",
+    "\n",
+    "**Le `F1 0.7769` est la moyenne harmonique des deux precedents**, et se situe donc logiquement entre eux.\n",
+    "\n",
+    "Reste la question qui rend ces quatre premiers chiffres lisibles : **contre quoi les comparer ?** Une accuracy seule ne veut rien dire. La cellule suivante y repond en construisant des baselines **executees sur la meme partition de test** — c'est cette confrontation, et non le niveau absolu, qui dira si le modele a appris quelque chose."
+    ]
   },
   {
    "cell_type": "code",
@@ -1347,6 +1394,22 @@
     "print(f\"  subsample: {xgb_model.subsample}\")\n",
     "print(f\"  colsample_bytree: {xgb_model.colsample_bytree}\")"
    ]
+  },
+  {
+    "cell_type": "markdown",
+    "metadata": {},
+    "id": "60349925",
+    "source": [
+    "**Interpretation** : meme lecture que pour le Random Forest — une configuration se juge par ce qu'elle rend possible, pas par le score qu'elle produira. Mais le contraste avec la configuration RF est ici le vrai contenu pedagogique : **quatre reglages sur cinq s'inversent**.\n",
+    "\n",
+    "**`max_depth=4`, plus faible que le `5` du Random Forest.** C'est contre-intuitif seulement si l'on oublie que les deux modeles agregent differemment. Le bagging moyenne des arbres **independants** : la capacite doit donc etre portee par chaque arbre, d'ou une profondeur plus grande. Le boosting enchaine des arbres **dependants**, chacun corrigeant le residu du precedent : la capacite vient de la **sequence**, pas de la profondeur — des arbres volontairement simples (les « weak learners ») suffisent, et les rendre profonds ferait surapprendre le residu.\n",
+    "\n",
+    "**`n_estimators=200`, le double du RF.** Consequence directe du meme arbitrage : beaucoup d'arbres faibles plutot que peu d'arbres forts. Le commentaire de la cellule precise que l'early stopping arretera la sequence avant les 200 — le nombre est donc un **plafond**, pas une cible.\n",
+    "\n",
+    "**`subsample=0.8` et `colsample_bytree=0.8`** sont les equivalents fonctionnels du `max_features='sqrt'` du RF : ils injectent de l'alea dans ce que chaque arbre voit (80 % des observations, 80 % des colonnes) pour decorreler les arbres d'une sequence qui, par construction, est fortement correlee.\n",
+    "\n",
+    "**`learning_rate=0.1`** n'a pas d'equivalent cote RF : il dose la contribution de chaque arbre au modele cumule. C'est le reglage qui arbitre vitesse de convergence et risque de depasser l'optimum — et c'est le premier parametre a faire varier en exercice."
+    ]
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -656,6 +656,22 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "id": "28c2b7dc",
+    "source": [
+    "**Interpretation** : cette cellule fabrique le **banc d'essai** sur lequel les deux architectures seront comparees, et ses parametres sont des choix pedagogiques autant que techniques. Trois d'entre eux meritent d'etre lus.\n",
+    "\n",
+    "**Un jeu synthetique, pas des donnees de marche.** La serie est construite (`sin` de periode `4*pi`, tendance `100`, bruit cumule) : elle porte donc une structure **connue d'avance**, ce qui rend l'ecart PatchTST / iTransformer interpretable sans le confondre avec du bruit de marche. Le revers est explicite — une conclusion tiree ici qualifie la **capacite des architectures sur cette famille de signaux**, pas leur performance de trading.\n",
+    "\n",
+    "**Une difficulte volontairement heterogene entre variables.** Les cinq canaux sont generes avec des ecarts-type de bruit `[0.1, 0.5, 0.3, 0.1, 1.0]` : le cinquieme est dix fois plus bruite que le premier. C'est ce contraste qui donne du sens a l'attention **cross-variable** d'iTransformer — si les cinq canaux etaient equivalents, ponderer les variables n'apporterait rien.\n",
+    "\n",
+    "**Une normalisation qui ne voit jamais le test.** `train_mean` et `train_std` sont calcules sur `X_train` seul (`axis=(0, 1)`, donc par variable et par pas de temps) puis appliques a `X_test` **et** a `Y_test`. C'est la forme correcte : normaliser sur l'ensemble des donnees ferait fuiter la moyenne et l'ecart-type du futur dans l'entrainement. Le `+ 1e-8` protege la division sur un canal a variance nulle.\n",
+    "\n",
+    "Le decoupage est chronologique (`int(0.8 * 500)` = **400 echantillons d'entrainement, 100 de test**), sans melange — condition necessaire pour que la comparaison qui suit mesure une **generalisation** et non une memorisation."
+    ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "065ed006",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-lean #15563

## Le defaut

`detect_consecutive_code_cells.py` (#12797) signale les runs de cellules code consecutives. Sur la serie `QuantConnect/Python`, **13 des 18 runs** portent une sortie qu'aucune prose n'interprete : le lecteur voit un resultat chiffre et passe directement au code suivant.

La resolution retenue par run est la **cellule markdown intermediaire** (interpretation / transition), jamais une fusion — les deux cellules d'un run sont des etapes logiquement distinctes (`count_exercises.py` classe le corpus, la classification kind est consommee depuis l'organe, pas reimplementee).

## Portee reelle : 6 cellules markdown sur 3 notebooks — pas 5

L'annonce de claim portait sur 5 notebooks. **Deux se sont reveles sans gap genuine**, et ce body le dit plutot que de les compter :

| Notebook | Runs signales | Runs genuines | Livre |
|---|---:|---:|---|
| `QC-Py-23b-PatchTST-iTransformer` | 2 | 1 | 1 cellule (apres c16) |
| `QC-Py-19-ML-Supervised-Classification` | 5 | 5 | 4 cellules (apres c8, c17, c21, c30) |
| `QC-Py-07-Futures-Forex` | 2 | 1 | 1 cellule (apres c4) |
| `QC-Py-14-Portfolio-Construction-Execution` | 2 | **0** | rien |
| `QC-Py-Dataset-Workflow` | 2 | **0** | rien |

**7 des 13 runs ont ete refuses**, et c'est deliberé : ce sont des stubs d'exercice (`sharpe_spy = None`, sortie « Exercice a completer ») ou des blocs `# [REFERENCE QC]` a copier dans QC Lab, **non executes** (`execution_count: None`). Les 7 runs concernes sont hors-corpus ou setup, donc exempts par la classification de `count_exercises.py` — inserer une interpretation sur une cellule qui n'a rien produit serait du remplissage. Note : les stubs d'exercice ne sont PAS exempts par la regle, mais un stub dont l'output dit « a completer » n'offre aucun resultat a interpreter ; la cellule de transition appartient au moment ou l'etudiant l'aura rempli.

Markdown-only : aucune cellule de code modifiee, donc **aucune re-execution C.2 due**.

## Verification — organes du depot, avant -> apres

Runs de cellules code consecutives (`detect_consecutive_code_cells.py`) :

| Notebook | Avant | Apres |
|---|---:|---:|
| `QC-Py-07` | 2 | 1 |
| `QC-Py-19` | 5 | 1 |
| `QC-Py-23b` | 2 | 1 |

**9 -> 3 runs au total ; les 6 insertions ferment exactement 6 runs.** Les 3 runs restants sont les runs bénins listes ci-dessus, non touches.

Densite prose / cellule de code (`pedagogy_density.py`, #10479) — denominateur constant (cellules code inchangees), donc hausse pure de prose :

| Notebook | Avant | Apres | Delta |
|---|---:|---:|---:|
| `QC-Py-23b` | 2018 | 2147 | +129 |
| `QC-Py-19` | 1620 | 1839 | +219 |
| `QC-Py-07` | 3973 | 4065 | +92 |

Autres organes :

- `detect_markdown_rendering.py --check` : liste de violations **byte-identique** a `origin/main` (voir finding ci-dessous).
- `check_output_failure_text.py` : aucun output modifie.
- Pre-commit complet (9 hooks, dont **H.3** `execution_count=null + outputs=[]`) : **Passed** — et les hooks auto-applicatifs n'ont modifie aucun fichier.
- `COURSE_CATALOG.generated.*` : **non touche** (catalogue byte-identique a `main`, appartient a l'automatisation).

## Ancrage des interpretations

Chaque cellule cite des valeurs **reellement presentes dans les sorties committees** — aucune valeur fabriquee :

- `QC-Py-19` c21 : `Accuracy: 0.8354 / Precision: 0.7705 / Recall: 0.7833 / F1 0.7769 / ROC AUC 0.8529`, lues ensemble et rattachees au `class_weight='balanced'` de c17 puis a la baseline `DummyClassifier` de c23.
- `QC-Py-19` c17 / c30 : contraste RF vs XGBoost (`max_depth` 5 -> 4, `n_estimators` 100 -> 200), rattache a l'arbitrage bagging (arbres independants) / boosting (arbres dependants).
- `QC-Py-07` c4 : `Valeur du contrat: $250,000`, `Marge Initiale (~5%): $12,500`, `Leverage effectif: 20:1`, decomposes en tableau marge initiale / maintenance.
- `QC-Py-23b` c16 : parametres du jeu synthetique (ecarts-type de bruit `[0.1, 0.5, 0.3, 0.1, 1.0]`), normalisation `train_mean`/`train_std` calculee sur le train seul.

Les renvois `§1.1` et « challenge Class Imbalance » cites dans `QC-Py-19` ont ete verifies dans le notebook : la section existe et son tableau porte bien `Class Imbalance -> Class weights, resampling` et `Lookahead Bias -> TimeSeriesSplit strict`.

Position de chaque insertion verifiee cellule par cellule : elle suit **la cellule de code dont la sortie porte la valeur citee**, jamais un id voisin (§D.4bis).

## Finding separe, non traite ici

`detect_markdown_rendering.py --check MyIA.AI.Notebooks/QuantConnect/Python` rend **`FAIL: 43 new ERROR-level`** sur `main` **a l'identique** (mesure sur `f9bf4229fb`, arbre propre) — la liste des violations est **byte-identique** entre cette branche et `main`, donc cette PR n'introduit rien. La baseline de l'organe est en retard sur le corpus (`QC-Py-04`, `QC-Py-11`, `QC-Py-12`, `QC-Py-31`, `research/*`). C'est un sujet distinct — nouvel organe / regeneration de baseline, choix de conception — et **aucun des trois notebooks de cette PR n'y figure**.

See #11601 (contribution partielle : 6 des 18 runs de la serie ; l'issue reste ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
