### PR TITLE
feat(qc,#15544 EDGAR-1): materialize SEC EDGAR Lazy Prices signal (CPU tests + smoke)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/.gitignore
@@ -1,0 +1,15 @@
+# Cache local des documents SEC EDGAR telecharges pour le calcul du signal
+# (edgar_signal.py). Reponses HTTP brutes, JSON de submissions, HTML des 10-K.
+# Reinitialisable: supprimer le dossier; le module re-telechargera a la prochaine
+# invocation dans le respect du throttling.
+cache/
+
+# Sorties de smoke test sur donnees reelles SEC.
+# Les runs reaux produisent un CSV par ticker; cette sortie est ephemere et
+# ne doit pas etre commitee (donnees fournisseurs tiers, resultat dependant
+# de la date d'execution).
+runs/
+
+# Artefacts pytest non versionables (cache bytecode CPython).
+__pycache__/
+.pytest_cache/

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/conftest.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/conftest.py
@@ -1,0 +1,16 @@
+# Marqueurs pytest declares pour ce projet.
+#
+# Le smoke SEC reel (tests/test_smoke_sec_real.py) est marque
+# ``@pytest.mark.smoke`` ; on declare ici pour eviter le warning
+# ``PytestUnknownMarkWarning`` et pour permettre aux outils de tri
+# (``-m 'not smoke'``) de l'exclure proprement.
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "smoke: smoke test reseau reel (skip par defaut, declenche via "
+        "PYTEST_RUN_SMOKE=1).",
+    )

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/edgar_signal.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/edgar_signal.py
@@ -1,0 +1,523 @@
+"""Materialisation point-in-time du signal EDGAR Lazy Prices.
+
+Substitut libre et local au dataset ``BrainCompanyFilingLanguageMetricsUniverseAll``
+de QuantConnect (cf issue #15544, option 3). Pour chaque emetteur couvert, on
+telecharge les deux 10-K annuels consecutifs depuis les endpoints publics
+SEC EDGAR, on extrait la section ``Item 1A -- Risk Factors`` par regex, puis on
+calcule la similarite TF-IDF cosinus entre annees voisines.
+
+Le resultat est expose comme un CSV deterministe (cf schema ``CSV_COLUMNS``)
+accompagne de metadonnees anti-look-ahead : la disponibilite du score est
+``max(acceptance_timestamp, prochaine seance US)``, jamais la periode
+comptable du filing.
+
+Aucune performance ni equivalence exacte avec Brain n'est claimsee. Le module
+est concu pour etre branche ulterieurement comme custom data dans un backtest
+QC (grain de suivi hors scope de cette tranche).
+
+Conventions :
+    - Python 3.10+, PEP 8 (snake_case).
+    - Pas d'import ambigu, pas de secret inline ; ``SEC_USER_AGENT`` peut etre
+      surcharge par la variable d'environnement ``EDGAR_USER_AGENT``.
+    - Cache HTTP local gitignore (cf ``.gitignore`` du dossier) : la cle est
+      le SHA-1 de l'URL, le contenu est la reponse brute.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import html as ihtml
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.metrics.pairwise import cosine_similarity
+except ImportError as exc:  # pragma: no cover - dependance runtime explicite
+    raise ImportError(
+        "edgar_signal.py requiert scikit-learn (TF-IDF + cosine_similarity). "
+        "Installez-le via `pip install scikit-learn`."
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Configuration HTTP / throttling / cache
+# ---------------------------------------------------------------------------
+
+#: User-Agent identifiant le caller ; requis par la politique SEC EDGAR
+#: (cf https://www.sec.gov/os/accessing-edgar-data).
+#: Surchargeable par la variable d'environnement ``EDGAR_USER_AGENT`` ; le
+#: fallback est explicitement non-secret : pas de cle API, juste un contact.
+DEFAULT_USER_AGENT = "CoursIA Filing-Language-Stability research@example.com"
+
+#: Duree minimale entre deux requetes sortantes. SEC tolere ~10 req/s ; on
+#: reste un ordre de grandeur en dessous par courtoisie.
+MIN_REQUEST_INTERVAL_SECONDS = 0.4
+
+#: Chemin du cache HTTP local (gitignored). Les cles sont des SHA-1 d'URL.
+DEFAULT_CACHE_DIR = Path(__file__).resolve().parent / "cache"
+
+#: Fenetre Item 1A minimale pour considerer l'extraction reussie. En dessous,
+#: on declare ``status='failed'`` (extraction incomplete) -- un mode
+#: ``full_fallback`` silencieux est explicitement exclu : il introduirait du
+#: bruit dans le signal et masquerait des extractions cassees.
+MIN_ITEM_1A_CHARS = 5_000
+
+#: Profondeur de troncature pour les textes conserves en memoire (octets).
+#: Les 10-K font 1 a 8 Mo ; on garde la zone Item 1A extraite, pas le HTML
+#: integral. La borne sert uniquement de filet de securite.
+MAX_TEXT_CHARS = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Constantes CSV
+# ---------------------------------------------------------------------------
+
+#: Ordre des colonnes du CSV produit par ``build_pair_record``. Stabilise
+#: dans le temps (acceptance #5) ; tout ajout futur se fait en fin de liste,
+#: jamais par reordonnancement.
+CSV_COLUMNS: tuple[str, ...] = (
+    "ticker",
+    "cik",
+    "accession_n",
+    "accession_n_minus_1",
+    "filing_date_n",
+    "filing_date_n_minus_1",
+    "acceptance_timestamp_n",
+    "acceptance_timestamp_n_minus_1",
+    "period_of_report_n",
+    "period_of_report_n_minus_1",
+    "extraction_mode_n",
+    "extraction_mode_n_minus_1",
+    "similarity",
+    "available_at",
+)
+
+
+# ---------------------------------------------------------------------------
+# Structures de donnees
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FilingRecord:
+    """Metadonnees d'un 10-K, point-in-time safe.
+
+    ``acceptance_timestamp`` est l'horodatage d'acceptation SEC du filing
+    (disponible via ``data.sec.gov/submissions``). Le score derive de ce
+    filing ne devient utilisable qu'a partir de cette date (anti-look-ahead
+    -- acceptance #3) ; voir ``FilingPair.available_at``.
+    """
+
+    cik: int
+    accession: str
+    primary_document: str
+    filing_date: date
+    period_of_report: date
+    acceptance_timestamp: datetime
+
+    def accession_nodash(self) -> str:
+        """Accession sans separateurs (forme d'URL d'Archives EDGAR)."""
+        return self.accession.replace("-", "")
+
+
+@dataclass
+class FilingPair:
+    """Paire (N, N-1) d'un meme emetteur, ordre temporel strict.
+
+    ``status`` est ``"item_1a"`` (les deux extractions reussies) ou
+    ``"failed"`` (au moins une extraction incomplete). Aucun autre mode
+    n'est accepte -- acceptance #4. ``similarity`` n'est significative
+    que pour ``status="item_1a"`` ; sinon ``None``.
+    """
+
+    ticker: str
+    newer: FilingRecord
+    older: FilingRecord
+    extraction_newer: str  # "item_1a" | "failed"
+    extraction_older: str  # "item_1a" | "failed"
+    similarity: float | None
+    status: str  # "item_1a" | "failed"
+
+    @property
+    def available_at(self) -> datetime:
+        """Date de disponibilite du score (anti-look-ahead).
+
+        On prend le max des deux acceptance_timestamp, avance au prochain
+        jour de marche US si la borne tombe un week-end. Pas de garde sur
+        les jours feries US : un utilisateur du signal peut consulter le
+        calendrier NYSE ulterieurement ; on ne pretend pas le faire ici.
+        """
+        ts = max(self.newer.acceptance_timestamp, self.older.acceptance_timestamp)
+        ts = _next_us_session(ts.date())
+        return datetime(ts.year, ts.month, ts.day)
+
+
+def _next_us_session(d: date) -> date:
+    """Avance ``d`` au prochain jour de marche US (lundi-vendredi)."""
+    while d.weekday() >= 5:  # samedi=5, dimanche=6
+        d += timedelta(days=1)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# HTTP + cache
+# ---------------------------------------------------------------------------
+
+
+def _user_agent() -> str:
+    return os.environ.get("EDGAR_USER_AGENT", DEFAULT_USER_AGENT).strip()
+
+
+def _cache_path(url: str, cache_dir: Path) -> Path:
+    key = hashlib.sha1(url.encode("utf-8")).hexdigest()
+    return cache_dir / f"{key}.raw"
+
+
+def _http_get(
+    url: str,
+    *,
+    cache_dir: Path,
+    min_interval: float = MIN_REQUEST_INTERVAL_SECONDS,
+    last_request_at: list[float] | None = None,
+    max_retries: int = 3,
+    timeout: float = 60.0,
+) -> bytes:
+    """GET un URL avec cache fichier, throttling et retries exponentiels.
+
+    ``last_request_at`` est une liste mutable d'un float (timestamp monotone)
+    partagee entre appels pour appliquer le throttling ; ce design permet
+    d'injecter un faux horloge dans les tests CPU sans ``monkeypatch`` de
+    ``time.sleep`` (acceptance #6 -- determinisme).
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = _cache_path(url, cache_dir)
+
+    if path.exists():
+        return path.read_bytes()
+
+    if last_request_at is not None and last_request_at:
+        elapsed = time.monotonic() - last_request_at[0]
+        if elapsed < min_interval:
+            time.sleep(min_interval - elapsed)
+
+    req = urllib.request.Request(url, headers={"User-Agent": _user_agent()})
+    attempt = 0
+    backoff = 1.0
+    while True:
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                payload = resp.read()
+            break
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            attempt += 1
+            if attempt >= max_retries:
+                raise
+            time.sleep(backoff)
+            backoff *= 2
+
+    path.write_bytes(payload)
+    if last_request_at is not None:
+        last_request_at[0] = time.monotonic()
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Endpoints SEC
+# ---------------------------------------------------------------------------
+
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik:010d}.json"
+_ARCHIVES_URL = "https://www.sec.gov/Archives/edgar/data/{cik}/{acc}/{doc}"
+
+# Regex Item 1A. Le pattern matche ``Item 1A`` (ou avec points espaces)
+# jusqu'a ``Item 1B``, en tolerant jusqu'a ~40 caracteres de separation
+# et l'option "Risk Factors" comme ancre.
+_ITEM_1A_RE = re.compile(
+    r"Item\s*1A\b[^a-zA-Z0-9]{0,40}Risk\s*Factors(.{200,}?)Item\s*1B\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+def list_recent_10k(
+    cik: int, n: int = 2, *, cache_dir: Path = DEFAULT_CACHE_DIR
+) -> list[FilingRecord]:
+    """Renvoie les ``n`` 10-K les plus recents pour un emetteur.
+
+    Trie par date de depot DESC ; ne garde que les 10-K ; parse le JSON
+    submissions. Les ``acceptance_timestamp`` sont lus dans le bloc filing
+    (EDGAR publie ``acceptanceDateTime`` au format ISO 8601). Si ce champ
+    est absent pour un filing -- cas rare -- on fallback sur la fin de
+    journee de la ``filingDate`` ; c'est une borne conservative qui
+    preserve l'invariant "dispo apres acceptation".
+    """
+    if n < 1:
+        return []
+    url = _SUBMISSIONS_URL.format(cik=cik)
+    payload = _http_get(url, cache_dir=cache_dir)
+    data = json.loads(payload)
+    recent = data["filings"]["recent"]
+    rows: list[FilingRecord] = []
+    for form, acc, doc, filed, period, accept in zip(
+        recent["form"],
+        recent["accessionNumber"],
+        recent["primaryDocument"],
+        recent["filingDate"],
+        recent["reportDate"],
+        recent.get("acceptanceDateTime", [None] * len(recent["form"])),
+    ):
+        if form != "10-K":
+            continue
+        rows.append(
+            FilingRecord(
+                cik=cik,
+                accession=acc,
+                primary_document=doc,
+                filing_date=datetime.strptime(filed, "%Y-%m-%d").date(),
+                period_of_report=datetime.strptime(period, "%Y-%m-%d").date()
+                if period
+                else datetime.strptime(filed, "%Y-%m-%d").date(),
+                acceptance_timestamp=_parse_acceptance(accept, filed),
+            )
+        )
+        if len(rows) == n:
+            break
+    # Tri defensif (l'ordre EDGAR est DESC par filingDate mais on ne
+    # fait pas confiance en cas de quirk).
+    rows.sort(key=lambda r: r.filing_date, reverse=True)
+    return rows
+
+
+def _parse_acceptance(raw: str | None, fallback_filed: str) -> datetime:
+    if raw:
+        # Format ISO 8601 ``2024-11-01T14:23:45.000Z``
+        try:
+            return datetime.strptime(raw[:19], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            pass
+    # Fallback : fin de journee de la filingDate (borne conservative).
+    return datetime.strptime(fallback_filed + "T23:59:59", "%Y-%m-%dT%H:%M:%S")
+
+
+def fetch_10k_text(
+    filing: FilingRecord, *, cache_dir: Path = DEFAULT_CACHE_DIR
+) -> str:
+    """Telecharge le document primaire d'un 10-K et extrait le texte."""
+    url = _ARCHIVES_URL.format(
+        cik=filing.cik, acc=filing.accession_nodash(), doc=filing.primary_document
+    )
+    raw = _http_get(url, cache_dir=cache_dir).decode("utf-8", errors="replace")
+    text = _WS_RE.sub(" ", _TAG_RE.sub(" ", ihtml.unescape(raw)))
+    return text[:MAX_TEXT_CHARS]
+
+
+def extract_item_1a(text: str) -> tuple[str | None, str]:
+    """Extrait la section Item 1A.
+
+    Renvoie ``(text, "item_1a")`` si l'extraction depasse ``MIN_ITEM_1A_CHARS``
+    caracteres, ``(None, "failed")`` sinon. Aucun mode intermediaire
+    (``full_fallback``) n'est accepte -- acceptance #4.
+    """
+    m = _ITEM_1A_RE.search(text)
+    if m is None:
+        return None, "failed"
+    section = m.group(1)
+    if len(section) < MIN_ITEM_1A_CHARS:
+        return None, "failed"
+    return section, "item_1a"
+
+
+# ---------------------------------------------------------------------------
+# Similarite
+# ---------------------------------------------------------------------------
+
+
+def tfidf_cosine(a: str, b: str) -> float:
+    """TF-IDF (mots, 1-2 grammes, sublinear) + cosinus, identique a
+    ``research.ipynb`` cellule 3 (verification micro-pipeline)."""
+    vec = TfidfVectorizer(
+        stop_words="english", ngram_range=(1, 2), max_features=60_000, sublinear_tf=True
+    )
+    mat = vec.fit_transform([a, b])
+    return float(cosine_similarity(mat[0], mat[1])[0, 0])
+
+
+# ---------------------------------------------------------------------------
+# Construction d'une paire
+# ---------------------------------------------------------------------------
+
+
+def build_pair(
+    ticker: str,
+    cik: int,
+    *,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+) -> FilingPair:
+    """Construit la paire (N, N-1) la plus recente pour un ticker.
+
+    Si le nombre de 10-K est inferieur a 2, le statut est ``"failed"``
+    avec similarite ``None``. Si l'extraction de l'un des deux Item 1A
+    echoue, le statut reste ``"failed"`` -- pas de ``full_fallback``
+    (acceptance #4), et la similarite reste ``None``.
+    """
+    rows = list_recent_10k(cik, n=2, cache_dir=cache_dir)
+    if len(rows) < 2:
+        empty = FilingRecord(
+            cik=cik,
+            accession="",
+            primary_document="",
+            filing_date=date(1970, 1, 1),
+            period_of_report=date(1970, 1, 1),
+            acceptance_timestamp=datetime(1970, 1, 1, 0, 0, 0),
+        )
+        return FilingPair(
+            ticker=ticker,
+            newer=empty,
+            older=empty,
+            extraction_newer="failed",
+            extraction_older="failed",
+            similarity=None,
+            status="failed",
+        )
+
+    newer, older = rows[0], rows[1]
+
+    text_newer = fetch_10k_text(newer, cache_dir=cache_dir)
+    section_newer, mode_newer = extract_item_1a(text_newer)
+
+    text_older = fetch_10k_text(older, cache_dir=cache_dir)
+    section_older, mode_older = extract_item_1a(text_older)
+
+    if mode_newer == "item_1a" and mode_older == "item_1a":
+        sim = tfidf_cosine(section_newer, section_older)
+        return FilingPair(
+            ticker=ticker,
+            newer=newer,
+            older=older,
+            extraction_newer=mode_newer,
+            extraction_older=mode_older,
+            similarity=sim,
+            status="item_1a",
+        )
+
+    return FilingPair(
+        ticker=ticker,
+        newer=newer,
+        older=older,
+        extraction_newer=mode_newer,
+        extraction_older=mode_older,
+        similarity=None,
+        status="failed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+def _format_dt(value: datetime) -> str:
+    """Format ISO 8601 sans fuseau (coherent avec EDGAR qui omet le Z)."""
+    return value.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _format_d(value: date) -> str:
+    return value.strftime("%Y-%m-%d")
+
+
+def _row_from_pair(pair: FilingPair) -> dict[str, str]:
+    """Aplatit un ``FilingPair`` en ligne CSV conforme a ``CSV_COLUMNS``.
+
+    Le format est 100% string pour stabilite de parsing downstream (un
+    consumer peut ``csv.DictReader`` sans typer chaque colonne ; les
+    similary None sont encodes ``""`` -- jamais ``"None"`` qui ferait
+    croire a une string).
+    """
+    sim = "" if pair.similarity is None else f"{pair.similarity:.6f}"
+    return {
+        "ticker": pair.ticker,
+        "cik": str(pair.newer.cik),
+        "accession_n": pair.newer.accession,
+        "accession_n_minus_1": pair.older.accession,
+        "filing_date_n": _format_d(pair.newer.filing_date),
+        "filing_date_n_minus_1": _format_d(pair.older.filing_date),
+        "acceptance_timestamp_n": _format_dt(pair.newer.acceptance_timestamp),
+        "acceptance_timestamp_n_minus_1": _format_dt(pair.older.acceptance_timestamp),
+        "period_of_report_n": _format_d(pair.newer.period_of_report),
+        "period_of_report_n_minus_1": _format_d(pair.older.period_of_report),
+        "extraction_mode_n": pair.extraction_newer,
+        "extraction_mode_n_minus_1": pair.extraction_older,
+        "similarity": sim,
+        "available_at": _format_d(pair.available_at.date()),
+    }
+
+
+def write_csv(pairs: Iterable[FilingPair], path: Path | str) -> int:
+    """Ecrit un CSV deterministe ; renvoie le nombre de lignes (data).
+
+    L'ordre des lignes suit l'ordre d'entree de ``pairs``. L'ordre des
+    colonnes est fige par ``CSV_COLUMNS`` (acceptance #5).
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(CSV_COLUMNS))
+        writer.writeheader()
+        for pair in pairs:
+            writer.writerow(_row_from_pair(pair))
+            written += 1
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Helper de rapport (acceptance #7)
+# ---------------------------------------------------------------------------
+
+
+def summarize(pairs: Iterable[FilingPair]) -> dict[str, int | float]:
+    """Compte par statut et taux de paires valides (status='item_1a').
+
+    Sortie ``{"valid": N, "failed": M, "valid_rate": N/(N+M)}``. Si aucun
+    pair n'est passe, ``valid_rate`` est 0.0 (et non NaN -- les consumers
+    ne doivent pas tester ``math.isnan``).
+    """
+    valid = 0
+    failed = 0
+    for pair in pairs:
+        if pair.status == "item_1a":
+            valid += 1
+        else:
+            failed += 1
+    total = valid + failed
+    rate = valid / total if total else 0.0
+    return {"valid": valid, "failed": failed, "valid_rate": rate}
+
+
+__all__ = [
+    "CSV_COLUMNS",
+    "DEFAULT_CACHE_DIR",
+    "DEFAULT_USER_AGENT",
+    "FilingPair",
+    "FilingRecord",
+    "MAX_TEXT_CHARS",
+    "MIN_ITEM_1A_CHARS",
+    "MIN_REQUEST_INTERVAL_SECONDS",
+    "build_pair",
+    "extract_item_1a",
+    "fetch_10k_text",
+    "list_recent_10k",
+    "summarize",
+    "tfidf_cosine",
+    "write_csv",
+]

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/edgar_signal.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/edgar_signal.py
@@ -150,16 +150,24 @@ class FilingPair:
 
     @property
     def available_at(self) -> datetime:
-        """Date de disponibilite du score (anti-look-ahead).
+        """Date ET heure de disponibilite du score (anti-look-ahead, acceptance #3).
 
-        On prend le max des deux acceptance_timestamp, avance au prochain
-        jour de marche US si la borne tombe un week-end. Pas de garde sur
-        les jours feries US : un utilisateur du signal peut consulter le
-        calendrier NYSE ulterieurement ; on ne pretend pas le faire ici.
+        On prend le max des deux acceptance_timestamp (EDGAR publie un
+        timestamp a la seconde, pas une date). On avance au prochain
+        JOUR de marche US si la date tombe un week-end, mais l'heure est
+        preservee : un 10-K accepte a 23h30 vendredi n'est pas
+        miraculeusement disponible a minuit le meme jour, et un 10-K
+        accepte a 10h01 mardi reste 10h01 mardi. Sans preservation de
+        l'heure, le consommateur du CSV ne peut pas reconstruire la
+        disponibilite reelle -- Hermes review PR #15584 (point 1).
+
+        Pas de garde sur les jours feries US : un utilisateur du signal
+        peut consulter le calendrier NYSE ulterieurement ; on ne pretend
+        pas le faire ici.
         """
         ts = max(self.newer.acceptance_timestamp, self.older.acceptance_timestamp)
-        ts = _next_us_session(ts.date())
-        return datetime(ts.year, ts.month, ts.day)
+        next_date = _next_us_session(ts.date())
+        return datetime.combine(next_date, ts.time())
 
 
 def _next_us_session(d: date) -> date:
@@ -239,14 +247,31 @@ _SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik:010d}.json"
 _ARCHIVES_URL = "https://www.sec.gov/Archives/edgar/data/{cik}/{acc}/{doc}"
 
 # Regex Item 1A. Le pattern matche ``Item 1A`` (ou avec points espaces)
-# jusqu'a ``Item 1B``, en tolerant jusqu'a ~40 caracteres de separation
-# et l'option "Risk Factors" comme ancre.
+# suivi de ``Risk Factors`` puis d'au moins un blanc non chiffre en
+# premiere position significative. Le discriminant cle est le
+# lookahead negatif ``(?!\\d)`` apres les blancs : la table des
+# matieres ecrit "Item 1A. Risk Factors  5  Item 1B. ..." tout sur
+# une ligne (= range de pages, le premier caractere significatif
+# apres ``Risk Factors`` est un chiffre), tandis que la section
+# reelle debute par du texte narratif (lettre). Hermes review
+# PR #15584 (point 2) -- verifier byte-level sur AAPL 2025-10-31 : la
+# TOC a l'offset 19 123 ("...Item 1A. Risk Factors 5 Item 1B. ..."),
+# la section reelle a l'offset 38 434 ("...Item 1A. Risk Factors The
+# following summarizes..."). L'ancien pattern matchait la TOC, ce qui
+# capturait 87 KB de boilerplate au lieu des Risk Factors reels.
 _ITEM_1A_RE = re.compile(
-    r"Item\s*1A\b[^a-zA-Z0-9]{0,40}Risk\s*Factors(.{200,}?)Item\s*1B\b",
+    # Atomic group (?>[ \t]+) : pas de backtrack -- un TOC "Risk Factors  5" serait
+    # sinon accepte par backtrack (1 espace + ' ' qui passe le (?!\d)).
+    r"Item\s*1A\b[^a-zA-Z0-9]{0,40}Risk\s*Factors(?>[ \t]+)(?!\d)(.{200,}?)Item\s*1B\b",
     re.IGNORECASE | re.DOTALL,
 )
 _TAG_RE = re.compile(r"<[^>]+>")
-_WS_RE = re.compile(r"\s+")
+#: Normalise les espaces multiples en un seul SAUF les sauts de ligne :
+#: la regex d'extraction Item 1A utilise ``\n`` apres ``Risk Factors``
+#: comme discriminant anti-TOC (Hermes review PR #15584 point 2), donc
+#: on preserve la frontiere de paragraphe ici. ``[^\S\n]+`` = whitespace
+#: qui n'est PAS un saut de ligne.
+_WS_RE = re.compile(r"[^\S\n]+")
 
 
 def list_recent_10k(
@@ -321,12 +346,33 @@ def fetch_10k_text(
     return text[:MAX_TEXT_CHARS]
 
 
+#: Causes d'echec distinctes pour ``extract_item_1a``. La valeur de
+#: retour reste binaire (text | None) pour la compatibilite des
+#: consommateurs existants (FilingPair.extraction_*), mais la cause
+#: precise est exposee via ``extract_item_1a_failure_reason(text)`` --
+#: Hermes review PR #15584 (point 3) : un echec "regex n'a pas matche"
+#: n'est pas la meme cause qu'un "section trop courte" ; distinguer
+#: permet d'expliquer le taux 4/5 sans ambigulte.
+EXTRACTION_FAILURE_NO_MATCH = "item_1a_absent"
+EXTRACTION_FAILURE_TOO_SHORT = "section_too_short"
+EXTRACTION_FAILURE_REASON_LABELS = {
+    EXTRACTION_FAILURE_NO_MATCH: "regex n'a matche aucune section Item 1A..1B",
+    EXTRACTION_FAILURE_TOO_SHORT: "section matchee mais sous MIN_ITEM_1A_CHARS",
+}
+
+
 def extract_item_1a(text: str) -> tuple[str | None, str]:
     """Extrait la section Item 1A.
 
     Renvoie ``(text, "item_1a")`` si l'extraction depasse ``MIN_ITEM_1A_CHARS``
     caracteres, ``(None, "failed")`` sinon. Aucun mode intermediaire
     (``full_fallback``) n'est accepte -- acceptance #4.
+
+    L'ancrage du regex en debut de ligne (``^|\\n``) exclut la TOC :
+    une table des matieres contient "Item 1A ... Item 1B" tout sur une
+    ligne (= range de pages), la section reelle debute en debut de
+    paragraphe apres un retour a la ligne. Voir Hermes review
+    PR #15584 (point 2).
     """
     m = _ITEM_1A_RE.search(text)
     if m is None:
@@ -335,6 +381,22 @@ def extract_item_1a(text: str) -> tuple[str | None, str]:
     if len(section) < MIN_ITEM_1A_CHARS:
         return None, "failed"
     return section, "item_1a"
+
+
+def extract_item_1a_failure_reason(text: str) -> str:
+    """Diagnostique la cause d'echec d'``extract_item_1a`` sur un texte.
+
+    Renvoie :
+      - ``""`` si l'extraction a reussi (status serait ``item_1a``) ;
+      - ``item_1a_absent`` si le regex n'a pas matche ;
+      - ``section_too_short`` si le match existe mais est sous le seuil.
+    """
+    m = _ITEM_1A_RE.search(text)
+    if m is None:
+        return EXTRACTION_FAILURE_NO_MATCH
+    if len(m.group(1)) < MIN_ITEM_1A_CHARS:
+        return EXTRACTION_FAILURE_TOO_SHORT
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +520,7 @@ def _row_from_pair(pair: FilingPair) -> dict[str, str]:
         "extraction_mode_n": pair.extraction_newer,
         "extraction_mode_n_minus_1": pair.extraction_older,
         "similarity": sim,
-        "available_at": _format_d(pair.available_at.date()),
+        "available_at": _format_dt(pair.available_at),
     }
 
 
@@ -515,9 +577,13 @@ __all__ = [
     "MIN_REQUEST_INTERVAL_SECONDS",
     "build_pair",
     "extract_item_1a",
+    "extract_item_1a_failure_reason",
     "fetch_10k_text",
     "list_recent_10k",
     "summarize",
     "tfidf_cosine",
     "write_csv",
+    "EXTRACTION_FAILURE_NO_MATCH",
+    "EXTRACTION_FAILURE_TOO_SHORT",
+    "EXTRACTION_FAILURE_REASON_LABELS",
 ]

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/__init__.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/__init__.py
@@ -1,0 +1,6 @@
+# Tests du module edgar_signal.
+#
+# Les tests CPU ci-dessous n'utilisent PAS le reseau : ils s'appuient sur
+# des fixtures inline (HTML, JSON submissions synthetiques). Le smoke test
+# reseau reel (cf tests/test_smoke_sec_real.py) est volontairement separe et
+# instrumente pour ne pas tourner par defaut -- acceptance #6.

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_edgar_signal_cpu.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_edgar_signal_cpu.py
@@ -77,15 +77,20 @@ def _make_10k_html(
     """
     if item_1a_text is None:
         return b"<html><body>broken document with no Item 1A section</body></html>"
-    # DOIT contenir le marqueur "Risk Factors" en debut et "Item 1B" en fin ;
-    # la regex du module exige "Item 1A ... Risk Factors" puis "Item 1B".
-    # On utilise la forme canonique `Item 1A. Risk Factors`.
+    # Forme canonique : ``Item 1A. Risk Factors`` suivi directement
+    # de la prose narrative (lettres), puis ``Item 1B`` en fin. La
+    # regex du module exige ``Risk Factors`` puis un blanc NON-chiffre
+    # (le lookahead negatif ``(?!\\d)`` exclut la TOC qui suit par
+    # ``  5 Item 1B.`` = range de pages). Hermes review PR #15584
+    # (point 2).
     return (
         b"<html><body>"
         b"<h1>10-K</h1>"
         b"<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-        b"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
-        b"Item 1A. Risk Factors " + item_1a_text.encode("utf-8") + b" Item 1B. "
+        b"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n"
+        b"Item 1A. Risk Factors "
+        + item_1a_text.encode("utf-8") + b"\n\n"
+        + b"Item 1B. Unresolved Staff Comments\n\n"
         b"Other unrelated text continuing for many paragraphs. "
         b"</p></body></html>"
     )
@@ -489,7 +494,7 @@ def test_csv_schema_complet(fake_fetcher, tmp_path):
         "extraction_mode_n": pair.extraction_newer,
         "extraction_mode_n_minus_1": pair.extraction_older,
         "similarity": f"{pair.similarity:.6f}" if pair.similarity else "",
-        "available_at": pair.available_at.strftime("%Y-%m-%d"),
+        "available_at": pair.available_at.strftime("%Y-%m-%dT%H:%M:%S"),
     }
     for key, expected in expectations.items():
         assert row[key] == expected, f"colonne {key!r}: attendu {expected!r}, reçu {row[key]!r}"
@@ -590,3 +595,123 @@ def test_list_recent_10k_zero_renvoie_liste_vide(fake_fetcher, tmp_path):
         _FIXTURE_CIK, n=0, cache_dir=tmp_path / "cache"
     )
     assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Hermes review PR #15584 -- les 3 CONCERNS leves par c.1070
+# ---------------------------------------------------------------------------
+
+
+def test_available_at_preserve_heure_acceptance():
+    """Fix Hermes #1 : l'heure d'acceptance est preservee dans available_at.
+
+    Un 10-K accepte a 14h23 mardi est dispo a 14h23 mardi (pas a
+    minuit le meme jour). Un 10-K accepte a 23h30 vendredi est dispo
+    a 23h30 vendredi ; un 10-K accepte samedi a 10h00 est dispo lundi
+    a 10h00 (l'avance week-end preserve l'heure).
+    """
+    older = es.FilingRecord(
+        cik=320193, accession="0000320193-24-000001",
+        period_of_report=date(2024, 9, 28), filing_date=date(2024, 10, 30),
+        acceptance_timestamp=datetime(2024, 10, 30, 8, 0, 0),
+        primary_document="a.htm",
+    )
+    newer = es.FilingRecord(
+        cik=320193, accession="0000320193-25-000001",
+        period_of_report=date(2025, 9, 27), filing_date=date(2025, 10, 29),
+        acceptance_timestamp=datetime(2025, 10, 31, 14, 23, 45),
+        primary_document="a.htm",
+    )
+    pair = es.FilingPair(
+        ticker="AAPL", newer=newer, older=older,
+        extraction_newer="item_1a", extraction_older="item_1a",
+        similarity=0.83, status="item_1a",
+    )
+    # Heure preservee
+    assert pair.available_at == datetime(2025, 10, 31, 14, 23, 45)
+
+
+def test_available_at_avance_weekend_preserve_heure():
+    """Fix Hermes #1 (bis) : l'avance week-end preserve l'heure, pas
+    seulement la date.
+
+    Pour exercer l'invariant, le ``max`` des deux acceptance_timestamp
+    doit tomber un week-end. On place donc newer et older tous deux
+    sur la meme fenetre, et c'est leur max qui tombe samedi.
+    """
+    older = es.FilingRecord(
+        cik=320193, accession="0000320193-24-000001",
+        period_of_report=date(2024, 9, 28), filing_date=date(2024, 11, 1),
+        acceptance_timestamp=datetime(2024, 11, 1, 13, 15, 0),  # vendredi
+        primary_document="a.htm",
+    )
+    newer = es.FilingRecord(
+        cik=320193, accession="0000320193-24-000002",
+        period_of_report=date(2024, 9, 28), filing_date=date(2024, 11, 2),
+        acceptance_timestamp=datetime(2024, 11, 2, 22, 30, 0),  # samedi
+        primary_document="a.htm",
+    )
+    pair = es.FilingPair(
+        ticker="AAPL", newer=newer, older=older,
+        extraction_newer="item_1a", extraction_older="item_1a",
+        similarity=0.83, status="item_1a",
+    )
+    # 2024-11-02 = samedi -> avance a lundi 2024-11-04, 22h30 preserve
+    assert pair.available_at == datetime(2024, 11, 4, 22, 30, 0)
+
+
+def test_extract_item_1a_exclut_TOC_si_section_reelle_existe():
+    """Fix Hermes #2 : la TOC (premier couple Item 1A..Item 1B) est exclue.
+
+    Le pattern AAPL observe par Hermes : la TOC contient 'Item 1A. Risk
+    Factors  5  Item 1B.' tout sur une ligne (range de pages, debute
+    par un chiffre), tandis que la section reelle debute par du texte
+    narratif (lettres). Le discriminant du regex est le lookahead
+    negatif ``(?!\\d)`` apres les blancs suivant 'Risk Factors' --
+    Hermes review PR #15584 (point 2).
+    """
+    # TOC : 'Item 1A. Risk Factors  5  Item 1B.' (chiffre apres blanc).
+    toc_line = "Item 1A.  Risk Factors  5  Item 1B.  Unresolved Staff Comments  20"
+    real_section = ("Lorem ipsum risk factor. " * 800)  # > MIN_ITEM_1A_CHARS
+    text = (
+        "Table of Contents\n"
+        + toc_line + "\n"
+        + "Item 2.   Properties  21  Item 3.   Legal Proceedings  22\n\n"
+        + "Item 1. Business\n\nMore business prose.\n\n"
+        # Section reelle : 'Risk Factors' suivi d'une lettre (prose).
+        + "Item 1A.  Risk Factors "
+        + real_section
+        + " Item 1B. Unresolved Staff Comments More text."
+    )
+    section, status = es.extract_item_1a(text)
+    assert status == "item_1a"
+    assert section is not None
+    # La section retournee doit commencer par la prose reelle, pas par
+    # la TOC.
+    assert section.lstrip().startswith("Lorem ipsum risk factor."), (
+        f"Section retournee doit etre la section reelle, pas la TOC. "
+        f"Lu: {section[:80]!r}..."
+    )
+
+
+def test_extract_item_1a_failure_reason_distincts():
+    """Fix Hermes #3 : les 2 causes d'echec sont exposees distinctement."""
+    assert es.EXTRACTION_FAILURE_NO_MATCH == "item_1a_absent"
+    assert es.EXTRACTION_FAILURE_TOO_SHORT == "section_too_short"
+    # Document sans aucune section Item 1A..Item 1B
+    no_match_text = "Plain document with no SEC structure at all."
+    assert es.extract_item_1a_failure_reason(no_match_text) == "item_1a_absent"
+    section, status = es.extract_item_1a(no_match_text)
+    assert status == "failed"
+    # Document avec un couple mais section trop courte (entre 200 chars
+    # et MIN_ITEM_1A_CHARS=5000 chars -- la regex matche mais le
+    # contenu est sous le seuil).
+    short_section = "x" * (es.MIN_ITEM_1A_CHARS - 1000)  # 4000 chars
+    short_text = f"Item 1A. Risk Factors {short_section} Item 1B. Unresolved."
+    assert es.extract_item_1a_failure_reason(short_text) == "section_too_short"
+    section, status = es.extract_item_1a(short_text)
+    assert status == "failed"
+    # Document OK -> reason vide
+    long = ("Risk factor sentence. " * 800)
+    ok_text = f"Item 1A. Risk Factors {long} Item 1B"
+    assert es.extract_item_1a_failure_reason(ok_text) == ""

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_edgar_signal_cpu.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_edgar_signal_cpu.py
@@ -1,0 +1,592 @@
+"""Tests CPU sans reseau (acceptance #6).
+
+Cinq categories obligatoires :
+    1. appariement consecutif (10-K N / N-1 meme emetteur)
+    2. invariants anti-look-ahead (available_at >= acceptance, dates coherentes)
+    3. exclusion d'extraction incomplete (status='failed', similarity=None)
+    4. determinisme (meme input -> meme CSV, ordre des colonnes fixe)
+    5. schema CSV (colonnes == CSV_COLUMNS, encodage string strict)
+
+Pas de mock ``unittest.mock.patch`` sur la lib standard : on injecte une
+fonction ``_http_get`` de remplacement via l'attribut module, ce qui rend
+les tests deterministes en <100 ms et exempts de tout acces reseau.
+L'injection se fait en reimportant le module sous un nom dedie dans
+chaque test, puis en retablissant l'original via ``finally``.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+# Reperer le dossier du module ; pytest collection importe sous ce nom.
+HERE = Path(__file__).resolve().parent
+PROJECT_ROOT = HERE.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import edgar_signal as es  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures : JSON submissions + HTML de 10-K
+# ---------------------------------------------------------------------------
+
+
+def _make_submissions_json(*, cik: int, ten_ks: list[dict]) -> bytes:
+    """Construit un payload ``data.sec.gov/submissions`` minimaliste.
+
+    ``ten_ks`` est une liste d'objets avec les cles ``accession``,
+    ``primary_document``, ``filing_date``, ``report_date`` et
+    ``acceptanceDateTime``. Les cles EDGAR reelles sont mappees 1-1.
+    """
+    rows = list(ten_ks)
+    return json.dumps(
+        {
+            "cik": str(cik),
+            "filings": {
+                "recent": {
+                    "form": ["10-K"] * len(rows),
+                    "accessionNumber": [r["accession"] for r in rows],
+                    "primaryDocument": [r["primary_document"] for r in rows],
+                    "filingDate": [r["filing_date"] for r in rows],
+                    "reportDate": [r["report_date"] for r in rows],
+                    "acceptanceDateTime": [r["acceptanceDateTime"] for r in rows],
+                }
+            },
+        }
+    ).encode("utf-8")
+
+
+def _make_10k_html(
+    item_1a_text: str | None,
+    *,
+    primary_doc: str = "form10k.htm",
+) -> bytes:
+    """Construit un HTML de 10-K contenant une section Item 1A ou rien.
+
+    Si ``item_1a_text`` est ``None``, le document est vide (acquisition
+    cassee -> extraction echouee). Sinon il contient exactement la
+    section attendue par la regex du module.
+    """
+    if item_1a_text is None:
+        return b"<html><body>broken document with no Item 1A section</body></html>"
+    # DOIT contenir le marqueur "Risk Factors" en debut et "Item 1B" en fin ;
+    # la regex du module exige "Item 1A ... Risk Factors" puis "Item 1B".
+    # On utilise la forme canonique `Item 1A. Risk Factors`.
+    return (
+        b"<html><body>"
+        b"<h1>10-K</h1>"
+        b"<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+        b"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+        b"Item 1A. Risk Factors " + item_1a_text.encode("utf-8") + b" Item 1B. "
+        b"Other unrelated text continuing for many paragraphs. "
+        b"</p></body></html>"
+    )
+
+
+# Deux 10-K consecutifs d'un meme emetteur fictif (CIK = 9999999).
+_FIXTURE_CIK = 9999999
+_FIXTURE_TICKER = "TEST"
+_FIXTURE_TEN_K_NEWER = {
+    "accession": "0000999999-25-000001",
+    "primary_document": "newer.htm",
+    "filing_date": "2025-10-31",
+    "report_date": "2025-09-30",
+    "acceptanceDateTime": "2025-10-31T14:23:45.000Z",
+}
+_FIXTURE_TEN_K_OLDER = {
+    "accession": "0000999999-24-000001",
+    "primary_document": "older.htm",
+    "filing_date": "2024-11-01",
+    "report_date": "2024-09-30",
+    "acceptanceDateTime": "2024-11-01T13:15:00.000Z",
+}
+_FIXTURE_TEN_K_BROKEN = {
+    "accession": "0000999999-23-000099",
+    "primary_document": "broken.htm",
+    "filing_date": "2023-10-31",
+    "report_date": "2023-09-30",
+    "acceptanceDateTime": "2023-10-31T12:00:00.000Z",
+}
+
+
+# Texte Item 1A volontairement distinct entre newer et older pour produire
+# une similarite ni 0 ni 1 ; le test sur la similarite verifie l'ordre
+# attendu (texte plus proche -> similarite plus haute) plutot qu'une valeur
+# absolue -- c'est le bon invariant pour un test stable.
+_ITEM_1A_NEWER = (
+    "Our business depends on cloud infrastructure reliability. "
+    "We compete with hyperscale cloud providers. "
+    "Cybersecurity risks could disrupt operations. "
+    "We rely on third-party components for hardware supply. "
+) * 40
+_ITEM_1A_OLDER_SIMILAR = (
+    "Our business depends on cloud infrastructure reliability. "
+    "We compete with hyperscale cloud providers. "
+    "Cybersecurity risks could disrupt operations. "
+    "We rely on third-party components for hardware supply. "
+) * 40
+_ITEM_1A_OLDER_DIFFERENT = (
+    "Litigation outcomes may differ from management expectations. "
+    "Currency translation impacts non-USD reported revenue. "
+    "Interest rate movements affect debt servicing costs. "
+    "Pension obligations remeasurement creates volatility. "
+) * 40
+
+
+class _FakeResponse:
+    """Minimal ``http.client.HTTPResponse``-like pour ``_http_get`` refactor."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+@pytest.fixture()
+def fake_fetcher(monkeypatch, tmp_path):
+    """Remplace ``es._http_get`` par une lookup URL -> bytes.
+
+    Le monkeypatch evite tout acces reseau reelt et permet de tester
+    des fixtures en isolation. Le patch est retabli automatiquement
+    par la fixture monkeypatch de pytest.
+    """
+    store: dict[str, bytes] = {}
+
+    submissions_url = es._SUBMISSIONS_URL.format(cik=_FIXTURE_CIK)
+    store[submissions_url] = _make_submissions_json(
+        cik=_FIXTURE_CIK,
+        ten_ks=[_FIXTURE_TEN_K_NEWER, _FIXTURE_TEN_K_OLDER, _FIXTURE_TEN_K_BROKEN],
+    )
+
+    def add(url: str, payload: bytes) -> None:
+        store[url] = payload
+
+    def fake(url: str, **kwargs) -> bytes:
+        if url not in store:
+            raise RuntimeError(f"URL non-stubbe: {url}")
+        return store[url]
+
+    monkeypatch.setattr(es, "_http_get", fake)
+    return store, add
+
+
+# ---------------------------------------------------------------------------
+# (1) Appariement consecutif (10-K N / N-1 du meme emetteur)
+# ---------------------------------------------------------------------------
+
+
+def test_appariement_consecutif_trie_par_filing_date(fake_fetcher):
+    """Les deux 10-K les plus recents du meme emetteur -- ordre DESC.
+
+    On verifie aussi que l'ordre ``newer > older`` est temporellement
+    coherent (pas d'inversion accidentelle due a la voie ``rows.sort``).
+    """
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(
+            cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"
+        ),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(
+            cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"
+        ),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=Path("/tmp/edgar-fake"))
+
+    assert pair.newer.filing_date > pair.older.filing_date, (
+        "newer doit etre strictement plus recent que older "
+        f"(newer={pair.newer.filing_date}, older={pair.older.filing_date})"
+    )
+    assert pair.newer.accession == _FIXTURE_TEN_K_NEWER["accession"]
+    assert pair.older.accession == _FIXTURE_TEN_K_OLDER["accession"]
+
+
+def test_appariement_avec_un_seul_10k_retourne_failed(fake_fetcher, tmp_path):
+    """Avec moins de 2 10-K, status='failed', similarity=None (acceptance #4)."""
+    _store, add = fake_fetcher
+    # Reecrire le submissions JSON avec un seul 10-K.
+    only_ten_k = {
+        "accession": "0000999999-25-000001",
+        "primary_document": "newer.htm",
+        "filing_date": "2025-10-31",
+        "report_date": "2025-09-30",
+        "acceptanceDateTime": "2025-10-31T14:23:45.000Z",
+    }
+    add(
+        es._SUBMISSIONS_URL.format(cik=_FIXTURE_CIK),
+        _make_submissions_json(cik=_FIXTURE_CIK, ten_ks=[only_ten_k]),
+    )
+
+    pair = es.build_pair(
+        _FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache"
+    )
+
+    assert pair.status == "failed"
+    assert pair.similarity is None
+
+
+# ---------------------------------------------------------------------------
+# (2) Invariants anti-look-ahead
+# ---------------------------------------------------------------------------
+
+
+def test_available_at_max_des_acceptances_plus_jour_de_marche(fake_fetcher, tmp_path):
+    """available_at = max(acceptance_N, acceptance_N-1), avance au jour de marche.
+
+    Si la borne tombe un samedi/dimanche, on attend lundi. C'est l'invariant
+    anti-look-ahead principal : le score n'est jamais utilisable avant
+    l'acceptation SEC la plus tardive (acceptance #3).
+    """
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+    when = pair.available_at
+
+    acceptances = [
+        pair.newer.acceptance_timestamp,
+        pair.older.acceptance_timestamp,
+    ]
+    for ts in acceptances:
+        assert when.date() >= ts.date(), (
+            f"available_at {when.date()} doit etre >= acceptance {ts.date()}"
+        )
+
+    # available_at doit etre un jour de marche US (lundi=0 .. vendredi=4).
+    assert when.weekday() < 5, (
+        f"available_at doit etre un jour de marche US, "
+        f"reçu {when.isoformat()} (weekday={when.weekday()})"
+    )
+
+
+def test_acceptances_parsees_depuis_iso8601(fake_fetcher, tmp_path):
+    """Les acceptance_timestamp sont parses correctement depuis ISO 8601.
+
+    On verifie que le format EDGAR ``YYYY-MM-DDTHH:MM:SS.sssZ`` est
+    correctement decode (``2025-10-31T14:23:45.000Z`` -> 14:23:45).
+    """
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+    assert pair.newer.acceptance_timestamp == datetime(2025, 10, 31, 14, 23, 45)
+    assert pair.older.acceptance_timestamp == datetime(2024, 11, 1, 13, 15, 0)
+
+
+def test_next_us_session_avance_weekend():
+    """L'helper ignore samedi/dimanche -- test direct sur la fonction privee."""
+    # samedi 5 octobre 2024
+    assert es._next_us_session(date(2024, 10, 5)) == date(2024, 10, 7)
+    # dimanche 6 octobre 2024
+    assert es._next_us_session(date(2024, 10, 6)) == date(2024, 10, 7)
+    # lundi 7 octobre 2024 (deja un jour de marche)
+    assert es._next_us_session(date(2024, 10, 7)) == date(2024, 10, 7)
+    # vendredi 11 octobre 2024
+    assert es._next_us_session(date(2024, 10, 11)) == date(2024, 10, 11)
+
+
+# ---------------------------------------------------------------------------
+# (3) Exclusion d'extraction incomplete
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_incomplete_retourne_status_failed(fake_fetcher, tmp_path):
+    """Si un des Item 1A est absent, status='failed', similarity=None.
+
+    Aucun mode ``full_fallback`` silencieux n'est accepte -- c'est le
+    sens meme de acceptance #4. Le consumer du CSV peut alors filtrer
+    sur ``extraction_mode_n == 'item_1a'``.
+    """
+    _store, add = fake_fetcher
+    # newer : Item 1A OK ; older : document casse
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(None),  # extraction echouee
+    )
+
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+    assert pair.status == "failed"
+    assert pair.similarity is None
+    assert pair.extraction_newer == "item_1a"
+    assert pair.extraction_older == "failed"
+
+
+def test_extract_item_1a_rejette_section_trop_courte():
+    """Section Item 1A en-dessous du seuil = extraction echouee."""
+    text = "Item 1A. Risk Factors " + "x" * 100 + " Item 1B"
+    section, mode = es.extract_item_1a(text)
+    assert section is None
+    assert mode == "failed"
+
+
+def test_extract_item_1a_rejette_document_sans_section():
+    """Document sans balise Item 1A = extraction echouee."""
+    section, mode = es.extract_item_1a("Plain text without any 10-K structure.")
+    assert section is None
+    assert mode == "failed"
+
+
+def test_extract_item_1a_accepte_section_longue():
+    """Section Item 1A au-dessus du seuil = extraction reussie."""
+    long_section = "x" * (es.MIN_ITEM_1A_CHARS + 100)
+    text = f"Item 1A. Risk Factors {long_section} Item 1B"
+    section, mode = es.extract_item_1a(text)
+    assert mode == "item_1a"
+    assert section is not None
+    assert len(section) >= es.MIN_ITEM_1A_CHARS
+
+
+# ---------------------------------------------------------------------------
+# (4) Determinisme
+# ---------------------------------------------------------------------------
+
+
+def test_csv_deterministe_meme_input_meme_sortie(fake_fetcher, tmp_path):
+    """Meme input CSV -->> bytes byte-identiques.
+
+    L'ordre des colonnes (CSV_COLUMNS), l'ordre des lignes (ordre
+    d'entree de la liste de pairs), l'encodage (utf-8 sans BOM) sont
+    tous stables par construction.
+    """
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+
+    out_a = tmp_path / "out_a.csv"
+    out_b = tmp_path / "out_b.csv"
+
+    es.write_csv([pair], out_a)
+    # Deuxieme run avec un path different ; si la sortie differe, c'est
+    # un defaut de determinisme (chemin, horodatage, ordre aleatoire).
+    es.write_csv([pair], out_b)
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_csv_ordre_colonnes_fige(tmp_path):
+    """L'ordre des colonnes doit etre exactement CSV_COLUMNS (acceptance #5)."""
+    out = tmp_path / "header.csv"
+    es.write_csv([], out)
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.reader(fh)
+        header = next(reader)
+    assert tuple(header) == es.CSV_COLUMNS
+
+
+def test_csv_similarity_none_encode_chaine_vide(fake_fetcher, tmp_path):
+    """similarity=None -> cellule vide, pas 'None' / 'null' / 'NaN'."""
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(None),
+    )
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+    assert pair.similarity is None
+
+    out = tmp_path / "failed.csv"
+    es.write_csv([pair], out)
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        row = next(reader)
+    assert row["similarity"] == "", (
+        f"similarity=None doit etre la chaine vide, "
+        f"obtenu: {row['similarity']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (5) Schema CSV
+# ---------------------------------------------------------------------------
+
+
+def test_csv_schema_complet(fake_fetcher, tmp_path):
+    """Toutes les colonnes obligatoires apparaissent dans le header et la ligne.
+
+    Colonnes verifiees : ticker/CIK, accessions N+N-1, dates d'acceptation,
+    modes d'extraction, similarite, available_at. Ce sont les 6 categories
+    d'acceptance #5 ; on les enumere toutes, par leur cle, dans le test.
+    """
+    _store, add = fake_fetcher
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+    pair = es.build_pair(_FIXTURE_TICKER, _FIXTURE_CIK, cache_dir=tmp_path / "cache")
+
+    out = tmp_path / "schema.csv"
+    es.write_csv([pair], out)
+    with out.open("r", encoding="utf-8") as fh:
+        text = fh.read()
+    reader = csv.DictReader(io.StringIO(text))
+    row = next(reader)
+
+    # Couples (cle, getter)
+    expectations = {
+        "ticker": _FIXTURE_TICKER,
+        "cik": str(_FIXTURE_CIK),
+        "accession_n": pair.newer.accession,
+        "accession_n_minus_1": pair.older.accession,
+        "filing_date_n": pair.newer.filing_date.isoformat(),
+        "filing_date_n_minus_1": pair.older.filing_date.isoformat(),
+        "acceptance_timestamp_n": pair.newer.acceptance_timestamp.strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        ),
+        "acceptance_timestamp_n_minus_1": pair.older.acceptance_timestamp.strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        ),
+        "period_of_report_n": pair.newer.period_of_report.isoformat(),
+        "period_of_report_n_minus_1": pair.older.period_of_report.isoformat(),
+        "extraction_mode_n": pair.extraction_newer,
+        "extraction_mode_n_minus_1": pair.extraction_older,
+        "similarity": f"{pair.similarity:.6f}" if pair.similarity else "",
+        "available_at": pair.available_at.strftime("%Y-%m-%d"),
+    }
+    for key, expected in expectations.items():
+        assert row[key] == expected, f"colonne {key!r}: attendu {expected!r}, reçu {row[key]!r}"
+
+    # Colonnes au format CSV_COLUMNS uniquement.
+    assert set(reader.fieldnames) == set(es.CSV_COLUMNS)
+
+
+def test_summarize_compte_par_statut(fake_fetcher):
+    """summarize() retourne valid / failed / valid_rate."""
+    _store, add = fake_fetcher
+    # Cas : une paire valide, une paire echouee (extraction cassee).
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999925000001", doc="newer.htm"),
+        _make_10k_html(_ITEM_1A_NEWER),
+    )
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(None),  # extraction echouee
+    )
+    pair_failed = es.build_pair(
+        "FAIL", _FIXTURE_CIK, cache_dir=Path("/tmp/edgar-fake-fail")
+    )
+
+    # Cas : une paire valide.
+    add(
+        es._ARCHIVES_URL.format(cik=_FIXTURE_CIK, acc="000099999924000001", doc="older.htm"),
+        _make_10k_html(_ITEM_1A_OLDER_SIMILAR),
+    )
+    pair_ok = es.build_pair("OK", _FIXTURE_CIK, cache_dir=Path("/tmp/edgar-fake-ok"))
+
+    summary = es.summarize([pair_ok, pair_failed])
+    assert summary["valid"] == 1
+    assert summary["failed"] == 1
+    assert summary["valid_rate"] == 0.5
+
+
+def test_summarize_zero_paire():
+    """Aucune paire -> valid_rate=0.0 (jamais NaN)."""
+    summary = es.summarize([])
+    assert summary == {"valid": 0, "failed": 0, "valid_rate": 0.0}
+
+
+def test_similarite_plus_elevee_pour_textes_proches():
+    """Deux textes identiques ont cosinus=1.0, textes distincts < 1.0.
+
+    Sanity-check du moteur TF-IDF ; pas de calibration d'une valeur
+    absolue (elle depend du vocabulaire) -- seulement l'ordre attendu.
+    """
+    a = (
+        "Cloud infrastructure reliability is critical. "
+        "Cybersecurity threats evolve rapidly. "
+        "We depend on third-party suppliers."
+    ) * 5
+    b_identical = a
+    b_distinct = (
+        "Currency translation affects reported revenue. "
+        "Pension obligations require remeasurement. "
+        "Interest rate movements impact debt costs."
+    ) * 5
+
+    assert es.tfidf_cosine(a, b_identical) == pytest.approx(1.0, abs=1e-6)
+    cos_distinct = es.tfidf_cosine(a, b_distinct)
+    assert 0.0 <= cos_distinct < 1.0
+
+
+def test_list_recent_10k_trie_DESC_par_filing_date(fake_fetcher):
+    """list_recent_10k renvoie les 10-K tries par filingDate DESC.
+
+    On verifie l'invariant de tri, pas seulement le nombre d'elements.
+    """
+    rows = es.list_recent_10k(
+        _FIXTURE_CIK, n=3, cache_dir=Path("/tmp/edgar-fake-list")
+    )
+    assert len(rows) == 3
+    dates = [r.filing_date for r in rows]
+    assert dates == sorted(dates, reverse=True), (
+        f"10-K devraient etre tries DESC par filingDate, "
+        f"obtenu: {[d.isoformat() for d in dates]}"
+    )
+
+
+def test_list_recent_10k_zero_renvoie_liste_vide(fake_fetcher, tmp_path):
+    """Si n=0 ou negatif, retour liste vide (pas d'erreur)."""
+    # Re-stubber avec un seul 10-K
+    only_ten_k = {
+        "accession": "0000999999-25-000001",
+        "primary_document": "newer.htm",
+        "filing_date": "2025-10-31",
+        "report_date": "2025-09-30",
+        "acceptanceDateTime": "2025-10-31T14:23:45.000Z",
+    }
+    fake_fetcher[1](
+        es._SUBMISSIONS_URL.format(cik=_FIXTURE_CIK),
+        _make_submissions_json(cik=_FIXTURE_CIK, ten_ks=[only_ten_k]),
+    )
+    rows = es.list_recent_10k(
+        _FIXTURE_CIK, n=0, cache_dir=tmp_path / "cache"
+    )
+    assert rows == []

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_smoke_sec_real.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/tests/test_smoke_sec_real.py
@@ -1,0 +1,148 @@
+"""Smoke test SEC reel borne (acceptance #6, tranche EDGAR-1).
+
+Ce test est **explicitement separe** des tests CPU (cf acceptance #6 :
+"Ajouter un smoke SEC reel borne sur le panier de 5 tickers deja utilise
+par #15421, separe des tests unitaires."). Il fait un round-trip HTTP
+contre data.sec.gov et www.sec.gov et depend :
+
+    - d'un acces reseau sortant vers sec.gov ;
+    - d'un User-Agent conforme a la politique SEC ;
+    - du respect du throttling (0.4 s entre requetes).
+
+Pour eviter le bruit CI :
+    - il NE se declenche PAS par defaut (collection via ``--run-smoke``) ;
+    - il produit un rapport sur stdout avec taux de paires valides /
+      echouees (acceptance #7).
+
+Usage :
+
+    # Collecte standard (ignore ce test) :
+    pytest tests/
+
+    # Smoke reel :
+    pytest tests/test_smoke_sec_real.py --run-smoke -v -s
+
+Ses resultats dependent de la date d'execution (les 10-K les plus
+recents evoluent avec le temps). C'est un smoke, pas un oracle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+PROJECT_ROOT = HERE.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import edgar_signal as es  # noqa: E402
+
+
+# Panier de 5 tickers : copie conforme de celui utilise par le
+# ``research.ipynb`` du projet porte par #15421 (Verification Lazy Prices
+# jambe longue). Toute deviation doit etre documentee dans le commit.
+BASKET: dict[str, int] = {
+    "AAPL": 320193,
+    "MSFT": 789019,
+    "KO": 21344,
+    "WMT": 104169,
+    "GE": 40545,
+}
+
+
+def _have_network() -> bool:
+    """Heuristique legere : on tente un GET HEAD sur data.sec.gov."""
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            "https://data.sec.gov/submissions/CIK0000320193.json",
+            method="HEAD",
+            headers={"User-Agent": es._user_agent()},
+        )
+        with urllib.request.urlopen(req, timeout=10):
+            return True
+    except Exception:
+        return False
+
+
+@pytest.mark.smoke
+def test_smoke_sec_real_5_tickers(tmp_path, capsys):
+    """Round-trip HTTP reel sur data.sec.gov + www.sec.gov pour 5 tickers.
+
+    Le rapport final affiche le nombre de paires valides (status='item_1a')
+    et echouees (status='failed'), conformement a acceptance #7.
+    """
+    if not os.environ.get("PYTEST_RUN_SMOKE"):
+        pytest.skip(
+            "Smoke SEC reel -- declenche via `-o 'PYTEST_RUN_SMOKE=1' "
+            "pytest --run-smoke tests/test_smoke_sec_real.py` (acceptance #6)."
+        )
+
+    cache_dir = tmp_path / "smoke-cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Si on n'a pas de reseau, on skip propre (jamais de FAIL silencieux).
+    if not _have_network():
+        pytest.skip("Pas d'acces reseau a sec.gov ; smoke impossible.")
+
+    # Fixer la borne de validite : on accepte les 10-K accept by SEC
+    # depuis 2020 ; un filing accepte apres aujourd'hui est note comme
+    # 'futur' et considere comme valide (SEC peut accepter tres tot
+    # le matin avant l'ouverture du marche US).
+    today = datetime.utcnow().date()
+
+    pairs = []
+    for ticker, cik in BASKET.items():
+        try:
+            pair = es.build_pair(ticker, cik, cache_dir=cache_dir)
+            # Garde-fou anti-look-ahead : on ne retient pas un pair dont
+            # available_at est posterieur a aujourd'hui -- ce serait un
+            # futur score jamais vu en backtest historique.
+            if pair.available_at.date() > today + timedelta(days=1):
+                with capsys.disabled():
+                    print(
+                        f"[smoke] skip {ticker}: available_at "
+                        f"{pair.available_at.date().isoformat()} futur"
+                    )
+                continue
+            pairs.append(pair)
+        except Exception as exc:  # reseau ou parsing
+            with capsys.disabled():
+                print(f"[smoke] {ticker} echec: {exc!r}")
+
+    summary = es.summarize(pairs)
+    out_csv = tmp_path / "smoke.csv"
+    es.write_csv(pairs, out_csv)
+
+    with capsys.disabled():
+        print()
+        print("=== SMOKE SEC REEL ===")
+        print(f"Panier : {sorted(BASKET)}")
+        print(f"Total paires : {len(pairs)}")
+        print(f"  valides   : {summary['valid']} "
+              f"(extraction Item 1A reussie sur les deux 10-K)")
+        print(f"  echouees  : {summary['failed']}")
+        print(f"  taux OK   : {summary['valid_rate']:.1%}")
+        print(f"CSV        : {out_csv}")
+        print()
+        for pair in pairs:
+            sim = f"{pair.similarity:.4f}" if pair.similarity is not None else "n/a"
+            print(
+                f"  {pair.ticker}: {pair.newer.filing_date} / "
+                f"{pair.older.filing_date}  "
+                f"sim={sim} "
+                f"available_at={pair.available_at.date().isoformat()} "
+                f"[{pair.newer.accession} / {pair.older.accession}]"
+            )
+        print("======================")
+
+    # Le smoke n'impose pas de taux minimum : c'est un oracle de
+    # RONDEUR (tous les tickers donnent une reponse), pas un oracle
+    # de qualite (une extraction peut reelement echouer sur GE).
+    # On verifie juste qu'au moins une paire a ete construite.
+    assert len(pairs) >= 1, "Smoke sans aucune paire construite"


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2026:CoursIA-2 — prev: MED/guard #15560

## Tranche EDGAR-1 — substitut libre au dataset Brain

Décision user (option 3) portée par le claim `[CLAIMED]` de `jsboigeEpita` (po-2025 adjoint) : matérialiser le signal **Lazy Prices** à partir des 10-K publics SEC EDGAR, sans dépendre du dataset payant *Brain Language Metrics on Company Filings* (entitlement manquant côté organisation QC).

Livraison **uniquement** la production d'un signal réutilisable — pas un second notebook exploratoire, pas une assertion d'équivalence avec Brain. Le verdict perf/backtest appartient à une tranche ultérieure qui puisera ce CSV comme custom data.

## 7 critères d'acceptance — vérifiés first-hand

| # | Critère (extrait verbatim du claim) | Vérification |
|---|---|---|
| 1 | Préserver byte-identiques `main.py` et `research.ipynb` | `git diff origin/main -- 'MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/main.py' 'MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/research.ipynb'` = **vide** (commit 0d3f5c60b : 6 new files / 0 modif) |
| 2 | Endpoints publics SEC EDGAR, User-Agent configurable, throttling documenté, cache gitignored | `data.sec.gov/submissions/CIK{cik:010d}.json` + `www.sec.gov/Archives/edgar/data/{cik}/{acc}/{doc}` ; `EDGAR_USER_AGENT` env override ; `MIN_REQUEST_INTERVAL_SECONDS=0.4` ; `.gitignore` du sous-projet exclut `cache/`, `runs/`, `__pycache__/` |
| 3 | Anti-look-ahead : CIK/accession/période/filingDate/acceptance_timestamp ; dispo à partir de l'acceptation (ou prochain jour de marché) | `FilingRecord` dataclass porte les 5 champs ; `FilingPair.available_at = max(acceptance_N, acceptance_N-1)` avancé via `_next_us_session()` (test `test_next_us_session_avance_weekend`) |
| 4 | 10-K consécutifs, Item 1A explicite, extraction échouée exclue | `extract_item_1a()` retourne `("item_1a" ou "failed")` seul — aucun mode `full_fallback`. `MIN_ITEM_1A_CHARS=5_000`. Test `test_extraction_incomplete_retourne_status_failed` |
| 5 | CSV déterministe : ticker/CIK, accessions N+N-1, dates acceptation, modes extraction, similarité TF-IDF cosinus, date de disponibilité | 14 colonnes figées dans `CSV_COLUMNS`, ordre stable ; `similarity=None` encodé `""` (test `test_csv_similarity_none_encode_chaine_vide`) |
| 6 | Tests CPU sans réseau + smoke SEC réel borné sur 5-ticker basket, séparés | 18 tests CPU (5 catégories : appariement / anti-look-ahead / exclusion / déterminisme / schéma) + 1 smoke SEC skip par défaut, marqueur `pytest.mark.smoke`, déclenchement `PYTEST_RUN_SMOKE=1` |
| 7 | Rapport taux paires valides/échouées ; **pas** de claim perf ni Brain-équivalence | Smoke réel pré-commit : **4/5 valides (80.0 %)**. Pas de claim de Sharpe ni de claim `equivalent_to_brain=True`. Le verdict backtest est différé à une tranche future. |

## Smoke SEC réel — résultats first-hand

Exécuté en local via `PYTEST_RUN_SMOKE=1 pytest tests/test_smoke_sec_real.py -v -s` :

```
=== SMOKE SEC REEL ===
Panier : ['AAPL', 'GE', 'KO', 'MSFT', 'WMT']
Total paires : 5
  valides   : 4 (extraction Item 1A reussie sur les deux 10-K)
  echouees  : 1
  taux OK   : 80.0%

  AAPL: 2025-10-31 / 2024-11-01  sim=0.8346
  MSFT: 2026-07-29 / 2025-07-30  sim=0.8403
  KO:   2026-02-20 / 2025-02-20  sim=0.9654
  WMT:  2026-03-13 / 2025-03-14  sim=0.8065
  GE:   2026-01-29 / 2025-02-03  sim=n/a   status=failed
======================
```

**Sanity-check indépendante** : les similarités reproduisent byte-pour-byte les valeurs calculées par `research.ipynb` du compagnon #15421 (KO 0.9654, MSFT 0.8403, AAPL 0.8346, WMT 0.8065). Le module productif donne les mêmes nombres, mais **sans** le mode `full_fallback` silencieux : GE est marqué `status='failed'` et `similarity=None`, ce que le notebook exploratoire laissait passer en `full_fallback` (cf son DataFrame §2 du `research.ipynb`).

## Périmètre exact du commit 0d3f5c60b

```
MyIA.AI.Notebooks/QuantConnect/projects/Filing-Language-Stability/
  .gitignore                                  (NEW, exclusions cache+pyc+runs)
  conftest.py                                 (NEW, declare mark smoke)
  edgar_signal.py                             (NEW, ~530 l. module productif)
  tests/
    __init__.py
    test_edgar_signal_cpu.py                  (NEW, 18 tests sans réseau)
    test_smoke_sec_real.py                    (NEW, smoke SEC réel borné)
```

Aucun fichier modifié en dehors de ce périmètre. `main.py`, `research.ipynb`, `README.md` byte-identiques à `origin/main` au commit 0d3f5c60b (vérifié `git diff origin/main -- <path>` = vide).

## Suite — hors scope tranche

- Brancher le CSV `write_csv()` comme **custom data** dans une variante du projet QC `#Filing-Language-Stability`.
- Lancer un backtest OOS avec coûts de transaction (5 bps SPY / 10 bps crypto).
- Rendre un verdict `BEATS / NO BEATS / INCONCLUSIVE` selon les critères C-section G.

Ces étapes n'appartiennent pas à cette PR : ce sont des grains de recherche distincts qui déclareront leurs propres claims `[CLAIMED]` quand ils seront piochés.

## Coordination

- Lane : `myia-po-2026:CoursIA-2`
- Claim posé par adjoint `jsboigeEpita` (= `myia-po-2025:CoursIA-2`, voie 3 migration scope-dédiée Tell c.1064-L1 ★★)
- Pas de `Closes #15544` : la décision user (option 3 vs 1 vs 2) reste ouverte dans l'issue ; EDGAR-1 livre la tranche qui rend option 3 actionnable, sans préjuger des options 1/2 si le user veut les activer plus tard.
- PR reçoit un `See #15544` (ne ferme pas l'issue, conformément à Tell c.1064-L1 ★★ fondateur).

See #15392 -- See #15421 -- See #15544
