### PR TITLE
docs(genai,#15047): tableau des sous-series aligne sur le marqueur CATALOG-STATUS (perimetre nomme)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -224,23 +224,25 @@ La série GenAI a un parti pris structurant que les autres hubs n'ont pas : **ch
 | **◐ Cloud API** | API propriétaire (OpenAI/Anthropic/HuggingFace) | Coût par token/image, zéro GPU, qualité par défaut élevée |
 | **◯ Hybride** | Les deux chemins sont démontrés (au choix selon contexte) | Notebooks basculent automatiquement si `.env` configuré |
 
-Cette partition traverse les **13 entrées** du marqueur `CATALOG-STATUS` ci-dessus (12 sous-séries + le notebook racine d'index) et structure le déploiement concret. Les volumes détaillés par sous-série et par maturité restent dans ce marqueur autoritatif ; le tableau ci-dessous récapitule la même information sous l'angle pédagogique **« qui consomme quoi »** plutôt que « qui contient combien » :
+Cette partition traverse les **14 sous-séries** du marqueur `CATALOG-STATUS` en fin de fichier et structure le déploiement concret. Les volumes détaillés par sous-série et par maturité restent dans ce marqueur **autoritatif** ; le tableau ci-dessous en reprend les volumes sous l'angle pédagogique **« qui consomme quoi »** plutôt que « qui contient combien ». **Le périmètre du compte est le catalogue** (`pedagogical_count`) : **215** notebooks — jamais l'arbre versionné (220) ni le parcours étudiant (200) ; les trois périmètres et leurs instruments sont nommés dans [`docs/reference/notebook-counters.md`](../../docs/reference/notebook-counters.md).
 
-| Sous-série | Notebooks | Stack dominante | Service / modèle phare |
-|------------|-----------|-----------------|------------------------|
+| Sous-série | Notebooks au catalogue | Stack dominante | Service / modèle phare |
+|------------|------------------------|-----------------|------------------------|
 | [00-GenAI-Environment](00-GenAI-Environment/) | 6 | ◯ Hybride | Docker Compose : ComfyUI/Qwen, Whisper, MusicGen, Forge |
-| [Image](Image/) | 20 | ◯ Hybride | **Qwen Image Edit** (self-hosted) ⇄ **gpt-image-1** (Cloud) |
-| [Audio](Audio/) | 30 | ◯ Hybride | **Whisper V3** + **Kokoro TTS** (self-hosted) ⇄ **OpenAI TTS** (Cloud) |
-| [Video](Video/) | 17 | ◯ Hybride | **HunyuanVideo** + **Wan** (self-hosted) ⇄ **Sora** (Cloud) |
-| [Texte](Texte/) | 20 | ◐ Cloud API | **GPT-4o-mini** (~0,15 $/M tokens) ; Structured Outputs + Function Calling |
+| [Image](Image/) | 17 | ◯ Hybride | **Qwen Image Edit** (self-hosted) ⇄ **gpt-image-1** (Cloud) |
+| [Audio](Audio/) | 31 | ◯ Hybride | **Whisper V3** + **Kokoro TTS** (self-hosted) ⇄ **OpenAI TTS** (Cloud) |
+| [Video](Video/) | 22 | ◯ Hybride | **HunyuanVideo** + **Wan** (self-hosted) ⇄ **Sora** (Cloud) |
+| [Texte](Texte/) | 30 | ◐ Cloud API | **GPT-4o-mini** (~0,15 $/M tokens) ; Structured Outputs + Function Calling |
 | [SemanticKernel](SemanticKernel/) | 20 | ◯ Hybride | SDK Microsoft .NET 9 + plugins Python ; orchestration multi-agents |
-| [FineTuning](FineTuning/) | 5 | ● self-hosted | **LoRA/QLoRA/SFT/DPO** sur GPU local ; PEFT + Transformers |
-| [PostTraining](PostTraining/) | 7 | ● self-hosted | **SFT/GRPO/RLVR** (rewardspy 0.1.0 git install) |
-| [CaseStudies](CaseStudies/) | 4 | ◯ Hybride | Projets étudiants bout-en-bout |
-| [Plateformes-Conversationnelles](Plateformes-Conversationnelles/) | 7 | ◯ Hybride | Plateforme Open WebUI + Playwright E2E (30+ tests) ; AI-Engine (WordPress) |
-| [Vibe-Coding](Vibe-Coding/) | 6 | ◯ Hybride | **Claude Code** + **Roo Code** ; **Claw-Systems** (bots Hermes/NanoClaw) + **Claudish** (proxy multi-provider) |
-| [RAG-et-Memoire-Semantique](RAG-et-Memoire-Semantique/) | 1 | ● self-hosted | **Qdrant** + embeddings + grounding SDDD |
-| [racine](.) | 1 | ◯ Hybride | Index général |
+| [Integrations-DotNet](Integrations-DotNet/) | 11 | ◯ Hybride | **.NET Aspire** + OpenTelemetry (services GenAI locaux) ; EFCore + **Copilot SDK** |
+| [FineTuning](FineTuning/) | 7 | ● self-hosted | **LoRA/QLoRA/SFT/DPO** sur GPU local ; PEFT + Transformers |
+| [PostTraining](PostTraining/) | 16 | ● self-hosted | **SFT/GRPO/RLVR** (rewardspy 0.1.0 git install) |
+| [CaseStudies](CaseStudies/) | 5 | ◯ Hybride | Projets étudiants bout-en-bout |
+| [FallacyDetection](FallacyDetection/) | 4 | ◐ Cloud API | **HuggingFace `datasets`** — taxonomie + couverture des fallacies |
+| [Plateformes-Conversationnelles](Plateformes-Conversationnelles/) | 28 | ◯ Hybride | Plateforme Open WebUI + Playwright E2E (30+ tests) ; AI-Engine (WordPress) |
+| [Vibe-Coding](Vibe-Coding/) | 8 | ◯ Hybride | **Claude Code** + **Roo Code** ; **Claw-Systems** (bots Hermes/NanoClaw) + **Claudish** (proxy multi-provider) |
+| [RAG-et-Memoire-Semantique](RAG-et-Memoire-Semantique/) | 10 | ● self-hosted | **Qdrant** + embeddings + grounding SDDD |
+| **Total** | **215** | — | = `pedagogical_count` du marqueur `CATALOG-STATUS` |
 
 **LLMs texte : le chemin self-hosted existe aussi.** La ligne Texte est ◐ Cloud API en dominante, mais les notebooks 10-12 (llama.cpp, quantization GPTQ/AWQ, vLLM) montrent comment servir localement les mêmes capacités — c'est exactement la voie que le cluster CoursIA emprunte en production, avec ses propres endpoints vLLM internes qui alimentent les sous-agents des workflows d'automatisation.
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: MED/refactor #15586

`See #15047` (contribution partielle : le residual « artefacts generes » reste, cf plus bas).

---

## Le tableau annonçait « la meme information » que le marqueur — il donnait une troisieme

La phrase qui precede le tableau disait : « les volumes detailles restent dans ce marqueur autoritatif ; le tableau ci-dessous **recapitule la meme information** ». A `f55886c82f`, c'est faux, et c'est mesurable.

| | marqueur `CATALOG-STATUS` | tableau (avant) |
|---|---:|---:|
| sous-series | **14** | 13 (dont **1 fictive**) |
| somme des volumes | **215** = `pedagogical_count` | **144** |

Detail, ligne a ligne :

| Sous-serie | tableau (avant) | marqueur | |
|---|---:|---:|---|
| 00-GenAI-Environment | 6 | 6 | ok |
| Image | 20 | **17** | faux |
| Audio | 30 | **31** | faux |
| Video | 17 | **22** | faux |
| Texte | 20 | **30** | faux |
| SemanticKernel | 20 | 20 | ok |
| Integrations-DotNet | *absent* | **11** | manquant |
| FineTuning | 5 | **7** | faux |
| PostTraining | 7 | **16** | faux |
| CaseStudies | 4 | **5** | faux |
| FallacyDetection | *absent* | **4** | manquant |
| Plateformes-Conversationnelles | 7 | **28** | faux |
| Vibe-Coding | 6 | **8** | faux |
| RAG-et-Memoire-Semantique | 1 | **10** | faux |
| racine | 1 | *inexistant* | fictif |

**11 lignes fausses sur 13, 2 sous-series manquantes, 1 ligne fictive.** Les anciens chiffres ne correspondent ni au marqueur (215) ni au parcours (200) : c'est un **troisieme jeu**, perime, dont rien dans le depot ne nommait le perimetre — exactement le mecanisme que decrit l'issue (« un nombre repris sans son perimetre devient un nombre faux des que la question change »). Le seul organe qui lit ce README (`verify_catalog_readme.py`) ne parse que le **bloc** `CATALOG-STATUS`, jamais le tableau : la derive n'etait attrapee par rien.

## Ce que fait la PR

1. **Aligne les 14 sous-series sur le `breakdown` du marqueur** — somme = 215 = `pedagogical_count`.
2. **Nomme le perimetre** : colonne `Notebooks` -> `Notebooks au catalogue` (acceptance de #15047 : « 220 versionnes », jamais « 220 notebooks » — un nombre nu se relit comme un decompte a jour six mois plus tard).
3. **Ajoute les 2 sous-series omises** (`Integrations-DotNet` 11, `FallacyDetection` 4), **retire la ligne `racine` fictive** (aucun `.ipynb` a la racine de `GenAI/` — verifie ; et `14 sous-series + 5 exclusions = 220` se referme exactement, donc une ligne racine donnerait 216).
4. **Corrige deux affirmations de prose** : « les **13 entrees** du marqueur (12 sous-series + le notebook racine d'index) » -> « les **14 sous-series** » ; et le marqueur est **en fin de fichier**, pas « ci-dessus ».
5. **Renvoie vers `docs/reference/notebook-counters.md`** pour les trois perimetres (220 / 215 / 200) et leurs instruments.

Classification des 2 nouvelles lignes, mesuree et non supposee : `FallacyDetection` = `◐ Cloud API` (65 occurrences de `datasets`, 14 de `huggingface`, aucun endpoint local) ; `Integrations-DotNet` = `◯ Hybride` (280 `Aspire`, 60 `OpenTelemetry`, 18 `OpenAI`, plus une dizaine de ports locaux).

**Aucun artefact genere touche** : `COURSE_CATALOG.generated.*` et les marqueurs `CATALOG-STATUS` sont byte-identiques a `main` (`catalog-pr-hygiene` R1). Le tableau corrige est de la prose — aucun script du depot ne l'emet (verifie par `grep` repo-entier).

## Verifications

Assertion outillee (le tableau reconcilie **exactement** avec le marqueur, sinon code 1) :

```
marqueur : 14 sous-series, pedagogical_count=215, somme=215
tableau  : 14 sous-series, somme=215, ligne Total=215
VERDICT : OK — tableau == marqueur, somme == pedagogical_count
```

Organes :

| Organe | Verdict |
|---|---|
| `check_docs_links.py --check` | `OK: No new broken links. (0 pre-existing, 6802 total)` |
| `check_prose_quantitative_claims.py --diff origin/main...HEAD` | `[OK] aucun compteur quantitatif en prose.` |
| `check_link_label_agreement.py` | `Desaccords libelle/cible : 0` (2064 fichiers) |
| `check_notebook_navlinks.py` | `OK: 0 lien casse (1244 notebooks)` |
| `check_notebook_link_render.py` | `MANQUE : 0` |

Diff : **1 fichier, +16 / -14**.

## Residual, nomme (pas oublie)

- **`COURSE_CATALOG.generated.md` et la page parcours portent toujours un compte nu** (« GenAI (215 notebooks) », « | Notebooks | 200 | »). Nommer le perimetre *dans l'emission* demande de toucher `generate_catalog.py` / `generate_parcours.py` — decision automation, laissee ouverte par #15054 et non tranchee ici.
- **Signalement, sujet separe** : le meme motif (tableau de volumes en prose, non couvert par un organe) existe probablement dans d'autres READMEs de serie (`Probas`, `SymbolicAI`, `RL`, `CaseStudies` portent des colonnes `Notebooks`). Non mesure ici — hors du perimetre de #15047 (GenAI) ; a traiter en sujet dedie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- refresh-adj: 2026-09-12T01:33:57Z -->



---

<!-- ai-01 : edition de corps destinee a emettre un evenement `edited` porteur d un payload frais.
Le verdict `Grain tag absent` etait peremptoire : le tag est correct en premiere ligne et l organe
le valide (`required_pass: true`). Cause du harnais tracee en #15697. Aucune faute de lane. -->
