### PR TITLE
fix(guard,#15578): le detecteur de collisions se tait quand la substance passe sur main

### DIFF
--- a/.github/workflows/pr-path-collision-advisory.yml
+++ b/.github/workflows/pr-path-collision-advisory.yml
@@ -42,6 +42,24 @@ name: PR path-collision advisory
 # is absent from the required set and from the PR gate roster. Its own run,
 # however, goes red when writes are lost (#14236, --fail-on-write-loss) --
 # a muted organ has no other way to say that it is mute.
+#
+# Candidate pool widened to recently-MERGED PRs (#15578). The pool was
+# `--state open` only, so a collision vanished from the report at the exact
+# moment it became irreversible. Measured on the founding instance: at
+# 2026-09-10T23:18Z the advisory posted a `faible` collision between #15513
+# and #15455 over five identical paths; #15455 merged at 2026-09-11T08:37Z and
+# the pair left the pool, though the duplicate was by then consumed. A pair
+# with one merged side now carries the TERMINAL verdict (never a tier: the
+# substance is on `main`), all-merged pairs stay excluded, and open/open tiers
+# are untouched. Depth is `--merged-window-days` (default 3, 0 disables).
+#
+# The merged side must also OVERLAP substantially (>= TERMINAL_MIN_OVERLAP_RATIO
+# of BOTH sides' signal paths, 0.5): measured on the 2026-09-11 snapshot, an
+# ungated rule reached 37 of the 64 open PRs -- every other open PR, the
+# "reports everything reports nothing" collapse -- while the gate cuts it to 16
+# and still keeps the founding duplicate (5 shared out of 5 and of 6 = 0.83).
+# A sub-threshold pair is not silently dropped: it is counted and named under
+# `merged-side low-overlap excluded` in the run summary.
 
 on:
   # Off-round minutes: the top of the hour is when every cron in the account
@@ -56,7 +74,7 @@ on:
         type: boolean
         default: true
       same_issue_only:
-        description: 'Post only strong-tier collisions (common cited issue)'
+        description: 'Post only the actionable tiers: strong (common cited issue) or terminal (other side already merged)'
         required: false
         type: boolean
         default: false

--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -55,6 +55,35 @@ noise that gets ignored:
 Strong pairs are additionally labelled ``pr-overlap`` (label on both sides),
 giving the coordinator a filterable queue. Weak pairs get the comment only.
 
+Terminal verdict: a merged side (#15578)
+----------------------------------------
+The candidate pool was ``--state open`` exclusively, so a collision *vanished
+from the report at the exact moment it became irreversible*: when one side
+merged. The organ was loudest while the risk was theoretical, and mute once
+the substance was on ``main``.
+
+Measured on the founding instance: at 2026-09-10T23:18Z the advisory posted a
+``faible`` collision between #15513 and #15455 over five identical paths --
+two independent implementations of the same paragraph-length detector. #15455
+merged at 2026-09-11T08:37Z, the pair left the pool, and the signal went
+silent although the duplicate was by then CONSUMED: the lane found it by
+itself and escalated without delivering.
+
+The pool therefore also carries PRs merged within a bounded window
+(``--merged-window-days`` -- an argument, never a buried constant):
+
+- a pair with ONE merged side is **terminal**. It is not graduated and not
+  tiered: the substance is already on ``main``, and the comment says exactly
+  that. Terminal *replaces the silence*, it does not inflate the open tiers;
+- a pair with BOTH sides merged carries no signal (both are already on
+  ``main``: history, not a collision) and is excluded, like stacked pairs;
+- the tier of OPEN/OPEN pairs is untouched (#15578 acceptance 4). The lesson
+  is not "everything is strong": it is that the state of the other side
+  dominates the path overlap.
+
+Only OPEN PRs are ever commented. An advisory written on a merged PR would be
+noise on a closed thread, and the actionable side is always the open one.
+
 Scope (from #13359)
 -------------------
 - Invent NO new claim lock. Do not touch `check_lane_claim.py` -- the claim
@@ -90,11 +119,15 @@ CLI flags
 ``--limit``       cap PRs fetched via ``gh pr list`` (default 500; the default
                   ``gh pr list`` limit is 30 -- a silent cap that hid entire
                   stacks this month). 500 covers the whole open pool here.
+``--merged-window-days``
+                  depth of the MERGED pool, in days (default 3; 0 disables).
+                  The bound is an argument, never a buried constant (#15578).
 ``--repo``        override repo (default: gh default / GITHUB_REPOSITORY).
 ``--dry-run``     log detections, post/retract/label nothing.
 ``--same-issue-only``
-                  post only STRONG-tier collisions (both PRs cite a common
-                  issue). Cuts the shared-README noise.
+                  post only the actionable tiers: STRONG (both PRs cite a
+                  common issue) and TERMINAL (the other side already merged).
+                  Cuts the shared-README noise.
 --json            always on stdout.
 --self-test       run the offline control suite; exit 2 if any control fails.
 """
@@ -103,7 +136,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import re
 import subprocess
@@ -127,6 +160,34 @@ OVERLAP_LABEL = "pr-overlap"
 
 TIER_STRONG = "strong"
 TIER_WEAK = "weak"
+# A pair with a merged side is not a tier, it is a terminal state (#15578).
+TIER_TERMINAL = "terminal"
+
+# ``gh`` reports PR state as OPEN / MERGED / CLOSED; only "merged" is terminal.
+MERGED_STATE = "merged"
+
+# Default depth of the merged window. The useful window is the one in which a
+# still-open branch could have been opened before the merge and can still be
+# unaware of it -- a few days, not a quarter. Overridden by the CLI argument
+# ``--merged-window-days`` (the bound is an argument, not a buried constant).
+DEFAULT_MERGED_WINDOW_DAYS = 3
+
+# A merged side is TERMINAL only when the two deliveries actually overlap --
+# the "full double delivery" of #15578, never a coincidental shared
+# ``.gitignore``. The measure is the share of EACH side's signal paths that is
+# covered by the shared ones: BOTH sides must be substantially covered, which
+# is what separates "the same substance delivered twice" from "a long-lived PR
+# that merely neighbours a small merge".
+#
+# Calibrated on ONE live snapshot (2026-09-11, 64 open + 282 merged, 3-day
+# window; the pool drifts, so these are that snapshot's numbers): ungated, 96
+# merged-side pairs reached 37 of the 64 open PRs -- every other open PR, i.e.
+# the "reports everything" collapse this module's docstring warns about. At 0.5
+# the same snapshot yields 23 pairs / 16 open PRs, and the founding
+# #15513/#15455 duplicate scores 0.83 (5 shared, out of 5 and of 6).
+# Rejected alternative, measured: ``shared / min(sizes)`` keeps the same ~37 --
+# a 1-file merged PR sharing its only file scores 1.00 for trivial reasons.
+TERMINAL_MIN_OVERLAP_RATIO = 0.5
 
 # The synthetic positive control. NOT a live repo pair (those are volatile:
 # they merge and vanish). It is seeded straight into the pure detector, so the
@@ -147,6 +208,28 @@ HISTORICAL_STRONG_PAIRS: tuple[tuple[int, int, str, int], ...] = (
     (12737, 13385,
      "MyIA.AI.Notebooks/GameTheory/GameTheory-04-NashEquilibrium.ipynb",
      13313),
+)
+
+# The founding instance of #15578, replayed at its state of then: #15455 merged
+# at 2026-09-11T08:37Z while #15513 was still open, over the same five paths --
+# two independent implementations of the same paragraph-length detector. The
+# paths are READ FROM THE TWO PRS (``gh pr view --json files``), not invented.
+# Under the pre-#15578 pool (``--state open`` only) the pair is invisible, and
+# that invisibility IS the defect.
+FOUNDING_TERMINAL_PAIR: tuple[int, int, tuple[str, ...], str] = (
+    15513, 15455,
+    (
+        ".github/workflows/paragraph-length-advisory.yml",
+        "scripts/notebook_tools/README.md",
+        "scripts/notebook_tools/detect_paragraph_length.py",
+        "scripts/notebook_tools/tests/fixtures/paragraph_wall_md.md",
+        "scripts/notebook_tools/tests/test_detect_paragraph_length.py",
+    ),
+    # #15455's sixth path, unshared -- the real overlap is 5 of 5 and 5 of 6,
+    # i.e. 0.83, NOT a trivial 1.00. A fixture that scores a perfect ratio
+    # would prove the gate admits the founding case for a reason the live pool
+    # never offers.
+    "scripts/ci/check_self_hosted_runner_policy.py",
 )
 
 # Generated artifacts with permanent structural overlap and zero signal
@@ -177,12 +260,21 @@ def _is_signal_path(path: str) -> bool:
 
 @dataclass(frozen=True)
 class PathCollision:
-    """An unordered pair of open PRs sharing at least one signal file path."""
+    """An unordered pair of PRs sharing at least one signal file path.
+
+    ``merged_side`` is set only for a terminal pair (#15578): it names the side
+    already on ``main``, so the comment can say which number is consumed
+    instead of guessing from the tier. ``overlap_ratio`` carries the measured
+    ``min`` coverage that put the pair over ``TERMINAL_MIN_OVERLAP_RATIO``, so
+    a reader can audit the gate's decision instead of trusting it.
+    """
     a_number: int
     b_number: int
     shared_paths: tuple[str, ...]
     tier: str = TIER_WEAK
     common_issues: tuple[int, ...] = ()
+    merged_side: int | None = None
+    overlap_ratio: float | None = None
 
     def other(self, number: int) -> int:
         if number == self.a_number:
@@ -198,18 +290,31 @@ class PathCollision:
             "shared_paths": list(self.shared_paths),
             "tier": self.tier,
             "common_issues": list(self.common_issues),
+            "merged_side": self.merged_side,
+            "overlap_ratio": self.overlap_ratio,
         }
 
 
 @dataclass(frozen=True)
 class PrRow:
-    """Minimal open PR record the detector needs."""
+    """Minimal PR record the detector needs.
+
+    ``state`` defaults to ``"open"``: every pre-#15578 construction -- and
+    every fixture in the unit suite -- is an open PR, so widening the pool
+    cannot silently move an existing pair into the terminal verdict.
+    """
     number: int
     title: str
     paths: tuple[str, ...]
     body: str = ""
     base_ref: str = ""
     head_ref: str = ""
+    state: str = "open"
+    merged_at: str = ""
+
+    @property
+    def is_merged(self) -> bool:
+        return self.state.strip().lower() == MERGED_STATE
 
     @classmethod
     def from_gh_dict(cls, d: dict) -> "PrRow":
@@ -225,6 +330,8 @@ class PrRow:
             body=(d.get("body") or ""),
             base_ref=(d.get("baseRefName") or "").strip(),
             head_ref=(d.get("headRefName") or "").strip(),
+            state=(d.get("state") or "open").strip().lower(),
+            merged_at=(d.get("mergedAt") or "").strip(),
         )
 
     def cited_issues(self) -> set[int]:
@@ -232,6 +339,25 @@ class PrRow:
         ``Closes|Fixes|Resolves|See|refs|Part of #N`` from the body."""
         from_title = {int(n) for n in re.findall(r"#(\d+)", self.title or "")}
         return from_title | {int(n) for n in _CITES_RE.findall(self.body or "")}
+
+
+def terminal_overlap_ratio(
+    shared_paths: Iterable[str], a: PrRow, b: PrRow,
+) -> float:
+    """Share of EACH side's signal paths covered by the shared ones (min).
+
+    ``min`` over the two sides: a large PR overlapping a small one on a single
+    file scores low, because that is not a duplicate delivery. Returns 0.0 when
+    either side carries no signal path -- an empty denominator must never read
+    as a perfect overlap.
+    """
+    shared = set(shared_paths)
+    a_sig = {p for p in a.paths if _is_signal_path(p)}
+    b_sig = {p for p in b.paths if _is_signal_path(p)}
+    if not a_sig or not b_sig:
+        return 0.0
+    return min(len(shared & a_sig) / len(a_sig),
+               len(shared & b_sig) / len(b_sig))
 
 
 def is_stacked(a: PrRow, b: PrRow) -> bool:
@@ -250,10 +376,13 @@ def is_stacked(a: PrRow, b: PrRow) -> bool:
 class ScanResult:
     """Aggregate of one detection run."""
     total_prs_scanned: int = 0
+    merged_prs_scanned: int = 0
     distinct_paths: int = 0
     collisions: list[PathCollision] = field(default_factory=list)
     colliding_prs: list[int] = field(default_factory=list)
     stacked_pairs_excluded: list[tuple[int, int]] = field(default_factory=list)
+    merged_pairs_excluded: list[tuple[int, int]] = field(default_factory=list)
+    merged_low_overlap_excluded: list[tuple[int, int]] = field(default_factory=list)
 
     @property
     def n_collisions(self) -> int:
@@ -263,30 +392,64 @@ class ScanResult:
     def strong_collisions(self) -> list[PathCollision]:
         return [c for c in self.collisions if c.tier == TIER_STRONG]
 
+    @property
+    def terminal_collisions(self) -> list[PathCollision]:
+        """Pairs whose substance is already on ``main`` (#15578)."""
+        return [c for c in self.collisions if c.tier == TIER_TERMINAL]
+
+    def actionable_collisions(self) -> list[PathCollision]:
+        """Pairs worth posting when the caller wants the noise cut.
+
+        STRONG and TERMINAL, never the open tiers' weak family-README noise.
+        A terminal pair is by definition not that noise: the substance is
+        already merged, which is the strongest thing this organ can observe.
+        """
+        return [c for c in self.collisions if c.tier in (TIER_STRONG, TIER_TERMINAL)]
+
     def as_dict(self) -> dict:
         return {
             "total_prs_scanned": self.total_prs_scanned,
+            "merged_prs_scanned": self.merged_prs_scanned,
             "distinct_paths": self.distinct_paths,
             "n_collisions": self.n_collisions,
+            "n_strong": len(self.strong_collisions),
+            "n_weak": sum(1 for c in self.collisions if c.tier == TIER_WEAK),
+            "n_terminal": len(self.terminal_collisions),
             "collisions": [c.as_dict() for c in self.collisions],
             "colliding_prs": self.colliding_prs,
             "stacked_pairs_excluded": [list(p) for p in self.stacked_pairs_excluded],
+            "merged_pairs_excluded": [list(p) for p in self.merged_pairs_excluded],
+            "merged_low_overlap_excluded": [
+                list(p) for p in self.merged_low_overlap_excluded
+            ],
         }
 
 
 def detect_path_collisions(prs: Iterable[PrRow]) -> ScanResult:
-    """Group open PRs by signal file path; report every pair sharing >=1 path.
+    """Group the pool by signal file path; report every pair sharing >=1 path.
 
     ``prs`` is consumed once. The result is deterministic: collisions sorted by
     (lowest number, highest number), shared paths sorted by path string.
 
-    Excluded before pairing (#13615): generated-artifact paths (dropped from
-    every row -- they never carry signal), and stacked PR pairs (dropped from
-    the pair set -- their overlap is the stack itself).
+    Excluded before pairing:
+    - generated-artifact paths (#13615): dropped from every row -- they never
+      carry signal;
+    - stacked PR pairs (#13615): dropped from the pair set -- their overlap is
+      the stack itself;
+    - all-merged pairs (#15578): dropped from the pair set -- both sides are
+      already on ``main``, which is history, not a collision;
+    - merged-side pairs below ``TERMINAL_MIN_OVERLAP_RATIO`` (#15578): dropped,
+      and recorded in ``merged_low_overlap_excluded`` -- an incidental shared
+      ``.gitignore`` is not a double delivery.
+
+    A pair with EXACTLY ONE merged side and a substantial overlap is reported
+    with the terminal verdict and carries ``merged_side`` + ``overlap_ratio``;
+    the open/open tiering is untouched.
     """
     result = ScanResult()
     rows = list(prs)
     result.total_prs_scanned = len(rows)
+    result.merged_prs_scanned = sum(1 for r in rows if r.is_merged)
     row_by_number = {r.number: r for r in rows}
 
     path_to_numbers: dict[str, set[int]] = {}
@@ -316,15 +479,34 @@ def detect_path_collisions(prs: Iterable[PrRow]) -> ScanResult:
         if ra is not None and rb is not None and is_stacked(ra, rb):
             result.stacked_pairs_excluded.append((a, b))
             continue
+        merged_sides = [
+            r.number for r in (ra, rb) if r is not None and r.is_merged
+        ]
+        if len(merged_sides) == 2:
+            result.merged_pairs_excluded.append((a, b))
+            continue
         common: tuple[int, ...] = ()
         if ra is not None and rb is not None:
             common = tuple(sorted(ra.cited_issues() & rb.cited_issues()))
+        if merged_sides:
+            ratio = (
+                terminal_overlap_ratio(paths, ra, rb)
+                if ra is not None and rb is not None else 0.0
+            )
+            if ratio < TERMINAL_MIN_OVERLAP_RATIO:
+                result.merged_low_overlap_excluded.append((a, b))
+                continue
+            tier, merged_side = TIER_TERMINAL, merged_sides[0]
+        else:
+            tier, merged_side, ratio = (TIER_STRONG if common else TIER_WEAK), None, None
         collisions.append(PathCollision(
             a_number=a,
             b_number=b,
             shared_paths=tuple(sorted(paths)),
-            tier=TIER_STRONG if common else TIER_WEAK,
+            tier=tier,
             common_issues=common,
+            merged_side=merged_side,
+            overlap_ratio=ratio,
         ))
     result.collisions = collisions
     result.colliding_prs = sorted(
@@ -354,6 +536,11 @@ def render_comment(number: int, title: str, own_collisions: list[PathCollision])
     Names each colliding PR by number, its tier, the shared paths, and (for
     the strong tier) the common cited issues. Marker-framed so a re-run can
     find, refresh, or retract it in place.
+
+    The open-pair rendering is byte-identical to the pre-#15578 one, so the
+    widened pool does not churn a single existing comment: only a pair that
+    actually went terminal changes its body (and the closing note is appended
+    only when such a pair is present).
     """
     lines = [
         "<!-- PR-PATH-COLLISION:START -->",
@@ -369,12 +556,34 @@ def render_comment(number: int, title: str, own_collisions: list[PathCollision])
     ]
     for c in sorted(own_collisions, key=lambda c: c.other(number)):
         other = c.other(number)
-        tier_fr = "fort" if c.tier == TIER_STRONG else "faible"
-        line = f"- **{tier_fr}** -- **#{other}** partage : {', '.join(c.shared_paths)}"
+        if c.tier == TIER_TERMINAL:
+            consumed = c.merged_side if c.merged_side is not None else other
+            ratio = (
+                f" (recouvrement {c.overlap_ratio:.0%})"
+                if c.overlap_ratio is not None else ""
+            )
+            line = (
+                f"- **terminal** -- **#{other}** partage : "
+                f"{', '.join(c.shared_paths)}{ratio} -- **#{consumed}** est "
+                "deja sur `main`, la substance est consommee."
+            )
+        else:
+            tier_fr = "fort" if c.tier == TIER_STRONG else "faible"
+            line = (
+                f"- **{tier_fr}** -- **#{other}** partage : "
+                f"{', '.join(c.shared_paths)}"
+            )
         if c.common_issues:
             issues = ", ".join(f"#{i}" for i in c.common_issues)
             line += f" (issues communes : {issues})"
         lines.append(line)
+    if any(c.tier == TIER_TERMINAL for c in own_collisions):
+        lines.append("")
+        lines.append(
+            "Le verdict **terminal** (#15578) signifie que la substance est "
+            "deja sur `main` : le cote merge n'est plus une collision a "
+            "arbitrer, c'est du travail deja integre."
+        )
     lines.append("")
     lines.append("<!-- PR-PATH-COLLISION:END -->")
     return "\n".join(lines)
@@ -522,6 +731,40 @@ def list_open_prs(repo: str, limit: int) -> list[PrRow]:
         "--json", "number,title,body,baseRefName,headRefName,files",
     ]) or []
     return [PrRow.from_gh_dict(d) for d in raw]
+
+
+def list_recently_merged_prs(
+    repo: str, since_date: str, limit: int,
+) -> list[PrRow]:
+    """PRs merged on or after ``since_date`` (``YYYY-MM-DD``), with paths.
+
+    The window is bounded SERVER-side (``merged:>=``) because ``gh pr list``
+    orders by CREATION date: a purely client-side window over a truncated page
+    would systematically lose the long-lived branches -- exactly the ones that
+    collide most. The client-side re-filter is kept as a cheap invariant (the
+    search qualifier and the ``mergedAt`` field must agree; a divergence would
+    make the pool silently wrong) and it is what makes the function testable
+    without the network.
+
+    A failure is NOT swallowed here. The caller decides -- an advisory organ
+    that goes mute on a query quirk is the very defect #15578 reports.
+    """
+    raw = _gh_json([
+        "pr", "list", "--repo", repo, "--state", "merged",
+        "--search", f"merged:>={since_date}",
+        "--limit", str(limit),
+        "--json",
+        "number,title,body,baseRefName,headRefName,files,state,mergedAt",
+    ]) or []
+    rows: list[PrRow] = []
+    for d in raw:
+        row = PrRow.from_gh_dict(d)
+        if row.state != MERGED_STATE:
+            continue
+        if row.merged_at and row.merged_at[:10] < since_date:
+            continue
+        rows.append(row)
+    return rows
 
 
 def find_marker(repo: str, number: int) -> tuple[str, str] | None:
@@ -702,14 +945,25 @@ def label_strong_pairs(
             print(f"  label {OVERLAP_LABEL} -> #{number}", file=sys.stderr)
 
 
+def _fmt_pairs(pairs: list[tuple[int, int]], limit: int = 8) -> str:
+    """Render exclusion pairs, capped -- a 176-pair line drowns the summary."""
+    shown = ", ".join(f"#{a}/#{b}" for a, b in pairs[:limit])
+    if len(pairs) > limit:
+        return f"({len(pairs)}) {shown}, ..."
+    return shown
+
+
 def _format_human_summary(result: ScanResult) -> str:
     lines = []
+    n_weak = sum(1 for c in result.collisions if c.tier == TIER_WEAK)
     lines.append(
         f"scanned={result.total_prs_scanned} "
+        f"(merged={result.merged_prs_scanned}) "
         f"distinct_paths={result.distinct_paths} "
         f"collisions={result.n_collisions} "
         f"(strong={len(result.strong_collisions)} "
-        f"weak={result.n_collisions - len(result.strong_collisions)})"
+        f"weak={n_weak} "
+        f"terminal={len(result.terminal_collisions)})"
     )
     for c in result.collisions[:20]:
         lines.append(
@@ -721,8 +975,20 @@ def _format_human_summary(result: ScanResult) -> str:
     if result.n_collisions > 20:
         lines.append(f"  ... and {result.n_collisions - 20} more (see JSON)")
     if result.stacked_pairs_excluded:
-        pairs = ", ".join(f"#{a}/#{b}" for a, b in result.stacked_pairs_excluded)
-        lines.append(f"  stacked excluded: {pairs}")
+        lines.append(
+            f"  stacked excluded: {_fmt_pairs(result.stacked_pairs_excluded)}"
+        )
+    if result.merged_pairs_excluded:
+        lines.append(
+            f"  both-merged excluded: "
+            f"{_fmt_pairs(result.merged_pairs_excluded)}"
+        )
+    if result.merged_low_overlap_excluded:
+        lines.append(
+            f"  merged-side low-overlap excluded "
+            f"(< {TERMINAL_MIN_OVERLAP_RATIO:.0%}): "
+            f"{_fmt_pairs(result.merged_low_overlap_excluded)}"
+        )
     return "\n".join(lines)
 
 
@@ -770,6 +1036,83 @@ def _self_test() -> int:
               and coll.tier == TIER_STRONG
               and issue in coll.common_issues
               and path in coll.shared_paths)
+
+    # Founding instance of #15578 (#15578 acceptance 3): one side merged ->
+    # TERMINAL and the merged side is NAMED. Reverting the fix reds this
+    # control -- an open-only pool does not even carry the merged row, so the
+    # pair disappears (measured: see the PR body's replay of the suite against
+    # the pre-fix script).
+    f_open, f_merged, f_paths, f_extra = FOUNDING_TERMINAL_PAIR
+    founding = detect_path_collisions([
+        PrRow(number=f_open, title="tooling(notebook): detecteur", paths=f_paths),
+        PrRow(number=f_merged, title="tooling(#15405): detecteur",
+              paths=f_paths + (f_extra,),
+              state=MERGED_STATE, merged_at="2026-09-11T08:37:34Z"),
+    ])
+    term = next((c for c in founding.collisions
+                 if {c.a_number, c.b_number} == {f_open, f_merged}), None)
+    check(f"founding #{f_open}/#{f_merged} flagged terminal, merged side named",
+          term is not None
+          and term.tier == TIER_TERMINAL
+          and term.merged_side == f_merged
+          and len(term.shared_paths) == len(f_paths))
+
+    # Calibration control: the gate must ADMIT the founding case, and it must
+    # do so at its REAL ratio (5 of 5 and 5 of 6 = 0.83), not a fixture-perfect
+    # 1.00. If someone raises TERMINAL_MIN_OVERLAP_RATIO past the measured
+    # duplicate, this reds -- which is the point.
+    check(f"founding pair clears the gate at its measured ratio "
+          f"(>= {TERMINAL_MIN_OVERLAP_RATIO:.0%})",
+          term is not None
+          and term.overlap_ratio is not None
+          and abs(term.overlap_ratio - 5 / 6) < 1e-9
+          and len(f_extra) > 0)
+
+    # Calibration negative: an incidental shared path is NOT a double
+    # delivery. A 12-file PR sharing one `.gitignore` with a 1-file merged PR
+    # is noise, and posting it is how the organ becomes unreadable.
+    low = detect_path_collisions([
+        PrRow(number=900070, title="feat: big",
+              paths=(".gitignore",) + tuple(f"big/{i}.py" for i in range(11))),
+        PrRow(number=900071, title="fix: small", paths=(".gitignore",),
+              state=MERGED_STATE),
+    ])
+    check("incidental low-overlap merged pair is excluded, not reported",
+          low.n_collisions == 0
+          and (900070, 900071) in low.merged_low_overlap_excluded)
+
+    # ... and a terminal pair is NOT dropped by the --same-issue-only filter:
+    # the substance being already merged is the loudest thing this organ sees.
+    check("terminal survives the actionable (same-issue-only) selector",
+          [c.tier for c in founding.actionable_collisions()] == [TIER_TERMINAL])
+
+    # Negative: TWO merged sides are history, not a collision -> NOTHING.
+    both_merged = detect_path_collisions([
+        PrRow(number=900050, title="old a", paths=("gone/x.md",),
+              state=MERGED_STATE),
+        PrRow(number=900051, title="old b", paths=("gone/x.md",),
+              state=MERGED_STATE),
+    ])
+    check("both-merged pair produces no collision",
+          both_merged.n_collisions == 0
+          and (900050, 900051) in both_merged.merged_pairs_excluded)
+
+    # Acceptance 4: a merged row must not inflate (nor deflate) an unrelated
+    # OPEN/OPEN pair -- the open tiers keep their own behaviour.
+    mixed = detect_path_collisions([
+        PrRow(number=900060, title="fix(#500): a", paths=("open/y.md",)),
+        PrRow(number=900061, title="fix(#500): b", paths=("open/y.md",)),
+        PrRow(number=900062, title="merged z", paths=("gone/z.md",),
+              state=MERGED_STATE),
+    ])
+    check("open pair keeps its strong tier beside a merged row",
+          any(c.tier == TIER_STRONG
+              and {c.a_number, c.b_number} == {900060, 900061}
+              for c in mixed.collisions))
+
+    # Acceptance 4 (negative half): a merged row sharing NO path adds nothing.
+    check("merged row without a shared path is not reported",
+          mixed.n_collisions == 1)
 
     # Negative: stacked pair (base of one = head of the other) -> NOTHING.
     stacked = detect_path_collisions([
@@ -847,6 +1190,17 @@ def _cli(argv: list[str] | None = None) -> int:
             "(#14236), and a green run reads as `nothing to report`."
         ),
     )
+    ap.add_argument(
+        "--merged-window-days", type=int,
+        default=DEFAULT_MERGED_WINDOW_DAYS,
+        help=(
+            "depth of the MERGED pool, in days (default "
+            f"{DEFAULT_MERGED_WINDOW_DAYS}). A pair whose other side merged "
+            "inside the window is reported with the terminal verdict instead "
+            "of vanishing (#15578). 0 disables the merged pool entirely, "
+            "restoring the pre-#15578 behaviour."
+        ),
+    )
     ap.add_argument("--self-test", action="store_true",
                     help="run the offline control suite; exit 2 if any fails")
     args = ap.parse_args(argv)
@@ -856,15 +1210,38 @@ def _cli(argv: list[str] | None = None) -> int:
 
     repo = args.repo or _repo_default()
     try:
-        prs = list_open_prs(repo, args.limit)
+        open_prs = list_open_prs(repo, args.limit)
     except RuntimeError as e:
         print(str(e), file=sys.stderr)
         return 0  # advisory: a listing failure must not red the run
 
+    merged_prs: list[PrRow] = []
+    if args.merged_window_days > 0:
+        since = (
+            datetime.now(timezone.utc) - timedelta(days=args.merged_window_days)
+        ).strftime("%Y-%m-%d")
+        try:
+            merged_prs = list_recently_merged_prs(repo, since, args.limit)
+        except RuntimeError as e:
+            # Never silent. A lost merged pool returns the organ to the very
+            # muteness #15578 reports, and a green run would read as "nothing
+            # to report". The loss is logged here AND left visible in the JSON
+            # (merged_prs_scanned=0 over a window that cannot be empty).
+            print(
+                f"WARN: merged pool unavailable ({args.merged_window_days}d "
+                f"window, since {since}) -- falling back to open PRs only: {e}",
+                file=sys.stderr,
+            )
+
+    prs = open_prs + merged_prs
+    open_numbers = {p.number for p in open_prs}
     result = detect_path_collisions(prs)
 
     if args.same_issue_only and result.collisions:
-        result.collisions = strong_collisions(result.collisions)
+        # STRONG and TERMINAL (#15578): a terminal pair is not the family-
+        # README noise this flag exists to cut, it is the loudest signal the
+        # organ has -- the substance is already on main.
+        result.collisions = result.actionable_collisions()
         result.colliding_prs = sorted(
             {n for c in result.collisions for n in (c.a_number, c.b_number)}
         )
@@ -872,10 +1249,14 @@ def _cli(argv: list[str] | None = None) -> int:
     print(json.dumps(result.as_dict(), ensure_ascii=False, indent=2))
     print(_format_human_summary(result), file=sys.stderr)
 
-    # Plan over the UNION colliding ∪ marker-carriers (#13489): reads only.
-    title_by_number = {p.number: p.title for p in prs}
+    # Plan over the UNION (colliding ∩ open) ∪ marker-carriers (#13489).
+    # Merged PRs are excluded from the write set (#15578): an advisory on a
+    # closed thread is noise, and the actionable side of a terminal pair is
+    # always the open one. The marker scan stays on the OPEN pool for the same
+    # reason -- no API call is spent on a PR that can never be written to.
+    title_by_number = {p.number: p.title for p in open_prs}
     marker_by_number, scan_failed = scan_markers(
-        repo, [p.number for p in prs]
+        repo, [p.number for p in open_prs]
     )
     for number in sorted(scan_failed):
         print(
@@ -885,7 +1266,8 @@ def _cli(argv: list[str] | None = None) -> int:
         )
     plan = [
         a for a in plan_actions(
-            set(result.colliding_prs), result.collisions, title_by_number,
+            sorted(set(result.colliding_prs) & open_numbers),
+            result.collisions, title_by_number,
             marker_by_number,
             datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ"),
         )

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -45,9 +45,11 @@ HISTORICAL_STRONG_PAIRS = _mod.HISTORICAL_STRONG_PAIRS
 
 
 def _pr(number: int, paths: list[str], title: str = "", body: str = "",
-        base_ref: str = "", head_ref: str = "") -> PrRow:
+        base_ref: str = "", head_ref: str = "", state: str = "open",
+        merged_at: str = "") -> PrRow:
     return PrRow(number=number, title=title, paths=tuple(paths), body=body,
-                 base_ref=base_ref, head_ref=head_ref)
+                 base_ref=base_ref, head_ref=head_ref, state=state,
+                 merged_at=merged_at)
 
 
 class TestDetectPathCollisions(unittest.TestCase):
@@ -272,6 +274,252 @@ class TestHistoricalPairs(unittest.TestCase):
                     proc.returncode, 0,
                     f"fixture path {path} does not exist in the checkout",
                 )
+
+
+class TestTerminalMergedPairs(unittest.TestCase):
+    """#15578: the collision must NOT vanish when one side merges.
+
+    The founding instance: #15455 merged at 2026-09-11T08:37Z while #15513 was
+    still open, over five identical paths. Under the pre-fix pool
+    (``--state open`` only) the pair was invisible -- so the organ was loudest
+    while the risk was theoretical and mute once the substance was on ``main``.
+    """
+
+    def test_founding_instance_is_terminal_not_silent(self):
+        """Acceptance 1+2: a merged side yields a TERMINAL verdict, named."""
+        f_open, f_merged, f_paths, f_extra = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(f_open, list(f_paths), title="tooling(notebook): detecteur"),
+            _pr(f_merged, list(f_paths) + [f_extra],
+                title="tooling(#15405): detecteur",
+                state="merged", merged_at="2026-09-11T08:37:34Z"),
+        ])
+        self.assertEqual(result.n_collisions, 1)
+        c = result.collisions[0]
+        # Deterministic pair order is (lowest, highest) -- #15455 < #15513.
+        self.assertEqual((c.a_number, c.b_number), (f_merged, f_open))
+        self.assertEqual(c.tier, "terminal")
+        self.assertEqual(c.merged_side, f_merged)
+        self.assertEqual(len(c.shared_paths), len(f_paths))
+        self.assertEqual(result.terminal_collisions, [c])
+
+    def test_terminal_is_distinct_from_the_open_tiers(self):
+        """The verdict is terminal, NOT a graduation of strong/weak."""
+        _, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(1, list(f_paths), title="fix(#42): same issue"),
+            _pr(f_merged, list(f_paths), title="fix(#42): same issue",
+                state="merged"),
+        ])
+        c = result.collisions[0]
+        self.assertEqual(c.tier, "terminal")
+        self.assertNotEqual(c.tier, "strong")
+        # A terminal pair is NOT strong: it must not reach the label path,
+        # which would tag the merged side of a closed thread.
+        self.assertEqual(result.strong_collisions, [])
+
+    def test_both_merged_pair_is_history_not_a_collision(self):
+        """Acceptance 4: two merged sides are both on main -> NOTHING."""
+        result = detect_path_collisions([
+            _pr(900050, ["gone/x.md"], state="merged"),
+            _pr(900051, ["gone/x.md"], state="merged"),
+        ])
+        self.assertEqual(result.n_collisions, 0)
+        self.assertIn((900050, 900051), result.merged_pairs_excluded)
+
+    def test_terminal_carries_the_measured_overlap_ratio(self):
+        """Acceptance 3: the verdict is auditable, not merely asserted.
+
+        The founding pair's real overlap is 5 of 5 and 5 of 6 -> 0.833..., so a
+        fixture scoring a perfect 1.00 would hide how close the gate runs to
+        its threshold.
+        """
+        f_open, f_merged, f_paths, f_extra = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(f_open, list(f_paths)),
+            _pr(f_merged, list(f_paths) + [f_extra], state="merged"),
+        ])
+        c = result.collisions[0]
+        self.assertAlmostEqual(c.overlap_ratio, 5 / 6)
+
+    def test_incidental_low_overlap_merged_pair_is_excluded(self):
+        """A shared ``.gitignore`` is not a double delivery (#15578 calibration).
+
+        Ungated, this measurement put 95 pairs on 36 of 63 open PRs -- every
+        other open PR -- which is the "reports everything" collapse the module
+        docstring warns about.
+        """
+        result = detect_path_collisions([
+            _pr(900070, [".gitignore"] + [f"big/{i}.py" for i in range(11)]),
+            _pr(900071, [".gitignore"], state="merged"),
+        ])
+        self.assertEqual(result.n_collisions, 0)
+        self.assertIn((900070, 900071), result.merged_low_overlap_excluded)
+        self.assertEqual(result.terminal_collisions, [])
+
+    def test_overlap_ratio_boundary_is_inclusive(self):
+        """Exactly at the threshold is KEPT: the gate is a floor, not a cliff."""
+        n_shared = int(round(_mod.TERMINAL_MIN_OVERLAP_RATIO * 4))
+        shared = [f"s/{i}.py" for i in range(n_shared)]
+        result = detect_path_collisions([
+            _pr(900080, shared + [f"a/{i}.py" for i in range(4 - n_shared)]),
+            _pr(900081, shared + [f"b/{i}.py" for i in range(4 - n_shared)],
+                state="merged"),
+        ])
+        self.assertEqual(result.terminal_collisions[0].overlap_ratio,
+                         _mod.TERMINAL_MIN_OVERLAP_RATIO)
+
+    def test_overlap_ratio_of_an_empty_side_is_zero(self):
+        """A degenerate denominator must never read as a perfect overlap."""
+        empty = _mod.PrRow(number=1, title="", paths=())
+        other = _mod.PrRow(number=2, title="", paths=("a/x.md",))
+        self.assertEqual(
+            _mod.terminal_overlap_ratio(("a/x.md",), empty, other), 0.0,
+        )
+
+    def test_open_pair_tier_untouched_beside_a_merged_row(self):
+        """Acceptance 4: no inflation, no deflation of open/open pairs."""
+        result = detect_path_collisions([
+            _pr(1, ["open/y.md"], title="fix(#500): a"),
+            _pr(2, ["open/y.md"], title="fix(#500): b"),
+            _pr(3, ["gone/z.md"], title="merged", state="merged"),
+        ])
+        self.assertEqual(result.n_collisions, 1)
+        self.assertEqual(result.collisions[0].tier, "strong")
+        self.assertIsNone(result.collisions[0].merged_side)
+
+    def test_weak_open_pair_stays_weak_beside_a_merged_row(self):
+        result = detect_path_collisions([
+            _pr(1, ["README.md"], title="docs(#1): a"),
+            _pr(2, ["README.md"], title="docs(#2): b"),
+            _pr(3, ["gone/z.md"], state="merged"),
+        ])
+        self.assertEqual(result.collisions[0].tier, "weak")
+
+    def test_actionable_selector_keeps_terminal_and_drops_weak(self):
+        """--same-issue-only must not swallow the loudest signal it has."""
+        _, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(1, ["README.md"], title="docs(#1): a"),
+            _pr(2, ["README.md"], title="docs(#2): b"),
+            _pr(700, list(f_paths), title="open side"),
+            _pr(f_merged, list(f_paths), title="merged side", state="merged"),
+        ])
+        self.assertEqual(
+            sorted(c.tier for c in result.actionable_collisions()),
+            ["terminal"],
+        )
+
+    def test_terminal_render_names_the_merged_side_and_main(self):
+        """Acceptance 2: the comment SAYS the substance is already on main."""
+        f_open, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(f_open, list(f_paths), title="tooling(notebook): detecteur"),
+            _pr(f_merged, list(f_paths), title="tooling(#15405): detecteur",
+                state="merged"),
+        ])
+        body = render_comment(
+            f_open, "tooling(notebook): detecteur",
+            collisions_for_pr(f_open, result.collisions),
+        )
+        self.assertIn("terminal", body)
+        self.assertIn(f"#{f_merged}", body)
+        self.assertIn("`main`", body)
+        self.assertIn(_mod.COMMENT_MARKER_END, body)
+
+    def test_merged_side_render_does_not_claim_the_open_side_is_merged(self):
+        """Rendering for the merged number names the merged one, not the other."""
+        f_open, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
+        result = detect_path_collisions([
+            _pr(f_open, list(f_paths), title="open side"),
+            _pr(f_merged, list(f_paths), title="merged side", state="merged"),
+        ])
+        body = render_comment(
+            f_merged, "merged side", collisions_for_pr(f_merged, result.collisions)
+        )
+        self.assertIn(f"**#{f_merged}**", body)
+        self.assertIn("est deja sur", body)
+
+    def test_widening_the_pool_does_not_churn_open_pair_comments(self):
+        """The pre-existing comment body is byte-identical -> no mass re-post.
+
+        Widening the pool must not rewrite the comment of a PR whose situation
+        did not change: a churned body means a PATCH per open PR on the first
+        run, which is exactly the write storm the marker protocol avoids.
+        """
+        open_rows = [
+            _pr(1, ["x.ipynb"], title="fix(#9): a"),
+            _pr(2, ["x.ipynb"], title="fix(#9): b"),
+        ]
+        before = detect_path_collisions(open_rows)
+        after = detect_path_collisions(
+            open_rows + [_pr(3, ["gone/z.md"], title="m", state="merged")]
+        )
+        b_before = render_comment(1, "fix(#9): a",
+                                  collisions_for_pr(1, before.collisions))
+        b_after = render_comment(1, "fix(#9): a",
+                                 collisions_for_pr(1, after.collisions))
+        self.assertEqual(b_before, b_after)
+        self.assertNotIn("terminal", b_before)
+
+
+class TestMergedPoolWiring(unittest.TestCase):
+    """The gh-side wiring of #15578: window filter + never comment a merge."""
+
+    def test_list_recently_merged_prs_filters_state_and_window(self):
+        payload = [
+            {"number": 10, "title": "in window", "state": "MERGED",
+             "mergedAt": "2026-09-10T00:00:00Z", "files": [{"path": "a.md"}]},
+            {"number": 11, "title": "too old", "state": "MERGED",
+             "mergedAt": "2026-08-01T00:00:00Z", "files": [{"path": "a.md"}]},
+            {"number": 12, "title": "not merged after all", "state": "OPEN",
+             "mergedAt": "", "files": [{"path": "a.md"}]},
+        ]
+        with mock.patch.object(_mod, "_gh_json", return_value=payload):
+            rows = _mod.list_recently_merged_prs("owner/repo", "2026-09-08", 500)
+        self.assertEqual([r.number for r in rows], [10])
+        self.assertTrue(rows[0].is_merged)
+
+    def test_merged_window_zero_disables_the_merged_pool(self):
+        """0 is a real opt-out, and it must not call the merged listing."""
+        calls = []
+
+        def _fake_merged(repo, since, limit):
+            calls.append(since)
+            return []
+
+        with mock.patch.object(_mod, "list_open_prs", return_value=[]),              mock.patch.object(_mod, "list_recently_merged_prs",
+                               side_effect=_fake_merged),              mock.patch.object(_mod, "_repo_default", return_value="o/r"),              mock.patch.object(_mod, "scan_markers", return_value=({}, set())),              mock.patch.object(_mod, "label_strong_pairs", return_value=None):
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = _mod._cli(["--merged-window-days", "0"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, [])
+
+    def test_cli_comments_the_open_side_and_never_the_merged_one(self):
+        """Acceptance 2 wired: the write set is the OPEN side of the pair."""
+        f_open, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
+        open_rows = [_pr(f_open, list(f_paths), title="open side")]
+        merged_rows = [_pr(f_merged, list(f_paths), title="merged side",
+                           state="merged")]
+        written: list[int] = []
+        posted_bodies: list[str] = []
+
+        def _capture_post(repo, number, body, dry_run):
+            written.append(number)
+            posted_bodies.append(body)
+            return True
+
+        with mock.patch.object(_mod, "list_open_prs", return_value=open_rows),              mock.patch.object(_mod, "list_recently_merged_prs",
+                               return_value=merged_rows),              mock.patch.object(_mod, "_repo_default", return_value="o/r"),              mock.patch.object(_mod, "scan_markers", return_value=({}, set())),              mock.patch.object(_mod, "label_strong_pairs", return_value=None),              mock.patch.object(_mod, "post_comment", side_effect=_capture_post):
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = _mod._cli([])
+        self.assertEqual(rc, 0)
+        self.assertEqual(written, [f_open])
+        self.assertNotIn(f_merged, written)
+        self.assertIn("terminal", posted_bodies[0])
+        self.assertIn(str(f_merged), posted_bodies[0])
 
 
 class TestCommentProtocol(unittest.TestCase):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15586

## Summary

Le pool de candidats de `scripts/check_pr_path_collisions.py` etait construit
avec `--state open` **exclusivement**. Consequence mesuree : une collision
**disparait du rapport a l'instant precis ou elle devenait irreversible** --
quand un cote mergeait. L'organe etait donc le plus bruyant tant que le risque
etait theorique, et **muet** une fois la substance sur `main`.

**Instance fondatrice** (#15578) : le 2026-09-10T23:18Z l'advisory postait une
collision `faible` **#15513/#15455** sur cinq chemins identiques -- deux
implementations independantes du meme detecteur de murs de paragraphes.
`#15455` a merge le 2026-09-11T08:37Z ; la paire est sortie du pool et le signal
s'est tu **alors que le doublon etait consomme**.

## Ce que fait la PR

1. **Pool elargi** aux PRs recemment mergees. La profondeur est un **argument**
   (`--merged-window-days`, defaut 3, `0` desactive), jamais une constante
   enterree. Echec de fetch merged = non fatal + WARN.
2. **Verdict `TERMINAL`** pour une paire a **un** cote merge : ce n'est pas une
   graduation de tier, c'est un etat terminal. Le commentaire **nomme** le cote
   consomme et dit que la substance est deja sur `main`. Seules les PRs
   **ouvertes** sont commentees -- une advisory sur un fil ferme est du bruit.
3. **Paire aux deux cotes merges = exclue** (histoire, pas collision), comme les
   paires empilees.
4. **Tiers open/open intacts** (acceptation 4) : le corps du commentaire d'une
   paire open/open est **byte-identique**, donc aucun PATCH en masse au premier
   run.

## Calibration -- mesuree, pas supposee

Ma premiere implementation sur-attaquait. Mesure sur **un** snapshot live
(2026-09-11, 64 open + 282 merged, fenetre 3 jours ; le pool derive, ce sont les
chiffres de ce snapshot) :

| regle | paires terminales | PRs OUVERTES ecrites |
|---|---|---|
| sans garde (ratio 0.0) | 96 | **37 / 64** |
| garde `min-both >= 0.5` | 23 | **16 / 64** |

37 des 64 PRs ouvertes = **une PR sur deux**. C'est exactement l'effondrement
« rapporte tout, ne rapporte rien » contre lequel le docstring de ce module met
en garde (#13615). La garde retenue est le **recouvrement minimal des DEUX
cotes** : `min(n_partages / |a|, n_partages / |b|) >= 0.5`. Elle **garde l'ancre
fondatrice** (5 chemins partages sur 5 et 6 = **0.83**) et coupe le bruit d'un
facteur ~2,3.

Alternative rejetee, **aussi mesuree** : `partages / min(|a|,|b|)` garde les
memes ~37 -- une PR mergee d'un seul fichier qui partage son unique fichier
score 1.00 pour des raisons triviales.

Les paires sous le seuil ne sont **pas** silencieusement jetees : elles sont
comptees et nommees (`merged-side low-overlap excluded`) dans le resume de run.

## Preuve d'acceptation 3 (rouge sous le code pre-fix)

- **Sonde comportementale** (`probe_old.py`, API publique de l'ancien script
  uniquement) : pool construit par l'ancien code = `[15513]` -> **0 collision**.
  La paire fondatrice est invisible.
- **Replay de la nouvelle suite** contre le script pre-fix : **65 runs, 41
  erreurs** (l'ancien `PrRow` n'a ni `state` ni `mergedAt` : le champ est
  `['base_ref','body','head_ref','number','paths','title']`).
- **Verdict** : meme visible, la paire ne peut etre tierce que `weak` -- l'ancien
  code n'a aucun vocabulaire pour « l'autre cote a deja merge »
  (`has TIER_TERMINAL: False`, aucun champ `merged_side`).

## Verification

- `--self-test` : **14/14** controles (dont l'admission de l'ancre a son ratio
  reel 0.83, et le rejet d'une paire a recouvrement incident).
- `pytest scripts/tests/test_check_pr_path_collisions.py` : **65 passed**
  (61 avant + 4 nouveaux controles de calibration).
- `--dry-run` live : `scanned=346 (merged=282) collisions=50 (strong=6 weak=21
  terminal=23)`.

## Notes de review

- **Un seul sujet**, 3 fichiers, 672 insertions / 24 suppressions : loin des
  seuils composites (G.4).
- **Aucun artefact genere touche** : ni `COURSE_CATALOG.generated.*`, ni
  `docs/curriculum/*`. (catalog-pr-hygiene HARD 1 respectee.)
- Branche rebasee sur `origin/main` frais (`105db5299a`) avant push
  (catalog-pr-hygiene HARD 2).
- **Acceptation 4 explicite** : les tiers open/open sont inchanges, et un test
  assert l'egalite byte-a-byte du corps de commentaire d'une paire open/open
  avant/apres elargissement du pool.

See #15578

🤖 Generated with [Claude Code](https://claude.com/claude-code)


