### PR TITLE
docs(lean,#14821): synchro inventaire/README sur l'état mesuré de knot_lean (10 réels)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/LEAN_INVENTORY.md
@@ -24,7 +24,7 @@ FLT/pin Mathlib `db584cd`, même forme CI dispatcher que hecke).
 |------|-----------|--------------------:|--------------:|---------------:|--------|-------|
 | `grothendieck_lean` | v4.32.1 | 0 | 118 | 4 | REF | #1646, #2159 |
 | `conway_lean` | v4.32.1 | 1¹ | 72 | 23 | PEDA | #1453, #1651, #2162 |
-| `knot_lean` | v4.32.1 | 11² | 15 | 4 | PEDA/REF | #2874, #3003 |
+| `knot_lean` | v4.32.1 | 10² | 15 | 4 | PEDA/REF | #2874, #3003, #14821 |
 | `finiteness_lean` | v4.32.1 | 0 | 4 | 4 | PEDA | #2978, #3111 |
 | `sensitivity_lean` | v4.32.1 | 0 | 11 | 5 | PEDA/REF | famille calibration |
 | `mimo_lean` | v4.32.1 | 0 | 13 | 3 | PEDA/REF | #10984, #10986 |
@@ -33,7 +33,7 @@ FLT/pin Mathlib `db584cd`, même forme CI dispatcher que hecke).
 | `mathlib_examples` | v4.32.1 | 0 | 4 | 0 | REF | référence |
 | `hecke_lean` | v4.33.0 | 0 | 4 | 0 | PEDA/REF | #14784, #14771 |
 | `formal_groups_lean` | v4.33.0 | 0 | 10 | 0 | PEDA/REF | #14785, #14771 |
-| **Total** | — | **12** | **263** | — | — | — |
+| **Total** | — | **11** | **263** | — | — | — |
 
 ¹ `conway_lean` : **1 distinct** sorry (cible de prover intentionnelle dans
 `Conway/Life/HashlifeCorrectness.lean` — sous-but auto-contenu destiné au harnais de preuve
@@ -43,17 +43,28 @@ FLT/pin Mathlib `db584cd`, même forme CI dispatcher que hecke).
 ont été closes** (P4 décomposé en `p4_double_nine_shape` / `p4_wave1_ih` / `p4_wave2_ih`
 sorry-free, vérifié par `lake build Conway.Life` post-#4780), seule `HashlifeCorrectness`
 reste en cible prover. Régression de compte documentée et HONNÊTE — pas un défaut.
-² `knot_lean` = **research-HOLD** : théorie des nœuds (#2874). Le compte **est monté** de
-3 (inventaire 2026-07-15) à 12 distincts (inventaire 2026-08-27), puis rebaissé à
-**11 distincts actuels (mesure 2026-08-28, `count_code_sorry.py` distinct_code_sorry)**
-— la majorité des 11 sont des **définitions non définies** (`AreMutants`,
-`alexanderPolynomial`, `IsSmoothlySlice`, `IsTopologicallySlice := sorry`) et des
-preuves de transfert classique ouvertes. Le pont GF(3) Path B
-(`triColorFoxCondition_iff_sum_mod_three`) est **prouvé** (#3003, sorry net-zéro vs
-`main`). Niveau recherche, pas un gap pédagogique. **Évolution documentée**
-(3 → 12 → 11) — n'est PAS une régression silencieuse. Le delta 12 → 11 résulte des
-décharges successives #8766 + #11227 (cf. `knot_lean/README.md` pour la trace par
-fichier) — l'inventaire suit avec un cycle de retard.
+² `knot_lean` = **research-HOLD** : théorie des nœuds (#2874). Compte **mesuré sur `origin/main`
+le 2026-09-11** : **10 distincts** (`count_code_sorry.py --json`, champ `distinct_code_sorry`),
+soit `0 (Basic) + 2 (Reidemeister) + 0 (Invariant, post-#15082) + 6 (Conway) + 2 (Lidman)
++ 0 (Mathlib) = 10`. La baseline CI `lean-knot.yml` porte la même valeur (`sorry-baseline: "10"`).
+La majorité des 10 restants sont des **définitions non définies** (`IsSmoothlySlice`,
+`IsTopologicallySlice := sorry`, etc.) et des preuves de transfert classique ouvertes.
+Le pont GF(3) Path B (`triColorFoxCondition_iff_sum_mod_three`) est **prouvé** (#3003,
+sorry net-zéro vs `main`) et `trefoil_not_unknot` **prouvé** (#8766). Niveau recherche, pas un
+gap pédagogique.
+
+**Évolution documentée** (3 → 12 → 11 → 10) — n'est PAS une régression silencieuse :
+- **3** (inventaire 2026-07-15) → **12** (2026-08-27, montée initiale recherche HOLD)
+- **12 → 11** (2026-08-28, #8766 `trefoil_not_unknot` + #11227 `fox`/`col` §9.1)
+- **11 → 10** (2026-09-09, #15082 `unknottingNumber` par `Nat.sInf`, baseline CI recalibrée)
+
+**Trajectoire à venir** — `10 → 9` par #15440 (`conway_trivial_alexander`, unité 2 du split
+#14821) puis `9 → 8` par #15460 (`KT_trivial_alexander`, unité 3). Ces deux PRs portent
+elles-mêmes la recalibration `10 → 9 → 8` de la baseline CI dans `lean-knot.yml`.
+
+Cette unité 4 synchronise la présente table et `knot_lean/README.md` sur l'état **mesuré à
+date**, pas sur l'état projeté : les deux fichiers restent ainsi vrais quel que soit l'ordre de
+merge vis-à-vis de #15440/#15460. Cf. `knot_lean/README.md` pour la trace par fichier.
 ³ `calibration_lean` est un **composant de harnais** (prover calibration, déplacé depuis
 GameTheory, #1764). Les `· sorry` inline de `Calibration/Nash.lean` sont un **fixture de
 test intentionnel** (le harnais doit gérer un *sorry-increase* 1→2 sans régression) — pas

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,7 +5,7 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.32.1` (migration post-#11325, cf #11256).
 
-## État des sorries (vérifié 2026-08-28 contre `origin/main`, **11 réels**)
+## État des sorries (vérifié 2026-09-10 contre `origin/main`, **10 réels**)
 
 Deux comptes, selon le filtre CI :
 
@@ -13,16 +13,20 @@ Deux comptes, selon le filtre CI :
 |---------|------------|-------------------|
 | `Knots/Basic.lean` | 0 | 3 |
 | `Knots/Reidemeister.lean` | 2 | 2 |
-| `Knots/Invariant.lean` | **1** | 15 |
+| `Knots/Invariant.lean` | **0** | 15 |
 | `Knots/Conway.lean` | 6 | 11 |
 | `Knots/Lidman.lean` | 2 | 4 |
 | `Knots/MathlibPrerequisites.lean` | 0 | 2 |
-| **Total** | **11** | **37** |
+| **Total** | **10** | **37** |
 
-- **sorry réels** = ce qui manque vraiment comme preuve. **11** au total (code-only
+- **sorry réels** = ce qui manque vraiment comme preuve. **10** au total (code-only
   après strip `--`/`/- -/`, mesuré par `scripts/lean/count_code_sorry.py` champ
-  `distinct_code_sorry`), tous stables : 1 dans `Invariant.lean`
-  (`Knot.unknottingNumber` L2143 — `tricolorable_invariant` est résolu), 2
+  `distinct_code_sorry`, baseline CI `lean-knot.yml` recalibrée à `"10"`
+  par #15082), tous stables : 0 dans `Invariant.lean`
+  (`Knot.unknottingNumber` **DISCHARGÉ par #15082** : redéfini via `Nat.sInf` de
+  `{n | k.UnknottableIn n}` + témoin `unknot_unknottingNumber = 0` prouvé —
+  0 sorry résiduel, voir § Phase 5 / § #14992 pour la modélisation indexée
+  des changements de croisement et l'accessibilité Reidemeister), 2
   `reidemeister_theorem` (PL), 6 Conway (les 2 defs `IsSmoothlySlice` /
   `IsTopologicallySlice := sorry` + 4 `exact sorry` de bornes), 2 Lidman. Les
   **2 résiduels §9.1 `fox`/`col` du backward transfer ont été DISCHARGÉS par
@@ -33,14 +37,16 @@ Deux comptes, selon le filtre CI :
   **bi-implication R1 connectée est COMPLÈTE** (forward #3000 + backward
   #3124/#11227).
 
-- **Baisse historique 17 → 16 → 14 → 11** : #8766 a déchargé `trefoil_not_unknot`
+- **Baisse historique 17 → 16 → 14 → 11 → 10** : #8766 a déchargé `trefoil_not_unknot`
   (composition), #9966 a surélevé à 17 (wall du wrapper
   `tricolorable_forward_r1`), puis le wall a été déchargé (16) et #11227 a
-  clos fox/col (14) ; la lecture fine par fichier (post-strip commentaires,
-  compter les `sorry` réels restants) donne **11** : la table de ce README
-  sous-comptait `tricolorable_invariant` (déjà résolu mais présenté comme
-  résiduel) et sur-comptait les defs Conway comme 2 entrées distinctes quand
-  le script compte 6 occurrences mais 5 déclarations (cf. mesure 2026-08-28).
+  clos fox/col (14) ; la lecture fine par fichier au 2026-08-28 (post-strip
+  commentaires, compter les `sorry` réels restants) donnait **11** : la table
+  de ce README sous-comptait `tricolorable_invariant` (déjà résolu mais présenté
+  comme résiduel) et sur-comptait les defs Conway comme 2 entrées distinctes
+  quand le script en attribue 6 (6 déclarations à 1 `sorry` chacune — mesure
+  2026-08-28 re-vérifiée le 2026-09-11). **#15082 a ensuite déchargé
+  `Knot.unknottingNumber` via `Nat.sInf` (-1), amenant le baseline à 10.**
   #11276 a ajouté **sans sorry** le transfer `tricolorable_forward_r2_up`
   PROVEN + les murs nommés `r2_append_only_wall` (L1151) et
   `r3_determined_wall` (L1293) qui bornent l'iff maître.
@@ -51,16 +57,18 @@ Deux comptes, selon le filtre CI :
 - **sorry prose** = **37** (raw, any-line matchant `sorry` — la prose de
   documentation des murs R2/R3 en a ajouté). Le mode CI officiel est
   **`real`** : strippe `--` et `/- -/`, puis compte le mot-bounded
-  `\bsorry\b`. La CI gate sur baseline **11** (alignée avec
+  `\bsorry\b`. La CI gate sur baseline **10** (alignée avec
   `LEAN_INVENTORY.md`, voir #13312).
 
-La CI `.github/workflows/lean-knot.yml` gate sur le **real-mode baseline 11**
-(alignement post-#13312, mesure 2026-08-28 ; historique : prose-header 25→28
+La CI `.github/workflows/lean-knot.yml` gate sur le **real-mode baseline 10**
+(alignement post-#13312, mesure 2026-09-10 ; historique : prose-header 25→28
 dans #3124, baissée à 27 après #3163, re-bumpée à 28 par #3003 ;
 switch prose-header→real à baseline 17 le 2026-07-11 ; 16 après #8766, re-17
 par #9966, 16 au wall discharge, 14 après #11227, **11 après mesure
-`count_code_sorry.py` 2026-08-28**) : toute PR qui ajoute un sorry réel fait
-monter le compte real et échoue la CI, sauf justification documentée dans le
+`count_code_sorry.py` 2026-08-28**, **10 après #15082** (`Knot.unknottingNumber`
+DISCHARGÉ via `Nat.sInf` — voir § Phase 5 / § #14992) : toute PR qui ajoute
+un sorry réel fait monter le compte real et échoue la CI, sauf justification
+documentée dans le
 body PR.
 
 **Corridor Reidemeister #8696** (c.8162-c.8169, 5 PRs MERGED 2026-07-29 →
@@ -114,7 +122,9 @@ Le compte `sorry` reste à 2 dans `Reidemeister.lean` (le pair
   d'équivalence, Phase 4+)
 - [ ] Conway (11n34) : `conway_not_smoothly_slice` (Piccirillo 2018/Annals 2020),
   `conway_topologically_slice` (Freedman 1982), mutation Kinoshita-Terasaka —
-  8 sorry, scaffolding permanent
+  6 sorry, scaffolding permanent (les 2 sorries historiquement Open de
+  `conway_trivial_alexander` et `KT_trivial_alexander` sont visés par les
+  PRs #15440 / #15460 du split #14821 — voir aussi note ² de `LEAN_INVENTORY.md`)
 - [ ] Lidman 11n102 : unknotting number = 2 (Heegaard-Floer) — 2 sorry, scaffolding
   (le sorry du diagramme L39 a été éliminé par #4899, PD-code 11n102 depuis KnotInfo)
 - [ ] `reidemeister_theorem` — équivalence Reidemeister ↔ isotopie ambiante
@@ -315,8 +325,8 @@ Référence : Fox (1962), A quick trip through knot theory ; Adams, *The Knot Bo
 |---------|---------|-------------|
 | `Knots/Basic.lean` | Définitions (Knot, Link, PD-code, nœuds nommés), `KnotDiagram.wf` | 0 |
 | `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 2 |
-| `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1, bi-implication R1 connectée (#3000 + #3124/#11227), transfer R2-up + murs nommés (#11276) | 2 |
-| `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 8 |
+| `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, contre-exemple PR1, bi-implication R1 connectée (#3000 + #3124/#11227), transfer R2-up + murs nommés (#11276), `unknottingNumber` via `Nat.sInf` (#15082) | 0 |
+| `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 6 |
 | `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
 | `Knots/MathlibPrerequisites.lean` | Index des prérequis Mathlib manquants par tier | 0 |
 
@@ -405,7 +415,8 @@ résiduels `fox`/`col` (mode all-distinct vacuus, `#11227`) sont clos — la
 (sorry-bearing) et des deux lemmes composants. Le **transfer forward R2-up**
 (`tricolorable_forward_r2_up`, #11276) est **prouvé sans sorry**, encadré par
 les murs nommés `r2_append_only_wall`/`r3_determined_wall` (**14 sorry réels**
-au total, baseline CI #11227).
+au total à l'époque de #11227 ; baseline CI recalibrée à 10 post-#15082,
+cf. § État des sorries).
 
 Le **corridor Reidemeister #8696** (5 PRs MERGED, c.8162-c.8169) a par
 ailleurs clarifié la structure des 6 sites de move-surgery en `Reidemeister.lean` :


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2027:CoursIA — prev: LIGHT/readme #15580

## Résumé

**Unité 4 du split de #14821** : la synchro documentaire inventaire/README. Les unités 1-3 sont portées ailleurs — infra par **#15434 (MERGED)**, preuve `conway_trivial_alexander` par **#15440**, preuve `KT_trivial_alexander` par **#15460**. La branche de #14821 ne conserve donc que ces deux fichiers.

Périmètre : 2 fichiers, 1 domaine, +60/−37 lignes. Aucun code, aucun notebook.

## Ce qui est synchronisé — et sur quel état

| Surface | Valeur sur `main` | Valeur dans cette PR |
|---|---|---|
| `lean-knot.yml` `sorry-baseline` | `"10"` (l.141) | inchangé |
| `count_code_sorry.py` `distinct_code_sorry` | **10** | **10** |
| `LEAN_INVENTORY.md` ligne `knot_lean` | 11² (**stale**) | **10²** |
| `LEAN_INVENTORY.md` Total | 12 (**stale**) | **11** |
| `knot_lean/README.md` Total « sorry réels » | 11 (**stale**) | **10** |

Décomposition mesurée le 2026-09-11 sur `origin/main`, par fichier :

```
0 (Basic) + 2 (Reidemeister) + 0 (Invariant post-#15082) + 6 (Conway) + 2 (Lidman) + 0 (Mathlib) = 10
```

Mesurée, pas recopiée : `python scripts/lean/count_code_sorry.py --lake MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean --json` rend `code_sorry=20`, `distinct_code_sorry=10`, `naive_sorry=55`.

## Le point de méthode : état mesuré, pas état projeté

Le contenu préparé pour cette unité annonçait `8` dans l'inventaire — la cible atteinte **après** #15440 et #15460 — tout en laissant le README de la même PR à `10`, l'état de `main`. Une même PR décrivant deux états du même lake, c'est un défaut en soi : le README et l'inventaire se seraient contredits.

J'ai retenu l'état **mesuré à date** (10) et documenté la suite (`10 → 9` par #15440, `9 → 8` par #15460) comme trajectoire à venir, dans les deux fichiers. Deux raisons :

1. **Un chiffre projeté est faux tant que la projection n'est pas réalisée.** Un doc de synchronisation doit être vrai au moment où il arrive sur `main` ; je ne contrôle pas l'ordre de merge, et une valeur qui annonce un état non encore mergé est exactement l'entité fantôme que ce dépôt traque.
2. **Cela supprime une contrainte de couplage.** Avec l'état mesuré, cette PR est mergeable indépendamment de #15440/#15460 — plus de « merge requis après », donc plus de fenêtre où une PR bloquée bloque l'autre.

L'état post-pile est néanmoins **mesuré**, pas supposé : sur la branche de #15460 (qui est empilée sur #15440), `lean-knot.yml` porte `sorry-baseline: "8"` et `Conway.lean` rend `distinct=4`. Le chiffre 8 existe, il est simplement à venir.

Si le coordinateur préfère que cette unité porte la cible 8 — c'est-à-dire qu'elle merge après la pile — la bascule est de trois valeurs (`10²`→`8²`, Total `11`→`9`, Conway `6`→`4` avec baseline `10`→`8`). Dites-le et je la fais.

## Correction d'un sous-claim démenti

Le passage historique de `knot_lean/README.md` expliquait l'écart de comptage par « le script compte 6 occurrences mais **5 déclarations** » pour les sorries de `Conway.lean`. Mesuré à deux dates — commit `883c6e9f5ba9` (2026-08-28) et `main` courant — c'est **6 déclarations à 1 `sorry` chacune** : `conway_trivial_alexander`, `KT_trivial_alexander`, `IsSmoothlySlice`, `IsTopologicallySlice`, `conway_not_smoothly_slice`, `conway_topologically_slice`. Le chiffre est corrigé en « 6 déclarations à 1 `sorry` chacune », avec les deux dates de mesure.

## Points de conformité

- **Non-régression documentaire** : aucun chiffre retiré sans son remplaçant mesuré ; la colonne « sorry (prose, CI) » du README (Total 37) est laissée telle quelle — elle est auto-cohérente (3+2+15+11+4+2 = 37) et hors du périmètre de cette synchro.
- **EOL** : `git ls-files --eol` rend `i/lf w/lf` sur les deux fichiers ; `git diff --check` propre.
- **CATALOG-STATUS** : marqueurs non touchés.
- **Aucun notebook** modifié — pas de ré-exécution Papermill due (C.3).

See #14821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
