### PR TITLE
fix(qc,#14991): controle negatif du detecteur spectral + seuil de detection

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity.ipynb
@@ -5,10 +5,10 @@
    "id": "67c14319",
    "metadata": {
     "papermill": {
-     "duration": 0.003748,
-     "end_time": "2026-09-10T09:16:51.601428+00:00",
+     "duration": 0.003179,
+     "end_time": "2026-09-11T11:42:33.582805+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:51.597680+00:00",
+     "start_time": "2026-09-11T11:42:33.579626+00:00",
      "status": "completed"
     },
     "tags": []
@@ -56,16 +56,16 @@
    "id": "443adf3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.619377Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.619083Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.725689Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.725065Z"
+     "iopub.execute_input": "2026-09-11T11:42:33.592010Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.591745Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.712278Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.711353Z"
     },
     "papermill": {
-     "duration": 1.465729,
-     "end_time": "2026-09-10T09:16:53.071556+00:00",
+     "duration": 0.12597,
+     "end_time": "2026-09-11T11:42:33.713672+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:51.605827+00:00",
+     "start_time": "2026-09-11T11:42:33.587702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -108,10 +108,10 @@
    "id": "76b8ae5f",
    "metadata": {
     "papermill": {
-     "duration": 0.001449,
-     "end_time": "2026-09-10T09:16:53.074695+00:00",
+     "duration": 0.004368,
+     "end_time": "2026-09-11T11:42:33.722491+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.073246+00:00",
+     "start_time": "2026-09-11T11:42:33.718123+00:00",
      "status": "completed"
     },
     "tags": []
@@ -135,16 +135,16 @@
    "id": "0b11aa7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.730046Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.729753Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.737309Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.736723Z"
+     "iopub.execute_input": "2026-09-11T11:42:33.732136Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.731795Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.743819Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.742824Z"
     },
     "papermill": {
-     "duration": 0.024422,
-     "end_time": "2026-09-10T09:16:53.100455+00:00",
+     "duration": 0.017984,
+     "end_time": "2026-09-11T11:42:33.744733+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.076033+00:00",
+     "start_time": "2026-09-11T11:42:33.726749+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,10 +186,10 @@
    "id": "1c40b05a",
    "metadata": {
     "papermill": {
-     "duration": 0.001458,
-     "end_time": "2026-09-10T09:16:53.103604+00:00",
+     "duration": 0.003806,
+     "end_time": "2026-09-11T11:42:33.751894+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.102146+00:00",
+     "start_time": "2026-09-11T11:42:33.748088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -197,7 +197,7 @@
    "source": [
     "## Lecture du resultat\n",
     "\n",
-    "Sur la serie synthetique, le pic de puissance le plus eleve (apres le continu DC) doit tomber sur la periode injectee de 30 minutes. Cela valide la methode : une FFT directe sur le volume intraday detecte une periodicite connue. Sur une serie reelle, la meme methode donne un pic dominant a la periodicite structurelle du marche (cf. Wu et al. 2025 - periodicites U-shape a 30 min et 60 min selon univers).\n",
+    "Sur la serie synthetique, le pic de puissance le plus eleve (apres le continu DC) doit tomber sur la periode injectee de 30 minutes. Cela confirme que la chaine de traitement restitue la periodicite injectee -- mais sur une serie ou la reponse est connue par construction, ce resultat ne prouve pas que le detecteur distingue une vraie periodicite du contenu basse frequence du U-shape et du bruit. C'est l'objet de la section suivante. Sur une serie reelle, la meme methode donne un pic dominant a la periodicite structurelle du marche (cf. Wu et al. 2025 - periodicites U-shape a 30 min et 60 min selon univers).\n",
     "\n",
     "## Limites pedagogiques\n",
     "\n",
@@ -208,13 +208,266 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fd73b53b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002953,
+     "end_time": "2026-09-11T11:42:33.757798+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.754845+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Controle negatif - le detecteur discrimine-t-il ?\n",
+    "\n",
+    "La cellule precedente detecte la periode qu'elle a elle-meme injectee : c'est une\n",
+    "demonstration de bout en bout, pas une validation. Un test qui ne peut pas echouer ne\n",
+    "mesure rien. Pour que la detection ait un sens, il faut mesurer ce que l'outil rend\n",
+    "**en l'absence** de periodicite, puis comparer les deux regimes.\n",
+    "\n",
+    "On repete donc l'experience sur deux bras, **20 seeds chacun** (meme construction que la\n",
+    "cellule 1, seule la sinusoide change) :\n",
+    "\n",
+    "- **bras temoin** : U-shape + bruit log-normal, **aucune** periodicite injectee ;\n",
+    "- **bras periodique** : le meme signal augmente de la sinusoide 30 min d'amplitude 0.25.\n",
+    "\n",
+    "Pour chaque serie on releve deux nombres, sans rien supposer sur leur distribution :\n",
+    "\n",
+    "- le **rang** du bac de frequence a 30 min dans le spectre de puissance (1 = pic\n",
+    "  dominant, continu exclu) ;\n",
+    "- le **rapport de puissance** entre ce bac et la mediane du spectre.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5ab151fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T11:42:33.765214Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.764727Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.796466Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.795494Z"
+    },
+    "papermill": {
+     "duration": 0.036696,
+     "end_time": "2026-09-11T11:42:33.797293+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.760597+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bac 30 min -- 20 seeds par bras, amplitude injectee = 0.25\n",
+      "bras         pic dominant  rang median  rapport median  rapport min  rapport max\n",
+      "temoin           0/20               44             2.0         0.20         5.25\n",
+      "periodique      11/20                1            19.3         5.32        39.34\n",
+      "\n",
+      "Paires (temoin, periodique) ou le temoin fait aussi bien ou mieux : 0 / 400\n",
+      "Borne haute du temoin = 5.25 ; borne basse du periodique = 5.32\n",
+      "\n",
+      "Seed 42 (la serie committee en cellule 1) : temoin -> rang 26 (rapport 3.46) ; periodique -> rang 1 (rapport 31.19)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Controle negatif : deux bras, 20 seeds chacun. Seule difference avec la cellule 1 :\n",
+    "# inject=False supprime la sinusoide 30 min.\n",
+    "from numpy.fft import rfft, rfftfreq\n",
+    "\n",
+    "SEEDS = [0, 1, 7, 42, 99, 2, 3, 5, 11, 13, 17, 23, 29, 31, 37, 41, 43, 47, 53, 61]\n",
+    "N_MIN = 390\n",
+    "AMP = 0.25\n",
+    "\n",
+    "\n",
+    "def build_volume(seed, inject, amplitude=AMP, n_min=N_MIN):\n",
+    "    \"\"\"Serie synthetique intraday. inject=False => aucune periodicite (temoin).\"\"\"\n",
+    "    rng = np.random.default_rng(seed=seed)\n",
+    "    tt = np.arange(n_min)\n",
+    "    u = (1.0 + 1.2 * np.exp(-((tt - 30) ** 2) / (2 * 25 ** 2))\n",
+    "         + 0.9 * np.exp(-((tt - 380) ** 2) / (2 * 30 ** 2))\n",
+    "         + 0.3 * np.exp(-((tt - 200) ** 2) / (2 * 60 ** 2)))\n",
+    "    p = amplitude * np.sin(2 * np.pi * tt / 30) if inject else 0.0\n",
+    "    b = rng.lognormal(mean=0.0, sigma=0.6, size=n_min)\n",
+    "    return u * (1.0 + p) * b\n",
+    "\n",
+    "\n",
+    "def rank_and_ratio(vol):\n",
+    "    \"\"\"Rang du bac a 30 min (1 = pic dominant) et rapport a la mediane du spectre.\"\"\"\n",
+    "    n = len(vol)\n",
+    "    sp = np.abs(rfft(vol - vol.mean())) ** 2\n",
+    "    sp = sp.copy()\n",
+    "    sp[0] = 0.0                                   # on ecarte le continu (DC)\n",
+    "    i30 = int(np.argmin(np.abs(rfftfreq(n, d=1.0) - 1.0 / 30.0)))\n",
+    "    order = np.argsort(sp)[::-1]\n",
+    "    return int(np.where(order == i30)[0][0]) + 1, float(sp[i30] / np.median(sp[1:]))\n",
+    "\n",
+    "\n",
+    "temoin_ranks, temoin_ratio = [], []\n",
+    "period_ranks, period_ratio = [], []\n",
+    "for seed in SEEDS:\n",
+    "    r, q = rank_and_ratio(build_volume(seed, inject=False))\n",
+    "    temoin_ranks.append(r)\n",
+    "    temoin_ratio.append(q)\n",
+    "    r, q = rank_and_ratio(build_volume(seed, inject=True))\n",
+    "    period_ranks.append(r)\n",
+    "    period_ratio.append(q)\n",
+    "\n",
+    "print(f\"Bac 30 min -- {len(SEEDS)} seeds par bras, amplitude injectee = {AMP}\")\n",
+    "print(f\"{'bras':<11} {'pic dominant':>13} {'rang median':>12} {'rapport median':>15} \"\n",
+    "      f\"{'rapport min':>12} {'rapport max':>12}\")\n",
+    "for nom, ranks, ratios in ((\"temoin\", temoin_ranks, temoin_ratio),\n",
+    "                           (\"periodique\", period_ranks, period_ratio)):\n",
+    "    pic = sum(1 for r in ranks if r == 1)\n",
+    "    print(f\"{nom:<11} {pic:>6}/{len(ranks):<6} {np.median(ranks):>12.0f} \"\n",
+    "          f\"{np.median(ratios):>15.1f} {min(ratios):>12.2f} {max(ratios):>12.2f}\")\n",
+    "\n",
+    "# Les deux distributions de rapport se recouvrent-elles ?\n",
+    "inversions = sum(1 for a in temoin_ratio for b in period_ratio if a >= b)\n",
+    "paires = len(temoin_ratio) * len(period_ratio)\n",
+    "print(f\"\\nPaires (temoin, periodique) ou le temoin fait aussi bien ou mieux : \"\n",
+    "      f\"{inversions} / {paires}\")\n",
+    "print(f\"Borne haute du temoin = {max(temoin_ratio):.2f} ; \"\n",
+    "      f\"borne basse du periodique = {min(period_ratio):.2f}\")\n",
+    "\n",
+    "i42 = SEEDS.index(42)\n",
+    "print(f\"\\nSeed 42 (la serie committee en cellule 1) : temoin -> rang \"\n",
+    "      f\"{temoin_ranks[i42]} (rapport {temoin_ratio[i42]:.2f}) ; \"\n",
+    "      f\"periodique -> rang {period_ranks[i42]} (rapport {period_ratio[i42]:.2f})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cef6bc85",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002936,
+     "end_time": "2026-09-11T11:42:33.803299+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.800363+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Seuil de detection\n",
+    "\n",
+    "La comparaison precedente fixe l'amplitude a 0.25, celle du notebook. Reste la question\n",
+    "qui decide de l'utilite pratique : **a partir de quelle amplitude** la periodicite\n",
+    "devient-elle detectable ? On balaie l'amplitude injectee de 0 (temoin pur) a 0.50, sur\n",
+    "les 20 memes seeds, en comptant combien de fois le bac 30 min sort en tete.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0f8c9eff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T11:42:33.810006Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.809742Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.836902Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.836084Z"
+    },
+    "papermill": {
+     "duration": 0.031755,
+     "end_time": "2026-09-11T11:42:33.837627+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.805872+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " amplitude   bac 30 min en tete  rang median  rapport median\n",
+      "      0.00              0/20              44             2.0\n",
+      "      0.02              0/20              48             1.9\n",
+      "      0.05              0/20              44             2.3\n",
+      "      0.10              0/20               8             5.3\n",
+      "      0.15              4/20               4             8.9\n",
+      "      0.25             11/20               1            19.3\n",
+      "      0.50             20/20               1            70.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Seuil de detection : balayage d'amplitude, 20 seeds par point.\n",
+    "AMPLITUDES = [0.00, 0.02, 0.05, 0.10, 0.15, 0.25, 0.50]\n",
+    "\n",
+    "print(f\"{'amplitude':>10} {'bac 30 min en tete':>20} {'rang median':>12} \"\n",
+    "      f\"{'rapport median':>15}\")\n",
+    "for amp in AMPLITUDES:\n",
+    "    ranks, ratios = [], []\n",
+    "    for seed in SEEDS:\n",
+    "        r, q = rank_and_ratio(build_volume(seed, inject=(amp > 0.0), amplitude=amp))\n",
+    "        ranks.append(r)\n",
+    "        ratios.append(q)\n",
+    "    pic = sum(1 for r in ranks if r == 1)\n",
+    "    print(f\"{amp:>10.2f} {pic:>14}/{len(ranks):<5} {np.median(ranks):>12.0f} \"\n",
+    "          f\"{np.median(ratios):>15.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d413c51",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002423,
+     "end_time": "2026-09-11T11:42:33.844324+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.841901+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du controle negatif\n",
+    "\n",
+    "Les nombres ci-dessus sont mesures, pas illustratifs.\n",
+    "\n",
+    "**Le detecteur discrimine.** Sur le rapport de puissance, les deux bras ne se recouvrent\n",
+    "pas : la borne haute du temoin vaut 5.25, la borne basse du bras periodique 5.32, soit\n",
+    "**0 inversion sur 400 paires** (temoin, periodique). Un rapport eleve signale donc bien\n",
+    "une periodicite reelle, et non le seul contenu basse frequence du U-shape.\n",
+    "\n",
+    "**Mais le critere \"pic dominant\" n'est pas robuste.** A l'amplitude du notebook (0.25),\n",
+    "le bac 30 min n'est en tete que dans **11 series sur 20**. La serie committee (seed 42)\n",
+    "fait partie de ces 11 (rang 1, rapport 31.19, contre rang 26 et rapport 3.46 pour son\n",
+    "temoin) : la demonstration de la cellule 3 est donc un **cas favorable**, pas le\n",
+    "comportement generique du detecteur.\n",
+    "\n",
+    "**Le seuil de detection est bas, mais reel.** Le balayage situe la premiere detection en\n",
+    "tete a une amplitude de **0.15** (4 series sur 20), et 20 sur 20 a 0.50. En dessous de\n",
+    "0.10 le pic injecte reste noye : 0 sur 20, rang median 8 a 0.10, et le rapport median\n",
+    "retombe au niveau du temoin (5.3 contre 2.0 au temoin pur).\n",
+    "\n",
+    "**Ce que ce controle n'etablit pas.** Il porte sur une serie **synthetique**, a bruit\n",
+    "log-normal independant, et sur une periodicite **sinusoidale pure a 30 min**. Une serie\n",
+    "reelle a une periodicite qui derive, un bruit autocorrele et une non-stationnarite\n",
+    "intraday : ces nombres ne s'y transposent pas tels quels. Aucune conclusion de\n",
+    "rentabilite n'en est tiree ici.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f88628b9",
    "metadata": {
     "papermill": {
-     "duration": 0.001435,
-     "end_time": "2026-09-10T09:16:53.106498+00:00",
+     "duration": 0.002193,
+     "end_time": "2026-09-11T11:42:33.848821+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.105063+00:00",
+     "start_time": "2026-09-11T11:42:33.846628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -235,20 +488,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "0155ee50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.741471Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.741263Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.746377Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.745287Z"
+     "iopub.execute_input": "2026-09-11T11:42:33.854418Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.854202Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.858241Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.857388Z"
     },
     "papermill": {
-     "duration": 0.00794,
-     "end_time": "2026-09-10T09:16:53.115832+00:00",
+     "duration": 0.007958,
+     "end_time": "2026-09-11T11:42:33.858934+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.107892+00:00",
+     "start_time": "2026-09-11T11:42:33.850976+00:00",
      "status": "completed"
     },
     "tags": []
@@ -284,10 +537,10 @@
    "id": "207821f0",
    "metadata": {
     "papermill": {
-     "duration": 0.001776,
-     "end_time": "2026-09-10T09:16:53.119446+00:00",
+     "duration": 0.002278,
+     "end_time": "2026-09-11T11:42:33.863686+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.117670+00:00",
+     "start_time": "2026-09-11T11:42:33.861408+00:00",
      "status": "completed"
     },
     "tags": []
@@ -306,20 +559,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "b1fe7934",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.749110Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.748851Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.754562Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.753347Z"
+     "iopub.execute_input": "2026-09-11T11:42:33.869577Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.869364Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.873137Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.872527Z"
     },
     "papermill": {
-     "duration": 0.009787,
-     "end_time": "2026-09-10T09:16:53.131301+00:00",
+     "duration": 0.007834,
+     "end_time": "2026-09-11T11:42:33.873849+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.121514+00:00",
+     "start_time": "2026-09-11T11:42:33.866015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -355,10 +608,10 @@
    "id": "30e8461f",
    "metadata": {
     "papermill": {
-     "duration": 0.00227,
-     "end_time": "2026-09-10T09:16:53.135899+00:00",
+     "duration": 0.002729,
+     "end_time": "2026-09-11T11:42:33.879430+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.133629+00:00",
+     "start_time": "2026-09-11T11:42:33.876701+00:00",
      "status": "completed"
     },
     "tags": []
@@ -384,20 +637,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "4a653ffa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.758668Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.758396Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.764370Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.763276Z"
+     "iopub.execute_input": "2026-09-11T11:42:33.886189Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.885926Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.890886Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.890102Z"
     },
     "papermill": {
-     "duration": 0.009706,
-     "end_time": "2026-09-10T09:16:53.147729+00:00",
+     "duration": 0.009382,
+     "end_time": "2026-09-11T11:42:33.891464+00:00",
      "exception": false,
-     "start_time": "2026-09-10T09:16:53.138023+00:00",
+     "start_time": "2026-09-11T11:42:33.882082+00:00",
      "status": "completed"
     },
     "tags": []
@@ -435,7 +688,16 @@
   {
    "cell_type": "markdown",
    "id": "a1b2c3d4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002825,
+     "end_time": "2026-09-11T11:42:33.897180+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.894355+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 - Detection multi-jours (60 min)\n",
     "\n",
@@ -460,22 +722,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "e5f6a7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T02:18:35.767999Z",
-     "iopub.status.busy": "2026-09-11T02:18:35.767674Z",
-     "iopub.status.idle": "2026-09-11T02:18:35.775049Z",
-     "shell.execute_reply": "2026-09-11T02:18:35.773835Z"
-    }
+     "iopub.execute_input": "2026-09-11T11:42:33.903982Z",
+     "iopub.status.busy": "2026-09-11T11:42:33.903754Z",
+     "iopub.status.idle": "2026-09-11T11:42:33.909970Z",
+     "shell.execute_reply": "2026-09-11T11:42:33.909221Z"
+    },
+    "papermill": {
+     "duration": 0.010561,
+     "end_time": "2026-09-11T11:42:33.910580+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T11:42:33.900019+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : generer 10 series avec seeds differents et\n",
+      "Exercice a completer : generer 10 series avec seeds differents et\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "   calculer la moyenne des spectres. Stub actuel : 1 seul spectre (la serie\n",
       "   de base), donc spectrum_mean == spectrum. La procedure est en place,\n",
       "   il manque la diversification des seeds.\n"
@@ -526,18 +802,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.15"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.769728,
-   "end_time": "2026-09-10T09:16:56.227205+00:00",
+   "duration": 2.242304,
+   "end_time": "2026-09-11T11:42:34.157933+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity.ipynb",
-   "output_path": "MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity_output.ipynb",
+   "input_path": "intraday_volume_periodicity.ipynb",
+   "output_path": "intraday_volume_periodicity_output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-10T09:16:49.457477+00:00",
+   "start_time": "2026-09-11T11:42:31.915629+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity.py
+++ b/MyIA.AI.Notebooks/QuantConnect/research/intraday_volume_periodicity.py
@@ -18,6 +18,11 @@ executable en CLI (utile pour batch / CI / debug) :
 2. Calcule le spectre de puissance (FFT) et detecte les frequences
    dominantes par top-N (ici 5).
 3. Confirme la detection de la periodicite injectee (periode 30 min).
+4. Mesure un controle negatif : compare, sur 20 seeds, le bras temoin
+   (sans periodicite) au bras periodique, puis balaie l'amplitude
+   injectee pour situer le seuil de detection. Chercher la periode
+   injectee ne prouve rien en soi ; c'est l'ecart entre les deux bras
+   qui mesure la capacite du detecteur.
 
 Le script expose les memes primitives que le notebook pour que les
 exercices puissent les appeler directement (sans re-implementation) :
@@ -38,7 +43,7 @@ Dependances : numpy >= 1.25 (helper scalaire/vecteur compatible).
 import numpy as np
 
 
-def generate_synthetic_volume(n_min=390, seed=42):
+def generate_synthetic_volume(n_min=390, seed=42, inject=True, amplitude=0.25):
     """Genere une serie synthetique de volume minute US.
 
     Parametres
@@ -47,6 +52,11 @@ def generate_synthetic_volume(n_min=390, seed=42):
         Nombre de minutes (defaut 390 = 6h30 de trading US).
     seed : int
         Graine RNG pour reproductibilite.
+    inject : bool
+        Si False, la serie ne contient AUCUNE periodicite : c'est le bras
+        temoin du controle negatif (U-shape + bruit seulement).
+    amplitude : float
+        Amplitude de la sinusoide 30 min (ignoree si inject=False).
 
     Retour
     ------
@@ -67,7 +77,7 @@ def generate_synthetic_volume(n_min=390, seed=42):
 
     # Periodicite artificielle : 30 min (Wu et al. trouvent typiquement
     # un cycle de l'ordre de 30 min sur des donnees reelles).
-    periodicite = 0.25 * np.sin(2 * np.pi * t / 30)
+    periodicite = amplitude * np.sin(2 * np.pi * t / 30) if inject else 0.0
 
     # Bruit log-normal multiplicatif (heteroscedasticite typique du volume).
     bruit = rng.lognormal(mean=0.0, sigma=0.6, size=n_min)
@@ -152,6 +162,79 @@ def aggregate_spectra(seed_list):
     return np.mean(np.array(spectra), axis=0)
 
 
+DEFAULT_SEEDS = [0, 1, 7, 42, 99, 2, 3, 5, 11, 13,
+                 17, 23, 29, 31, 37, 41, 43, 47, 53, 61]
+
+
+def rank_and_ratio(volume):
+    """Rang du bac a 30 min et rapport de puissance a la mediane du spectre.
+
+    Parametre
+    ---------
+    volume : np.ndarray
+        Serie temporelle (espacement uniforme 1 minute).
+
+    Retour
+    ------
+    (int, float)
+        Rang du bac 30 min (1 = pic dominant, continu DC exclu) et
+        rapport puissance(bac 30 min) / mediane(spectre hors DC).
+    """
+    n = len(volume)
+    spectrum = np.abs(np.fft.rfft(volume - volume.mean())) ** 2
+    spectrum = spectrum.copy()
+    spectrum[0] = 0.0                       # on ecarte le continu (DC)
+    freqs = np.fft.rfftfreq(n, d=1.0)
+    i30 = int(np.argmin(np.abs(freqs - 1.0 / 30.0)))
+    order = np.argsort(spectrum)[::-1]
+    rank = int(np.where(order == i30)[0][0]) + 1
+    return rank, float(spectrum[i30] / np.median(spectrum[1:]))
+
+
+def _arm_stats(seeds, inject, amplitude=0.25):
+    """Statistiques d'un bras : pics dominants, rangs et rapports."""
+    ranks, ratios = [], []
+    for seed in seeds:
+        _, vol = generate_synthetic_volume(seed=seed, inject=inject,
+                                           amplitude=amplitude)
+        rank, ratio = rank_and_ratio(vol)
+        ranks.append(rank)
+        ratios.append(ratio)
+    return {
+        "pic_dominant": sum(1 for r in ranks if r == 1),
+        "rang_median": float(np.median(ranks)),
+        "rapport_median": float(np.median(ratios)),
+        "rapport_min": min(ratios),
+        "rapport_max": max(ratios),
+        "ratios": ratios,
+    }
+
+
+def null_control(seeds=None, amplitude=0.25):
+    """Controle negatif : bras temoin (sans periodicite) contre bras periodique.
+
+    Chercher une periode qu'on a soi-meme injectee ne mesure rien : le
+    resultat est garanti. La mesure utile est l'ecart entre le bras temoin
+    et le bras periodique, sur les memes seeds.
+
+    Parametres
+    ----------
+    seeds : list[int] | None
+        Seeds des deux bras (defaut : 20 seeds).
+    amplitude : float
+        Amplitude de la sinusoide dans le bras periodique.
+
+    Retour
+    ------
+    (dict, dict)
+        (stats_temoin, stats_periodique) au format de _arm_stats.
+    """
+    if seeds is None:
+        seeds = DEFAULT_SEEDS
+    return _arm_stats(seeds, inject=False, amplitude=amplitude), \
+        _arm_stats(seeds, inject=True, amplitude=amplitude)
+
+
 def main():
     t, volume = generate_synthetic_volume()
     print(
@@ -171,8 +254,10 @@ def main():
     expected_period = 30.0
     period_match = abs(period_top - expected_period) < 1.0
     if period_match:
-        print(f"\nOK : la periodicite injectee a {expected_period:.0f} min "
-              f"est detectee en tete (periode observee = {period_top:.1f} min).")
+        print(f"\nOK (seed 42) : la periodicite injectee a {expected_period:.0f} min "
+              f"est detectee en tete (periode observee = {period_top:.1f} min). "
+              f"Une seed favorable ne dit rien de la robustesse -- c'est ce que "
+              f"mesure le controle negatif ci-dessous.")
     else:
         print(f"\nWARN : la periodicite {expected_period:.0f} min injectee "
               f"n'est pas en tete (periode tete = {period_top:.1f} min).")
@@ -188,6 +273,31 @@ def main():
         period_min = 1.0 / f if f > 0 else float('inf')
         print(f"  f = {f:.4f} cycle/min  ->  periode {period_min:.1f} min  "
               f"(puissance {spectrum_mean[i]:.0f})")
+
+    # Controle negatif : chercher la periode injectee ne prouve rien seul.
+    temoin, periodique = null_control()
+    n_seeds = len(DEFAULT_SEEDS)
+    print(f"\nControle negatif ({n_seeds} seeds par bras, amplitude 0.25) :")
+    print(f"{'bras':<11} {'pic dominant':>13} {'rang median':>12} "
+          f"{'rapport median':>15} {'rapport min':>12} {'rapport max':>12}")
+    for nom, stats in (("temoin", temoin), ("periodique", periodique)):
+        print(f"{nom:<11} {stats['pic_dominant']:>6}/{n_seeds:<6} "
+              f"{stats['rang_median']:>12.0f} {stats['rapport_median']:>15.1f} "
+              f"{stats['rapport_min']:>12.2f} {stats['rapport_max']:>12.2f}")
+    inversions = sum(1 for a in temoin["ratios"] for b in periodique["ratios"]
+                     if a >= b)
+    paires = len(temoin["ratios"]) * len(periodique["ratios"])
+    print(f"Paires (temoin, periodique) ou le temoin fait aussi bien ou mieux : "
+          f"{inversions} / {paires}")
+
+    # Seuil de detection : balayage de l'amplitude injectee.
+    print("\nSeuil de detection :")
+    print(f"{'amplitude':>10} {'bac 30 min en tete':>20} {'rang median':>12} "
+          f"{'rapport median':>15}")
+    for amp in (0.00, 0.02, 0.05, 0.10, 0.15, 0.25, 0.50):
+        stats = _arm_stats(DEFAULT_SEEDS, inject=(amp > 0.0), amplitude=amp)
+        print(f"{amp:>10.2f} {stats['pic_dominant']:>14}/{n_seeds:<5} "
+              f"{stats['rang_median']:>12.0f} {stats['rapport_median']:>15.1f}")
     return 0
 
 


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/guard #15576

## Tranche d'extension de #14991 — le detecteur spectral discrimine-t-il ?

Le notebook livre par **#15280** (lane `myia-po-2027:CoursIA-2`, merge 2026-09-11T04:40:43Z) construit une serie synthetique ou la periodicite 30 min est **injectee par construction**, puis la retrouve par FFT. Sa cellule « Lecture du resultat » en concluait :

> Cela valide la methode : une FFT directe sur le volume intraday detecte une periodicite connue.

C'est circulaire : **un test qui ne peut pas echouer ne mesure rien.** Le notebook ne contenait aucun bras temoin, donc la capacite du detecteur n'etait nulle part mesuree — ni sa specificite (que rend-il quand il n'y a **pas** de periodicite ?), ni son seuil.

Le verdict `IGNORE` du body de #14991 vise le **rotator QC** (signal proprietaire, in-sample, draft). Il ne dit rien de l'illustration CPU-only, qui est l'objet de cette tranche.

## Ce que la tranche ajoute

5 cellules (3 markdown, 2 code), inserees apres la lecture du resultat, plus la correction de la phrase circulaire ci-dessus :

- **Controle negatif** — 20 seeds par bras : bras **temoin** (U-shape + bruit, aucune periodicite) contre bras **periodique** (meme signal + sinusoide 30 min, amplitude 0.25, celle du notebook). Pour chaque serie, deux nombres sans hypothese de distribution : le **rang** du bac 30 min (1 = pic dominant, continu exclu) et le **rapport** puissance(bac 30 min) / mediane du spectre.
- **Seuil de detection** — balayage d'amplitude (0 a 0.50) sur les 20 memes seeds, en comptant les detections en tete.
- **Lecture mesuree** de ces deux resultats.

Le script compagnon `intraday_volume_periodicity.py` porte **les memes mesures aux memes nombres** (`null_control()`, `_arm_stats()`, `rank_and_ratio()` exposes ; `generate_synthetic_volume` gagne un parametre `inject` dont le defaut preserve exactement le comportement anterieur). La paire est verifiee coherente, pas supposee.

## Mesures (sorties reelles, reproduites ci-dessous telles quelles)

```
bras         pic dominant  rang median  rapport median  rapport min  rapport max
temoin           0/20               44             2.0         0.20         5.25
periodique      11/20                1            19.3         5.32        39.34

Paires (temoin, periodique) ou le temoin fait aussi bien ou mieux : 0 / 400
Borne haute du temoin = 5.25 ; borne basse du periodique = 5.32

Seed 42 (la serie committee en cellule 1) : temoin -> rang 26 (rapport 3.46) ;
periodique -> rang 1 (rapport 31.19)
```

```
 amplitude   bac 30 min en tete  rang median  rapport median
      0.00              0/20              44             2.0
      0.02              0/20              48             1.9
      0.05              0/20              44             2.3
      0.10              0/20               8             5.3
      0.15              4/20               4             8.9
      0.25             11/20               1            19.3
      0.50             20/20               1            70.4
```

Trois lectures, dont une qui **corrige** ce que le notebook affirmait :

1. **Le detecteur discrimine.** Les deux distributions de rapport ne se recouvrent pas : borne haute du temoin 5.25, borne basse du bras periodique 5.32 — **0 inversion sur 400 paires**. Un rapport eleve signale une periodicite reelle, pas le seul contenu basse frequence du U-shape.
2. **Le critere « pic dominant » n'est pas robuste.** A l'amplitude du notebook (0.25), le bac 30 min n'est en tete que **11 fois sur 20**. La seed committee (42) est un **cas favorable** : la demonstration de la cellule 3 tient parce que la seed a ete choisie chanceuse, pas parce que le detecteur est fiable a cette amplitude. C'est exactement ce que la phrase « cela valide la methode » masquait.
3. **Le seuil est bas mais reel** : premiere detection en tete a amplitude **0.15** (4/20), 20/20 a 0.50 ; a 0.10 et en dessous, le pic injecte reste noye et le rapport median retombe au niveau du temoin.

## §C — ce qui s'applique et ce qui ne s'applique pas

- **Multi-seed ≥ 4 : applique**, et au-dela — **20 seeds par bras**, 7 points de balayage.
- **Verdict honnete : applique** — les trois constats ci-dessus sont des mesures, avec leurs bornes ; aucune formulation « promising ».
- **`dm_p_median` / Diebold-Mariano : sans objet ici, et je ne le simule pas.** Le DM compare deux series **appariees de pertes de prevision** (`loss_fn` sur `mse`/`mae`). Cette tranche ne produit ni prevision ni perte : elle compare une **distribution de rangs et de rapports** entre deux bras, sur des series synthetiques. Le test pertinent pour un recouvrement de distributions est celui du comptage de paires, qui est exact et sans hypothese — **0 inversion sur 400** — et c'est celui qui est rapporte.
- **Aucun claim de rentabilite.** Le notebook le dit explicitement : la porte reste ouverte cote rotator (verdict `IGNORE` du body), et cette tranche ne le rouvre pas.

## Verification

- **Re-execution reelle** : `notebook_tools.py execute --kernel python3` → SUCCESS en 6.3 s, **0 cellule en erreur**, `execution_count` **1..8 contigus** (`check_exec_sequence.py` : CLEAN 1..N, 0 gap/duplicate/unordered).
- **Determinisme du corpus existant** : les 13 cellules d'origine sont preservees, **12 byte-identiques en source**, et leurs **sorties commitees sont byte-identiques apres re-execution** (comparaison texte des 6 cellules de code contre `HEAD`). Le diff de sorties est donc uniquement de l'horodatage d'execution.
- **C.2 / H.3** : `check_c2_compliance.py` 1/1 conforme ; `validate_pr_notebooks.py` 1/1 PASS (8 cellules code) ; pre-commit complet **9 hooks Passed**, dont H.3 (`execution_count=null + outputs=[]`) et le scrubber de chemins papermill.
- **Hygiène** : fichier **LF**, **0 caractere non-ASCII** (le fichier etait deja en ASCII sans accents, la convention est preservee) ; `metadata.papermill.input_path`/`output_path` ramenes au **basename** — ils contenaient le chemin absolu du worktree, ce qui aurait ete un chemin machine commite.
- **Ratchet sorties** : `check_output_failure_text.py` → 0 notebook change, **0 regresse** (aucune banniere `TOOL_FAILURE` / `MACHINE_PATH` introduite).
- **Aucune collision** : `check_lane_claim.py 14991 --paths <les 2 fichiers>` → `CLEAR` ; `gh pr list --state open --json files` ne montre **aucune** PR ouverte sur ces deux chemins (les deux PR ouvertes qui touchent `research/`, #15446 et #15146, portent sur `research_m11ef_ensemble.ipynb` et `research_rl_multi_asset.ipynb`).
- `COURSE_CATALOG.generated.*` : **non touche** (byte-identique a `main`).

## Ce que cette PR ne fait pas

- Pas de rotator, pas de QC Cloud, pas de backtest : le verdict `IGNORE` du body de #14991 sur le rotator reste valide et n'est pas rouvert.
- Pas de generalisation a une serie reelle : la mesure porte sur une periodicite **sinusoidale pure** et un bruit **log-normal independant**. C'est ecrit dans le notebook, dans la section « Ce que ce controle n'etablit pas ».

See #14991 (contribution : l'issue coordonne l'experience et ne sera pas auto-close par une vague partielle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
