### PR TITLE
fix(notebooks,#15227): canari hr_separator sur Search/Applications/CSP (7 separateurs)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
@@ -1454,7 +1454,7 @@
     "\n",
     "**Lien avec les Foundations** : CSP ⇄ [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), propagation ⇄ [`CSP-1` §consistance arc](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), CP-SAT ⇄ [`App-11-Picross`](App-11-Picross.ipynb) (twin Python, solveur industriel).\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon .NET ⇄ Python #4956 — Search/Applications, tranche Picross / nonogrammes. See #4956, #3801.*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
@@ -3016,7 +3016,7 @@
     "- [Sports Scheduling Literature](https://www.sportscheduling.org/)\n",
     "- Twin Python : [App-15-SportsScheduling.ipynb](App-15-SportsScheduling.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "*Marathon .NET / Python #4956 -- Search/Applications/CSP, tranche planification sportive. See #4956, #3801.*\n",
     "\n"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb
@@ -1500,7 +1500,7 @@
     "\n",
     "Twin de parite legitime (Prong B) : OR-Tools CP-SAT cote Python vs backtracking + forward-checking from-scratch cote C#. L'intérêt est la visibilite des internes (extraction de slots, MRV, forward-checking) et la confirmation que les deux approches convergent vers la même solution sur la grille exemple.\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon #4956 (parite .NET <-> Python).*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
@@ -1515,7 +1515,7 @@
     "\n",
     "**Références** : Maxim Gumin (WFC original, 2016) ; Korman & Norin, *Wave Function Collapse is Constraint Solving in Disguise* (2023).\n",
     "\n",
-    "---\n",
+    "***\n",
     "*See #4956 (marathon parité .NET/Python), #3801 (SOTA ledger). Twin C# du notebook Python [App-19-ProceduralGeneration-WFC.ipynb](App-19-ProceduralGeneration-WFC.ipynb).*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
@@ -1711,7 +1711,7 @@
     "- Comparer au **recuit simulé** (cf Search-11 SA) sur les mêmes instances.\n",
     "- Mesurer l'impact de la **brisure de symétrie déclarative** sur le temps d'énumération.\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon .NET ⇄ Python #4956 — Search/Applications, tranche N-Reines. See #4956, #3801.*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
@@ -1655,7 +1655,7 @@
     "\n",
     "**Lien avec les Foundations** : CSP ⇄ [`CSP-1`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), backtracking ⇄ [`Search-1`](../../Part1-Foundations/Search-01-StateSpace-Csharp.ipynb), CP-SAT ⇄ [`App-2-GraphColoring`](App-2-GraphColoring.ipynb) (twin Python, solveur industriel).\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon .NET ⇄ Python #4956 — Search/Applications, tranche coloration de graphes. See #4956, #3801.*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "Ce notebook jumeau C# est un **twin from-scratch** (BCL .NET 9, 0 NuGet) qui transpose les algorithmes en C#. Le jumeau Python utilise **OR-Tools CP-SAT** (le vrai solveur SOTA). Voir la section 6 sur la complementarite pedagogique.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Verdict SOTA (EPIC #3801)** : RECOVERABLE-MACHINE Prong-B assumé. From-scratch assumé pedagogiquement pour exhiber la mecanique du branch-and-bound que CP-SAT encapsule (cf section 6). Cross-link vers [App-5-Timetabling.ipynb](App-5-Timetabling.ipynb) qui **invoque** le vrai OR-Tools CP-SAT."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,16 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: b4340188b2bad3f9c05b78a5f658838116fee768
+csharp_sha: 7c38a8b53ea79d85b1be351c36dc03a9a1bc891c
+content_python_sha: 9a4d60c485a287b4b90d79240438bdfce044d567c3f085290d861e7b7f63c1a4
+content_csharp_sha: 07f2681a82de74004c5c5377115a6f302e5e392246e974709fd8e21c6cb3d32d
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-1b-NQueens-CSharp.ipynb) est converti d'une regle horizontale en asterisques par
+  scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
+  frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun
+  separateur standalone equivalent, verifie sur origin/main par parcours JSON complet de
+  ses cellules markdown. Diff = 1 ligne de source JSON par fichier ; cellules code,
+  outputs, execution_count et metadata byte-identiques. Aucun strip outille posterieur :
+  le blob atteste ici est celui du HEAD de la PR. parity_level native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-1-nqueens/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-1-nqueens/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 9a4d60c485a287b4b90d79240438bdfce044d567c3f085290d861e7b7f63
 content_csharp_sha: 07f2681a82de74004c5c5377115a6f302e5e392246e974709fd8e21c6cb3d32d
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 16 (sur 17, derniere) du cote C#
   (App-1b-NQueens-CSharp.ipynb) est converti d'une regle horizontale en asterisques par
   scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
   frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun

--- a/scripts/notebook_tools/twin_pairs.d/app-11-picross/0011-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-11-picross/0011-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,16 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 97d989ba36db777b637dfb7a1eb0de65ed459da0
+csharp_sha: ee5c62a0f289329943aaf4d77d3155f733292f3b
+content_python_sha: 8ecedf594b7a3f058ac082475b8e09a6847b88a9c4b987d7388f4e17fcd46ded
+content_csharp_sha: d23b05bafa7c63ba63c6ffba81c32a1d18f097daada9b23caa0bda3b6c317578
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-11b-Picross-CSharp.ipynb) est converti d'une regle horizontale en asterisques par
+  scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
+  frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun
+  separateur standalone equivalent, verifie sur origin/main par parcours JSON complet de
+  ses cellules markdown. Diff = 1 ligne de source JSON par fichier ; cellules code,
+  outputs, execution_count et metadata byte-identiques. Aucun strip outille posterieur :
+  le blob atteste ici est celui du HEAD de la PR. parity_level native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-11-picross/0011-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-11-picross/0011-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 8ecedf594b7a3f058ac082475b8e09a6847b88a9c4b987d7388f4e17fcd4
 content_csharp_sha: d23b05bafa7c63ba63c6ffba81c32a1d18f097daada9b23caa0bda3b6c317578
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 14 (sur 15, derniere) du cote C#
   (App-11b-Picross-CSharp.ipynb) est converti d'une regle horizontale en asterisques par
   scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
   frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun

--- a/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,17 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 25bd1e99bac08467847225c6c1bef27284108879
+csharp_sha: 97d0469904ade53273ba8654bc673e5bd497aea8
+content_python_sha: 6bc97a786ead73280efd5ab9062fd87f8625ba308268932374d4234885dbbb46
+content_csharp_sha: f633f237ad12bdd1e9c4a580533442ace2ceb1bc3522bf236a5afd8dc2ae6209
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-15b-SportsScheduling-CSharp.ipynb) est converti d'une regle horizontale en
+  asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
+  allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python
+  ne porte aucun separateur standalone equivalent, verifie sur origin/main par parcours
+  JSON complet de ses cellules markdown. Diff = 1 ligne de source JSON par fichier ;
+  cellules code, outputs, execution_count et metadata byte-identiques. Aucun strip
+  outille posterieur : le blob atteste ici est celui du HEAD de la PR. parity_level
+  native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 6bc97a786ead73280efd5ab9062fd87f8625ba308268932374d4234885db
 content_csharp_sha: f633f237ad12bdd1e9c4a580533442ace2ceb1bc3522bf236a5afd8dc2ae6209
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 24 (sur 25, derniere) du cote C#
   (App-15b-SportsScheduling-CSharp.ipynb) est converti d'une regle horizontale en
   asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
   allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python

--- a/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp/0009-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp/0009-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,17 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 31610a1a8cc2be4f8d3e82b7f38327ad05e2a692
+csharp_sha: 90779e7a0699d30f7107364803d2a7bd2dc96327
+content_python_sha: 205d4cc7c2024f6de21848d1672b499b339e408c371a1163cbfaa8c7c499907c
+content_csharp_sha: b23c83c5af98d568cfaf4290f8c2ed439454a6ca4bcb1b92398593284c96ce89
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-16-Crossword-CSP-Csharp.ipynb) est converti d'une regle horizontale en
+  asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
+  allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python
+  ne porte aucun separateur standalone equivalent, verifie sur origin/main par parcours
+  JSON complet de ses cellules markdown. Diff = 1 ligne de source JSON par fichier ;
+  cellules code, outputs, execution_count et metadata byte-identiques. Aucun strip
+  outille posterieur : le blob atteste ici est celui du HEAD de la PR. parity_level
+  native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp/0009-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp/0009-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 205d4cc7c2024f6de21848d1672b499b339e408c371a1163cbfaa8c7c499
 content_csharp_sha: b23c83c5af98d568cfaf4290f8c2ed439454a6ca4bcb1b92398593284c96ce89
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 14 (sur 15, derniere) du cote C#
   (App-16-Crossword-CSP-Csharp.ipynb) est converti d'une regle horizontale en
   asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
   allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python

--- a/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc/0006-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc/0006-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 859105f0a9c8bb3ae9085ab1f32430ef3b211249882a8465451129f99aa2
 content_csharp_sha: 365da44d73ef9551d9732edd40ad7cdfef4771b55a28a51a0dce984c18ef4550
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 13 (sur 14, derniere) du cote C#
   (App-19-ProceduralGeneration-WFC-Csharp.ipynb) est converti d'une regle horizontale en
   asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
   allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python

--- a/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc/0006-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc/0006-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,17 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 080c42747ab3d0904965070b39ea7db869767349
+csharp_sha: 4784f200cb1ca7247a27846c8df0af4682ec20d8
+content_python_sha: 859105f0a9c8bb3ae9085ab1f32430ef3b211249882a8465451129f99aa2c935
+content_csharp_sha: 365da44d73ef9551d9732edd40ad7cdfef4771b55a28a51a0dce984c18ef4550
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-19-ProceduralGeneration-WFC-Csharp.ipynb) est converti d'une regle horizontale en
+  asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
+  allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python
+  ne porte aucun separateur standalone equivalent, verifie sur origin/main par parcours
+  JSON complet de ses cellules markdown. Diff = 1 ligne de source JSON par fichier ;
+  cellules code, outputs, execution_count et metadata byte-identiques. Aucun strip
+  outille posterieur : le blob atteste ici est celui du HEAD de la PR. parity_level
+  native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,17 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 33d3703bfded2f1ac286c06bb1a9c0ba13a04cc2
+csharp_sha: f3ae02bf17ccf6d66a03220c57a18b7d85ce7044
+content_python_sha: d64b538c024f4d94b07f15505d34dcf445a524705c1ee89cb6d796edeefef232
+content_csharp_sha: 4a59198bca360690f5086d01de5e1cb692c8bbf5c1333aa9dbd451ae38c07b5b
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-2b-GraphColoring-CSharp.ipynb) est converti d'une regle horizontale en
+  asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
+  allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python
+  ne porte aucun separateur standalone equivalent, verifie sur origin/main par parcours
+  JSON complet de ses cellules markdown. Diff = 1 ligne de source JSON par fichier ;
+  cellules code, outputs, execution_count et metadata byte-identiques. Aucun strip
+  outille posterieur : le blob atteste ici est celui du HEAD de la PR. parity_level
+  native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring/0008-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring/0008-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: d64b538c024f4d94b07f15505d34dcf445a524705c1ee89cb6d796edeefe
 content_csharp_sha: 4a59198bca360690f5086d01de5e1cb692c8bbf5c1333aa9dbd451ae38c07b5b
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 15 (sur 16, derniere) du cote C#
   (App-2b-GraphColoring-CSharp.ipynb) est converti d'une regle horizontale en
   asterisques par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son
   allowlist (hors frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling/0005-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling/0005-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,16 @@
+date: '2026-09-11'
+by: myia-po-2024:CoursIA
+python_sha: 63a0bb7f77ef4b5103c436c1dc9976d394b2e45c
+csharp_sha: dfb33334f88bc104a217d17c05c7b23cd3c1e24b
+content_python_sha: 1aa065cca423e8805bb8b7c38339b9b0364c5fc0c4c831c3e9458a51168d76ee
+content_csharp_sha: a6af73b2bfeb94f14402adc40f5c65ad4a81eb1c0b98644c95bb40cb39677791
+reason: >-
+  Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
+  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  (App-5-Timetabling-CSharp.ipynb) est converti d'une regle horizontale en asterisques
+  par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
+  frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun
+  separateur standalone equivalent, verifie sur origin/main par parcours JSON complet de
+  ses cellules markdown. Diff = 1 ligne de source JSON par fichier ; cellules code,
+  outputs, execution_count et metadata byte-identiques. Aucun strip outille posterieur :
+  le blob atteste ici est celui du HEAD de la PR. parity_level native-both intacte.

--- a/scripts/notebook_tools/twin_pairs.d/app-5-timetabling/0005-2026-09-11-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-5-timetabling/0005-2026-09-11-myia-po-2024-CoursIA.yaml
@@ -6,7 +6,7 @@ content_python_sha: 1aa065cca423e8805bb8b7c38339b9b0364c5fc0c4c831c3e9458a51168d
 content_csharp_sha: a6af73b2bfeb94f14402adc40f5c65ad4a81eb1c0b98644c95bb40cb39677791
 reason: >-
   Re-attestation de parite -- canari hr_separator (#15227, lane myia-po-2024:CoursIA),
-  markdown-only. Le separateur decoratif de fin de derniere cellule markdown du cote C#
+  markdown-only. Le separateur decoratif standalone de la cellule markdown d'index 0 (sur 17, cellule d'en-tete de 45 lignes, ligne 43) du cote C#
   (App-5-Timetabling-CSharp.ipynb) est converti d'une regle horizontale en asterisques
   par scripts/notebook_tools/fix_hr_separator.py, dans le cadre de son allowlist (hors
   frontmatter, bloc cloture et setext). Cote C# SEUL : le jumeau Python ne porte aucun


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2024:CoursIA — prev: MED/guard #15576

## Bras batch du pilote #15227 — premiere vague canari, `Search/Applications/CSP`

Le body de #15227 propose comme premiere vague un « petit canari `fix_hr_separator.py` sur `Search/Applications/CSP` », et precise que les autres sous-series restent non claimées tant que ce canari n'est pas valide. Cette PR est ce canari.

Elle etait **bloquee** jusqu'ici : #15232 (mergée 2026-09-09T03:40:01Z, `fix(tooling,#15230): fix_hr_separator ecriture byte-preserving hors source ciblee`) a corrige **l'outil lui-meme** — il ecrivait hors de la source ciblee. Le canari devient donc executable.

## Perimetre

7 separateurs dans 7 notebooks, tous sous `Search/Applications/CSP/` :

| Notebook | Separateurs |
|---|---:|
| `App-1b-NQueens-CSharp` | 1 |
| `App-2b-GraphColoring-CSharp` | 1 |
| `App-5-Timetabling-CSharp` | 1 |
| `App-11b-Picross-CSharp` | 1 |
| `App-15b-SportsScheduling-CSharp` | 1 |
| `App-16-Crossword-CSP-Csharp` | 1 |
| `App-19-ProceduralGeneration-WFC-Csharp` | 1 |

La conversion est `---` (regle horizontale decorative) vers `***`, dans les cellules **markdown** uniquement.

**Plus 7 entrees d'attestation twin** (voir section suivante) — perimetre effectif : **14 fichiers** :

- les 7 notebooks ci-dessus ;
- `scripts/notebook_tools/twin_pairs.d/app-1-nqueens/0008-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-2-graphcoloring/0008-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-5-timetabling/0005-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-11-picross/0011-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling/0008-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-16-crossword-csp/0009-2026-09-11-myia-po-2024-CoursIA.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-19-proceduralgeneration-wfc/0006-2026-09-11-myia-po-2024-CoursIA.yaml`

## Twin parity — pourquoi ces 7 entrees existent

Les 7 notebooks du canari appartiennent tous a des paires jumelles enregistrees (`app-1`, `app-2`, `app-5`, `app-11`, `app-15`, `app-16`, `app-19`). Le registre epingle le git blob SHA de chaque cote : toute edition le deplace, y compris markdown-only — le gate `Twin parity audit (#8057)` rendait donc **DRIFT INTRODUCED x7** sur la premiere tete.

Le remede est le geste que le gate prescrit lui-meme : re-attestation apres audit firsthand (`--update --pair`, selecteur obligatoire). Cote C# seul ; le jumeau Python de chaque paire ne porte aucun separateur `---` standalone (verifie sur `origin/main`). Les `csharp_sha` attestes sont ceux du HEAD de la PR — verifies par `git hash-object`, 0 mismatch. Verification post-commit : `check_twin_parity.py --check --per-pair --base origin/main` rend **drift_introduced: 0** (exit 0) ; les 3 paires en DRIFT pre-existant citees par le rapport restent hors perimetre (PR dediee, #8264). Detail complet : issuecomment-5634533852.

## Bright lines du pilote — verifiees, pas affirmees

Le body de #15227 pose : « markdown mecanique seulement ; zero changement de cellule code, output, `execution_count`, metadata, prose semantique, catalogue, traduction ou twin ledger ; un fixer par PR ; lots de moins de 15 fichiers ».

Verification **cellule par cellule** contre `origin/main` (comparaison structurelle des deux JSON, pas une relecture visuelle) :

- 7 notebooks, **7 cellules markdown modifiees au total** — exactement 1 par notebook ;
- `cell_type`, `execution_count`, `outputs`, `metadata` : **byte-identiques** sur les 7 ;
- le markdown restant est **identique ligne a ligne** : la seule difference est une ligne `---` devenue `***` (comptage verifie — 1 `---` en base, 1 `***` apres, par notebook) ;
- **aucune** cellule de code touchee, donc C.2 non due (exception markdown-only) ;
- 1 fixer sur les notebooks ; le lot total porte 14 fichiers (7 notebooks + 7 entrees d'attestation twin ecrites par `check_twin_parity.py --update`, l'organe du registre) — sous le seuil du pilote de 15. **Tension assumée avec la bright line « twin ledger »** : la clause contraint le *sweeper* (`corrective-sweeper.md` §6 : « twin checks read-only, without automatic rebaseline ») — l'attestation deliberement motivee par la lane livrante est le remede que le gate prescrit. Fait saillant pour le pilote : les 7 hits hr_separator de cette sous-serie sont **tous** sur des notebooks jumeaux enregistres ; decision de design a trancher cote coordinateur.

## Hors perimetre, deliberement

- **Le bras profond q3 n'est pas pris ici.** La question 3 de #15227 porte sur `App-23-PRESENT-Differential-Cryptanalysis-SAT.ipynb` (« recalculer independamment les poids de trails et le seuil SAT/UNSAT annonce ») — mais **deux PR ouvertes touchent deja ce chemin** : #15447 (`split T2a Search Foundations/CSP/Hybrid`) et #15146 (`normaliser 174 cellules source str->list sur 44 notebooks`). L898 interdit d'editer un chemin sous PR ouverte ; la question reste donc ouverte pour la tranche suivante.
- Les **27 autres separateurs** mesures par le pilote (34 dans 30 notebooks) restent non claimes : le body demande explicitement de ne pas elargir avant validation de ce canari.
- `_archive` (4 separateurs) et `MGS-10-CenterBias.ipynb` (1 separateur, intersecte par la PR ouverte #15147) sont exclus conformement a la deconfliction du body.
- Aucune collision : `gh pr list --state open --json files` ne rend **aucune** PR ouverte sur les 7 chemins, et `check_lane_claim.py 15227 --paths "Search/Applications/CSP/**"` rend `CLEAR`.

## Verification

- Pre-commit complet, **10 hooks dont H.3** (`execution_count=null + outputs=[]`) et le hook `yaml_block_open_no_close` (openers `---` decoratifs) : **Passed** — aucun hook auto-applicatif n'a modifie un fichier.
- `COURSE_CATALOG.generated.*` : **non touche** (byte-identique a `main`, appartient a l'automatisation).

See #15227 (vague partielle : l'issue coordonne l'experience et ne sera pas auto-close par une vague partielle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-11T12:56:21Z -->

