### PR TITLE
fix(probas,#15592): restaurer l'intervalle HDI de DecPyMC-2 (arviz 1.1 ci_kind)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.004505,
-     "end_time": "2026-09-08T01:22:22.501351+00:00",
+     "duration": 0.016555,
+     "end_time": "2026-09-11T11:58:15.772759",
      "exception": false,
-     "start_time": "2026-09-08T01:22:22.496846+00:00",
+     "start_time": "2026-09-11T11:58:15.756204",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.005999,
-     "end_time": "2026-09-08T01:22:22.513620+00:00",
+     "duration": 0.023923,
+     "end_time": "2026-09-11T11:58:15.815344",
      "exception": false,
-     "start_time": "2026-09-08T01:22:22.507621+00:00",
+     "start_time": "2026-09-11T11:58:15.791421",
      "status": "completed"
     },
     "tags": []
@@ -69,10 +69,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.005083,
-     "end_time": "2026-09-08T01:22:22.523703+00:00",
+     "duration": 0.019789,
+     "end_time": "2026-09-11T11:58:15.852266",
      "exception": false,
-     "start_time": "2026-09-08T01:22:22.518620+00:00",
+     "start_time": "2026-09-11T11:58:15.832477",
      "status": "completed"
     },
     "tags": []
@@ -87,16 +87,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:22.537141Z",
-     "iopub.status.busy": "2026-09-08T01:22:22.537141Z",
-     "iopub.status.idle": "2026-09-08T01:22:25.257007Z",
-     "shell.execute_reply": "2026-09-08T01:22:25.255417Z"
+     "iopub.execute_input": "2026-09-11T11:58:15.895446Z",
+     "iopub.status.busy": "2026-09-11T11:58:15.895446Z",
+     "iopub.status.idle": "2026-09-11T11:58:23.065948Z",
+     "shell.execute_reply": "2026-09-11T11:58:23.064218Z"
     },
     "papermill": {
-     "duration": 2.728842,
-     "end_time": "2026-09-08T01:22:25.258056+00:00",
+     "duration": 7.194516,
+     "end_time": "2026-09-11T11:58:23.067694",
      "exception": false,
-     "start_time": "2026-09-08T01:22:22.529214+00:00",
+     "start_time": "2026-09-11T11:58:15.873178",
      "status": "completed"
     },
     "tags": []
@@ -136,10 +136,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.010288,
-     "end_time": "2026-09-08T01:22:25.281493+00:00",
+     "duration": 0.015718,
+     "end_time": "2026-09-11T11:58:23.097273",
      "exception": false,
-     "start_time": "2026-09-08T01:22:25.271205+00:00",
+     "start_time": "2026-09-11T11:58:23.081555",
      "status": "completed"
     },
     "tags": []
@@ -156,16 +156,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:25.309296Z",
-     "iopub.status.busy": "2026-09-08T01:22:25.308293Z",
-     "iopub.status.idle": "2026-09-08T01:22:25.789798Z",
-     "shell.execute_reply": "2026-09-08T01:22:25.788196Z"
+     "iopub.execute_input": "2026-09-11T11:58:23.132759Z",
+     "iopub.status.busy": "2026-09-11T11:58:23.131563Z",
+     "iopub.status.idle": "2026-09-11T11:58:23.681812Z",
+     "shell.execute_reply": "2026-09-11T11:58:23.679608Z"
     },
     "papermill": {
-     "duration": 0.497632,
-     "end_time": "2026-09-08T01:22:25.791405+00:00",
+     "duration": 0.57041,
+     "end_time": "2026-09-11T11:58:23.683480",
      "exception": false,
-     "start_time": "2026-09-08T01:22:25.293773+00:00",
+     "start_time": "2026-09-11T11:58:23.113070",
      "status": "completed"
     },
     "tags": []
@@ -241,16 +241,16 @@
    "id": "a74b4b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:25.814822Z",
-     "iopub.status.busy": "2026-09-08T01:22:25.814281Z",
-     "iopub.status.idle": "2026-09-08T01:22:27.289587Z",
-     "shell.execute_reply": "2026-09-08T01:22:27.289077Z"
+     "iopub.execute_input": "2026-09-11T11:58:23.715611Z",
+     "iopub.status.busy": "2026-09-11T11:58:23.715094Z",
+     "iopub.status.idle": "2026-09-11T11:58:27.076842Z",
+     "shell.execute_reply": "2026-09-11T11:58:27.074831Z"
     },
     "papermill": {
-     "duration": 1.488583,
-     "end_time": "2026-09-08T01:22:27.291233+00:00",
+     "duration": 3.379878,
+     "end_time": "2026-09-11T11:58:27.078554",
      "exception": false,
-     "start_time": "2026-09-08T01:22:25.802650+00:00",
+     "start_time": "2026-09-11T11:58:23.698676",
      "status": "completed"
     },
     "tags": []
@@ -353,10 +353,10 @@
    "id": "277c2867",
    "metadata": {
     "papermill": {
-     "duration": 0.007506,
-     "end_time": "2026-09-08T01:22:27.305890+00:00",
+     "duration": 0.015565,
+     "end_time": "2026-09-11T11:58:27.111148",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.298384+00:00",
+     "start_time": "2026-09-11T11:58:27.095583",
      "status": "completed"
     },
     "tags": []
@@ -378,10 +378,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.007572,
-     "end_time": "2026-09-08T01:22:27.320200+00:00",
+     "duration": 0.019037,
+     "end_time": "2026-09-11T11:58:27.145451",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.312628+00:00",
+     "start_time": "2026-09-11T11:58:27.126414",
      "status": "completed"
     },
     "tags": []
@@ -399,16 +399,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:27.337557Z",
-     "iopub.status.busy": "2026-09-08T01:22:27.336044Z",
-     "iopub.status.idle": "2026-09-08T01:22:27.940735Z",
-     "shell.execute_reply": "2026-09-08T01:22:27.939731Z"
+     "iopub.execute_input": "2026-09-11T11:58:27.185488Z",
+     "iopub.status.busy": "2026-09-11T11:58:27.184491Z",
+     "iopub.status.idle": "2026-09-11T11:58:28.608130Z",
+     "shell.execute_reply": "2026-09-11T11:58:28.606120Z"
     },
     "papermill": {
-     "duration": 0.613531,
-     "end_time": "2026-09-08T01:22:27.941240+00:00",
+     "duration": 1.446132,
+     "end_time": "2026-09-11T11:58:28.609641",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.327709+00:00",
+     "start_time": "2026-09-11T11:58:27.163509",
      "status": "completed"
     },
     "tags": []
@@ -486,10 +486,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.009875,
-     "end_time": "2026-09-08T01:22:27.958184+00:00",
+     "duration": 0.015056,
+     "end_time": "2026-09-11T11:58:28.641351",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.948309+00:00",
+     "start_time": "2026-09-11T11:58:28.626295",
      "status": "completed"
     },
     "tags": []
@@ -513,16 +513,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:27.981325Z",
-     "iopub.status.busy": "2026-09-08T01:22:27.980814Z",
-     "iopub.status.idle": "2026-09-08T01:22:27.988878Z",
-     "shell.execute_reply": "2026-09-08T01:22:27.987800Z"
+     "iopub.execute_input": "2026-09-11T11:58:28.683785Z",
+     "iopub.status.busy": "2026-09-11T11:58:28.682780Z",
+     "iopub.status.idle": "2026-09-11T11:58:28.699696Z",
+     "shell.execute_reply": "2026-09-11T11:58:28.698119Z"
     },
     "papermill": {
-     "duration": 0.02146,
-     "end_time": "2026-09-08T01:22:27.989947+00:00",
+     "duration": 0.039808,
+     "end_time": "2026-09-11T11:58:28.701206",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.968487+00:00",
+     "start_time": "2026-09-11T11:58:28.661398",
      "status": "completed"
     },
     "tags": []
@@ -614,10 +614,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.009499,
-     "end_time": "2026-09-08T01:22:28.008213+00:00",
+     "duration": 0.017521,
+     "end_time": "2026-09-11T11:58:28.736539",
      "exception": false,
-     "start_time": "2026-09-08T01:22:27.998714+00:00",
+     "start_time": "2026-09-11T11:58:28.719018",
      "status": "completed"
     },
     "tags": []
@@ -633,10 +633,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.011546,
-     "end_time": "2026-09-08T01:22:28.028926+00:00",
+     "duration": 0.021525,
+     "end_time": "2026-09-11T11:58:28.776114",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.017380+00:00",
+     "start_time": "2026-09-11T11:58:28.754589",
      "status": "completed"
     },
     "tags": []
@@ -661,16 +661,16 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:28.051546Z",
-     "iopub.status.busy": "2026-09-08T01:22:28.050542Z",
-     "iopub.status.idle": "2026-09-08T01:22:28.587842Z",
-     "shell.execute_reply": "2026-09-08T01:22:28.587842Z"
+     "iopub.execute_input": "2026-09-11T11:58:28.812875Z",
+     "iopub.status.busy": "2026-09-11T11:58:28.812875Z",
+     "iopub.status.idle": "2026-09-11T11:58:30.138736Z",
+     "shell.execute_reply": "2026-09-11T11:58:30.135876Z"
     },
     "papermill": {
-     "duration": 0.547235,
-     "end_time": "2026-09-08T01:22:28.589106+00:00",
+     "duration": 1.346215,
+     "end_time": "2026-09-11T11:58:30.139373",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.041871+00:00",
+     "start_time": "2026-09-11T11:58:28.793158",
      "status": "completed"
     },
     "tags": []
@@ -765,10 +765,10 @@
    "id": "a7b8fa7d",
    "metadata": {
     "papermill": {
-     "duration": 0.007582,
-     "end_time": "2026-09-08T01:22:28.603844+00:00",
+     "duration": 0.033967,
+     "end_time": "2026-09-11T11:58:30.192968",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.596262+00:00",
+     "start_time": "2026-09-11T11:58:30.159001",
      "status": "completed"
     },
     "tags": []
@@ -799,16 +799,16 @@
    "id": "7877d00f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:28.621814Z",
-     "iopub.status.busy": "2026-09-08T01:22:28.621814Z",
-     "iopub.status.idle": "2026-09-08T01:22:28.626040Z",
-     "shell.execute_reply": "2026-09-08T01:22:28.626040Z"
+     "iopub.execute_input": "2026-09-11T11:58:30.241990Z",
+     "iopub.status.busy": "2026-09-11T11:58:30.240990Z",
+     "iopub.status.idle": "2026-09-11T11:58:30.251637Z",
+     "shell.execute_reply": "2026-09-11T11:58:30.249583Z"
     },
     "papermill": {
-     "duration": 0.015186,
-     "end_time": "2026-09-08T01:22:28.627044+00:00",
+     "duration": 0.03802,
+     "end_time": "2026-09-11T11:58:30.253161",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.611858+00:00",
+     "start_time": "2026-09-11T11:58:30.215141",
      "status": "completed"
     },
     "tags": []
@@ -858,10 +858,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.007514,
-     "end_time": "2026-09-08T01:22:28.642712+00:00",
+     "duration": 0.024101,
+     "end_time": "2026-09-11T11:58:30.295826",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.635198+00:00",
+     "start_time": "2026-09-11T11:58:30.271725",
      "status": "completed"
     },
     "tags": []
@@ -884,10 +884,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.007746,
-     "end_time": "2026-09-08T01:22:28.657428+00:00",
+     "duration": 0.021796,
+     "end_time": "2026-09-11T11:58:30.339347",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.649682+00:00",
+     "start_time": "2026-09-11T11:58:30.317551",
      "status": "completed"
     },
     "tags": []
@@ -912,16 +912,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:28.675583Z",
-     "iopub.status.busy": "2026-09-08T01:22:28.674582Z",
-     "iopub.status.idle": "2026-09-08T01:22:28.684354Z",
-     "shell.execute_reply": "2026-09-08T01:22:28.683349Z"
+     "iopub.execute_input": "2026-09-11T11:58:30.388724Z",
+     "iopub.status.busy": "2026-09-11T11:58:30.387722Z",
+     "iopub.status.idle": "2026-09-11T11:58:30.407058Z",
+     "shell.execute_reply": "2026-09-11T11:58:30.405527Z"
     },
     "papermill": {
-     "duration": 0.018771,
-     "end_time": "2026-09-08T01:22:28.684354+00:00",
+     "duration": 0.044613,
+     "end_time": "2026-09-11T11:58:30.409055",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.665583+00:00",
+     "start_time": "2026-09-11T11:58:30.364442",
      "status": "completed"
     },
     "tags": []
@@ -1019,16 +1019,16 @@
    "id": "79be8518",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:28.703738Z",
-     "iopub.status.busy": "2026-09-08T01:22:28.703738Z",
-     "iopub.status.idle": "2026-09-08T01:22:29.216465Z",
-     "shell.execute_reply": "2026-09-08T01:22:29.215458Z"
+     "iopub.execute_input": "2026-09-11T11:58:30.449440Z",
+     "iopub.status.busy": "2026-09-11T11:58:30.448895Z",
+     "iopub.status.idle": "2026-09-11T11:58:31.847182Z",
+     "shell.execute_reply": "2026-09-11T11:58:31.844726Z"
     },
     "papermill": {
-     "duration": 0.523079,
-     "end_time": "2026-09-08T01:22:29.216465+00:00",
+     "duration": 1.422478,
+     "end_time": "2026-09-11T11:58:31.848791",
      "exception": false,
-     "start_time": "2026-09-08T01:22:28.693386+00:00",
+     "start_time": "2026-09-11T11:58:30.426313",
      "status": "completed"
     },
     "tags": []
@@ -1120,10 +1120,10 @@
    "id": "54e25556",
    "metadata": {
     "papermill": {
-     "duration": 0.009036,
-     "end_time": "2026-09-08T01:22:29.234713+00:00",
+     "duration": 0.048982,
+     "end_time": "2026-09-11T11:58:31.920927",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.225677+00:00",
+     "start_time": "2026-09-11T11:58:31.871945",
      "status": "completed"
     },
     "tags": []
@@ -1141,10 +1141,10 @@
    "id": "cell-17",
    "metadata": {
     "papermill": {
-     "duration": 0.010525,
-     "end_time": "2026-09-08T01:22:29.254265+00:00",
+     "duration": 0.022534,
+     "end_time": "2026-09-11T11:58:31.978841",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.243740+00:00",
+     "start_time": "2026-09-11T11:58:31.956307",
      "status": "completed"
     },
     "tags": []
@@ -1165,10 +1165,10 @@
    "id": "cell-18",
    "metadata": {
     "papermill": {
-     "duration": 0.009229,
-     "end_time": "2026-09-08T01:22:29.273206+00:00",
+     "duration": 0.029327,
+     "end_time": "2026-09-11T11:58:32.036484",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.263977+00:00",
+     "start_time": "2026-09-11T11:58:32.007157",
      "status": "completed"
     },
     "tags": []
@@ -1189,16 +1189,16 @@
    "id": "cell-19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:29.296533Z",
-     "iopub.status.busy": "2026-09-08T01:22:29.296533Z",
-     "iopub.status.idle": "2026-09-08T01:22:29.562024Z",
-     "shell.execute_reply": "2026-09-08T01:22:29.560950Z"
+     "iopub.execute_input": "2026-09-11T11:58:32.092912Z",
+     "iopub.status.busy": "2026-09-11T11:58:32.091764Z",
+     "iopub.status.idle": "2026-09-11T11:58:32.722394Z",
+     "shell.execute_reply": "2026-09-11T11:58:32.720384Z"
     },
     "papermill": {
-     "duration": 0.277739,
-     "end_time": "2026-09-08T01:22:29.563101+00:00",
+     "duration": 0.65745,
+     "end_time": "2026-09-11T11:58:32.723392",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.285362+00:00",
+     "start_time": "2026-09-11T11:58:32.065942",
      "status": "completed"
     },
     "tags": []
@@ -1300,10 +1300,10 @@
    "id": "8be1aeac",
    "metadata": {
     "papermill": {
-     "duration": 0.01003,
-     "end_time": "2026-09-08T01:22:29.586406+00:00",
+     "duration": 0.0196,
+     "end_time": "2026-09-11T11:58:32.763112",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.576376+00:00",
+     "start_time": "2026-09-11T11:58:32.743512",
      "status": "completed"
     },
     "tags": []
@@ -1334,16 +1334,16 @@
    "id": "d35f27b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:29.622672Z",
-     "iopub.status.busy": "2026-09-08T01:22:29.622144Z",
-     "iopub.status.idle": "2026-09-08T01:22:29.629740Z",
-     "shell.execute_reply": "2026-09-08T01:22:29.628084Z"
+     "iopub.execute_input": "2026-09-11T11:58:32.812787Z",
+     "iopub.status.busy": "2026-09-11T11:58:32.812231Z",
+     "iopub.status.idle": "2026-09-11T11:58:32.820532Z",
+     "shell.execute_reply": "2026-09-11T11:58:32.819523Z"
     },
     "papermill": {
-     "duration": 0.026208,
-     "end_time": "2026-09-08T01:22:29.630907+00:00",
+     "duration": 0.036116,
+     "end_time": "2026-09-11T11:58:32.822533",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.604699+00:00",
+     "start_time": "2026-09-11T11:58:32.786417",
      "status": "completed"
     },
     "tags": []
@@ -1389,10 +1389,10 @@
    "id": "cell-20",
    "metadata": {
     "papermill": {
-     "duration": 0.021319,
-     "end_time": "2026-09-08T01:22:29.668569+00:00",
+     "duration": 0.019632,
+     "end_time": "2026-09-11T11:58:32.861541",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.647250+00:00",
+     "start_time": "2026-09-11T11:58:32.841909",
      "status": "completed"
     },
     "tags": []
@@ -1412,10 +1412,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.023856,
-     "end_time": "2026-09-08T01:22:29.716489+00:00",
+     "duration": 0.027738,
+     "end_time": "2026-09-11T11:58:32.919805",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.692633+00:00",
+     "start_time": "2026-09-11T11:58:32.892067",
      "status": "completed"
     },
     "tags": []
@@ -1432,16 +1432,16 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:29.767867Z",
-     "iopub.status.busy": "2026-09-08T01:22:29.767300Z",
-     "iopub.status.idle": "2026-09-08T01:22:29.796653Z",
-     "shell.execute_reply": "2026-09-08T01:22:29.795044Z"
+     "iopub.execute_input": "2026-09-11T11:58:32.966619Z",
+     "iopub.status.busy": "2026-09-11T11:58:32.966077Z",
+     "iopub.status.idle": "2026-09-11T11:58:33.001381Z",
+     "shell.execute_reply": "2026-09-11T11:58:32.999199Z"
     },
     "papermill": {
-     "duration": 0.056812,
-     "end_time": "2026-09-08T01:22:29.797851+00:00",
+     "duration": 0.06167,
+     "end_time": "2026-09-11T11:58:33.003536",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.741039+00:00",
+     "start_time": "2026-09-11T11:58:32.941866",
      "status": "completed"
     },
     "tags": []
@@ -1520,16 +1520,16 @@
    "id": "852f3a8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:29.839259Z",
-     "iopub.status.busy": "2026-09-08T01:22:29.838741Z",
-     "iopub.status.idle": "2026-09-08T01:22:32.016085Z",
-     "shell.execute_reply": "2026-09-08T01:22:32.015070Z"
+     "iopub.execute_input": "2026-09-11T11:58:33.044772Z",
+     "iopub.status.busy": "2026-09-11T11:58:33.043773Z",
+     "iopub.status.idle": "2026-09-11T11:58:37.442350Z",
+     "shell.execute_reply": "2026-09-11T11:58:37.439968Z"
     },
     "papermill": {
-     "duration": 2.200128,
-     "end_time": "2026-09-08T01:22:32.016085+00:00",
+     "duration": 4.422767,
+     "end_time": "2026-09-11T11:58:37.444649",
      "exception": false,
-     "start_time": "2026-09-08T01:22:29.815957+00:00",
+     "start_time": "2026-09-11T11:58:33.021882",
      "status": "completed"
     },
     "tags": []
@@ -1600,10 +1600,10 @@
    "id": "b60863ff",
    "metadata": {
     "papermill": {
-     "duration": 0.010348,
-     "end_time": "2026-09-08T01:22:32.037462+00:00",
+     "duration": 0.028731,
+     "end_time": "2026-09-11T11:58:37.495252",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.027114+00:00",
+     "start_time": "2026-09-11T11:58:37.466521",
      "status": "completed"
     },
     "tags": []
@@ -1621,10 +1621,10 @@
    "id": "cell-23",
    "metadata": {
     "papermill": {
-     "duration": 0.011,
-     "end_time": "2026-09-08T01:22:32.059786+00:00",
+     "duration": 0.029197,
+     "end_time": "2026-09-11T11:58:37.558084",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.048786+00:00",
+     "start_time": "2026-09-11T11:58:37.528887",
      "status": "completed"
     },
     "tags": []
@@ -1646,10 +1646,10 @@
    "id": "cell-24",
    "metadata": {
     "papermill": {
-     "duration": 0.01316,
-     "end_time": "2026-09-08T01:22:32.087493+00:00",
+     "duration": 0.033722,
+     "end_time": "2026-09-11T11:58:37.634959",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.074333+00:00",
+     "start_time": "2026-09-11T11:58:37.601237",
      "status": "completed"
     },
     "tags": []
@@ -1668,16 +1668,16 @@
    "id": "cell-25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:32.115110Z",
-     "iopub.status.busy": "2026-09-08T01:22:32.115110Z",
-     "iopub.status.idle": "2026-09-08T01:22:32.123927Z",
-     "shell.execute_reply": "2026-09-08T01:22:32.122751Z"
+     "iopub.execute_input": "2026-09-11T11:58:37.697036Z",
+     "iopub.status.busy": "2026-09-11T11:58:37.695869Z",
+     "iopub.status.idle": "2026-09-11T11:58:37.714773Z",
+     "shell.execute_reply": "2026-09-11T11:58:37.713178Z"
     },
     "papermill": {
-     "duration": 0.024735,
-     "end_time": "2026-09-08T01:22:32.124926+00:00",
+     "duration": 0.050656,
+     "end_time": "2026-09-11T11:58:37.716910",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.100191+00:00",
+     "start_time": "2026-09-11T11:58:37.666254",
      "status": "completed"
     },
     "tags": []
@@ -1770,10 +1770,10 @@
    "id": "cell-26",
    "metadata": {
     "papermill": {
-     "duration": 0.011109,
-     "end_time": "2026-09-08T01:22:32.146666+00:00",
+     "duration": 0.03337,
+     "end_time": "2026-09-11T11:58:37.774196",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.135557+00:00",
+     "start_time": "2026-09-11T11:58:37.740826",
      "status": "completed"
     },
     "tags": []
@@ -1796,16 +1796,16 @@
    "id": "cell-27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:32.173899Z",
-     "iopub.status.busy": "2026-09-08T01:22:32.173387Z",
-     "iopub.status.idle": "2026-09-08T01:22:45.630519Z",
-     "shell.execute_reply": "2026-09-08T01:22:45.629506Z"
+     "iopub.execute_input": "2026-09-11T11:58:37.832020Z",
+     "iopub.status.busy": "2026-09-11T11:58:37.831470Z",
+     "iopub.status.idle": "2026-09-11T11:59:05.676883Z",
+     "shell.execute_reply": "2026-09-11T11:59:05.675355Z"
     },
     "papermill": {
-     "duration": 13.471625,
-     "end_time": "2026-09-08T01:22:45.631519+00:00",
+     "duration": 27.876354,
+     "end_time": "2026-09-11T11:59:05.678895",
      "exception": false,
-     "start_time": "2026-09-08T01:22:32.159894+00:00",
+     "start_time": "2026-09-11T11:58:37.802541",
      "status": "completed"
     },
     "tags": []
@@ -1845,7 +1845,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 11 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 5_000 draw iterations (4_000 + 20_000 draws total) took 23 seconds.\n"
      ]
     },
     {
@@ -1917,10 +1917,10 @@
     "print(f\"Analytique : E[theta] = {alpha_post/(alpha_post+beta_post):.3f}\")\n",
     "print()\n",
     "\n",
-    "# Credible interval (ArviZ 1.x : colonnes eti89_lb/eti89_ub)\n",
-    "summary = az.summary(trace_risk, var_names=[\"theta\"], ci_prob=0.89)\n",
-    "ci_lo = float(summary[\"eti89_lb\"].iloc[0])\n",
-    "ci_hi = float(summary[\"eti89_ub\"].iloc[0])\n",
+    "# Credible interval (ArviZ 1.x : colonnes hdi89_lb/hdi89_ub)\n",
+    "summary = az.summary(trace_risk, var_names=[\"theta\"], ci_prob=0.89, ci_kind=\"hdi\")\n",
+    "ci_lo = float(summary[\"hdi89_lb\"].iloc[0])\n",
+    "ci_hi = float(summary[\"hdi89_ub\"].iloc[0])\n",
     "\n",
     "print(f\"Intervalle de credibilite 89% : [{ci_lo:.3f}, {ci_hi:.3f}]\")\n",
     "\n",
@@ -1972,10 +1972,10 @@
    "id": "cell-28",
    "metadata": {
     "papermill": {
-     "duration": 0.01167,
-     "end_time": "2026-09-08T01:22:45.653695+00:00",
+     "duration": 0.025158,
+     "end_time": "2026-09-11T11:59:05.726185",
      "exception": false,
-     "start_time": "2026-09-08T01:22:45.642025+00:00",
+     "start_time": "2026-09-11T11:59:05.701027",
      "status": "completed"
     },
     "tags": []
@@ -2001,16 +2001,16 @@
    "id": "e6514730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:45.680039Z",
-     "iopub.status.busy": "2026-09-08T01:22:45.679039Z",
-     "iopub.status.idle": "2026-09-08T01:22:46.083183Z",
-     "shell.execute_reply": "2026-09-08T01:22:46.082132Z"
+     "iopub.execute_input": "2026-09-11T11:59:05.779938Z",
+     "iopub.status.busy": "2026-09-11T11:59:05.778929Z",
+     "iopub.status.idle": "2026-09-11T11:59:07.085552Z",
+     "shell.execute_reply": "2026-09-11T11:59:07.083022Z"
     },
     "papermill": {
-     "duration": 0.4176,
-     "end_time": "2026-09-08T01:22:46.084182+00:00",
+     "duration": 1.334761,
+     "end_time": "2026-09-11T11:59:07.086548",
      "exception": false,
-     "start_time": "2026-09-08T01:22:45.666582+00:00",
+     "start_time": "2026-09-11T11:59:05.751787",
      "status": "completed"
     },
     "tags": []
@@ -2097,10 +2097,10 @@
    "id": "68d79778",
    "metadata": {
     "papermill": {
-     "duration": 0.012277,
-     "end_time": "2026-09-08T01:22:46.108453+00:00",
+     "duration": 0.028003,
+     "end_time": "2026-09-11T11:59:07.141184",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.096176+00:00",
+     "start_time": "2026-09-11T11:59:07.113181",
      "status": "completed"
     },
     "tags": []
@@ -2124,10 +2124,10 @@
    "id": "p15b-md-00",
    "metadata": {
     "papermill": {
-     "duration": 0.012678,
-     "end_time": "2026-09-08T01:22:46.133649+00:00",
+     "duration": 0.029292,
+     "end_time": "2026-09-11T11:59:07.198592",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.120971+00:00",
+     "start_time": "2026-09-11T11:59:07.169300",
      "status": "completed"
     },
     "tags": []
@@ -2146,10 +2146,10 @@
    "id": "p15b-md-01",
    "metadata": {
     "papermill": {
-     "duration": 0.012528,
-     "end_time": "2026-09-08T01:22:46.158789+00:00",
+     "duration": 0.027578,
+     "end_time": "2026-09-11T11:59:07.252612",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.146261+00:00",
+     "start_time": "2026-09-11T11:59:07.225034",
      "status": "completed"
     },
     "tags": []
@@ -2166,16 +2166,16 @@
    "id": "p15b-code-01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:46.187165Z",
-     "iopub.status.busy": "2026-09-08T01:22:46.186591Z",
-     "iopub.status.idle": "2026-09-08T01:22:46.460607Z",
-     "shell.execute_reply": "2026-09-08T01:22:46.459474Z"
+     "iopub.execute_input": "2026-09-11T11:59:07.315789Z",
+     "iopub.status.busy": "2026-09-11T11:59:07.314789Z",
+     "iopub.status.idle": "2026-09-11T11:59:08.125627Z",
+     "shell.execute_reply": "2026-09-11T11:59:08.124103Z"
     },
     "papermill": {
-     "duration": 0.287161,
-     "end_time": "2026-09-08T01:22:46.460607+00:00",
+     "duration": 0.846244,
+     "end_time": "2026-09-11T11:59:08.128147",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.173446+00:00",
+     "start_time": "2026-09-11T11:59:07.281903",
      "status": "completed"
     },
     "tags": []
@@ -2251,10 +2251,10 @@
    "id": "p15b-md-02",
    "metadata": {
     "papermill": {
-     "duration": 0.015057,
-     "end_time": "2026-09-08T01:22:46.491028+00:00",
+     "duration": 0.026329,
+     "end_time": "2026-09-11T11:59:08.179883",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.475971+00:00",
+     "start_time": "2026-09-11T11:59:08.153554",
      "status": "completed"
     },
     "tags": []
@@ -2269,16 +2269,16 @@
    "id": "p15b-code-02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:46.523476Z",
-     "iopub.status.busy": "2026-09-08T01:22:46.522933Z",
-     "iopub.status.idle": "2026-09-08T01:22:46.753806Z",
-     "shell.execute_reply": "2026-09-08T01:22:46.752731Z"
+     "iopub.execute_input": "2026-09-11T11:59:08.245577Z",
+     "iopub.status.busy": "2026-09-11T11:59:08.244566Z",
+     "iopub.status.idle": "2026-09-11T11:59:08.903618Z",
+     "shell.execute_reply": "2026-09-11T11:59:08.901342Z"
     },
     "papermill": {
-     "duration": 0.248403,
-     "end_time": "2026-09-08T01:22:46.754370+00:00",
+     "duration": 0.696126,
+     "end_time": "2026-09-11T11:59:08.905266",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.505967+00:00",
+     "start_time": "2026-09-11T11:59:08.209140",
      "status": "completed"
     },
     "tags": []
@@ -2328,16 +2328,16 @@
    "id": "p15b-code-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:46.787398Z",
-     "iopub.status.busy": "2026-09-08T01:22:46.786381Z",
-     "iopub.status.idle": "2026-09-08T01:22:46.960167Z",
-     "shell.execute_reply": "2026-09-08T01:22:46.959055Z"
+     "iopub.execute_input": "2026-09-11T11:59:08.982236Z",
+     "iopub.status.busy": "2026-09-11T11:59:08.981593Z",
+     "iopub.status.idle": "2026-09-11T11:59:09.459845Z",
+     "shell.execute_reply": "2026-09-11T11:59:09.457174Z"
     },
     "papermill": {
-     "duration": 0.192566,
-     "end_time": "2026-09-08T01:22:46.961161+00:00",
+     "duration": 0.526643,
+     "end_time": "2026-09-11T11:59:09.462019",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.768595+00:00",
+     "start_time": "2026-09-11T11:59:08.935376",
      "status": "completed"
     },
     "tags": []
@@ -2418,10 +2418,10 @@
    "id": "p15b-md-03",
    "metadata": {
     "papermill": {
-     "duration": 0.016112,
-     "end_time": "2026-09-08T01:22:46.997487+00:00",
+     "duration": 0.044856,
+     "end_time": "2026-09-11T11:59:09.542439",
      "exception": false,
-     "start_time": "2026-09-08T01:22:46.981375+00:00",
+     "start_time": "2026-09-11T11:59:09.497583",
      "status": "completed"
     },
     "tags": []
@@ -2436,16 +2436,16 @@
    "id": "p15b-code-04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:47.035610Z",
-     "iopub.status.busy": "2026-09-08T01:22:47.034603Z",
-     "iopub.status.idle": "2026-09-08T01:22:47.157511Z",
-     "shell.execute_reply": "2026-09-08T01:22:47.156506Z"
+     "iopub.execute_input": "2026-09-11T11:59:09.628587Z",
+     "iopub.status.busy": "2026-09-11T11:59:09.627533Z",
+     "iopub.status.idle": "2026-09-11T11:59:10.115195Z",
+     "shell.execute_reply": "2026-09-11T11:59:10.112469Z"
     },
     "papermill": {
-     "duration": 0.145151,
-     "end_time": "2026-09-08T01:22:47.158016+00:00",
+     "duration": 0.531919,
+     "end_time": "2026-09-11T11:59:10.116881",
      "exception": false,
-     "start_time": "2026-09-08T01:22:47.012865+00:00",
+     "start_time": "2026-09-11T11:59:09.584962",
      "status": "completed"
     },
     "tags": []
@@ -2513,10 +2513,10 @@
    "id": "p15b-md-04",
    "metadata": {
     "papermill": {
-     "duration": 0.016499,
-     "end_time": "2026-09-08T01:22:47.190656+00:00",
+     "duration": 0.040597,
+     "end_time": "2026-09-11T11:59:10.191747",
      "exception": false,
-     "start_time": "2026-09-08T01:22:47.174157+00:00",
+     "start_time": "2026-09-11T11:59:10.151150",
      "status": "completed"
     },
     "tags": []
@@ -2538,16 +2538,16 @@
    "id": "p15b-code-05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:47.229589Z",
-     "iopub.status.busy": "2026-09-08T01:22:47.229589Z",
-     "iopub.status.idle": "2026-09-08T01:22:47.383532Z",
-     "shell.execute_reply": "2026-09-08T01:22:47.382526Z"
+     "iopub.execute_input": "2026-09-11T11:59:10.281612Z",
+     "iopub.status.busy": "2026-09-11T11:59:10.281061Z",
+     "iopub.status.idle": "2026-09-11T11:59:10.801764Z",
+     "shell.execute_reply": "2026-09-11T11:59:10.799753Z"
     },
     "papermill": {
-     "duration": 0.17429,
-     "end_time": "2026-09-08T01:22:47.383532+00:00",
+     "duration": 0.569772,
+     "end_time": "2026-09-11T11:59:10.802765",
      "exception": false,
-     "start_time": "2026-09-08T01:22:47.209242+00:00",
+     "start_time": "2026-09-11T11:59:10.232993",
      "status": "completed"
     },
     "tags": []
@@ -2619,16 +2619,16 @@
    "id": "p15b-code-06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:22:47.422895Z",
-     "iopub.status.busy": "2026-09-08T01:22:47.422895Z",
-     "iopub.status.idle": "2026-09-08T01:23:00.824577Z",
-     "shell.execute_reply": "2026-09-08T01:23:00.823566Z"
+     "iopub.execute_input": "2026-09-11T11:59:10.870364Z",
+     "iopub.status.busy": "2026-09-11T11:59:10.869138Z",
+     "iopub.status.idle": "2026-09-11T11:59:36.556019Z",
+     "shell.execute_reply": "2026-09-11T11:59:36.553449Z"
     },
     "papermill": {
-     "duration": 13.422867,
-     "end_time": "2026-09-08T01:23:00.825572+00:00",
+     "duration": 25.724045,
+     "end_time": "2026-09-11T11:59:36.557981",
      "exception": false,
-     "start_time": "2026-09-08T01:22:47.402705+00:00",
+     "start_time": "2026-09-11T11:59:10.833936",
      "status": "completed"
     },
     "tags": []
@@ -2659,7 +2659,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 2_000 tune and 2_000 draw iterations (8_000 + 8_000 draws total) took 12 seconds.\n"
+      "Sampling 4 chains for 2_000 tune and 2_000 draw iterations (8_000 + 8_000 draws total) took 22 seconds.\n"
      ]
     },
     {
@@ -2737,10 +2737,10 @@
    "id": "p15b-md-05",
    "metadata": {
     "papermill": {
-     "duration": 0.019495,
-     "end_time": "2026-09-08T01:23:00.863891+00:00",
+     "duration": 0.043906,
+     "end_time": "2026-09-11T11:59:36.643707",
      "exception": false,
-     "start_time": "2026-09-08T01:23:00.844396+00:00",
+     "start_time": "2026-09-11T11:59:36.599801",
      "status": "completed"
     },
     "tags": []
@@ -2755,16 +2755,16 @@
    "id": "p15b-code-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:00.904312Z",
-     "iopub.status.busy": "2026-09-08T01:23:00.903312Z",
-     "iopub.status.idle": "2026-09-08T01:23:01.755364Z",
-     "shell.execute_reply": "2026-09-08T01:23:01.754351Z"
+     "iopub.execute_input": "2026-09-11T11:59:36.739679Z",
+     "iopub.status.busy": "2026-09-11T11:59:36.739116Z",
+     "iopub.status.idle": "2026-09-11T11:59:38.864284Z",
+     "shell.execute_reply": "2026-09-11T11:59:38.863272Z"
     },
     "papermill": {
-     "duration": 0.874298,
-     "end_time": "2026-09-08T01:23:01.756395+00:00",
+     "duration": 2.176602,
+     "end_time": "2026-09-11T11:59:38.866284",
      "exception": false,
-     "start_time": "2026-09-08T01:23:00.882097+00:00",
+     "start_time": "2026-09-11T11:59:36.689682",
      "status": "completed"
     },
     "tags": []
@@ -2776,7 +2776,7 @@
      "text": [
       "Diagnostics de convergence MCMC (rho, kappa)\n",
       "==================================================\n",
-      "       mean    sd eti89_lb eti89_ub  ess_bulk  ess_tail r_hat mcse_mean mcse_sd\n",
+      "       mean    sd hdi89_lb hdi89_ub  ess_bulk  ess_tail r_hat mcse_mean mcse_sd\n",
       "rho    2.99  0.73      1.9      4.2      3913      3933  1.00     0.012  0.0085\n",
       "kappa  4.13  1.61      1.8      6.9      3499      3441  1.00     0.026    0.02\n",
       "\n",
@@ -2796,7 +2796,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAACI0AAADMCAYAAAD0mcEpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8ekN5oAAAACXBIWXMAAA9hAAAPYQGoP6dpAABnvElEQVR4nO3dB3iV5f3/8U/23nsSIEDYewg4ELfi3m0dta2tHY62alvrqFVrrVY7tLb/Vuvoz71xoaKIIHuvACEhi+y91/+675McEoaikpwk5/3yOtc5z3NOkscnITn3/Xzu79ejo6OjQwAAAAAAAAAAAAAAAHArnq4+AAAAAAAAAAAAAAAAAPQ9QiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAKBPpaWl6ayzzuKsAwAAAACAfu/OO++Uh4eHSktLXX0oAAAAvYLQCAAAAAAAAAAAAAAAgBsiNAIAAAAAAAAAAAAAAOCGCI0AAIA+U1dXx9kGAAAAAAAAAADoJwiNAACAXu35u3XrVl1++eWKiIjQ3Llznc8vXbpUM2bMkL+/v4YNG6annnrqoM+RlZWliy66SJGRkQoMDNSsWbO0cOFCvmMAAAAAAMBlcnJylJ6ernHjxqmoqEhPPPGETjzxRMXGxsrPz09jxozRY489dtDHpaWl6ayzztL777+vSZMm2TkR89pXXnmlx+uefPJJO6eyZMkSXXvttYqKilJoaKiuuOIKVVRU9Hjt66+/rjPPPFOJiYn2aw8fPlx333232traev08AACAwYHQCAAA6FUm9FFfX697771X3//+9+2+Xbt26cILL9TJJ5+sBx980AZKrrrqKm3ZssX5cWbSZfbs2Xrvvfd03XXX6Z577lFjY6POPvtsvfrqq3zXAAAAAABAn9u9e7eOO+44hYSE6OOPP1ZcXJwNiAwZMkS//vWv7TxHSkqKncv4+9//ftDH79y5U5dccolOP/103XffffL29rZzJ4sWLTrotT/5yU+0bds2uzDHBEaeffZZnXvuuero6OgRMAkODtZNN92kRx55RFOnTtXtt9+uW2+9tdfPBQAAGBw8Orq/uwAAADhKzITGXXfdpcsuu0z/+9//eqyqMStyzGqZY4891u4rKSmxEypmMuRPf/qT3XfjjTfq4Ycf1qeffuqsUFJbW6sJEybYyREzSePpSf4VAAAAAAD0/vyGmbsoLS3V/PnzlZSUZBe5mEUwRkNDgwICAnp83GmnnWYDImb+4sA5kZdfflnnn3++3VddXa2MjAzFx8dr7dq1ziDI1VdfbQMgy5cvl4+Pj93/wAMP6Oabb7bVRcyimsN97R/+8Id6+umnVV5ebquPAAAAfBGutAAAgF5lJioOZEqvdgVGjJiYGI0aNcq2o+ny9ttv2/Y13VvamJUzP/jBD5SdnW3b3gAAAAAAAPSFzZs36/jjj7fBjw8++MAZGDG6hzaqqqpsuMS81sxzmO3uTBuZ8847z7nd1XZm3bp12rdvX4/XmjmQrsCI8aMf/chWJjFzJof62jU1NfZrmzkXU/V1+/btR/EMAACAwYrQCAAA6FVDhw49aF9qaupB+8xkS/e+vGbljQmSHGj06NHO5wEAAAAAAPrCggULbEsaU2HEBD26++yzz3TSSScpKChI4eHhdnGMaVVjHBgaSU9Pl4eHR499I0eOtPdmkUx3I0aM6LFtFtMkJCT0eJ1p9WtCKGFhYfa4zNf+9re/fcivDQAAcCiERgAAQK86sESq4eXldcjX0jUPAAAAAAD0RxdccIFtNfPss8/22G/2mZY1psLHQw89pIULF2rRokW27a7R3t7ea8dUWVlpK5ps2LBBv/vd7/Tmm2/ar33//ff3+tcGAACDh7erDwAAAOBQhgwZoh07dhy0v6u0qnkeAAAAAACgLzzwwAO2Ncx1111nK45cfvnldr8JajQ1NemNN97oUVl18eLFh/w8u3btsotmulcbyczMtPem9U13O3fu1Lx585zbtbW1Kiws1BlnnGG3P/74Y5WVlemVV17Rcccd53zdnj17jtr/NwAAGPyoNAIAAPolMwGycuVKLV++3Lmvrq5O//znP+0kypgxY1x6fAAAAAAAwH2YkIeZk7jwwgt15ZVX2pBI92qq3aunmrYwTzzxxCE/T0FBgV599VXndnV1tZ566ilNmjRJ8fHxPV5rvl5LS4tz+7HHHlNra6tOP/30w37t5uZmPfroo0fp/xoAALgDKo0AAIB+6dZbb9X//d//2YmQn/3sZ4qMjNR///tfu1rm5Zdflqcn2VcAAAAAANB3zFzEM888o3PPPVcXX3yx3n77bZ1yyiny9fXVggULdO2119pqIP/6178UGxtrq4IcaOTIkbrmmmu0atUqxcXF6T//+Y+KiooOGTIxARDT+sZ8LVON1YRB5s6dq7PPPts+P3v2bEVERNgQi5k7McGWp59+mva/AADgK+FqCwAA6JfMxMmyZct08skn669//at+9atf2UkYU/b1vPPOc/XhAQAAAAAAN+Tj46OXXnpJs2bN0jnnnKPKykq7bQIbv/jFL/SPf/xDP/jBD3T99dcf8uNHjBih559/3gZOzIIZU0nEbJ966qkHvfZvf/ubRo8erdtvv11PPvmkLrvsMr3++uvO1jZRUVF66623lJCQoNtuu01/+tOf7DzKH//4x14/DwAAYPDw6OhetwwAAAAAAAAAAABHnWm3O27cOBv0+CImIHL11VfbaiTTpk3jOwEAAHoVlUYAAAAAAAAAAAAAAADcEKERAAAAAAAAAAAAAAAAN0RoBAAAAAAAAAAAAAAAwA15dHR0dLj6IAAAAAAAAAAAAAAAANC3qDQCAAAAAAAAAAAAAADghgiNAAAAAAAAAAAAAAAAuCFCIwAAAAAAAAAAAAAAAG6I0AgAAAAAAAAAAAAAAIAbIjQCAAAAAAAAAAAAAADghgiNAAAAAAAAAAAAAAAAuCFCIwAAAAAAAAAAAAAAAG6I0AgAAAAAAAAAAAAAAIAb8nb1AQAA+re6plbtq25UcXWTqhpaVG1ujS32sbnVN7eppa3d3ppbO5yPOzokby8PeXp4yNvTQ56ejvsAXy8F+nopyNdbgb7eCvLzUpCftyICfRQZ5KfIIF97Cw/wsR8DAAAAAACOvsaWNpXUNKm4ptHeV9a3qLap1d7MXIDjcZtaWtvV2t6h9o4Oe9/W3q629g55e3racb8Z63c99vX2VLCfGet7O+7N+L/zcbC/t8IDfBUd4hj3+3l78W0FAAAA+gFCIwDg5lrb2pVX0aDdJbX2tqe0TgWVjdpX1ajCqgZVN7a65LhMXiQi0FcRQb6KDfFTYniAvSWF+zsfJ4YF2BAKAAAAAADoySz42FtWr9zyeuWU12tvueNxfmWDSqqbVNPkmvF+l1B/b0UH+9lbUkSAUswtMtDeUiMDFRfqLy8WkwAAAAC9zqOjw6wFBwC4g4q6Zm3Kr9Lmgiptya9WZlGNcsrq1dzW/oUfF+LnrdhQP4UH+tpJnbAAH4UG+Nh7Uy3Ep3M1kY9X181RIcSuQmpzrEYyX6K1vV0NzW22Okl9c6vqzH1Tq2oaW1Ve32yPr6yu2W4fKbM6aUhUoIZFB2tYTJCGxwRpWEyw3ceqJQAAAADAYFfT2KLMolrtLKpx3BfXaMe+GhXXNH3px/p5e9rxfkywY8wf4u+oEmLmAboqhvh4e9pqIibA4WWqiXp5yMPDw1YcMWN+U33E3tra1dTa7qxSYu7rmtp6VC6pqG9WWW2zff2XMfMM6THByogP0cj4EI1JCNXE5HCFBfocpTMHAAAAwCA0AgCDVFNrmzbnV2lVdoXW7620YRGzmuhwk0QmaNEVuEiOCFBCmL+9mZU9If59OyHT3NquSjORVNes8rpmWyrXVD8xx19Q2aD8igb72IRPDscsRjL/L6MTQjU6IcTej00IVUyIn53cAgAAAABgIAZEthRUa1NelR3nm5upGHo4UUG+tnKHWVhhqneYm6nqYcb6ZnxswiF9PUZub++wVVBKa5tUWmvG/E3KqzBVUBrsvamIYsb9hwuWDIsO0qSUcE1Ni9Ds4dFKiwpknA8AAAB8A4RGAGAQTRytzq7Qquxye78+r9KGLw5kJlPGJYVpfFKYRsWHKD022LZ58RxgJV9NoazqhlblVtQru6xOe0rqlFVap6ySWmWV1B22zK4pe2sml6YMCdfklAhNSA6zK6cAAAAAAOhv417TTtaM8x23Cu0qrj3ka+NC/TQyLkQjYkM0Mi5YI8zjuGCF9vEikKOlrb3DBke273NUSd2+r8aGZQ4VkDELXo4ZHqXjR8bohFGxtioqAAAAgCNHaAQABigTCFmfW6mlu0r12a5S+9hMqnQXHeyraUMibUBifFK4xiaFDtgJo686sWZWKm0trNY2e6vR1gLH6qsDFyqZrExGfKimda5QmjUs0pbkBQAAAACgr+2ratTHO4q1bHeZDYoUVjUe9Jqk8ACNSwrVhORw56IQ07rVHZi2tmaRzLq9lVqRVWbvu7fcNW10Zg6L1Mmj43Ty2Hh7rgAAAAB8MUIjADCAghA7imq0dKcjJLJiT/lB7VlMudkZaZGabm5DIynReoCG5jZtLayyk0rmtnZvxUETcKYq77jEMM0eHqXZ6dH2fAb4evX+NxgAAAAA4HZa2tq1NqdCH2eWaPH2YltRozsTgjDBkBlDHWP9yanhtoIm9o/z1+RU2AU1H24r0s4DKrGMTQzVWRMSdc6kRCUSIAEAAAAOidAIAPRjdU2tNiCyeEeJXWl0YMDB9CY2wYa56VG2SobpU4yvprCqwQZIPs8qsyu5Diz16+/jqbnp0Zo/Ok7zM2IVG+rPKQYAAAAAfKPKoZ/uLNFbGwv1wbYi1TS29ljIMDE5XMeNjNGsoZGalBquQF9aqh4pU2F00dZ9WrS1SKtzKtTRsf+8zhoapfMmJ+n08fEKcYMqrAAAAMCRIjQCAP2smoiZ4Phoe7E+3lGilXvKe5RZNQGGmUOjbIhhTnq0MuJD5Gn6q+CoKa5utOGRZbtLbVWXggOCOhOSw3TS6DidMT5B6bHBnHkAAAAAwBGN980Y/+W1eXp38z5VdwuKRAT62JDIvFGxOnZEtKKoJHJUlNU26f2tRXp1Xb499138vD118pg4XTo91VYZZV4FAAAA7o7QCAC4WGNLm61yYUIii3cUK6esvsfzqZGBOjEjVieMitGsYVHy96FVSl9O6pnSwKbE7aJtxdqQW9nj+dEJoVowMUELJiRS5QUAAAAAcJCi6ka9tCZPL67OVXa38X5MiJ/OHJ+gMyckaEpqhLxYENKr8irq9fr6Ar2yNk+7S+qc+9OiAnXZjFRdODWZsA4AAADcFqERAHCBkpomfbS9yJZLNX13G1v2VxPx8fKw1URMSGReRqyGRQfJw9RRRb+oQmKqwLy7ZZ+tQtLa3lnnVrJ9pRd09klmVRgAAAAAuPcChLV7K/Wfz/bYqiJtnWPHIF8vLZiYqHMnJ2l6WiRBERd9bzbnV+uF1bl6bV2+apocFV98vTx16rh4XT4jVbOGRTIPAwAAALdCaAQA+siu4lobEjH9itfu3d9X14gP9de8DEcp2tnp0Qr2o19xf1dR12zDI29uKLCVYrryIyb0Y9rXXDQtWceNiJG3l6erDxUAAAAA0Ada29q1cFOh/rN0jzbkVTn3TxsSoYunp9jKIkGM9/uN+uZWO6Z/dsVebez2/RoWE2TDIxdNS1FYgI9LjxEAAADoC4RGAKCXmJVE6/ZW2KCIuWWV7i9/aoxPCrM9dE3AYHRCCKtYBrDimka9vbFQr6zL7zHRFBvipwumJuviaSkaGh3k0mMEAAAAAPSOlrZ2vbo2X49+vMvZgsbX21PnTEzU1XOGakxiKKe+n9ucX2XDI6+vz1d9c5vdF+jrpQumJOvK2WlKjw129SECAAAAvYbQCAAcRY0tbfp0Z6ne37LPtjEpq2t2PmcqUBwzPFonj47VSWPilBAWwLkfhLYVVuvF1Xl6dV2eKupbnPuPHRGt78waohMzYqk+AgAAAACDJCxi2pw8uni38isb7L6IQB8bFPnWzFRalw5AtU2ttm3NU8uzlVlU22NMf/WcNJ0wMlaenrQQBgAAwOBCaAQAjkJQ5OMdJXp7U6E+3Fakus4VKUaov7fmZcTaiiLHj4xRiD9lTd1Fc2u7/Xl4fnWuPskscbYjSgzz17dmDbHVR2JC/Fx9mAAAAACAr6i9vUNvbSrUQ+/vcFYWMeO7a48bpstmpNKCZhDo6OjQ8t1lemJZtm0z3DWmT4sK1BXHpOnCackKZY4HAAAAgwShEQD42kGRYi3ctE8fHRAUSQjz16lj421QZMbQSPl4eXKO3dzesno9uzJHL6zKdVYfMZVnzhifYKuPTB0SQXsiAAAAABgAlu4s1X3vbNOWgmq7HR3sqx/PS7dhEX8fL1cfHnppTP/059l6blWuahpb7b4gXy9dODVZV8xO0/AYWtcAAABgYCM0AgBHqLWt3baeeXVdvl1l0tXj1kgKD9Dp4+J1xoQETUoOp1QpDhs2WrixUE9/nqP1uZXO/WMSQnXl7CE6Z1ISk4wAAAAA0A/lltfr9wu36r0tRXY72M9bPzhumK6ZO5TKIm6irqnVzgk9uSxbu4r3t64xlWWvmp1m72ldAwAAgIGI0AgAfEk50s351XplXZ7e3FCg0trmHkGRM8bH22oRk1LCqRSBr2RTXpVdqfT6+gI1tbbbfeGBPrpkeoqtPpIcEcgZBQAAAAAXq29u1WMf79bjS7JsG1IvTw87ZvvZ/BGKDPJ19eHBRXNFn+0q05PL9ujD7cXO1jVDo4PszwatawAAADDQEBoBgEMoqGzQa+vz9cra/B6rR8yE0NkTE3XOpESCIjgqKuqa9fzqXD29PEf5lQ12n6eHdNLoOLtS6ZjhUQSSAAAAAMAFwYA3Nxbqvre3qbCq0e6bkx6lOxaM1ci4EL4fsHLK6vTU8hy9sLpn65oLTOuaY9KUHkvrGgAAAPR/hEYAoFNLW7s+3FakZ1fs1dJdpc6VIr7enjp5TJzOn5yk40bGyMfLk3OGo66tvcP+/P13ebZdsdRlZFywnWg6f0qSAn29OfMAAAAA0MuyS+v061c3adlux9gsOSJAt505WqeOjSfUj8O2rnllXb7+e0DrmmNHROvKY9I0LyPWVqkBAAAA+iNCIwDcnulL/NyqvXphdZ5Kapqc52PG0EgbFDl9fILCAnzc/jyh7+wsqrHhEVPppr65ze4L8ffWxdNSdMUxQzQkKohvBwAAAAD0wmKSf32apUc+2GnbiPp5e+q6E9J17fHD5O/jxfnGEVWoMWGjJz7L1ofbi5wLklIiA3TFrDQ7rg8LZI4JAAAA/QuhEQBuqb29Q5/sLLErQD7JLHEO4qODfXXRtBRdNj1VqVGBrj5MuLmqhha9tCZPTy3PVk5Zvd3n4SHNGxWrK2en6dj0aHmyUgkAAAAAvrF1eyv0q1c2afu+Grs9Nz1a95w3jtA+vtEipac/z9Hzq3Lt+N4I8PHSuZOTbDvaUfG0OQIAAED/QGgEgFupb2611Rue+GyPdpfU9SgXetmMVJ00Os62owH6Xcgps0RPdoacugyLDrKVR0yv5BB/VioBAAAAwNdpK/LAeztstUezoCQi0Ee/PWuMzpucRCsaHBUNzW16bb2jdU1XKMmYNSxSV80eqpNGx8qbVsgAAABwIUIjANxCYVWDnlqeo/+t2Otc3RHi561Lpqfo27OGKC2adh8YGLJKau3PsqlAUtvUavcF+XrpvClJtszt+KQwJjYBAAAA4Ah8nlWmX760QbnlDXbbtKj9zZmjFRXsx/lDr7SuWbGn3IZH3t9apLZ2R9nbpPAAOzd16fQURQT5cuYBAADQ5wiNABjU9pTW6bGPd9nqIq2dg/HUyEBdPSfNtqEJ9vN29SECX4sJjLy6Ns9WH+leNWdUXIgumpZsV8Ux0QkAAAAAh6788Mf3tuuJz7KdF+3vO3+8jhsZw+lCnyiobNAzn+fo/1buVUW9Y3GTn7enzpmUaNvRjk0M4zsBAACAPkNoBMCgtGNfjf6+eJfe2ligzqyIZgyN1DVzTdnPOHl5erj6EIGjtlJp2e4yvbA6V+9s3qfm1na739vTQ/NHx9rwyAmjYuXv48UZBwAAAOD21uSU6xcvbrSLTAxT3cFUF6HlJ1yhsaVNb24osO2RNudXO/dPGxJhwyOnjYuXD61rAAAA0MsIjQAYVDblVekvH+3Uoq1Fzn0nZsTqx/PSNXVIhEuPDehtVfUtemNjgV5anasNeVXO/aZ9zUlj4nTWhEQdNzJaft4ESAAAAAC438X5hxZl6l+fZqmjQ4oP9dcfLhhvQ/ZAf1gQsnZvhZ5clqN3NhU6q+XGhvjp8pmp9hYb4u/qwwQAAMAgRWgEwKCws6hGD76fqXe37LPbHh7S6ePidd0J6RqXRElPuJ/t+6ptW6aFGwuVX+noz22E+Hnr5LFxtuLO3BHRCvX3celxAgAAAEBv25BbqZteWO9s7Xnh1GT99qwxCgtgPIT+p6i6Uf9bsVf/W7lXJTVNdp+Pl4dOH5egK2cP0ZTUCHmYiS8AAADgKCE0AmBAyy2v18Mf7NSr6/JsGxozZj5nYqJ+cmK60mNDXH14gMu1t3doXW6lDY8s3FSgomrHhFNXC5vpaZGalxFjK/IMjwlm4gkAAADAoNHa1q5HP96tRz7cqbb2DsWE+Om+88bbSoxAf2faz76zuVBPLc/RmpwK5/5xSaG64pg0nT0xkVa0AAAAOCoIjQAYkMxKi799tNOuumhpc5TsPHVsnH5+yiiNjCMsAhwuQLJmb4Xe3bxPi3cUK6tzlV2XpPAAzRwWqVlDo+x9amQgIRIAAAAAA9Lesnrd+MJ658X2BRMTdfc5YxUe6OvqQwO+ss35VXpqebZeX1+gptZ2uy8i0EeXTE/Vt2elKjkikLMKAACAr43QCIAB14P430v36NHFu1TX3Gb3HTsi2oZFJqWEu/rwgAElu7TOhkcW7yjR51lldhVTd6bHtwmPTBsSoQnJ4cpICJGft5fLjhcAAAAAvkxHR4deXpuvO9/YotqmVtui8+5zx+ncyUmcPAx4FXXNen51rp5enuNsRevpIc0fHacrj0nTnPQoFn8AAADgKyM0AmDATPq8ubFQ97+z3TkonpgcpltOz9Ds4dGuPjxgwKtvbtXq7Aqt2FOmFVnl2pBX6azi08XXy1OjE0JsgGRCcpgmpoTbljZeZoYKAAAAAFyssr5Zv3l1sxZuKrTbM9Ii9eDFE5USSRUGDC6m3dJH24v132XZWrqr1Ll/eEyQrpydpvOnJCvYz9ulxwgAAICBg9AIgH5v7d4K3f3WVq3bW2m3E8L8dctpGbZ3qycXq4Fe0dDcZv/trcgq07rcSm3Mq1JVQ8tBrwvy9dKYxFCNTQzTuCRzC1V6TLC8vTz5zgAAAADoM5/tKtXPX9igfdWN8vb00I0nj9QPjx9OyB2D3q7iGlt55KU1ec6qvCH+3rp8Zqq+O2eo4kL9XX2IAAAA6OcIjQDot8rrmnXf29v04po8ux3g46UfnTBc3z92mAJ8aZEB9HW1n73l9dqQV6WNnSGSzQVVqu+ckOrOz9tTGQkmSBKqcTZMEqqRcSHy9+HfLQAAAICjq6m1TX96b4f+9ekeuz0sOkgPXzrJVkgE3ElNY4teWZuv/y7PVlZJnd3n4+Whcycl6QfHDdOIuBBXHyIAAAD6KUIjAPpt/+F7Fm5VRb2jssGFU5P1y1NHsToC6GflcHeX1GpzfpW2FFTb+60F1appaj3otWaln5mgGmeCJElhtr2NqU7i601FEgAAAABfT2ZRjX72f+u0fV+N3TaVFW47c7QCfWnLAffV3t6hD7cX659LdmtVdoVz/4kZsTY8MnNopDw8aDMLAACA/QiNAOhXdhXX6rbXNunzrHK7PSouRPeeP05Th0S6+tAAHOHklKlIYqqQbM6v1hZ7X+UMgHXn7+OpSSnhmp4WqWlpkZqSGq4Qfx/OMwAAAIAvHXeYagr3vbNdza3tigzy1f0XTNDJY+I4c0A3pu3sPz/J0ntb96mjw7FvYnKYrpuXrlPGxBEeAQAAgEVoBEC/0NjSpkcX79I/PslSc1u7vZh8/fyR+t6xQ+XjRSUCYKBXDyqsarThkc2dFUnW7a04KEji6SFbQvqEUTE6YVSsxieF0X8cAAAAQA/F1Y36xUsbtSSzxG6b8cMfL5yg2BB/zhRwGHtK6/T/Ps3SS2vy1NTabveNTgjV9fNNeCRenmZADgAAALdFaASAy322q1S3vbbZDmCNeaNi9LtzxiklMtDVhwagF1cGZpXW2lK5q7LL7S23vKHHa8xqwWNHRNtJ4BMz4hQWQBUSAAAAwJ29t2Wfbn15ow2g+3l76jdnjtZ3Zg2hWgJwhEprm/TEZ3v032U5qu1sLZsRH6KfzR+h08YSHgEAAHBXhEYAuHSg+vu3tuq19QV2OzbET3eePVanj4tnwgdwQwWVDXa14CeZJVq6s1Q1nRNYho+Xh+amR+uM8Ql2FVRYIAESAAAAwF3UNbXq7re26rlVuXZ7TEKoHrl0kkbEhbj60IABqbK+Wf9eukdPfJbtDI+YFtE/P2WkbfPk4UHlEQAAAHdCaASASyoMPL86V/e9vU3Vja0y49ArZg3Rz08dpVB/LgQDkFra2rU2p8IGSD7YVqTMotoeAZKTRsfpwqnJOn5kjLxpYQUAAAAMWutzK3XDc+uUXVZv5w9+cOww3XTKSPl5e7n60IABr6q+Rf/+bI+eWLrHuXBj6pAI3XJahmYMjXT14QEAAKCPEBoB0Kd27KvRb17dpNU5Fc7VQfeeP16TUsL5TgA4rF3FNVq4cZ/e3lSoHUU1zv3RwX46f0qSLUlNSysAAABg8Ghr79Cji3fp4Q932scJYf568OKJmj082tWHBgzK8MjjS3brP5/tUWNLu903PyNWN5+WoVHxVPQBAAAY7AiNAOgTDc1t+stHO/WvJVlqbe9QoK+Xbjp5pK6anUaVAABfydaCar28Nk+vrctXWV2z3WdWHM7PiLO/U+akR1FKFwAAABjAcsvrdePz650LTs6ckKB7zx1Pm0qglxVVN+rhD3bqhdW5NqxlxtrnT07WzaeNUlyoP+cfAABgkCI0AqDXLd5RrNtf36zc8ga7bXqj3nn2WCWFB3D2AXyjFjaLtxfrmRV7tSSzxLk/PTZYV85O0/mTkxTk580ZBgAAAAaIjo4OvbouX7e/vkW1Ta0K9vPW784Zq/MmJxEMB/rQ7pJaPfj+Dr29aZ/dNou/fjwvXdfMHSp/H1pDAQAADDaERgD0muLqRt311lYt3Fhot00p2bvOHqtTxsZz1gEc9Qmtp5Zl66U1eaprbrP7wgN99N05Q22AJCzAhzMOAAAA9PP2GL95bZPe6pxDmDYkQn++ZBJtKAEXWre3Qr97a6vW7a202ymRAfrNGWN06tg4glwAAACDCKERAEedKV/57IocPfDuDtU0tcrTQ7p6zlDdePJIu0oIAHpLTWOLDY78d1m2ssvq7b4QP29dMXuIDZBEBftx8gEAAIB+ZtnuUv38hQ0qrGqUl6eHbpg/Qj86YTjtbIF+oL29Q29sKNB972xTUXWT3Td7eJTuWDBWo+JDXH14AAAAOAoIjQA4qrYUVOnXr27WhlzHCoSJyWG657zxGpcUxpkG0KfhtYWbCvX3j3ZpR1GN3Rfg46XLZ6bq2uOHKTaEXswAAACAqzW3tuvBRTv0zyVZ6uiQ0qICbXWRyakRrj40AAeoa2rVPz7ZrceXZNl/uybg9b25Q3X9SSMU6MsiMQAAgIGM0AiAozZwfPiDTP3ns2x7sdZUFLn5tFH61swhdhAJAK5aEfXBtiL9bfEubcyrcoZHrp6TpmuPH07bGgAAAMBFdhXX6Prn1mtLQbXdvnR6in571hgFUaEU6Ndyy+v1+4Vb9d6WIrudFB6gO88eq5PHxLn60AAAAPA1ERoB8I0t2lqkO17frIKqRrt95vgE3b5gjOJCWckPoH/o6OjQkp2l+vOiTK3vrIQUFuCjHx4/XFfNTlOAr5erDxEAAABwm/fmz3yeo98v3Kam1nZFBProvvMn6LRx8a4+NABfwYfbinT761uUX9lgt01oxIRHTIgEAAAAAwuhEQBfW0Flg+58Y4ve3+pYWZAcEaC7zxmneRmxnFUA/XaC2gTdHnhvh3YW19p9sSF++tn8Ebpkeop8vDxdfYgAAADAoFVS06SbX9qgxTtK7PaxI6L1p4smsugEGKAamtv0l4926l9LstTa3mEre9548ghdPWco42sAAIABhNAIgK+sta1d/12eo4fe36G65jZ5mx6mxw7T9fNHsFofwIBg2mi9ti5ff/4gU3kVjlVRw2OC9JszR2veqFh5eNBWCwAAADjaVQlufmmjyuqa5evtqVtPy7BV/zxpaQsMeJlFNfrNq5u0KrvCbmfEh+ie88Zr6pAIVx8aAAAAjgChEQBfydq9Fbrt1c3aWujoOWwGf/ecN04Z8aGcSQADTlNrm/5vxV795aNdKq9rtvvmpkfb8MjoBH6vAQAAAEejEsHvF27Vsyv2Oi8mP3zpJOYRgEGmvb1DL63N031vb1NFfYvMWozLZ6Tq5tMybHtYAAAA9F+ERgAckcr6Zt3/7g49t2qvOjpkB3u3nJahS6ensCoIwIBX3diivy/epSeWZqu5rV1msePF01J00ykjFRvi7+rDAwAAAAakTXlVuv75dcoqqbPb18wdql+eOkr+Pl6uPjQAvcQsyLj37W16aU2e3Y4J8dOdC8bqjPHxVPUEAADopwiNADiiVQJ/eGe7cxX+hVOTdevpGYoO9uPsARhUcsvr9Yd3t2vhxkK7HeTrpR+dMNy24GJiGwAAADjydpCPL9mth97PVGt7h+JC/fTgRZM0d0Q0pxBwE8t2l+o3r27WnlJHaOzEjFj97pyxSo4IdPWhAQAA4ACERgAc1vZ91frta5ud/UhHxgXr9+eO14yhkZw1AIPa6uxy3b1wmzbkVtrtxDB/W1L37ImJVFcCAAAAvkB+ZYNuen69Vuwpt9unjY3XfeePV0SQL+cNcDONLW169OPdeuzjXWpp61CAj5d+fspIXTU7Td5enq4+PAAAAHQiNALgIHVNrXrkw53699I9dnVQoK+XbjhphK6eM1Q+DOgAuFGlpTc3Fuj+d7aroKrR7puYHKbbzhqj6WmE5wAAAIADvb4+X7e9tlk1ja12LsG0pLhoWjItKQA3t6u4Rr9+ZbNWZjvCZGMTQ22YbEJyuKsPDQAAAIRGAHTX0dGhdzbv091vbVVh5wVSsyLo9gVjlBgewMkC4LYro0yI7tHFu1TX3Ob83WjadKVFB7n68AAAAACXq25s0e2vbdZr6wvs9qSUcD18ySTeLwPosTDjhdW5uvftbapubJWnh3Tl7DT9/JRRCvbz5kwBAAC4EJVGAFg79tXorje3aNnuMrudEhmg3509TvMyYjlDACCpuKZRf160U8+v2qv2DsnHy0NXHJOmn56YrvBASm0DAADAPa3cU64bn19v29KYi8A/PXGEfnJiOpVKARxSSU2Tfr9wq17vDJklhPnrrrPH6pSx8ZwxAAAAFyE0Ari5qvoW/fmDTD39eY5tRePr7akfHjdM181Ll7+Pl6sPDwD6ZcjOrIz6JLPEbocF+Ohn80foO7OG2N+hAAAAgDtoaWvXwx9k6rGPd9tQdWpkoP58ySRNHRLh6kMDMACYMfVtr21SbnmD3T51bJzuOnuc4sP8XX1oAAAAbofQCOCm2jpLQj7w3g6V1zU7B2e3nTlGKZGBrj48AOj3lmSW6J6F27SjqMZup0UF2pY1p46Np2c7AAAABrWsklrd8Px6bcyrstsXTk3WnWePpcUEgK+koblNj3y4U//6NMvOVZo2Nb88dZS+PWuIvEzpIgAAAPQJQiOAG1qTU6473tiizfnVdjs9Nlh3LhiruSOiXX1oADCgmEmtF1fn6sFFmbbErjEjLVK/OXO0JqaEu/rwAAAAgKOqo6NDz6/K1V1vblVDS5utunff+eN1xvgEzjSAr21bYbV+9comrc+ttNsTksN0x4KxVC4CAADoI4RGADdSVN2oP7yzXa+uy7fbIf7euvGkkfrOMUPoNQwA30BdU6se/2S3/vlplhpb2u2+cyYl6henjKJ6EwAAAAaFyvpm3fryJr27ZZ/dnj08Sg9ePFEJYQGuPjQAg2RRxv9W5OiP7+5QTVOr3XfupETdcnoGv2cAAAB6GaERwA00tbbpP0uz9dePdqq+uU0eHtIl01L0i1NHKTrYz9WHBwCDRmFVg/70XqZeWZenjg7Jx8tDl0xP0U9PHKG4UPoyAwAAYGBatrtUNz2/QfuqG+Xt6WHbR3z/2GHypH0EgKPMVPH803s79MKaXDuuDvDx0nUnDNf3jxsmfx8vzjcAAEAvIDQCDPKysR9sK9a9b2/TntI6u29yarjuOnusJiTTNgEAesvm/Crd/+52fbqz1G77eXvqytlp+uHxwxUZ5MuJBwAAwIDQ0tauhxZl6h+f7LYXb4dFB+mRSydrfHKYqw8NwCC3Ka9Kd725RatzKux2UniAbj5tlBZMSCSwBgAAcJQRGgEG8QXLexZu0/KsMrsdE+KnX52eoXMnJTGwAoA+8nlWmV0h1TXJFeznre/OHarvHTtUof4+fB8AAADQb5nFJ9c/t04b86rs9qXTU3T7gjEK9PV29aEBcKMFcW9uLNR9b29TYVWj3Tc6IVS/PHWk5o2KlYcppwwAAIBvjNAIMMgUVTfaC5QvrXW0RvD19tT3jx1qV7eHcIESAFwyyfVxZokefH+HNudX233hgT76wXHDdMUxaTZIAgAAAPSn968vrsnTnW9ssS1uwwJ89Ifzx+v08QmuPjQAbqqhuU3/79Ms/XNJlmqaWu2+6WkRuvm0DE1Pi3T14QEAAAx4hEaAQTR4+tenWbZkrJnUMc6emGjLNiZHBLr68ADA7ZnJ93c379ODizK1q7jWng8zAW/a1lw9O00RtK0BAACAi1XVt+jXr27Swk2FdnvWsEg9dPEkJYYHuPrQAEAVdc127vPJZdlqam23Z2TeqBhdf9JITUqhFTcAAMDXRWgEGODa2zv02vp8/fHdHdpX7SjTOCU1XLedNUZTUiNcfXgAgAO0tXfo9fX5+tviXcoqqbP7An299K2Zqfr+scMUG+rPOQMAAECfW5FVphufX6+CqkZ5e3roxpNH2qqlXp60fwDQv+yratQjH+7UC6tz7RjbmJserevmDdcxw6JoWwMAAPAVERoBBviEzu8XbtOmfEd/4aTwAN16eobOmpDA4AgA+jkzsWUqj/x98S5tLXS0rTEtxS6ammwn51MiqRIFAACA3tfS1q5HPtipRz/eJXPtdUhUoB65dDKr9gH0e3tK6/S3j3bZBXVd4RGzmO7H89J1YkYs86MAAABHiNAIMADllNXpvre3690t++x2sJ+3HQxdPSdN/j5erj48AMBXbFvz8Y4SW3lkTU6F3WdWcy6YkKDvHTtM45LCOJ8AAADotfmF659br/W5lXb7wqnJuvPssXaeAQAGitzyev1zSZaeX52r5s62NRnxIfru3KG2fTfzpQAAAF+M0AgwgJTWNumvH+7Usyv2qrW9Q6ZC7GUzUm3J2OhgP1cfHgDgG4ZHPs8qtys8P91Z6tw/c2ikDY/Mz4iVJ6XBAQAAcJTee76yNl+3v75Zdc1tCvH31r3njdeCiYmcXwADVnFNo/796R4983mO/d1mRAX52naw3541hHawAAAAh0FoBBgA6ppa9f8+3aN/LtntHPAcNzJGvzljtEbFh7j68AAAR9nGvEr9e+keLdxYaEOCRlpUoF0lZVZ/Bvqy8hMAAABfT3Vji257dbPe2FBgt6enRejPl0xScgTtEQEMDlX1LXpu1V79d1m2Cqoa7T4fLw+dNSFRV81O04TkMFrXAAAAdENoBOjnfYWfW7lXj3y4U6W1zXafGdTcelqGZqdHu/rwAAC9rLCqQf9dlqP/rchRdWOr3RcW4GOrTH3nmCFKCg/gewAAAIAjtjq73Lajya9ssC0Rb5g/QtfNS7ePAWCwaW1r13tbivTEZ3u0urMdrDEuKVSXzxiicyYlKoh2XAAAAIRGgP5aJnbhpkL96b0dyi6rt/uGRAXql6eO0pnjE0jCA4AbVpx6aU2enejq+rtg5vXnj47TFccM0dz0aP42AAAA4AsvnP71o13660c7ZQrZpUQG6JFLJ2tKagRnDYBb2JBbqSeXZds51+bWdrsv2M/bBke+NXOIxiSGuvoQAQAAXIZKI0A/s2x3qf7wznZtzKuy29HBvrp+/ghdOiNVPl6erj48AIALtbV36MNtZpVUtpZnlTn3D4sOsv2ZL5yWrFB/H75HAAAAcMotr9cNz6/Xms5V9udPTtJd54xVCO8bAbih8rpmvbwmT/9buVd7Suuc+yelhOtbM1N15oQEWsICAAC3Q2gE6CfM5M1Di3bos12Oi4BBvl76wXHD9b1jh1ImEQBwkJ1FNXr68xy9sjZftU2O1jUBPl46d3KSrT4yOoFVUgAAAO5exfS19fm6/bUtqmlqVYift35/3jidMynJ1YcGAP3id+Ty3WV6duVevbd5n1pNGSbJ/q5cMClRl05P0fikMKp6AgAAt0BoBHCxjXmVemhRpj7eUWK3fbw8dPmMVP10/ghFB/u5+vAAAP2cCYy8ujZPTy3P0c7iWuf+6WkRtvrIaePi5eft5dJjBAAAQN+qamjRba9t1psbCuz2lNRw244mJTKQbwUAHKCkpkkvrsnV/63cq9zyBuf+jPgQXTI9RedNTlJ4oC/nDQAADFqERgAX2VpQrT9/kKlFW4vstpenhy6ckqyfnJjOJA4A4Gutklqxp1xPL8/Ru1v22VY2RkSgjy6cmmzbnA2PCebMAgAADHIrssp00wsblF/ZYOcafnbiCP143nB50/IWAL5Qe3uHPs8q0/Orc/XO5n1qbm23+329PHXquHhdMi1Fs4dHydPTgzMJAAAGFUIjgAvaCTz8wU4t3FRot80Yw7QSMJM4adFBfD8AAN9YUXWj/rdir55flat91Y3O/TOHRurymak6dWy8/H2oPgIAADCYmIubD3+Qqcc+2a2ODmlIVKD+fMkkTUmNcPWhAcCAU1XfYlt8PbcqV9sKq537kyMCdPG0FLs4IzE8wKXHCAAAcLQQGgH6yJ7SOj3yQaZe31BgJ288PKSzJiTq+vkjlB7Lym8AwNHX2tauTzJLbIndj7YXq7P4iMIDfXTBlGRdNiNF6bEhnHoAAIABbndJrW54br025VfZ7YumJuuOs8cq2M/b1YcGAAO+qufm/Go9v3qvXl9foJrGVrvfzO0eNyJGl05P0fzRcfL19nT1oQIAAHxthEaAXrZjX43+vniX3tpY4LxYd9rYeN148kiNiudCHQCgbxRWNeiFVXl6ftVeFVTtrz4yIy1Sl81M0enjEqg+AgAAMAAvZppV8L97c6saWtoUFuCj+84frzPGJ7j60ABg0GlobtM7mwttVU/THrZLVJCvzpucpEump2hEHPO9AABg4CE0AvSSDbmV+tviXVq0tci576TRsbrhpJEalxTGeQcAuERbe4eWZJbof53VR8y2YS4wnDMpURdNTdG4pFB5mGVTAAAA6LfK65p1y8sbnfMOs4dH6cGLJyohjHYJANDbskvr9MLqXL20Jk/FNU3O/VNSw214xFSYDqLaEwAAGCAIjQBH2YqsMhsW+XRnqeMfmYfsCp8fn5CuMYmhnG8AQL+xr6pRL67OtatT8ysbnPtHxYXY/sznTk5STIifS48RAAAAB3t38z7d9tomldY2y8fLQzefmqFr5g6VpyfBXwDo67awH+8o0fOrc3sszAjy9bLBkYunp9ggCQszAABAf0ZoBDhK5WA/ySyxbWhWZVfYfV6eHjp3UpJ+dMJwpccGc54BAP2WmdT6bFepXSH13pZ9amptd/4tmzcqxgZITsygRzMAAICrVdQ16843t+j19QV2e2RcsP58ySSNTaSiKQC4WnF1o15em28rkOwprXPuHxEbbKuPmBY2UcEszAAAAP0PoRHgG2hv79D7W4tsWGRTfpXd5+vlqYumJeuHxw9XSmQg5xcAMKBUNbTorY0FNkCybm+lc39EoGlfk2QDJGMTaV8DAADQ10wbml+/ukklNU0yBUXMvMP1J42Qn7cX3wwA6GcLDFfuKbfVR97eVKjGFsfCDFMZ6uQxcbp4WoqOHRFjF2oAAAD0B4RGgK+hpa1db24o0D8+2a3Molq7L8DHS9+amarvHzdMcaH+nFcAwIC3q7jWhkdeWduzR/PwmCCdPTFJZ09K1NDoIJceIwAAwGBXVd+iu97colfW5dttU830TxdN1KSUcFcfGgDgS1Q3tuiN9QW2+sjGPMeiQyMxzF/nTUnS+VOSNTyGKtUAAMC1CI0AX0FtU6ueW7lX/166R4VVjXZfiJ+3rpqTpqvnDFVkkC/nEwAwKHs0L91VqhfX5OmDrUXO9jXGxOQwnT0pSQsmJCiW0CQAAMBR9dH2Iv3qlU0qqnZUFzELVW48aaT8faguAgADzdaCahseeXVdvq3y2cWEAC+YmmzH1eGBzC8DAIC+R2gEOALFNY168rNsPf15jmoaW+2+mBA/XT0nTd+eNUSh/j6cRwCAW6hpbNH7W4r0+oYCfbarVG3tHXa/h4d0zLAonTUh0ZbbNX8nAQAA8PWU1jbp7re26vX1BXZ7WHSQHrhooqYOieCUAsAA19jSpg+2FemVtfn6JLPEOa42bc/nj47VBVOSdfyoGPl4ebr6UAEAgJsgNAJ8gd0ltfrXkiz7Br65zbGqelhMkK49bpjOnZxE32AAgFsrqWmy/Znf2FCgNTkVzv1mFey0tEidPi5ep46NV2J4gEuPEwAAYKDo6Oiwq9DvfXu7XYVu3ld9d85Q/eLUUVQXAYBBuljRtK95eW2+thVWO/dHBfnalrDnT07WuKRQeZiVGgAAAL2E0AhwCObC1+Of7NaibUXqcAS97WoeExY5aXScPM2sDQAAcMotr7fhkXc379Om/P19mo2JKeE6bWy8DZGkRQdx1gAAAA6zcOXXr2zSij3ldntMQqj+cMF4TUgO53wBgJu0r3l5bZ5eX5+v0tpm5/7UyECdOSFBZ45P0NhEAiQAAODoIzQCdGpv79BH24v1+JLdWpW9f7W0KbFvwiJmxTQAAPhyeRX1em9Lkd7dXKjVORXOAKaRER+i08bF2xAmk10AAACONgX/+GS3Hl2821Y5DfDx0k0nj7Qtcb1pTQAAbqe1rV1LdpbY6iMfbitSY4ujArYxNDrIhkdMiMSMr6lAAgAAjgZCI3B7Ta1ten1dgQ2L7C6pc/aPPG9ykr5/3FClx4a4/TkCAOCblNp9f0uR3tuyT8t2lzl7NRtxoX46MSNWJ2bEaU56lAJ9vTnRAADArVrRLNpapLsXblVueYPdN29UjH53zjilRAa6+vAAAP1AfXOrXei4cGOhvW9q3R8gMW3UTxkTr/mjYzUlNUJeVMcGAABfE6ERuK3qxhb9b8Ve/WfpHhXXNNl9IX7e+tasIXY1T1yov6sPEQCAQaWyvlkfbCvW+1v2aemuUtU3tzmf8/X21DHDouxk17xRsVwoAQAAg74VzV1vbtWSzBK7nRDmr9+cOdquHmfVOADgUGqbWm3lERMg+TizRM3dAiQRgT46YVSsHVMfNzJGof4+nEQAAHDECI3A7eyratR/PttjAyPmjbYRH+qv785N02UzUhXCG2oAAPqk0teKrHK7UurD7UXO1bVdRsYF2wokZsJrcko4pdkBAMCgYOYh/vrRTruApaWtw1Y6NVVOfzwvnaprAIAjVtPY4hhPbyvWxzuKVd3omOc2TMWRSSnhmpMerTnDozQ5NcIu1AAAADgcQiNwG1sLqvXvpXv0xoZ8OzFjjIgN1rXHD9fZExN54wwAgAtLs5vVtmay68PtxVqTU9GjjU1YgI/mpkfr+JExdsVUfBjVwAAAwMDS2tauF9fk6aFFmSrprHZq2vTdftYYpUUHufrwAAAD/G+MGUeb8bSpRNLVgr1LgI+XZgyN1OzhUZqWFqFxSWHy8/Zy2fECAID+h9AIBrX29g59nFms//fpHi3bXebcb94k//D4YTphZKw86fUIAEC/UlXfok92luijbUW25G5lfUuP5zPiQ2yAxNympkUw2QUAAPp1ONa8n7nv7W3KLKq1+4ZEBdqwyPzRca4+PADAIJRbXq9lu0u1dFeZlu0qVVldc4/nTZWr8clhmjYkQlM7b1HBfi47XgAA4HqERjAoNTS36eW1ebYNTVZnstqU5Tt9XLyumTvUluQDAAD9n6k4siGvUp/sKNEnmSX2ccf+IiQK9PWyq6W6qpAMiWKlLgAA6B+2FFTpvre3a+muUrsdHuijn504Qt+eNYRqpwCAPltUuaOoRp/tKtXKPeW2IsmBIRJjWHSQnTOfnBpub6PiQmgTCwCAGyE0gkGluLpRTy3P0TMrcpyrkkP8vHXZzFRdOTtNSeEBrj5EAADwDVTUNevTXaU2RLJkZ4mzvHuXtKhARxWSUTGaNSxKgb7enG8AANCnskvr9MiHO/Xa+nwbdjUruq+ak6Yfn5CusEAfvhsAAJdWwMouq9fqbEeAxNx2FjsqYR3Y0mZCctj+IElKuGJDaRULAMBgRWgEg8KG3Er9d3m23txQoJY2x/LjlMgAfXfOUF00LUXBflwwAgBgME52bSussRVIPsks1ursCrW27y9DYi7QmJZ0XSGSEbHB8vDwcOkxAwCAwSu/skF//XCnXlyTZ6ulGQsmJurmU0cpJTLQ1YcHAMAhVdY3a+3eCq3bW6n1uZVav7dSNU2tB73OLMic1BkgMWGSsYmh8vfx4qwCADAIEBrBgNXY0qY3NhTomc9ztDGvyrnf9GL83rFDdfKYeNuSBgAAuIeaxhYt313WGSIpUV5FQ4/nE8L8ddwIR4BkTnq0wgJY6QsAAI5O1dO/L96l/1uZq+a2drtv3qgY3XTyKI1PDuMUAwAGXEub3SW1NkSyLtcRJjEtbrq3ijV8vDw0JjGsM0RiwiQRdiEnizUAABh4CI1gQJZ5fXZFjl5YnaeqhhbnSuKzJiToitlpmpQS7upDBAAA/aAKSVZpnbONjQmTNLU6LuIYJlc6ITlcx46I1tz0aLtKytfb06XHDAAABpbyumY9/sluW/m0scXxPmPWsEj94pRRmpYW6erDAwDgqKltatXGvEpHkMRWJKlQaW3zQa+LCvJ1BEhMW5uUcE1MCVcQVcABAOj3CI1gQGhpa9fi7cV6ZsVeLcksce5PjgjQt2YO0cXTkhUV7OfSYwQAAP27QtnKPeW2AsnHO4q1u6Sux/NBvl6aOSzKhkjMbXgMrWwAAMChldQ06f8tzdIzy3NU19xm95kLZL88ZZRmp0dz2gAAbrFQw1T37Gprsy63UlsLqpyt47t4e3rY4Mjs4VE6ZniUpqRG0NIGAIB+iNAI+rXt+6r10uo8vbY+35lc9vCQjh8ZoyuOGaLjR8bSggYAAHxlBZUNWrqrVEt3luqzXaUqq+u5Qio+1F9zOwMkppVNNOFUAADcXn5lg60s8vyqXGcFszEJofrFqSM1b1Qs5fgBAHL3xRpbC6s7q5E4wiTmb2d3psLn1NQIZ4jEBEp8vKj6CQCAqxEaQb9TUdestzYW6MU1edqYV+Xcby7WXDAlSZfPTNWQqCCXHiMAABhc/ZrNxFZXiGRldrmau7WyMUYnhDpb2cwYGsnKKAAA3EhWSa0e+3i3Xl2Xr9Z2xwpq0xr3J/PSNX80YREAAA4nt7zetotdtrtUy3aXqbimqcfzIX7emp0eZReHHjcyWskRgZxMAABcgNAI+oXqxhYt2lKkNzcW2Is1XZMwpnydmYC5aGqKjh8VQ+oYAAD0yeqoVdnl9j3JpztLbaCkO18vT1uCftYwx8ooc9HI38eL7wwAAIPMloIqPfrxbr29qVAdndX2zcpoExYx7wE8TClUAABwxC1tskrrbHjk884gSUV9S4/XDIsJslXGjxsZo1lDoxTgy1gbAIC+QGgELlPT2KLFO0r01oYCfZxZ0mNFrynvesHUZJ07KVFRlIMHAAAuVFrbZFvYmBCJqUZSWNXY43k/b0/bl7krRDIxJUx+3kxsAQAwUCuQfZJZov+3NEuf7Spz7j9pdKyum5du/+YDAIBvrq29Q5vzq7Qks8T+7V2XW2n3dW9lM3NopI4bEWMXlI6IDSawCQBALyE0gj6VV1GvD7cV64NtRfo8q0wtbfvfBKbHBmvBhESdNTFBw2OC+c4AAIB+uTJqT2mdPs8q1/KsMvt+puSA8rr+Pp6aOiTCrooyIZIJyeF2sgsAAPTvSmOvrM3Xv5dmaXdJnd3n5emhM8Yn6LoThttWdQAAoPdUNbRo+e5SGyBZklmq/MqGHs8nhPnbAImpQmJax4YF+vDtAADgKCE0gl7V1NqmtTmVdnXuh9uLte2A8u7DooN0+vh4LZiYqFFxISSFAQDAgCyva3o0mwCJuZXWNvd4TYCPl6alRWh6WqS9N+1sAn29XXbMAABgv+KaRj2zPEfPrNir8jrH3/AQP29dNjNVV85OU1J4AKcLAAAXjLV3l9Tqk8xSW4nEjLWbulUq9/SQHVubAIlpZ2MWa5iwJwAA+HoIjeCol3HdWlhtQyKf7S7Tyj1lamzp+WZu2pBInTQmVvNHx1FRBAAADMqJLUeIpNxObJV1XoDqYiayxiaG2mok5n2RCZLEhfq77JgBAHDHv9dr91bq2c9z9NbGQjW3OeYtkiMCdPWcobpkeoqC/Qh4AgDQnyqCrdxT7mxls7O4tsfz4YE+tvpIV4iEMTYAAF8NoRF8Iy1t7dqxr0Zr91ZoRVa5lu0uVUV9S4/XRAf7aU56lC0dd2JGrCKCfDnrAADAbS5KmcksEx5ZlV2hNdnlKqhqPOh1KZEBNkBigiSmIonp1ezJKikAAI6quqZWvb6+QE9/ntOjEuqU1HB979hhOmVMnLy9aCkHAEB/V1DZYAMkS3aWaOnOUlU3tvZ4PiM+xBkgMQs1/Ly9XHasAAAMBIRG8JUUVTdq3d4KrdtbaW8b8yt7VBIxzGqcmUMjNSc92t5GxgXTdgZwQ4sWLdIHH3yg0tJSu52UlKTzzz9fkyZN+sKP+/zzz/Xiiy/aj4uPj9ell16qyZMn99FRA0DvM32ZV2eXa01OhVZnV2j7vmq1d/R8TYi/tyYkh2licrgmpoTb+/gwqpEAAPB1ZBbV6JnPc/TK2nzVNjkuKvl5e9pWud+eNcSWtwfwzbzxxht67rnndNppp+mKK6447Ovy8vLsmH/Pnj123P+d73xHp59+OqcfwNfW2tauDXmVtpWNqUKyMa9SHR09W8YeM9wsanVUIhkaHcT1CgAADkBoBF9Y8m1LQbUjJJJbqXU5FYdcGRvq763JqRGakhqhuSOibP9AH1bmAG5vzZo18vT0tMEPY8mSJXrrrbd03333KTk5+ZDnJzMzU7/73e90ySWXaMqUKfrss8/05ptv6t5771VKSorbn1MAg1NNY4sN467OqdCanHL7uL657aDXxYX69QiRjE8OU1iAj0uOGQCAgVBV5J3N+/TC6lxbzr6LuVD0rZmpunBqssIDqYQKHA27d+/WX/7yFwUEBGjMmDFfGBoxrzWLRYYOHapnnnlGCxYsIDQC4KiqqGvWp7tKHZVIMktUXNPU4/n4UH/NGhapWcOibJgkNTKQEAkAwO0RGoGzdHpeRYNtM2OriORWamtBlVraei57NVXSR8WHanJquA2JmPuhUUGUTwdwRL7//e/r8ssv17x58w75vJlkampq0i9/+Uvnvttvv11DhgzRNddcc8iPeemll2xA5dRTT9XLL7+s2tpaHXvssbrqqqu0cOFCvf322/Z3nFntdO655zo/rq6uTs8++6z92NbWVjthZVY4ma9lFBUV2QmsnTt32mMylVJMmGX8+PHOz/Gzn/1MJ554on3tihUrFBQUZL/G/Pnz+YkA8I1WSW3fV6ONeVV2hdT63Eq7QvrAaiTGsOggGyIZmxiqMeaWEMoFMACA22pv79DK7HK9tCZPb28qdIYwvTw9dNLoWFtVZM7waOYwgKOosbFRv/71r3X11Vfrtddes2PqLwqNdGfG1KbKyJdVGvnkk0/09NNP67rrrrPj+LKyMlvF9Ec/+pEdi5t5gfr6ejsXYMb1ZgGL0dLSohdeeEHLli2zz5sFLJdddpkNthg1NTV68skntX37djtHEBcXp3POOUezZ892fu27775bqamp8vHx0eLFi+Xt7W3H/BdeeOE3Om8A+oaZEzTjaxMeMVVITLXP5raeldMTwkyIJErHDIvS9KGRSosiRAIAcD/erj4AuG7FjbkQsS53f6uZ0tqeiVsjOthXk1IiNGVIuCanRNgy6UF+/NgA+Gra29vtSiITvhgxYsRhX2cCGmeccUaPfRMmTNDq1au/8POb0Mb69et1yy232MePPPKIiouLlZCQoN/+9re2gsk///lPjRs3Tunp6fZjzGt8fX3tx5jVUB999JHuuecePfTQQwoODrYTX2YS6uKLL7aTQp9++qn+9Kc/6cEHH1R0dLTza5tQykUXXWQnllauXKn//Oc/Gj16tBITE/kxAfC1eHt5alxSmL1dPjPV7qtvbrUV4DbkVmpDXpW931ter6zSOnt7dV2+8+MTw/w1OmF/iMQ8NiunPE36FwCAQSi3vN62nnl5bZ79+9jFXPQxFUUumJqshLAAlx4jMFg98cQTtqWsWWBhQiO9xcwnvPfee/rpT3+qhoYG/fnPf7bjd7N44+abb7ZzAA8//LBGjhypY445xn6MCYTk5+fbj4mIiNCqVat0//336w9/+IOdLzChErOAxFQ7MfMCZl7h0UcfVWxsrHPuoKtyqpmrMJVRzbzF448/rlGjRvVYVAKgf/Lw8LBjYnO79vjhtrr62pwKfZ5VpuVZZXaRRmFVox1Td42rIwJ9bGX1ySnhmjLEcU0kxJ8qnwCAwY2r/26y0mZPWZ0NhnRVEtmxr/qg1ao+Xh4akxhm3wx1VRJJjgigNBuAr23v3r2644477ESMv7+/brzxxsO2pjEqKysVFhbWY5/ZNvu/bNXAtddeayd5zOc3q4YKCwvtxJFZYWQCHKbNzdatW+3Ej1lFZEri/uMf/7CrhYxvfetbNpxiVimZVUNmdVRX1RHDhEfM811VTbqYYMnJJ59sH5uJJhMiMV+H0AiAoynQ11vT0yLtrUt5XbOtRLIht0pbC6u0rbDGXigz7QTN7cPtxc7XBvl6KSMhVCNig5UeG6wRcSH23gRMzCQaAAADTUlNk97dsk9vbSjQim7tZ4L9vHXWhAQbFpk6JIK/c0AvMhU8srOzbTWO3tbW1qbvfve7thqIMXPmTC1dulSPPfaYnW/omgsw43ETGiktLbUVSv7617/awIhx1llnacOGDXb/pZdeqsjISLuvixnrb9y40c4LdA+NmEojF1xwgX1swibvv/++Nm/eTGgEGID8fbw0Oz3a3oyG5jat6RYi2ZRXpYr6Fn20vdjeDDNkHhkbYq+ZjE0Ks4szMuJDWFwLABhUCI0MQlUNLTYhu64zIGIem30HMhcJbGI21RESGZsYZt80AcDRYoIT9913ny0Da6pwmJCGqfzxRcGRr8NU/jCBke5BExMW6SpJ27WvqqrKGWYxlUR+8IMf9Pg8zc3NdnWSYZ437W7WrVtnQytmgso8b8rgdpeSkuJ8bC68hoeHq7q6+qj+/wHAoUQG+eqEUbH21qWmscWW3t1aUG1v2/ZV2+26zokwc+vOhElMeGS4CZLEhthQybCYICVHBMrXe//vUAAA+gMTmHx38z69tbHAXtzpWgxjLuaYtjMmKHLq2HgF+DK3AfQ2MzZ+6qmnbGsaU8Wzt/n5+TkDI11jfDMXYAIj3fd1jcdzc3Nt1dObbrqpx+cx7WlDQkLsY/O8qY5iQiLl5eX2OXM78P/HhEa6MyEUxv3A4GDeM8wdEW1vRlNrmx1L2+rsnddY8ioatKOoxt60Ktf53mNIZKCt8Dk6PtSOqc1YOi0qiGssAIABidDIANfW3mF73DtazFTYNzK7imsPep2ft6cto9ZVVs3cx4ftH1QBQG8wbV3i4+Pt42HDhtnqHu+++66+973vHfL1JnDRFezoYrbN/i/7Ot2Z8IaXl9dB+0xFkq5AiJnkue222w76XIGBgfbe9EnetGmTrUBiJqbMpJFpaWMmkL7sa5uJJwBwBVMy98CKJK1t7dpTWqdt+2rs+8RdxTXaWVRr95kwiW13k9fzd6/pZJMUEWAnvMxtSFSg43F0oA2UEDQGAPSVstomfbCtSG9tLNSy3WV2HqTLxJRwnTU+QWdMSFBSOO1ngL6UlZVlgxMmNNLFjIVNZU9TicMESrov5PimDhzjf9l43Iz7zdc3bWgPPI6uoMlbb71l5yiuuOIKuyDEBFOefvrpg8b9h/raXfMLAAYXP2+vzoW2jgpFRnFNo9Z3Ls7dWuhYoFFc06Tssnp7e3vTPudrTZjEvCcZFhOsYdFB9rEZW5v7xPAARQf7UgUNANAvERoZYEprm+wblHW5FVqbU2lLkpvJ/gOZif2ucIhpM5ORECIfL1aLAnAtM6ly4ORLdyNGjLAlXk8//XTnPhPcMPuPJtOz2FQPMRM/MTExh3xNZmamjjvuOE2fPt054VRSUqLRo0cf1WMBgN7m7eVp29GYW3ctbe3KKat3hkh2Fjtu2aV1amhpU255g719urO0x8eZSbCEUH8bHuma/DL3ZgLMPg4PYIU3AOAbjRnMSt4PtxXrw21FdnFM92uz45JCddaERJ05PkEpkY7AN4C+N27cON1///099j3++OO24qhp3Xo0AyNfR1pamg2QmGBLRkbGIV+zY8cOTZs2TXPnzrXb5vWm1W1SUlIfHy2A/iw2xF+njI23t+7XabYVVtubqe6ZVVKnrJJaVTe22sok5rYks+SQi3u7xtBxof6KCfFTTLCf477bLcTPm3AJAKBPERrpx0x58U35VdqYV+XsV59f2XDQ60xZ8UmmxUyKo9XMpJRwRQX7ueSYAaDLc889p4kTJ9pysQ0NDbbX8bZt23Trrbc6X/Poo4/aHsKml7Bx2mmn2V7ICxcu1KRJk7R8+XK7eulwlUm+yeSWCaI89NBDuuyyy2xP4oqKCtuKxoRETFUUUyFl1apVmjJlih2kvfjii6wkAjComECxaU1jbqeN63mxrsS5aqpOOWV19rG9L61XbVOrCqoa7U3Zh/7cUUG+PVZTmVtcqJ+dFIsL8VdsqB/VSgAATo0tbbbdzEfbTVCk+KC5j7GJoTpjfIINiqRFB3HmgH7AtIjt3q7VMJU6goODe+w/cNxvFpLk5eU5H5u2MNnZ2bb6R1el0qPBjPPnzJmjxx57zFYQNSESEyDZsmWLbTczefJk+/VMK12zaCQoKEhvv/22rXZKaATAl4kO9tOxI2LsrftYuqyu2RkgMeNo854mv8Jxb6qTNLW2K6u0zt6+iAmXmPCI+TqOm6+9jwr2tdd+urbNLTzAR56mXCgAAN8AoZF+wvTK21ZYY8MhpsyZCYrsLqntsZqmi5nYn2JCIrZMWrjtP+/FmwIA/YyZjDGTM6aih2n5YiaNTGBk/PjxPXogd199NHLkSP34xz+2AY3nn3/eTuCY/sMHTkR9UyYEcvPNN+uFF16wK6HMsZoWOGb1kemBbHz729+2z915552237FZKWXCLwAw2JnfkbGhJtjhrxlD97e56T4JluOc/GpQfmW9vS+obLT7TKjEvMbczHvawwkP9HEGSEyYJN4ESkL97Nc1E2BRQY4JsWBWWAHAoNPe3mHLuy/bXaqlu8q0ak+5rXLV/ULJnPRozR8dqxMzYpUQRusZYKA6cNxvFmx0b2ljFo2Ym6nq+dvf/vaofu1rr71Wr732mm0/a8IpZmxvFpCYwIhx3nnnqbi4WH/4wx9sS9oTTzzRVh6pr68/qscBwH3G0l1BjgPH0kZza7sKqxzj6LzKBrtYo8et1nFvxtQmXNJVseTLmGtDEYG+3YIkjmBJVPftID9Fh/jZBR60mwUAHIpHBw0YXVJBxJQs6ypftqXAcd/SdnBCxKzOnJAcpgnJ4ZqYHKZxyWEK9ffp+4MGAAAAvoQZWlQ3tCqvM0jSFSzZV92o4uomFdU0al9Vo50AO1K+3p6KDto/6WUnu+wkmONxZJCvQgN8FBbgY4Mo5p62jADQ/0IimcU1Wp1doeW7y2xYpKK+pcdrTHDwxIw4zc+ItYGRAF8vlx0vAACAqzQ0t9n2N6YySUlNo0prm1VmbnVNdr9j23Ff1dDz/dSRMK1vulcssfdBvp2hkm77gn3t+NqEYQAAgx+hkV5kkqOmjLepGGKqiNiQyL5q2xv+UCICfRzhkBRHQMQ8NiXIAAAAgMEWLDEBkqJqR4jETIaZx45bk50MM5Ni9c37V51/FYG+XrZE74FhEnML9vNRkJ+XrWAS5Odt74P9vRXk63hsnjP7zSp3JscA4Oupb2611abW5FRoVXa51uZUqLqx9aDf1bOGRWn28CgbEsmID+H3LgAAwFe8BlVe12zDJKbaZ2nN/vG0qVxi7u1znaGTQy1c/iLenh77F2/Ydjm+iulqmROyv0WOuZkFHVTEB4CBi9DIUVgtYya5Tb/3rl51tiddSa32lter/TB/gxPC/DU6IdROioxJDNXE5HAlRwQwQQIAAAB0W2HVNeHlWFXVucKqa0KstkmV9S12dVVlfbNqmloP2d7x6/Dx8rDhkSBfR5AkwNdbgT5ePR6bVfDmoqd5XYCP47Fjn/m4/Y+79pvP5e9DGAXA4FLX1GpbzWzKq9Lm/Cptyne02z1wPsT8LjQtdqenRWpuerRdMENlKAAAgL5dwFFa1z1MYtridI6xu/Z1jrVrDgj8fhlPD9ngiAmQmMXQXa1xnMGSbqET8zpvr/2tywAArkdo5EtWxpTWNNs/oiahaSapzerH/f3bG2wPui9KZ5rJ4mExwRoVH2JDIqMTQjQ6PlQRQb698f0EAAAA3FZbe4dtBekIkXTeNzjuqzuDJbVNbfYCp7mZkEnX4679DS1fr7rJkTKVfbsHTIJ8vZ3hkwAfR8DEBlM6HzuDKd1fd5hgCtVRAPQm8/t1d0mddhbVaFdJrXYV1Wpnca1yK+oPGdgz7WamDYnU1CERNihi5kO4OAAAADAwNLa0OauYdLXFsfc13fc59lfUN3+lBRxmXBwRaAIlPauVdFUviekWPDGVTggaA0Dvc4vQiFmh+O+lWWpu61BLW7ta29pt0KPZ3Le2q6651aYmza3WTB43mknlI58wNgnKpIgADYsO1rCYIA2P2X8fG+JH9RAA6EPt7e3avn27KisrFR4eroyMDHl6klwHABwZM1aoa94fLDHjA9Mmx3Hb/7ih+eD9DV3bLW2q7/w4M6Ywzze2tPf6t8CMSwJ7hFAOVQmlM5jS7fGhgildr+0Kpvh6USEFGKzMPImZ6K+oa7FVncz9vupG5VXU2wUzeZ2LZkwA73BMQGR8UpjGJYXZe3OLDfXv0/8PAO6DcT8A9L9xtAmYlHSFS+wi7J5hk5LOhdnldU2HrdB/OKaVbNgB7WfNvWlJGx7g22N/qL+PAk3bWTPe7bynbQ4AfDm3CI1U1bdo4u/e/1ofa1brdZXOijGls0L8lBQeYEMiiWGO+/hQf1bLAEA/sHLlSj311FMqLy937ouMjNQVV1yhGTNmuPTYAADuzVRB6QqQOMMlhwqcdD5f1z2Y0uJ4vqsSyv7Xt9rXmT7Wvc1MsnW15Dm4Hc/+wImvt6cNmPh03bw9em57edjXdG17m+3Ox+Zr2JuHh0zec/9jx73Z7npsAjLOxwd+XOdrPczyNQB6enm23t9aZFeLNrW2q6mlXU2tjsfm90r1Vyg9buZERsQG21u6vYXYe7MfAPoC434AGPhjYxNYPrBqSckhqpiYljmtXzVhcgimTWxQtxCJo1Knl/x8HONXM0Y12457x63rcdcY17tzPOvt6RjHdt1332fHuJ6d95377fPmYz0d9/Z1zs/BuBVA/+EWoREzMXLnG1t6TFyaX8pdv7hNStHcQvy9FezvbZOI5nFUsJ9dWcdkIwAMjImjhx9++LDP33DDDQRHAACDdlWXCZN0BU/qDgimNLSYqindK6F0f7579ZSDt011xoHKZEa6QiUmZOIIm5hJOUfgxDw2+814z6vbYxM88ez+2s7nux53PW9fe+DnPczzXY+7nndsm8/b87U9n+/+sfuDMt2PyXnMh3neeUzO577+MadEBGpEXIirv634Gu56c4ue+Cz7iEqERwT6KCrIUQ48OcKxUMbehwfax2buBABchXE/ALiX9vaOHm1nTctZc29v9d33d7akbWi2HQVs5dDmNhtQ6e9McKRHkORwARPn/v3hFK+DQimH//iujzkw/NL1+FDhl+6v7fo63UMxXZ/bLNpwHA8hGGAgc4vQCNDbzD+jpqYmTjTgwtK0v/zlL1VRUXHY15iKI3/84x9pVQMMYn5+tAUEeiOQ4mi3060qSme1k64WPI5KKI7HpupJS2c7UMd9z9agPba7bq2ObTOhZ27tHT3vHY8dK9LaOjrsxKG5ZyTbt66anaY7zx7bx18VR8OG3ErtKa1zrJr08ZR/56pKs5rSVAiKDPS1pb0p2z14MEeBwYhxP9C/MP7GQHg/ZMaZZizb1XbWLLAw2+beUYHPsVDCjGPNtuPeMa7tsa+t3Y6NW804t72j2+POe7Pdtd/ed6i13TH2Nfu6PmYAZFiOCufig8MsyrALFbotauj+vK0weuACiAM+15cthuj+cd2/huNr9vy8h1vAcahjPuj1X7CI41CvP1wx1MPWSD3MBxxq7+E/92E+x1c8FvOj2zUH02H+cz7e/0SP15g5m66P7eh8Xed+9djfcYjX9Nzf/eO+6HXOz9z5tbue73rO+Xrn9sHPdXT7N9r1/9D13G1njpG/j5cGM0IjwFHQ2Nio7373u5xLAABc6D//+Y/8/f35HgBuwgzg9wdJZO9twOSAcInZZwb5JoTS3nnf0e2x+VjHc4d4vjOwcsjnnR/X83nHx+5/3nzttgOf7/Z5u46tKwjT87n9j7/s+Z7/L92O4wift8fZGdbZf772v3bBxER979hhrv62AzgCzFEAAHob42/gqzNjua6gyeFCJy0HBE7Mfvt89/3O5w9+besXfLzzax/2+YMDMd1DLz0/h5skYIBOG+44RWEBPhrMqCsKAAAAABhwzIodW37X1QcCAAAAAMCXMJUo/Dy9NBg6PpqFBV0hFRMkOXDBxaEXJXQt3Dj4tfsrjnYtcPgarz3EAo6ur+tYhHHw53N8jkMtyjj0QovDL+I4zOu7LUg55HncXx/jgPN7uPN+FD7HYb+nh3u1h7M6SVclEsfjbvs7n7D7nI8d8zb7Hx96//7X76/G0vP1jv37q6N88esO+hqdx9p1/I7P1Xn0h3jO6L7PPDD3pnLnYEelEeAooPQr4Frbt2+3rWe+zM0336yMjIw+OSYAfY/yuAAAAMxRYHBi3A/0L4y/AQAYXAZBng1wPZNKoxw+4DoTJkxQZGSkysvLD/uaqKgo+zpP05wQAAAAAAYp5igwGDHuBwAAAHoPV84AAAOeCYJcccUVX/ia73znOwRGAAAAAAAYgBj3AwAAAL2H9jQAgEFj5cqVeuqpp3pUHDEVRkxgZMaMGS49NgAAAAAA8M0w7gcAAABcFBoxL6mpqemFLw8AwNHV3t6uzMxMVVVVKSwsTCNHjqTCCAAAABQSEmLbdnwVzIcAQP/DuB8AAAA4unMi3kfySUxgxFx4AwAAAAAAGIhMqDg0NPQrfQzzIQAAAAAAYLDPifRppZH169fr+OOP1yeffKJJkyZ9488HuAv+7QD82wH4uwP0f7xnA/r3v52BWGmE3yvgZw/uht974OcO7oTfeeDnDu6E33mDoNKI+QRfdTXOoQQHBzvvj8bnA9wF/3YA/u0A/N0B+j/eswGD79/O0ZoPGYznBoMbP3vgZw/uhN954GcP7oTfeeBnD4fieci9AAAAAAAAAAAAAAAAGNT6NDSSkJCgO+64w94D4N8OwN8doH/iPRvAvx2Avzv9A3+Twc8e3A2/98DPHdwJv/PAzx3cCb/z+jePDtOgFwAAAAAAAAAAAAAAAG6F9jQAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALihPgmNLFmyRAsWLFBiYqI8PDz02muv9cWXBQa8++67T9OnT1dISIhiY2N17rnnaseOHa4+LKDfe+yxxzRhwgSFhoba2zHHHKN33nnH1YcFDCh/+MMf7Pu2G264wdWHAvR7d955p/330v2WkZHh6sMC+r38/Hx9+9vfVlRUlAICAjR+/HitXr3a1YfVr/z9739XWlqa/P39NXPmTK1cudLVh4RBjnkI9AeMRdCXeD+CvtbW1qbf/va3Gjp0qH0PPHz4cN19993q6Ojgm4E+vTZrfuZuv/12JSQk2J/Fk046STt37uS7gF792WtpadEtt9xix/9BQUH2NVdccYUKCgo48+4QGqmrq9PEiRPtZAeAI/fJJ5/oxz/+sT7//HMtWrTI/jI95ZRT7L8pAIeXnJxsJ5nWrFljLzyceOKJOuecc7RlyxZOG3AEVq1apccff9yGrwAcmbFjx6qwsNB5W7p0KacO+AIVFRWaM2eOfHx8bLh369atevDBBxUREcF56/T888/rpptu0h133KG1a9faeZVTTz1VxcXFnCP0GuYh4GqMRdCXeD8CV7j//vvtgre//e1v2rZtm93+4x//qL/+9a98Q9Cn12bNz91f/vIX/eMf/9CKFSvsBXwz3mhsbOQ7gV772auvr7fjWxOeM/evvPKKXSx/9tlnc9ZdzKOjj+OLJlH06quv2ooJAL6akpISW3HETOIcd9xxnD7gK4iMjNQDDzyga665hvMGfIHa2lpNmTJFjz76qH7/+99r0qRJevjhhzlnwJdUGjGrJtavX895Ao7Qrbfeqs8++0yffvop5+wwTGURU3nSXFAw2tvblZKSop/+9Kf2/AF9gXkI9CXGIuhrvB+BK5x11lmKi4vTv//9b+e+Cy64wFZ6eOaZZ/imoE+uzZpLw6bCw89//nP94he/sPuqqqrsz+aTTz6pSy+9lO8EeuVn73Ch4RkzZignJ0epqamc+cFcaQTA0WH+aHdd/AZw5CUfn3vuOZtuNW1qAHwxU+HqzDPPtCUpARw5U8LVTLgMGzZM3/rWt7R3715OH/AF3njjDU2bNk0XXXSRDcZPnjxZ//rXvzhnnZqbm23VvO5/jz09Pe328uXLOU/oM8xDoC8xFkFf4/0IXGH27Nn68MMPlZmZabc3bNhgK1WefvrpfEPQZ/bs2aN9+/b1GG+EhYXZ4DrjDbhizGHCJeHh4Zx8F/J25RcHcOTMqrIbbrjBlnAeN24cpw74Eps2bbIhEVNOLzg42KZZx4wZw3kDvoAJWJmygCbdDeDImUkVsxJn1KhRtjXNXXfdpWOPPVabN29WSEgIpxI4hKysLFuW27Rf+fWvf23/9vzsZz+Tr6+vrrzySrc/Z6WlpTb8bFb6dWe2t2/f7vbnB32DeQj0JcYicAXej8BVFW6qq6uVkZEhLy8v+57vnnvusYsPgL5iAiPGocYbXc8BfcFcv7nlllt02WWXKTQ0lJPuQoRGgAG02sJceDCpYwBfzly4M20CTEr1pZdeshcfTGsngiPAoeXm5ur666/XokWL5O/vz2kCvoLuK8ImTJhgQyRDhgzRCy+8QFs04AsuRptKI/fee6/dNpVGzHjH9NMmNAL0D8xDoK8wFoGr8H4ErmDGic8++6z+97//aezYsXb+0iwWNZUreR8MwJ20tLTo4osvtu2SzKISuBbtaYAB4Cc/+YneeustLV68WMnJya4+HGBAMKtU09PTNXXqVN13332aOHGiHnnkEVcfFtBvmRL4xcXFmjJliry9ve3NBK3+8pe/2Mdm5QuAI2PKaY4cOVK7du3ilAGHkZCQcFCYd/To0bR26hQdHW1XnhYVFfU4R2Y7Pj6enyv0OuYh0JcYi8BVeD8CV/jlL39pq41ceumlGj9+vL7zne/oxhtvtPOXQF/pGlMw3oCrAyM5OTl2ESNVRlyP0AjQj5l0nZmoMW01PvroIw0dOtTVhwQM6NUjTU1Nrj4MoN+aP3++betkVrh03cwKcFMe1Tw2F64AHJna2lrt3r3bTkIDODTTdnPHjh099pm+7qZKDxwBaBN+Nv3uu7+fNdumBSPQW5iHgCswFoGr8H4ErlBfXy9Pz56X5syci3mvB/QVc63JBEe6jzdM26QVK1Yw3kCfBUZ27typDz74QFFRUZx1d2lPYyZNu6+y27Nnj734EBkZqdTU1L44BGDAloI1Zepef/11hYSEOHvJhYWFKSAgwNWHB/Rbv/rVr2yrAPM3pqamxv47+vjjj/Xee++5+tCAfsv8nRk3blyPfUFBQfZN+4H7AfT0i1/8QgsWLLAXuwsKCnTHHXfYST/TjxXAoZnVlLNnz7btacxk0cqVK/XPf/7T3uBw00032RLlJsQ5Y8YMPfzww6qrq9PVV1/NKUKvYR4CrsBYBK7C+xG4ghk73nPPPXbe0rSnWbdunR566CF997vf5RuCPr02a9oi/f73v9eIESNsiOS3v/2tbZN07rnn8p1Ar/3smQVWF154odauXWs7LJjq1l3XPs3zZgEFXMOjwywh6GXmQt28efMO2m8mP5588sne/vLAgOXh4XHI/U888YSuuuqqPj8eYKC45pprbEq6sLDQhqwmTJigW265RSeffLKrDw0YUE444QRNmjTJXqQCcHimrPCSJUtUVlammJgYzZ07104CDh8+nNMGfAEzQWTCvmZ1kZmkNCGJ73//+5yzbv72t7/pgQcesJNo5m+yaRs3c+ZMzhF6DfMQ6C8Yi6Cv8H4Efc0scDMX5011cdMm2FykNwsObr/9di6Wok+vzZrLw2bRiwnuV1ZW2rmMRx991LbbBXrrZ+/OO+88bFeFxYsX2/eAGMShEQAAAAAAAAAAAAAAAPQvPRunAQAAAAAAAAAAAAAAwC0QGgEAAAAAAAAAAAAAAHBDhEYAAAAAAAAAAAAAAADcEKERAAAAAAAAAAAAAAAAN0RoBAAAAAAAAAAAAAAAwA0RGgEAAAAAAAAAAAAAAHBDhEYAAAAAAAAAAAAAAADcEKERAAAAAAAAAAAAAAAAN0RoBAAAAAAAAAAAAAAAwA0RGgEAAAAAAAAAAAAAAHBDhEYAAAAAAAAAAAAAAADcEKERAAAAAAAAAAAAAAAAuZ//DxX+HCHV2bolAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACI0AAADMCAYAAAD0mcEpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8ekN5oAAAACXBIWXMAAA9hAAAPYQGoP6dpAABnwElEQVR4nO3dB3iV5f3/8U/23nsSIEDYewg4ELfi3m0dta2tHY62alvrqFVrrVY7tLb/Vuvoz71xoaKIIHuvACEhi+y91/+675McEoaikpwk5/3yOtc5z3NOkscnITn3/Xzu79ejo6OjQwAAAAAAAAAAAAAAAHArnq4+AAAAAAAAAAAAAAAAAPQ9QiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAKBPpaWl6ayzzuKsAwAAAACAfu/OO++Uh4eHSktLXX0oAAAAvYLQCAAAAAAAAAAAAAAAgBsiNAIAAAAAAAAAAAAAAOCGCI0AAIA+U1dXx9kGAAAAAAAAAADoJwiNAACAXu35u3XrVl1++eWKiIjQ3Llznc8vXbpUM2bMkL+/v4YNG6annnrqoM+RlZWliy66SJGRkQoMDNSsWbO0cOFCvmMAAAAAAMBlcnJylJ6ernHjxqmoqEhPPPGETjzxRMXGxsrPz09jxozRY489dtDHpaWl6ayzztL777+vSZMm2TkR89pXXnmlx+uefPJJO6eyZMkSXXvttYqKilJoaKiuuOIKVVRU9Hjt66+/rjPPPFOJiYn2aw8fPlx333232traev08AACAwYHQCAAA6FUm9FFfX697771X3//+9+2+Xbt26cILL9TJJ5+sBx980AZKrrrqKm3ZssX5cWbSZfbs2Xrvvfd03XXX6Z577lFjY6POPvtsvfrqq3zXAAAAAABAn9u9e7eOO+44hYSE6OOPP1ZcXJwNiAwZMkS//vWv7TxHSkqKncv4+9//ftDH79y5U5dccolOP/103XffffL29rZzJ4sWLTrotT/5yU+0bds2uzDHBEaeffZZnXvuuero6OgRMAkODtZNN92kRx55RFOnTtXtt9+uW2+9tdfPBQAAGBw8Orq/uwAAADhKzITGXXfdpcsuu0z/+9//eqyqMStyzGqZY4891u4rKSmxEypmMuRPf/qT3XfjjTfq4Ycf1qeffuqsUFJbW6sJEybYyREzSePpSf4VAAAAAAD0/vyGmbsoLS3V/PnzlZSUZBe5mEUwRkNDgwICAnp83GmnnWYDImb+4sA5kZdfflnnn3++3VddXa2MjAzFx8dr7dq1ziDI1VdfbQMgy5cvl4+Pj93/wAMP6Oabb7bVRcyimsN97R/+8Id6+umnVV5ebquPAAAAfBGutAAAgF5lJioOZEqvdgVGjJiYGI0aNcq2o+ny9ttv2/Y13VvamJUzP/jBD5SdnW3b3gAAAAAAAPSFzZs36/jjj7fBjw8++MAZGDG6hzaqqqpsuMS81sxzmO3uTBuZ8847z7nd1XZm3bp12rdvX4/XmjmQrsCI8aMf/chWJjFzJof62jU1NfZrmzkXU/V1+/btR/EMAACAwYrQCAAA6FVDhw49aF9qaupB+8xkS/e+vGbljQmSHGj06NHO5wEAAAAAAPrCggULbEsaU2HEBD26++yzz3TSSScpKChI4eHhdnGMaVVjHBgaSU9Pl4eHR499I0eOtPdmkUx3I0aM6LFtFtMkJCT0eJ1p9WtCKGFhYfa4zNf+9re/fcivDQAAcCiERgAAQK86sESq4eXldcjX0jUPAAAAAAD0RxdccIFtNfPss8/22G/2mZY1psLHQw89pIULF2rRokW27a7R3t7ea8dUWVlpK5ps2LBBv/vd7/Tmm2/ar33//ff3+tcGAACDh7erDwAAAOBQhgwZoh07dhy0v6u0qnkeAAAAAACgLzzwwAO2Ncx1111nK45cfvnldr8JajQ1NemNN97oUVl18eLFh/w8u3btsotmulcbyczMtPem9U13O3fu1Lx585zbtbW1Kiws1BlnnGG3P/74Y5WVlemVV17Rcccd53zdnj17jtr/NwAAGPyoNAIAAPolMwGycuVKLV++3Lmvrq5O//znP+0kypgxY1x6fAAAAAAAwH2YkIeZk7jwwgt15ZVX2pBI92qq3aunmrYwTzzxxCE/T0FBgV599VXndnV1tZ566ilNmjRJ8fHxPV5rvl5LS4tz+7HHHlNra6tOP/30w37t5uZmPfroo0fp/xoAALgDKo0AAIB+6dZbb9X//d//2YmQn/3sZ4qMjNR///tfu1rm5Zdflqcn2VcAAAAAANB3zFzEM888o3PPPVcXX3yx3n77bZ1yyiny9fXVggULdO2119pqIP/6178UGxtrq4IcaOTIkbrmmmu0atUqxcXF6T//+Y+KiooOGTIxARDT+sZ8LVON1YRB5s6dq7PPPts+P3v2bEVERNgQi5k7McGWp59+mva/AADgK+FqCwAA6JfMxMmyZct08skn669//at+9atf2UkYU/b1vPPOc/XhAQAAAAAAN+Tj46OXXnpJs2bN0jnnnKPKykq7bQIbv/jFL/SPf/xDP/jBD3T99dcf8uNHjBih559/3gZOzIIZU0nEbJ966qkHvfZvf/ubRo8erdtvv11PPvmkLrvsMr3++uvO1jZRUVF66623lJCQoNtuu01/+tOf7DzKH//4x14/DwAAYPDw6OhetwwAAAAAAAAAAABHnWm3O27cOBv0+CImIHL11VfbaiTTpk3jOwEAAHoVlUYAAAAAAAAAAAAAAADcEKERAAAAAAAAAAAAAAAAN0RoBAAAAAAAAAAAAAAAwA15dHR0dLj6IAAAAAAAAAAAAAAAANC3qDQCAAAAAAAAAAAAAADghgiNAAAAAAAAAAAAAAAAuCFCIwAAAAAAAAAAAAAAAG6I0AgAAAAAAAAAAAAAAIAbIjQCAAAAAAAAAAAAAADghgiNAAAAAAAAAAAAAAAAuCFCIwAAAAAAAAAAAAAAAG6I0AgAAAAAAAAAAAAAAIAb8nb1AQAA+re6plbtq25UcXWTqhpaVG1ujS32sbnVN7eppa3d3ppbO5yPOzokby8PeXp4yNvTQ56ejvsAXy8F+nopyNdbgb7eCvLzUpCftyICfRQZ5KfIIF97Cw/wsR8DAAAAAACOvsaWNpXUNKm4ptHeV9a3qLap1d7MXIDjcZtaWtvV2t6h9o4Oe9/W3q629g55e3racb8Z63c99vX2VLCfGet7O+7N+L/zcbC/t8IDfBUd4hj3+3l78W0FAAAA+gFCIwDg5lrb2pVX0aDdJbX2tqe0TgWVjdpX1ajCqgZVN7a65LhMXiQi0FcRQb6KDfFTYniAvSWF+zsfJ4YF2BAKAAAAAADoySz42FtWr9zyeuWU12tvueNxfmWDSqqbVNPkmvF+l1B/b0UH+9lbUkSAUswtMtDeUiMDFRfqLy8WkwAAAAC9zqOjw6wFBwC4g4q6Zm3Kr9Lmgiptya9WZlGNcsrq1dzW/oUfF+LnrdhQP4UH+tpJnbAAH4UG+Nh7Uy3Ep3M1kY9X181RIcSuQmpzrEYyX6K1vV0NzW22Okl9c6vqzH1Tq2oaW1Ve32yPr6yu2W4fKbM6aUhUoIZFB2tYTJCGxwRpWEyw3ceqJQAAAADAYFfT2KLMolrtLKpx3BfXaMe+GhXXNH3px/p5e9rxfkywY8wf4u+oEmLmAboqhvh4e9pqIibA4WWqiXp5yMPDw1YcMWN+U33E3tra1dTa7qxSYu7rmtp6VC6pqG9WWW2zff2XMfMM6THByogP0cj4EI1JCNXE5HCFBfocpTMHAAAAwCA0AgCDVFNrmzbnV2lVdoXW7620YRGzmuhwk0QmaNEVuEiOCFBCmL+9mZU9If59OyHT3NquSjORVNes8rpmWyrXVD8xx19Q2aD8igb72IRPDscsRjL/L6MTQjU6IcTej00IVUyIn53cAgAAAABgIAZEthRUa1NelR3nm5upGHo4UUG+tnKHWVhhqneYm6nqYcb6ZnxswiF9PUZub++wVVBKa5tUWmvG/E3KqzBVUBrsvamIYsb9hwuWDIsO0qSUcE1Ni9Ds4dFKiwpknA8AAAB8A4RGAGAQTRytzq7Qquxye78+r9KGLw5kJlPGJYVpfFKYRsWHKD022LZ58RxgJV9NoazqhlblVtQru6xOe0rqlFVap6ySWmWV1B22zK4pe2sml6YMCdfklAhNSA6zK6cAAAAAAOhv417TTtaM8x23Cu0qrj3ka+NC/TQyLkQjYkM0Mi5YI8zjuGCF9vEikKOlrb3DBke273NUSd2+r8aGZQ4VkDELXo4ZHqXjR8bohFGxtioqAAAAgCNHaAQABigTCFmfW6mlu0r12a5S+9hMqnQXHeyraUMibUBifFK4xiaFDtgJo686sWZWKm0trNY2e6vR1gLH6qsDFyqZrExGfKimda5QmjUs0pbkBQAAAACgr+2ratTHO4q1bHeZDYoUVjUe9Jqk8ACNSwrVhORw56IQ07rVHZi2tmaRzLq9lVqRVWbvu7fcNW10Zg6L1Mmj43Ty2Hh7rgAAAAB8MUIjADCAghA7imq0dKcjJLJiT/lB7VlMudkZaZGabm5DIynReoCG5jZtLayyk0rmtnZvxUETcKYq77jEMM0eHqXZ6dH2fAb4evX+NxgAAAAA4HZa2tq1NqdCH2eWaPH2YltRozsTgjDBkBlDHWP9yanhtoIm9o/z1+RU2AU1H24r0s4DKrGMTQzVWRMSdc6kRCUSIAEAAAAOidAIAPRjdU2tNiCyeEeJXWl0YMDB9CY2wYa56VG2SobpU4yvprCqwQZIPs8qsyu5Diz16+/jqbnp0Zo/Ok7zM2IVG+rPKQYAAAAAfKPKoZ/uLNFbGwv1wbYi1TS29ljIMDE5XMeNjNGsoZGalBquQF9aqh4pU2F00dZ9WrS1SKtzKtTRsf+8zhoapfMmJ+n08fEKcYMqrAAAAMCRIjQCAP2smoiZ4Phoe7E+3lGilXvKe5RZNQGGmUOjbIhhTnq0MuJD5Gn6q+CoKa5utOGRZbtLbVWXggOCOhOSw3TS6DidMT5B6bHBnHkAAAAAwBGN980Y/+W1eXp38z5VdwuKRAT62JDIvFGxOnZEtKKoJHJUlNU26f2tRXp1Xb499138vD118pg4XTo91VYZZV4FAAAA7o7QCAC4WGNLm61yYUIii3cUK6esvsfzqZGBOjEjVieMitGsYVHy96FVSl9O6pnSwKbE7aJtxdqQW9nj+dEJoVowMUELJiRS5QUAAAAAcJCi6ka9tCZPL67OVXa38X5MiJ/OHJ+gMyckaEpqhLxYENKr8irq9fr6Ar2yNk+7S+qc+9OiAnXZjFRdODWZsA4AAADcFqERAHCBkpomfbS9yJZLNX13G1v2VxPx8fKw1URMSGReRqyGRQfJw9RRRb+oQmKqwLy7ZZ+tQtLa3lnnVrJ9pRd09klmVRgAAAAAuPcChLV7K/Wfz/bYqiJtnWPHIF8vLZiYqHMnJ2l6WiRBERd9bzbnV+uF1bl6bV2+apocFV98vTx16rh4XT4jVbOGRTIPAwAAALdCaAQA+siu4lobEjH9itfu3d9X14gP9de8DEcp2tnp0Qr2o19xf1dR12zDI29uKLCVYrryIyb0Y9rXXDQtWceNiJG3l6erDxUAAAAA0Ada29q1cFOh/rN0jzbkVTn3TxsSoYunp9jKIkGM9/uN+uZWO6Z/dsVebez2/RoWE2TDIxdNS1FYgI9LjxEAAADoC4RGAKCXmJVE6/ZW2KCIuWWV7i9/aoxPCrM9dE3AYHRCCKtYBrDimka9vbFQr6zL7zHRFBvipwumJuviaSkaGh3k0mMEAAAAAPSOlrZ2vbo2X49+vMvZgsbX21PnTEzU1XOGakxiKKe+n9ucX2XDI6+vz1d9c5vdF+jrpQumJOvK2WlKjw129SECAAAAvYbQCAAcRY0tbfp0Z6ne37LPtjEpq2t2PmcqUBwzPFonj47VSWPilBAWwLkfhLYVVuvF1Xl6dV2eKupbnPuPHRGt78waohMzYqk+AgAAAACDJCxi2pw8uni38isb7L6IQB8bFPnWzFRalw5AtU2ttm3NU8uzlVlU22NMf/WcNJ0wMlaenrQQBgAAwOBCaAQAjkJQ5OMdJXp7U6E+3Fakus4VKUaov7fmZcTaiiLHj4xRiD9lTd1Fc2u7/Xl4fnWuPskscbYjSgzz17dmDbHVR2JC/Fx9mAAAAACAr6i9vUNvbSrUQ+/vcFYWMeO7a48bpstmpNKCZhDo6OjQ8t1lemJZtm0z3DWmT4sK1BXHpOnCackKZY4HAAAAgwShEQD42kGRYi3ctE8fHRAUSQjz16lj421QZMbQSPl4eXKO3dzesno9uzJHL6zKdVYfMZVnzhifYKuPTB0SQXsiAAAAABgAlu4s1X3vbNOWgmq7HR3sqx/PS7dhEX8fL1cfHnppTP/059l6blWuahpb7b4gXy9dODVZV8xO0/AYWtcAAABgYCM0AgBHqLWt3baeeXVdvl1l0tXj1kgKD9Dp4+J1xoQETUoOp1QpDhs2WrixUE9/nqP1uZXO/WMSQnXl7CE6Z1ISk4wAAAAA0A/lltfr9wu36r0tRXY72M9bPzhumK6ZO5TKIm6irqnVzgk9uSxbu4r3t64xlWWvmp1m72ldAwAAgIGI0AgAfEk50s351XplXZ7e3FCg0trmHkGRM8bH22oRk1LCqRSBr2RTXpVdqfT6+gI1tbbbfeGBPrpkeoqtPpIcEcgZBQAAAAAXq29u1WMf79bjS7JsG1IvTw87ZvvZ/BGKDPJ19eHBRXNFn+0q05PL9ujD7cXO1jVDo4PszwatawAAADDQEBoBgEMoqGzQa+vz9cra/B6rR8yE0NkTE3XOpESCIjgqKuqa9fzqXD29PEf5lQ12n6eHdNLoOLtS6ZjhUQSSAAAAAMAFwYA3Nxbqvre3qbCq0e6bkx6lOxaM1ci4EL4fsHLK6vTU8hy9sLpn65oLTOuaY9KUHkvrGgAAAPR/hEYAoFNLW7s+3FakZ1fs1dJdpc6VIr7enjp5TJzOn5yk40bGyMfLk3OGo66tvcP+/P13ebZdsdRlZFywnWg6f0qSAn29OfMAAAAA0MuyS+v061c3adlux9gsOSJAt505WqeOjSfUj8O2rnllXb7+e0DrmmNHROvKY9I0LyPWVqkBAAAA+iNCIwDcnulL/NyqvXphdZ5Kapqc52PG0EgbFDl9fILCAnzc/jyh7+wsqrHhEVPppr65ze4L8ffWxdNSdMUxQzQkKohvBwAAAAD0wmKSf32apUc+2GnbiPp5e+q6E9J17fHD5O/jxfnGEVWoMWGjJz7L1ofbi5wLklIiA3TFrDQ7rg8LZI4JAAAA/QuhEQBuqb29Q5/sLLErQD7JLHEO4qODfXXRtBRdNj1VqVGBrj5MuLmqhha9tCZPTy3PVk5Zvd3n4SHNGxWrK2en6dj0aHmyUgkAAAAAvrF1eyv0q1c2afu+Grs9Nz1a95w3jtA+vtEipac/z9Hzq3Lt+N4I8PHSuZOTbDvaUfG0OQIAAED/QGgEgFupb2611Rue+GyPdpfU9SgXetmMVJ00Os62owH6Xcgps0RPdoacugyLDrKVR0yv5BB/VioBAAAAwNdpK/LAeztstUezoCQi0Ee/PWuMzpucRCsaHBUNzW16bb2jdU1XKMmYNSxSV80eqpNGx8qbVsgAAABwIUIjANxCYVWDnlqeo/+t2Otc3RHi561Lpqfo27OGKC2adh8YGLJKau3PsqlAUtvUavcF+XrpvClJtszt+KQwJjYBAAAA4Ah8nlWmX760QbnlDXbbtKj9zZmjFRXsx/lDr7SuWbGn3IZH3t9apLZ2R9nbpPAAOzd16fQURQT5cuYBAADQ5wiNABjU9pTW6bGPd9nqIq2dg/HUyEBdPSfNtqEJ9vN29SECX4sJjLy6Ns9WH+leNWdUXIgumpZsV8Ux0QkAAAAAh6788Mf3tuuJz7KdF+3vO3+8jhsZw+lCnyiobNAzn+fo/1buVUW9Y3GTn7enzpmUaNvRjk0M4zsBAACAPkNoBMCgtGNfjf6+eJfe2ligzqyIZgyN1DVzTdnPOHl5erj6EIGjtlJp2e4yvbA6V+9s3qfm1na739vTQ/NHx9rwyAmjYuXv48UZBwAAAOD21uSU6xcvbrSLTAxT3cFUF6HlJ1yhsaVNb24osO2RNudXO/dPGxJhwyOnjYuXD61rAAAA0MsIjQAYVDblVekvH+3Uoq1Fzn0nZsTqx/PSNXVIhEuPDehtVfUtemNjgV5anasNeVXO/aZ9zUlj4nTWhEQdNzJaft4ESAAAAAC438X5hxZl6l+fZqmjQ4oP9dcfLhhvQ/ZAf1gQsnZvhZ5clqN3NhU6q+XGhvjp8pmp9hYb4u/qwwQAAMAgRWgEwKCws6hGD76fqXe37LPbHh7S6ePidd0J6RqXRElPuJ/t+6ptW6aFGwuVX+noz22E+Hnr5LFxtuLO3BHRCvX3celxAgAAAEBv25BbqZteWO9s7Xnh1GT99qwxCgtgPIT+p6i6Uf9bsVf/W7lXJTVNdp+Pl4dOH5egK2cP0ZTUCHmYiS8AAADgKCE0AmBAyy2v18Mf7NSr6/JsGxozZj5nYqJ+cmK60mNDXH14gMu1t3doXW6lDY8s3FSgomrHhFNXC5vpaZGalxFjK/IMjwlm4gkAAADAoNHa1q5HP96tRz7cqbb2DsWE+Om+88bbSoxAf2faz76zuVBPLc/RmpwK5/5xSaG64pg0nT0xkVa0AAAAOCoIjQAYkMxKi799tNOuumhpc5TsPHVsnH5+yiiNjCMsAhwuQLJmb4Xe3bxPi3cUK6tzlV2XpPAAzRwWqVlDo+x9amQgIRIAAAAAA9Lesnrd+MJ658X2BRMTdfc5YxUe6OvqQwO+ss35VXpqebZeX1+gptZ2uy8i0EeXTE/Vt2elKjkikLMKAACAr43QCIAB14P430v36NHFu1TX3Gb3HTsi2oZFJqWEu/rwgAElu7TOhkcW7yjR51lldhVTd6bHtwmPTBsSoQnJ4cpICJGft5fLjhcAAAAAvkxHR4deXpuvO9/YotqmVtui8+5zx+ncyUmcPAx4FXXNen51rp5enuNsRevpIc0fHacrj0nTnPQoFn8AAADgKyM0AmDATPq8ubFQ97+z3TkonpgcpltOz9Ds4dGuPjxgwKtvbtXq7Aqt2FOmFVnl2pBX6azi08XXy1OjE0JsgGRCcpgmpoTbljZeZoYKAAAAAFyssr5Zv3l1sxZuKrTbM9Ii9eDFE5USSRUGDC6m3dJH24v132XZWrqr1Ll/eEyQrpydpvOnJCvYz9ulxwgAAICBg9AIgH5v7d4K3f3WVq3bW2m3E8L8dctpGbZ3qycXq4Fe0dDcZv/trcgq07rcSm3Mq1JVQ8tBrwvy9dKYxFCNTQzTuCRzC1V6TLC8vTz5zgAAAADoM5/tKtXPX9igfdWN8vb00I0nj9QPjx9OyB2D3q7iGlt55KU1ec6qvCH+3rp8Zqq+O2eo4kL9XX2IAAAA6OcIjQDot8rrmnXf29v04po8ux3g46UfnTBc3z92mAJ8aZEB9HW1n73l9dqQV6WNnSGSzQVVqu+ckOrOz9tTGQkmSBKqcTZMEqqRcSHy9+HfLQAAAICjq6m1TX96b4f+9ekeuz0sOkgPXzrJVkgE3ElNY4teWZuv/y7PVlZJnd3n4+Whcycl6QfHDdOIuBBXHyIAAAD6KUIjAPpt/+F7Fm5VRb2jssGFU5P1y1NHsToC6GflcHeX1GpzfpW2FFTb+60F1appaj3otWaln5mgGmeCJElhtr2NqU7i601FEgAAAABfT2ZRjX72f+u0fV+N3TaVFW47c7QCfWnLAffV3t6hD7cX659LdmtVdoVz/4kZsTY8MnNopDw8aDMLAACA/QiNAOhXdhXX6rbXNunzrHK7PSouRPeeP05Th0S6+tAAHOHklKlIYqqQbM6v1hZ7X+UMgHXn7+OpSSnhmp4WqWlpkZqSGq4Qfx/OMwAAAIAvHXeYagr3vbNdza3tigzy1f0XTNDJY+I4c0A3pu3sPz/J0ntb96mjw7FvYnKYrpuXrlPGxBEeAQAAgEVoBEC/0NjSpkcX79I/PslSc1u7vZh8/fyR+t6xQ+XjRSUCYKBXDyqsarThkc2dFUnW7a04KEji6SFbQvqEUTE6YVSsxieF0X8cAAAAQA/F1Y36xUsbtSSzxG6b8cMfL5yg2BB/zhRwGHtK6/T/Ps3SS2vy1NTabveNTgjV9fNNeCRenmZADgAAALdFaASAy322q1S3vbbZDmCNeaNi9LtzxiklMtDVhwagF1cGZpXW2lK5q7LL7S23vKHHa8xqwWNHRNtJ4BMz4hQWQBUSAAAAwJ29t2Wfbn15ow2g+3l76jdnjtZ3Zg2hWgJwhEprm/TEZ3v032U5qu1sLZsRH6KfzR+h08YSHgEAAHBXhEYAuHSg+vu3tuq19QV2OzbET3eePVanj4tnwgdwQwWVDXa14CeZJVq6s1Q1nRNYho+Xh+amR+uM8Ql2FVRYIAESAAAAwF3UNbXq7re26rlVuXZ7TEKoHrl0kkbEhbj60IABqbK+Wf9eukdPfJbtDI+YFtE/P2WkbfPk4UHlEQAAAHdCaASASyoMPL86V/e9vU3Vja0y49ArZg3Rz08dpVB/LgQDkFra2rU2p8IGSD7YVqTMotoeAZKTRsfpwqnJOn5kjLxpYQUAAAAMWutzK3XDc+uUXVZv5w9+cOww3XTKSPl5e7n60IABr6q+Rf/+bI+eWLrHuXBj6pAI3XJahmYMjXT14QEAAKCPEBoB0Kd27KvRb17dpNU5Fc7VQfeeP16TUsL5TgA4rF3FNVq4cZ/e3lSoHUU1zv3RwX46f0qSLUlNSysAAABg8Ghr79Cji3fp4Q932scJYf568OKJmj082tWHBgzK8MjjS3brP5/tUWNLu903PyNWN5+WoVHxVPQBAAAY7AiNAOgTDc1t+stHO/WvJVlqbe9QoK+Xbjp5pK6anUaVAABfydaCar28Nk+vrctXWV2z3WdWHM7PiLO/U+akR1FKFwAAABjAcsvrdePz650LTs6ckKB7zx1Pm0qglxVVN+rhD3bqhdW5NqxlxtrnT07WzaeNUlyoP+cfAABgkCI0AqDXLd5RrNtf36zc8ga7bXqj3nn2WCWFB3D2AXyjFjaLtxfrmRV7tSSzxLk/PTZYV85O0/mTkxTk580ZBgAAAAaIjo4OvbouX7e/vkW1Ta0K9vPW784Zq/MmJxEMB/rQ7pJaPfj+Dr29aZ/dNou/fjwvXdfMHSp/H1pDAQAADDaERgD0muLqRt311lYt3Fhot00p2bvOHqtTxsZz1gEc9Qmtp5Zl66U1eaprbrP7wgN99N05Q22AJCzAhzMOAAAA9PP2GL95bZPe6pxDmDYkQn++ZBJtKAEXWre3Qr97a6vW7a202ymRAfrNGWN06tg4glwAAACDCKERAEedKV/57IocPfDuDtU0tcrTQ7p6zlDdePJIu0oIAHpLTWOLDY78d1m2ssvq7b4QP29dMXuIDZBEBftx8gEAAIB+ZtnuUv38hQ0qrGqUl6eHbpg/Qj86YTjtbIF+oL29Q29sKNB972xTUXWT3Td7eJTuWDBWo+JDXH14AAAAOAoIjQA4qrYUVOnXr27WhlzHCoSJyWG657zxGpcUxpkG0KfhtYWbCvX3j3ZpR1GN3Rfg46XLZ6bq2uOHKTaEXswAAACAqzW3tuvBRTv0zyVZ6uiQ0qICbXWRyakRrj40AAeoa2rVPz7ZrceXZNl/uybg9b25Q3X9SSMU6MsiMQAAgIGM0AiAozZwfPiDTP3ns2x7sdZUFLn5tFH61swhdhAJAK5aEfXBtiL9bfEubcyrcoZHrp6TpmuPH07bGgAAAMBFdhXX6Prn1mtLQbXdvnR6in571hgFUaEU6Ndyy+v1+4Vb9d6WIrudFB6gO88eq5PHxLn60AAAAPA1ERoB8I0t2lqkO17frIKqRrt95vgE3b5gjOJCWckPoH/o6OjQkp2l+vOiTK3vrIQUFuCjHx4/XFfNTlOAr5erDxEAAABwm/fmz3yeo98v3Kam1nZFBProvvMn6LRx8a4+NABfwYfbinT761uUX9lgt01oxIRHTIgEAAAAAwuhEQBfW0Flg+58Y4ve3+pYWZAcEaC7zxmneRmxnFUA/XaC2gTdHnhvh3YW19p9sSF++tn8Ebpkeop8vDxdfYgAAADAoFVS06SbX9qgxTtK7PaxI6L1p4smsugEGKAamtv0l4926l9LstTa3mEre9548ghdPWco42sAAIABhNAIgK+sta1d/12eo4fe36G65jZ5mx6mxw7T9fNHsFofwIBg2mi9ti5ff/4gU3kVjlVRw2OC9JszR2veqFh5eNBWCwAAADjaVQlufmmjyuqa5evtqVtPy7BV/zxpaQsMeJlFNfrNq5u0KrvCbmfEh+ie88Zr6pAIVx8aAAAAjgChEQBfydq9Fbrt1c3aWujoOWwGf/ecN04Z8aGcSQADTlNrm/5vxV795aNdKq9rtvvmpkfb8MjoBH6vAQAAAEejEsHvF27Vsyv2Oi8mP3zpJOYRgEGmvb1DL63N031vb1NFfYvMWozLZ6Tq5tMybHtYAAAA9F+ERgAckcr6Zt3/7g49t2qvOjpkB3u3nJahS6ensCoIwIBX3diivy/epSeWZqu5rV1msePF01J00ykjFRvi7+rDAwAAAAakTXlVuv75dcoqqbPb18wdql+eOkr+Pl6uPjQAvcQsyLj37W16aU2e3Y4J8dOdC8bqjPHxVPUEAADopwiNADiiVQJ/eGe7cxX+hVOTdevpGYoO9uPsARhUcsvr9Yd3t2vhxkK7HeTrpR+dMNy24GJiGwAAADjydpCPL9mth97PVGt7h+JC/fTgRZM0d0Q0pxBwE8t2l+o3r27WnlJHaOzEjFj97pyxSo4IdPWhAQAA4ACERgAc1vZ91frta5ud/UhHxgXr9+eO14yhkZw1AIPa6uxy3b1wmzbkVtrtxDB/W1L37ImJVFcCAAAAvkB+ZYNuen69Vuwpt9unjY3XfeePV0SQL+cNcDONLW169OPdeuzjXWpp61CAj5d+fspIXTU7Td5enq4+PAAAAHQiNALgIHVNrXrkw53699I9dnVQoK+XbjhphK6eM1Q+DOgAuFGlpTc3Fuj+d7aroKrR7puYHKbbzhqj6WmE5wAAAIADvb4+X7e9tlk1ja12LsG0pLhoWjItKQA3t6u4Rr9+ZbNWZjvCZGMTQ22YbEJyuKsPDQAAAIRGAHTX0dGhdzbv091vbVVh5wVSsyLo9gVjlBgewMkC4LYro0yI7tHFu1TX3Ob83WjadKVFB7n68AAAAACXq25s0e2vbdZr6wvs9qSUcD18ySTeLwPosTDjhdW5uvftbapubJWnh3Tl7DT9/JRRCvbz5kwBAAC4EJVGAFg79tXorje3aNnuMrudEhmg3509TvMyYjlDACCpuKZRf160U8+v2qv2DsnHy0NXHJOmn56YrvBASm0DAADAPa3cU64bn19v29KYi8A/PXGEfnJiOpVKARxSSU2Tfr9wq17vDJklhPnrrrPH6pSx8ZwxAAAAFyE0Ari5qvoW/fmDTD39eY5tRePr7akfHjdM181Ll7+Pl6sPDwD6ZcjOrIz6JLPEbocF+Ohn80foO7OG2N+hAAAAgDtoaWvXwx9k6rGPd9tQdWpkoP58ySRNHRLh6kMDMACYMfVtr21SbnmD3T51bJzuOnuc4sP8XX1oAAAAbofQCOCm2jpLQj7w3g6V1zU7B2e3nTlGKZGBrj48AOj3lmSW6J6F27SjqMZup0UF2pY1p46Np2c7AAAABrWsklrd8Px6bcyrstsXTk3WnWePpcUEgK+koblNj3y4U//6NMvOVZo2Nb88dZS+PWuIvEzpIgAAAPQJQiOAG1qTU6473tiizfnVdjs9Nlh3LhiruSOiXX1oADCgmEmtF1fn6sFFmbbErjEjLVK/OXO0JqaEu/rwAAAAgKOqo6NDz6/K1V1vblVDS5utunff+eN1xvgEzjSAr21bYbV+9comrc+ttNsTksN0x4KxVC4CAADoI4RGADdSVN2oP7yzXa+uy7fbIf7euvGkkfrOMUPoNQwA30BdU6se/2S3/vlplhpb2u2+cyYl6henjKJ6EwAAAAaFyvpm3fryJr27ZZ/dnj08Sg9ePFEJYQGuPjQAg2RRxv9W5OiP7+5QTVOr3XfupETdcnoGv2cAAAB6GaERwA00tbbpP0uz9dePdqq+uU0eHtIl01L0i1NHKTrYz9WHBwCDRmFVg/70XqZeWZenjg7Jx8tDl0xP0U9PHKG4UPoyAwAAYGBatrtUNz2/QfuqG+Xt6WHbR3z/2GHypH0EgKPMVPH803s79MKaXDuuDvDx0nUnDNf3jxsmfx8vzjcAAEAvIDQCDPKysR9sK9a9b2/TntI6u29yarjuOnusJiTTNgEAesvm/Crd/+52fbqz1G77eXvqytlp+uHxwxUZ5MuJBwAAwIDQ0tauhxZl6h+f7LYXb4dFB+mRSydrfHKYqw8NwCC3Ka9Kd725RatzKux2UniAbj5tlBZMSCSwBgAAcJQRGgEG8QXLexZu0/KsMrsdE+KnX52eoXMnJTGwAoA+8nlWmV0h1TXJFeznre/OHarvHTtUof4+fB8AAADQb5nFJ9c/t04b86rs9qXTU3T7gjEK9PV29aEBcKMFcW9uLNR9b29TYVWj3Tc6IVS/PHWk5o2KlYcppwwAAIBvjNAIMMgUVTfaC5QvrXW0RvD19tT3jx1qV7eHcIESAFwyyfVxZokefH+HNudX233hgT76wXHDdMUxaTZIAgAAAPSn968vrsnTnW9ssS1uwwJ89Ifzx+v08QmuPjQAbqqhuU3/79Ms/XNJlmqaWu2+6WkRuvm0DE1Pi3T14QEAAAx4hEaAQTR4+tenWbZkrJnUMc6emGjLNiZHBLr68ADA7ZnJ93c379ODizK1q7jWng8zAW/a1lw9O00RtK0BAACAi1XVt+jXr27Swk2FdnvWsEg9dPEkJYYHuPrQAEAVdc127vPJZdlqam23Z2TeqBhdf9JITUqhFTcAAMDXRWgEGODa2zv02vp8/fHdHdpX7SjTOCU1XLedNUZTUiNcfXgAgAO0tXfo9fX5+tviXcoqqbP7An299K2Zqfr+scMUG+rPOQMAAECfW5FVphufX6+CqkZ5e3roxpNH2qqlXp60fwDQv+yratQjH+7UC6tz7RjbmJserevmDdcxw6JoWwMAAPAVERoBBviEzu8XbtOmfEd/4aTwAN16eobOmpDA4AgA+jkzsWUqj/x98S5tLXS0rTEtxS6ammwn51MiqRIFAACA3tfS1q5HPtipRz/eJXPtdUhUoB65dDKr9gH0e3tK6/S3j3bZBXVd4RGzmO7H89J1YkYs86MAAABHiNAIMADllNXpvre3690t++x2sJ+3HQxdPSdN/j5erj48AMBXbFvz8Y4SW3lkTU6F3WdWcy6YkKDvHTtM45LCOJ8AAADotfmF659br/W5lXb7wqnJuvPssXaeAQAGitzyev1zSZaeX52r5s62NRnxIfru3KG2fTfzpQAAAF+M0AgwgJTWNumvH+7Usyv2qrW9Q6ZC7GUzUm3J2OhgP1cfHgDgG4ZHPs8qtys8P91Z6tw/c2ikDY/Mz4iVJ6XBAQAAcJTee76yNl+3v75Zdc1tCvH31r3njdeCiYmcXwADVnFNo/796R4983mO/d1mRAX52naw3541hHawAAAAh0FoBBgA6ppa9f8+3aN/LtntHPAcNzJGvzljtEbFh7j68AAAR9nGvEr9e+keLdxYaEOCRlpUoF0lZVZ/Bvqy8hMAAABfT3Vji257dbPe2FBgt6enRejPl0xScgTtEQEMDlX1LXpu1V79d1m2Cqoa7T4fLw+dNSFRV81O04TkMFrXAAAAdENoBOjnfYWfW7lXj3y4U6W1zXafGdTcelqGZqdHu/rwAAC9rLCqQf9dlqP/rchRdWOr3RcW4GOrTH3nmCFKCg/gewAAAIAjtjq73Lajya9ssC0Rb5g/QtfNS7ePAWCwaW1r13tbivTEZ3u0urMdrDEuKVSXzxiicyYlKoh2XAAAAIRGgP5aJnbhpkL96b0dyi6rt/uGRAXql6eO0pnjE0jCA4AbVpx6aU2enejq+rtg5vXnj47TFccM0dz0aP42AAAA4AsvnP71o13660c7ZQrZpUQG6JFLJ2tKagRnDYBb2JBbqSeXZds51+bWdrsv2M/bBke+NXOIxiSGuvoQAQAAXIZKI0A/s2x3qf7wznZtzKuy29HBvrp+/ghdOiNVPl6erj48AIALtbV36MNtZpVUtpZnlTn3D4sOsv2ZL5yWrFB/H75HAAAAcMotr9cNz6/Xms5V9udPTtJd54xVCO8bAbih8rpmvbwmT/9buVd7Suuc+yelhOtbM1N15oQEWsICAAC3Q2gE6CfM5M1Di3bos12Oi4BBvl76wXHD9b1jh1ImEQBwkJ1FNXr68xy9sjZftU2O1jUBPl46d3KSrT4yOoFVUgAAAO5exfS19fm6/bUtqmlqVYift35/3jidMynJ1YcGAP3id+Ty3WV6duVevbd5n1pNGSbJ/q5cMClRl05P0fikMKp6AgAAt0BoBHCxjXmVemhRpj7eUWK3fbw8dPmMVP10/ghFB/u5+vAAAP2cCYy8ujZPTy3P0c7iWuf+6WkRtvrIaePi5eft5dJjBAAAQN+qamjRba9t1psbCuz2lNRw244mJTKQbwUAHKCkpkkvrsnV/63cq9zyBuf+jPgQXTI9RedNTlJ4oC/nDQAADFqERgAX2VpQrT9/kKlFW4vstpenhy6ckqyfnJjOJA4A4Gutklqxp1xPL8/Ru1v22VY2RkSgjy6cmmzbnA2PCebMAgAADHIrssp00wsblF/ZYOcafnbiCP143nB50/IWAL5Qe3uHPs8q0/Orc/XO5n1qbm23+329PHXquHhdMi1Fs4dHydPTgzMJAAAGFUIjgAvaCTz8wU4t3FRot80Yw7QSMJM4adFBfD8AAN9YUXWj/rdir55flat91Y3O/TOHRurymak6dWy8/H2oPgIAADCYmIubD3+Qqcc+2a2ODmlIVKD+fMkkTUmNcPWhAcCAU1XfYlt8PbcqV9sKq537kyMCdPG0FLs4IzE8wKXHCAAAcLQQGgH6yJ7SOj3yQaZe31BgJ288PKSzJiTq+vkjlB7Lym8AwNHX2tauTzJLbIndj7YXq7P4iMIDfXTBlGRdNiNF6bEhnHoAAIABbndJrW54br025VfZ7YumJuuOs8cq2M/b1YcGAAO+qufm/Go9v3qvXl9foJrGVrvfzO0eNyJGl05P0fzRcfL19nT1oQIAAHxthEaAXrZjX43+vniX3tpY4LxYd9rYeN148kiNiudCHQCgbxRWNeiFVXl6ftVeFVTtrz4yIy1Sl81M0enjEqg+AgAAMAAvZppV8L97c6saWtoUFuCj+84frzPGJ7j60ABg0GlobtM7mwttVU/THrZLVJCvzpucpEump2hEHPO9AABg4CE0AvSSDbmV+tviXVq0tci576TRsbrhpJEalxTGeQcAuERbe4eWZJbof53VR8y2YS4wnDMpURdNTdG4pFB5mGVTAAAA6LfK65p1y8sbnfMOs4dH6cGLJyohjHYJANDbskvr9MLqXL20Jk/FNU3O/VNSw214xFSYDqLaEwAAGCAIjQBH2YqsMhsW+XRnqeMfmYfsCp8fn5CuMYmhnG8AQL+xr6pRL67OtatT8ysbnPtHxYXY/sznTk5STIifS48RAAAAB3t38z7d9tomldY2y8fLQzefmqFr5g6VpyfBXwDo67awH+8o0fOrc3sszAjy9bLBkYunp9ggCQszAABAf0ZoBDhK5WA/ySyxbWhWZVfYfV6eHjp3UpJ+dMJwpccGc54BAP2WmdT6bFepXSH13pZ9amptd/4tmzcqxgZITsygRzMAAICrVdQ16843t+j19QV2e2RcsP58ySSNTaSiKQC4WnF1o15em28rkOwprXPuHxEbbKuPmBY2UcEszAAAAP0PoRHgG2hv79D7W4tsWGRTfpXd5+vlqYumJeuHxw9XSmQg5xcAMKBUNbTorY0FNkCybm+lc39EoGlfk2QDJGMTaV8DAADQ10wbml+/ukklNU0yBUXMvMP1J42Qn7cX3wwA6GcLDFfuKbfVR97eVKjGFsfCDFMZ6uQxcbp4WoqOHRFjF2oAAAD0B4RGgK+hpa1db24o0D8+2a3Molq7L8DHS9+amarvHzdMcaH+nFcAwIC3q7jWhkdeWduzR/PwmCCdPTFJZ09K1NDoIJceIwAAwGBXVd+iu97colfW5dttU830TxdN1KSUcFcfGgDgS1Q3tuiN9QW2+sjGPMeiQyMxzF/nTUnS+VOSNTyGKtUAAMC1CI0AX0FtU6ueW7lX/166R4VVjXZfiJ+3rpqTpqvnDFVkkC/nEwAwKHs0L91VqhfX5OmDrUXO9jXGxOQwnT0pSQsmJCiW0CQAAMBR9dH2Iv3qlU0qqnZUFzELVW48aaT8faguAgADzdaCahseeXVdvq3y2cWEAC+YmmzH1eGBzC8DAIC+R2gEOALFNY168rNsPf15jmoaW+2+mBA/XT0nTd+eNUSh/j6cRwCAW6hpbNH7W4r0+oYCfbarVG3tHXa/h4d0zLAonTUh0ZbbNX8nAQAA8PWU1jbp7re26vX1BXZ7WHSQHrhooqYOieCUAsAA19jSpg+2FemVtfn6JLPEOa42bc/nj47VBVOSdfyoGPl4ebr6UAEAgJsgNAJ8gd0ltfrXkiz7Br65zbGqelhMkK49bpjOnZxE32AAgFsrqWmy/Znf2FCgNTkVzv1mFey0tEidPi5ep46NV2J4gEuPEwAAYKDo6Oiwq9DvfXu7XYVu3ld9d85Q/eLUUVQXAYBBuljRtK95eW2+thVWO/dHBfnalrDnT07WuKRQeZiVGgAAAL2E0AhwCObC1+Of7NaibUXqcAS97WoeExY5aXScPM2sDQAAcMotr7fhkXc379Om/P19mo2JKeE6bWy8DZGkRQdx1gAAAA6zcOXXr2zSij3ldntMQqj+cMF4TUgO53wBgJu0r3l5bZ5eX5+v0tpm5/7UyECdOSFBZ45P0NhEAiQAAODoIzQCdGpv79BH24v1+JLdWpW9f7W0KbFvwiJmxTQAAPhyeRX1em9Lkd7dXKjVORXOAKaRER+i08bF2xAmk10AAACONgX/+GS3Hl2821Y5DfDx0k0nj7Qtcb1pTQAAbqe1rV1LdpbY6iMfbitSY4ujArYxNDrIhkdMiMSMr6lAAgAAjgZCI3B7Ta1ten1dgQ2L7C6pc/aPPG9ykr5/3FClx4a4/TkCAOCblNp9f0uR3tuyT8t2lzl7NRtxoX46MSNWJ2bEaU56lAJ9vTnRAADArVrRLNpapLsXblVueYPdN29UjH53zjilRAa6+vAAAP1AfXOrXei4cGOhvW9q3R8gMW3UTxkTr/mjYzUlNUJeVMcGAABfE6ERuK3qxhb9b8Ve/WfpHhXXNNl9IX7e+tasIXY1T1yov6sPEQCAQaWyvlkfbCvW+1v2aemuUtU3tzmf8/X21DHDouxk17xRsVwoAQAAg74VzV1vbtWSzBK7nRDmr9+cOdquHmfVOADgUGqbWm3lERMg+TizRM3dAiQRgT46YVSsHVMfNzJGof4+nEQAAHDECI3A7eyratR/PttjAyPmjbYRH+qv785N02UzUhXCG2oAAPqk0teKrHK7UurD7UXO1bVdRsYF2wokZsJrcko4pdkBAMCgYOYh/vrRTruApaWtw1Y6NVVOfzwvnaprAIAjVtPY4hhPbyvWxzuKVd3omOc2TMWRSSnhmpMerTnDozQ5NcIu1AAAADgcQiNwG1sLqvXvpXv0xoZ8OzFjjIgN1rXHD9fZExN54wwAgAtLs5vVtmay68PtxVqTU9GjjU1YgI/mpkfr+JExdsVUfBjVwAAAwMDS2tauF9fk6aFFmSrprHZq2vTdftYYpUUHufrwAAAD/G+MGUeb8bSpRNLVgr1LgI+XZgyN1OzhUZqWFqFxSWHy8/Zy2fECAID+h9AIBrX29g59nFms//fpHi3bXebcb94k//D4YTphZKw86fUIAEC/UlXfok92luijbUW25G5lfUuP5zPiQ2yAxNympkUw2QUAAPp1ONa8n7nv7W3KLKq1+4ZEBdqwyPzRca4+PADAIJRbXq9lu0u1dFeZlu0qVVldc4/nTZWr8clhmjYkQlM7b1HBfi47XgAA4HqERjAoNTS36eW1ebYNTVZnstqU5Tt9XLyumTvUluQDAAD9n6k4siGvUp/sKNEnmSX2ccf+IiQK9PWyq6W6qpAMiWKlLgAA6B+2FFTpvre3a+muUrsdHuijn504Qt+eNYRqpwCAPltUuaOoRp/tKtXKPeW2IsmBIRJjWHSQnTOfnBpub6PiQmgTCwCAGyE0gkGluLpRTy3P0TMrcpyrkkP8vHXZzFRdOTtNSeEBrj5EAADwDVTUNevTXaU2RLJkZ4mzvHuXtKhARxWSUTGaNSxKgb7enG8AANCnskvr9MiHO/Xa+nwbdjUruq+ak6Yfn5CusEAfvhsAAJdWwMouq9fqbEeAxNx2FjsqYR3Y0mZCctj+IElKuGJDaRULAMBgRWgEg8KG3Er9d3m23txQoJY2x/LjlMgAfXfOUF00LUXBflwwAgBgME52bSussRVIPsks1ursCrW27y9DYi7QmJZ0XSGSEbHB8vDwcOkxAwCAwSu/skF//XCnXlyTZ6ulGQsmJurmU0cpJTLQ1YcHAMAhVdY3a+3eCq3bW6n1uZVav7dSNU2tB73OLMic1BkgMWGSsYmh8vfx4qwCADAIEBrBgNXY0qY3NhTomc9ztDGvyrnf9GL83rFDdfKYeNuSBgAAuIeaxhYt313WGSIpUV5FQ4/nE8L8ddwIR4BkTnq0wgJY6QsAAI5O1dO/L96l/1uZq+a2drtv3qgY3XTyKI1PDuMUAwAGXEub3SW1NkSyLtcRJjEtbrq3ijV8vDw0JjGsM0RiwiQRdiEnizUAABh4CI1gQJZ5fXZFjl5YnaeqhhbnSuKzJiToitlpmpQS7upDBAAA/aAKSVZpnbONjQmTNLU6LuIYJlc6ITlcx46I1tz0aLtKytfb06XHDAAABpbyumY9/sluW/m0scXxPmPWsEj94pRRmpYW6erDAwDgqKltatXGvEpHkMRWJKlQaW3zQa+LCvJ1BEhMW5uUcE1MCVcQVcABAOj3CI1gQGhpa9fi7cV6ZsVeLcksce5PjgjQt2YO0cXTkhUV7OfSYwQAAP27QtnKPeW2AsnHO4q1u6Sux/NBvl6aOSzKhkjMbXgMrWwAAMChldQ06f8tzdIzy3NU19xm95kLZL88ZZRmp0dz2gAAbrFQw1T37Gprsy63UlsLqpyt47t4e3rY4Mjs4VE6ZniUpqRG0NIGAIB+iNAI+rXt+6r10uo8vbY+35lc9vCQjh8ZoyuOGaLjR8bSggYAAHxlBZUNWrqrVEt3luqzXaUqq+u5Qio+1F9zOwMkppVNNOFUAADcXn5lg60s8vyqXGcFszEJofrFqSM1b1Qs5fgBAHL3xRpbC6s7q5E4wiTmb2d3psLn1NQIZ4jEBEp8vKj6CQCAqxEaQb9TUdestzYW6MU1edqYV+Xcby7WXDAlSZfPTNWQqCCXHiMAABhc/ZrNxFZXiGRldrmau7WyMUYnhDpb2cwYGsnKKAAA3EhWSa0e+3i3Xl2Xr9Z2xwpq0xr3J/PSNX80YREAAA4nt7zetotdtrtUy3aXqbimqcfzIX7emp0eZReHHjcyWskRgZxMAABcgNAI+oXqxhYt2lKkNzcW2Is1XZMwpnydmYC5aGqKjh8VQ+oYAAD0yeqoVdnl9j3JpztLbaCkO18vT1uCftYwx8ooc9HI38eL7wwAAIPMloIqPfrxbr29qVAdndX2zcpoExYx7wE8TClUAABwxC1tskrrbHjk884gSUV9S4/XDIsJslXGjxsZo1lDoxTgy1gbAIC+QGgELlPT2KLFO0r01oYCfZxZ0mNFrynvesHUZJ07KVFRlIMHAAAuVFrbZFvYmBCJqUZSWNXY43k/b0/bl7krRDIxJUx+3kxsAQAwUCuQfZJZov+3NEuf7Spz7j9pdKyum5du/+YDAIBvrq29Q5vzq7Qks8T+7V2XW2n3dW9lM3NopI4bEWMXlI6IDSawCQBALyE0gj6VV1GvD7cV64NtRfo8q0wtbfvfBKbHBmvBhESdNTFBw2OC+c4AAIB+uTJqT2mdPs8q1/KsMvt+puSA8rr+Pp6aOiTCrooyIZIJyeF2sgsAAPTvSmOvrM3Xv5dmaXdJnd3n5emhM8Yn6LoThttWdQAAoPdUNbRo+e5SGyBZklmq/MqGHs8nhPnbAImpQmJax4YF+vDtAADgKCE0gl7V1NqmtTmVdnXuh9uLte2A8u7DooN0+vh4LZiYqFFxISSFAQDAgCyva3o0mwCJuZXWNvd4TYCPl6alRWh6WqS9N+1sAn29XXbMAABgv+KaRj2zPEfPrNir8jrH3/AQP29dNjNVV85OU1J4AKcLAAAXjLV3l9Tqk8xSW4nEjLWbulUq9/SQHVubAIlpZ2MWa5iwJwAA+HoIjeCol3HdWlhtQyKf7S7Tyj1lamzp+WZu2pBInTQmVvNHx1FRBAAADMqJLUeIpNxObJV1XoDqYiayxiaG2mok5n2RCZLEhfq77JgBAHDHv9dr91bq2c9z9NbGQjW3OeYtkiMCdPWcobpkeoqC/Qh4AgDQnyqCrdxT7mxls7O4tsfz4YE+tvpIV4iEMTYAAF8NoRF8Iy1t7dqxr0Zr91ZoRVa5lu0uVUV9S4/XRAf7aU56lC0dd2JGrCKCfDnrAADAbS5KmcksEx5ZlV2hNdnlKqhqPOh1KZEBNkBigiSmIonp1ezJKikAAI6quqZWvb6+QE9/ntOjEuqU1HB979hhOmVMnLy9aCkHAEB/V1DZYAMkS3aWaOnOUlU3tvZ4PiM+xBkgMQs1/Ly9XHasAAAMBIRG8JUUVTdq3d4KrdtbaW8b8yt7VBIxzGqcmUMjNSc92t5GxgXTdgZwQ4sWLdIHH3yg0tJSu52UlKTzzz9fkyZN+sKP+/zzz/Xiiy/aj4uPj9ell16qyZMn99FRA0DvM32ZV2eXa01OhVZnV2j7vmq1d/R8TYi/tyYkh2licrgmpoTb+/gwqpEAAPB1ZBbV6JnPc/TK2nzVNjkuKvl5e9pWud+eNcSWtwfwzbzxxht67rnndNppp+mKK6447Ovy8vLsmH/Pnj123P+d73xHp59+OqcfwNfW2tauDXmVtpWNqUKyMa9SHR09W8YeM9wsanVUIhkaHcT1CgAADkBoBF9Y8m1LQbUjJJJbqXU5FYdcGRvq763JqRGakhqhuSOibP9AH1bmAG5vzZo18vT0tMEPY8mSJXrrrbd03333KTk5+ZDnJzMzU7/73e90ySWXaMqUKfrss8/05ptv6t5771VKSorbn1MAg1NNY4sN467OqdCanHL7uL657aDXxYX69QiRjE8OU1iAj0uOGQCAgVBV5J3N+/TC6lxbzr6LuVD0rZmpunBqssIDqYQKHA27d+/WX/7yFwUEBGjMmDFfGBoxrzWLRYYOHapnnnlGCxYsIDQC4KiqqGvWp7tKHZVIMktUXNPU4/n4UH/NGhapWcOibJgkNTKQEAkAwO0RGoGzdHpeRYNtM2OriORWamtBlVraei57NVXSR8WHanJquA2JmPuhUUGUTwdwRL7//e/r8ssv17x58w75vJlkampq0i9/+Uvnvttvv11DhgzRNddcc8iPeemll2xA5dRTT9XLL7+s2tpaHXvssbrqqqu0cOFCvf322/Z3nFntdO655zo/rq6uTs8++6z92NbWVjthZVY4ma9lFBUV2QmsnTt32mMylVJMmGX8+PHOz/Gzn/1MJ554on3tihUrFBQUZL/G/Pnz+YkA8I1WSW3fV6ONeVV2hdT63Eq7QvrAaiTGsOggGyIZmxiqMeaWEMoFMACA22pv79DK7HK9tCZPb28qdIYwvTw9dNLoWFtVZM7waOYwgKOosbFRv/71r3X11Vfrtddes2PqLwqNdGfG1KbKyJdVGvnkk0/09NNP67rrrrPj+LKyMlvF9Ec/+pEdi5t5gfr6ejsXYMb1ZgGL0dLSohdeeEHLli2zz5sFLJdddpkNthg1NTV68skntX37djtHEBcXp3POOUezZ892fu27775bqamp8vHx0eLFi+Xt7W3H/BdeeOE3Om8A+oaZEzTjaxMeMVVITLXP5raeldMTwkyIJErHDIvS9KGRSosiRAIAcD/erj4AuG7FjbkQsS53f6uZ0tqeiVsjOthXk1IiNGVIuCanRNgy6UF+/NgA+Gra29vtSiITvhgxYsRhX2cCGmeccUaPfRMmTNDq1au/8POb0Mb69et1yy232MePPPKIiouLlZCQoN/+9re2gsk///lPjRs3Tunp6fZjzGt8fX3tx5jVUB999JHuuecePfTQQwoODrYTX2YS6uKLL7aTQp9++qn+9Kc/6cEHH1R0dLTza5tQykUXXWQnllauXKn//Oc/Gj16tBITE/kxAfC1eHt5alxSmL1dPjPV7qtvbrUV4DbkVmpDXpW931ter6zSOnt7dV2+8+MTw/w1OmF/iMQ8NiunPE36FwCAQSi3vN62nnl5bZ79+9jFXPQxFUUumJqshLAAlx4jMFg98cQTtqWsWWBhQiO9xcwnvPfee/rpT3+qhoYG/fnPf7bjd7N44+abb7ZzAA8//LBGjhypY445xn6MCYTk5+fbj4mIiNCqVat0//336w9/+IOdLzChErOAxFQ7MfMCZl7h0UcfVWxsrHPuoKtyqpmrMJVRzbzF448/rlGjRvVYVAKgf/Lw8LBjYnO79vjhtrr62pwKfZ5VpuVZZXaRRmFVox1Td42rIwJ9bGX1ySnhmjLEcU0kxJ8qnwCAwY2r/26y0mZPWZ0NhnRVEtmxr/qg1ao+Xh4akxhm3wx1VRJJjgigNBuAr23v3r2644477ESMv7+/brzxxsO2pjEqKysVFhbWY5/ZNvu/bNXAtddeayd5zOc3q4YKCwvtxJFZYWQCHKbNzdatW+3Ej1lFZEri/uMf/7CrhYxvfetbNpxiVimZVUNmdVRX1RHDhEfM811VTbqYYMnJJ59sH5uJJhMiMV+H0AiAoynQ11vT0yLtrUt5XbOtRLIht0pbC6u0rbDGXigz7QTN7cPtxc7XBvl6KSMhVCNig5UeG6wRcSH23gRMzCQaAAADTUlNk97dsk9vbSjQim7tZ4L9vHXWhAQbFpk6JIK/c0AvMhU8srOzbTWO3tbW1qbvfve7thqIMXPmTC1dulSPPfaYnW/omgsw43ETGiktLbUVSv7617/awIhx1llnacOGDXb/pZdeqsjISLuvixnrb9y40c4LdA+NmEojF1xwgX1swibvv/++Nm/eTGgEGID8fbw0Oz3a3oyG5jat6RYi2ZRXpYr6Fn20vdjeDDNkHhkbYq+ZjE0Ks4szMuJDWFwLABhUCI0MQlUNLTYhu64zIGIem30HMhcJbGI21RESGZsYZt80AcDRYoIT9913ny0Da6pwmJCGqfzxRcGRr8NU/jCBke5BExMW6SpJ27WvqqrKGWYxlUR+8IMf9Pg8zc3NdnWSYZ437W7WrVtnQytmgso8b8rgdpeSkuJ8bC68hoeHq7q6+qj+/wHAoUQG+eqEUbH21qWmscWW3t1aUG1v2/ZV2+26zokwc+vOhElMeGS4CZLEhthQybCYICVHBMrXe//vUAAA+gMTmHx38z69tbHAXtzpWgxjLuaYtjMmKHLq2HgF+DK3AfQ2MzZ+6qmnbGsaU8Wzt/n5+TkDI11jfDMXYAIj3fd1jcdzc3Nt1dObbrqpx+cx7WlDQkLsY/O8qY5iQiLl5eX2OXM78P/HhEa6MyEUxv3A4GDeM8wdEW1vRlNrmx1L2+rsnddY8ioatKOoxt60Ktf53mNIZKCt8Dk6PtSOqc1YOi0qiGssAIABidDIANfW3mF73DtazFTYNzK7imsPep2ft6cto9ZVVs3cx4ftH1QBQG8wbV3i4+Pt42HDhtnqHu+++66+973vHfL1JnDRFezoYrbN/i/7Ot2Z8IaXl9dB+0xFkq5AiJnkue222w76XIGBgfbe9EnetGmTrUBiJqbMpJFpaWMmkL7sa5uJJwBwBVMy98CKJK1t7dpTWqdt+2rs+8RdxTXaWVRr95kwiW13k9fzd6/pZJMUEWAnvMxtSFSg43F0oA2UEDQGAPSVstomfbCtSG9tLNSy3WV2HqTLxJRwnTU+QWdMSFBSOO1ngL6UlZVlgxMmNNLFjIVNZU9TicMESrov5PimDhzjf9l43Iz7zdc3bWgPPI6uoMlbb71l5yiuuOIKuyDEBFOefvrpg8b9h/raXfMLAAYXP2+vzoW2jgpFRnFNo9Z3Ls7dWuhYoFFc06Tssnp7e3vTPudrTZjEvCcZFhOsYdFB9rEZW5v7xPAARQf7UgUNANAvERoZYEprm+wblHW5FVqbU2lLkpvJ/gOZif2ucIhpM5ORECIfL1aLAnAtM6ly4ORLdyNGjLAlXk8//XTnPhPcMPuPJtOz2FQPMRM/MTExh3xNZmamjjvuOE2fPt054VRSUqLRo0cf1WMBgN7m7eVp29GYW3ctbe3KKat3hkh2Fjtu2aV1amhpU255g719urO0x8eZSbCEUH8bHuma/DL3ZgLMPg4PYIU3AOAbjRnMSt4PtxXrw21FdnFM92uz45JCddaERJ05PkEpkY7AN4C+N27cON1///099j3++OO24qhp3Xo0AyNfR1pamg2QmGBLRkbGIV+zY8cOTZs2TXPnzrXb5vWm1W1SUlIfHy2A/iw2xF+njI23t+7XabYVVtubqe6ZVVKnrJJaVTe22sok5rYks+SQi3u7xtBxof6KCfFTTLCf477bLcTPm3AJAKBPERrpx0x58U35VdqYV+XsV59f2XDQ60xZ8UmmxUyKo9XMpJRwRQX7ueSYAaDLc889p4kTJ9pysQ0NDbbX8bZt23Trrbc6X/Poo4/aHsKml7Bx2mmn2V7ICxcu1KRJk7R8+XK7eulwlUm+yeSWCaI89NBDuuyyy2xP4oqKCtuKxoRETFUUUyFl1apVmjJlih2kvfjii6wkAjComECxaU1jbqeN63mxrsS5aqpOOWV19rG9L61XbVOrCqoa7U3Zh/7cUUG+PVZTmVtcqJ+dFIsL8VdsqB/VSgAATo0tbbbdzEfbTVCk+KC5j7GJoTpjfIINiqRFB3HmgH7AtIjt3q7VMJU6goODe+w/cNxvFpLk5eU5H5u2MNnZ2bb6R1el0qPBjPPnzJmjxx57zFYQNSESEyDZsmWLbTczefJk+/VMK12zaCQoKEhvv/22rXZKaATAl4kO9tOxI2LsrftYuqyu2RkgMeNo854mv8Jxb6qTNLW2K6u0zt6+iAmXmPCI+TqOm6+9jwr2tdd+urbNLTzAR56mXCgAAN8AoZF+wvTK21ZYY8MhpsyZCYrsLqntsZqmi5nYn2JCIrZMWrjtP+/FmwIA/YyZjDGTM6aih2n5YiaNTGBk/PjxPXogd199NHLkSP34xz+2AY3nn3/eTuCY/sMHTkR9UyYEcvPNN+uFF16wK6HMsZoWOGb1kemBbHz729+2z915552237FZKWXCLwAw2JnfkbGhJtjhrxlD97e56T4JluOc/GpQfmW9vS+obLT7TKjEvMbczHvawwkP9HEGSEyYJN4ESkL97Nc1E2BRQY4JsWBWWAHAoNPe3mHLuy/bXaqlu8q0ak+5rXLV/ULJnPRozR8dqxMzYpUQRusZYKA6cNxvFmx0b2ljFo2Ym6nq+dvf/vaofu1rr71Wr732mm0/a8IpZmxvFpCYwIhx3nnnqbi4WH/4wx9sS9oTTzzRVh6pr68/qscBwH3G0l1BjgPH0kZza7sKqxzj6LzKBrtYo8et1nFvxtQmXNJVseTLmGtDEYG+3YIkjmBJVPftID9Fh/jZBR60mwUAHIpHBw0YXVJBxJQs6ypftqXAcd/SdnBCxKzOnJAcpgnJ4ZqYHKZxyWEK9ffp+4MGAAAAvoQZWlQ3tCqvM0jSFSzZV92o4uomFdU0al9Vo50AO1K+3p6KDto/6WUnu+wkmONxZJCvQgN8FBbgY4Mo5p62jADQ/0IimcU1Wp1doeW7y2xYpKK+pcdrTHDwxIw4zc+ItYGRAF8vlx0vAACAqzQ0t9n2N6YySUlNo0prm1VmbnVNdr9j23Ff1dDz/dSRMK1vulcssfdBvp2hkm77gn3t+NqEYQAAgx+hkV5kkqOmjLepGGKqiNiQyL5q2xv+UCICfRzhkBRHQMQ8NiXIAAAAgMEWLDEBkqJqR4jETIaZx45bk50MM5Ni9c37V51/FYG+XrZE74FhEnML9vNRkJ+XrWAS5Odt74P9vRXk63hsnjP7zSp3JscA4Oupb2611abW5FRoVXa51uZUqLqx9aDf1bOGRWn28CgbEsmID+H3LgAAwFe8BlVe12zDJKbaZ2nN/vG0qVxi7u1znaGTQy1c/iLenh77F2/Ydjm+iulqmROyv0WOuZkFHVTEB4CBi9DIUVgtYya5Tb/3rl51tiddSa32lter/TB/gxPC/DU6IdROioxJDNXE5HAlRwQwQQIAAAB0W2HVNeHlWFXVucKqa0KstkmV9S12dVVlfbNqmloP2d7x6/Dx8rDhkSBfR5AkwNdbgT5ePR6bVfDmoqd5XYCP47Fjn/m4/Y+79pvP5e9DGAXA4FLX1GpbzWzKq9Lm/Cptyne02z1wPsT8LjQtdqenRWpuerRdMENlKAAAgL5dwFFa1z1MYtridI6xu/Z1jrVrDgj8fhlPD9ngiAmQmMXQXa1xnMGSbqET8zpvr/2tywAArkdo5EtWxpTWNNs/oiahaSapzerH/f3bG2wPui9KZ5rJ4mExwRoVH2JDIqMTQjQ6PlQRQb698f0EAAAA3FZbe4dtBekIkXTeNzjuqzuDJbVNbfYCp7mZkEnX4679DS1fr7rJkTKVfbsHTIJ8vZ3hkwAfR8DEBlM6HzuDKd1fd5hgCtVRAPQm8/t1d0mddhbVaFdJrXYV1Wpnca1yK+oPGdgz7WamDYnU1CERNihi5kO4OAAAADAwNLa0OauYdLXFsfc13fc59lfUN3+lBRxmXBwRaAIlPauVdFUviekWPDGVTggaA0Dvc4vQiFmh+O+lWWpu61BLW7ta29pt0KPZ3Le2q6651aYmza3WTB43mknlI58wNgnKpIgADYsO1rCYIA2P2X8fG+JH9RAA6EPt7e3avn27KisrFR4eroyMDHl6klwHABwZM1aoa94fLDHjA9Mmx3Hb/7ih+eD9DV3bLW2q7/w4M6Ywzze2tPf6t8CMSwJ7hFAOVQmlM5jS7fGhgildr+0Kpvh6USEFGKzMPImZ6K+oa7FVncz9vupG5VXU2wUzeZ2LZkwA73BMQGR8UpjGJYXZe3OLDfXv0/8PAO6DcT8A9L9xtAmYlHSFS+wi7J5hk5LOhdnldU2HrdB/OKaVbNgB7WfNvWlJGx7g22N/qL+PAk3bWTPe7bynbQ4AfDm3CI1U1bdo4u/e/1ofa1brdZXOijGls0L8lBQeYEMiiWGO+/hQf1bLAEA/sHLlSj311FMqLy937ouMjNQVV1yhGTNmuPTYAADuzVRB6QqQOMMlhwqcdD5f1z2Y0uJ4vqsSyv7Xt9rXmT7Wvc1MsnW15Dm4Hc/+wImvt6cNmPh03bw9em57edjXdG17m+3Ox+Zr2JuHh0zec/9jx73Z7npsAjLOxwd+XOdrPczyNQB6enm23t9aZFeLNrW2q6mlXU2tjsfm90r1Vyg9buZERsQG21u6vYXYe7MfAPoC434AGPhjYxNYPrBqSckhqpiYljmtXzVhcgimTWxQtxCJo1Knl/x8HONXM0Y12457x63rcdcY17tzPOvt6RjHdt1332fHuJ6d95377fPmYz0d9/Z1zs/BuBVA/+EWoREzMXLnG1t6TFyaX8pdv7hNStHcQvy9FezvbZOI5nFUsJ9dWcdkIwAMjImjhx9++LDP33DDDQRHAACDdlWXCZN0BU/qDgimNLSYqindK6F0f7579ZSDt011xoHKZEa6QiUmZOIIm5hJOUfgxDw2+814z6vbYxM88ez+2s7nux53PW9fe+DnPczzXY+7nndsm8/b87U9n+/+sfuDMt2PyXnMh3neeUzO577+MadEBGpEXIirv634Gu56c4ue+Cz7iEqERwT6KCrIUQ48OcKxUMbehwfax2buBABchXE/ALiX9vaOHm1nTctZc29v9d33d7akbWi2HQVs5dDmNhtQ6e9McKRHkORwARPn/v3hFK+DQimH//iujzkw/NL1+FDhl+6v7fo63UMxXZ/bLNpwHA8hGGAgc4vQCNyP+bFuampy9WEA6MPStL/85S9VUVFx2NeYiiN//OMfaVUD9AI/P9rxAYM5kOJot9OtKkpntZOuFjyOSiiOx6bqSUtnO1DHfc/WoD22u26tjm0zoWdu7R097x2PHSvS2jo67MShuWck27eump2mO88e28dfFUfDhtxK7Smtc6ya9PGUf+eqSrOa0lQIigz0taW9Kdvd95i7AI4c437gizEuBw5+n2XGmWYs29V21iywMNvm3lGBz7FQwoxjzbbj3jGu7bGvrd2OjVvNOLe9o9vjznuz3bXf3neotd0x9jX7uj5mAGRYjgrn4oPDLMqwCxW6LWro/rytMHrgAogDPteXLYbo/nHdv4bja/b8vIdbwHGoYz7o9V+wiONQrz9cMdTD1kg9zAccau/hP/dhPsdXPBbzo9s1B9Nh/nM+3v9Ej9eYOZuuj+3ofF3nfvXY33GI1/Tc3/3jvuh1zs/c+bW7nu96zvl65/bBz3V0+zfa9f/Q9dxtZ46Rv4+XBjNCIxiUGhsb9d3vftfVhwEAgFv4z3/+I39/f1cfBgA3Ywbw+4Mksvc2YHJAuMTsM4N8E0Jp77zv6PbYfKzjuUM83xlYOeTzzo/r+bzjY/c/b75224HPd/u8XcfWFYTp+dz+x1/2fM//l27HcYTP2+PsDOvsP1/7X7tgYqK+d+wwV3/bgUGFuQsAwNHCuBzo/8xYritocrjQScsBgROz3z7ffb/z+YNf2/oFH+/82od9/uBATPfQS8/P4SYJGKDThjtOUViAjwYz6ooCAAAAAAYcs2LHlt919YEAAAAAAPAlTCUKP08vDYaOj2ZhQVdIxQRJDlxwcehFCV0LNw5+7f6Ko10LHL7Gaw+xgKPr6zoWYRz8+Ryf41CLMg690OLwizgO8/puC1IOeR7318c44Pwe7rwfhc9x2O/p4V7t4axO0lWJxPG42/7OJ+w+52PHvM3+x4fev//1+6ux9Hy9Y//+6ihf/LqDvkbnsXYdv+NzdR79IZ4zuu8zD8y9qdw52FFpBIMSJV4B97J9+3bbeubL3HzzzcrIyOiTYwLcCWVwAQAAvjrmLoAjx7gf+GKMywEAwDcxCPJswMFMSowy+YD7mDBhgiIjI1VeXn7Y10RFRdnXeZrmhAAAAADgYsxdAEeOcT8AAADQe7hyBgAY8EwQ5IorrvjC13znO98hMAIAAAAAwADEuB8AAADoPbSnAQAMGitXrtRTTz3Vo+KIqTBiAiMzZsxw6bEBAAAAAIBvhnE/AAAA4KLQiHlJTU1NL3x5AACOrvb2dmVmZqqqqkphYWEaOXIkFUYAAACgkJAQ2w7kq2A+BAD6H8b9AAAAwNGdE/E+kk9iAiPmwhsAAAAAAMBAZELFoaGhX+ljmA8BAAAAAACDfU6kTyuNrF+/Xscff7w++eQTTZo06Rt/PsBd8G8H4N8OwN8doP/jPRvQv//tDMRKI/xeAT97cDf83gM/d3An/M4DP3dwJ/zOGwSVRswn+KqrcQ4lODjYeX80Ph/gLvi3A/BvB+DvDtD/8Z4NGHz/do7WfMhgPDcY3PjZAz97cCf8zgM/e3An/M4DP3s4FM9D7gUAAAAAAAAAAAAAAMCg1qehkYSEBN1xxx32HgD/dgD+7gD9E+/ZAP7tAPzd6R/4mwx+9uBu+L0Hfu7gTvidB37u4E74nde/eXSYBr0AAAAAAAAAAAAAAABwK7SnAQAAAAAAAAAAAAAAcEOERgAAAAAAAAAAAAAAANwQoREAAAAAAAAAAAAAAAA3RGgEAAAAAAAAAAAAAADADfVJaGTJkiVasGCBEhMT5eHhoddee60vviww4N13332aPn26QkJCFBsbq3PPPVc7duxw9WEB/d5jjz2mCRMmKDQ01N6OOeYYvfPOO64+LGBA+cMf/mDft91www2uPhSg37vzzjvtv5fut4yMDFcfFtDv5efn69vf/raioqIUEBCg8ePHa/Xq1a4+rH7l73//u9LS0uTv76+ZM2dq5cqVrj4kDHLMQ6A/YCyCvsT7EfS1trY2/fa3v9XQoUPte+Dhw4fr7rvvVkdHB98M9Om1WfMzd/vttyshIcH+LJ500knauXMn3wX06s9eS0uLbrnlFjv+DwoKsq+54oorVFBQwJl3h9BIXV2dJk6caCc7ABy5Tz75RD/+8Y/1+eefa9GiRfaX6SmnnGL/TQE4vOTkZDvJtGbNGnvh4cQTT9Q555yjLVu2cNqAI7Bq1So9/vjjNnwF4MiMHTtWhYWFztvSpUs5dcAXqKio0Jw5c+Tj42PDvVu3btWDDz6oiIgIzlun559/XjfddJPuuOMOrV271s6rnHrqqSouLuYcodcwDwFXYyyCvsT7EbjC/fffbxe8/e1vf9O2bdvs9h//+Ef99a9/5RuCPr02a37u/vKXv+gf//iHVqxYYS/gm/FGY2Mj3wn02s9efX29Hd+a8Jy5f+WVV+xi+bPPPpuz7mIeHX0cXzSJoldffdVWTADw1ZSUlNiKI2YS57jjjuP0AV9BZGSkHnjgAV1zzTWcN+AL1NbWasqUKXr00Uf1+9//XpMmTdLDDz/MOQO+pNKIWTWxfv16zhNwhG699VZ99tln+vTTTzlnh2Eqi5jKk+aCgtHe3q6UlBT99Kc/tecP6AvMQ6AvMRZBX+P9CFzhrLPOUlxcnP797387911wwQW20sMzzzzDNwV9cm3WXBo2FR5+/vOf6xe/+IXdV1VVZX82n3zySV166aV8J9ArP3uHCw3PmDFDOTk5Sk1N5cwP5kojAI4O80e76+I3gCMv+fjcc8/ZdKtpUwPgi5kKV2eeeaYtSQngyJkSrmbCZdiwYfrWt76lvXv3cvqAL/DGG29o2rRpuuiii2wwfvLkyfrXv/7FOevU3Nxsq+Z1/3vs6elpt5cvX855Qp9hHgJ9ibEI+hrvR+AKs2fP1ocffqjMzEy7vWHDBlup8vTTT+cbgj6zZ88e7du3r8d4IywszAbXGW/AFWMOEy4JDw/n5LuQtyu/OIAjZ1aV3XDDDbaE87hx4zh1wJfYtGmTDYmYcnrBwcE2zTpmzBjOG/AFTMDKlAU06W4AR85MqpiVOKNGjbKtae666y4de+yx2rx5s0JCQjiVwCFkZWXZstym/cqvf/1r+7fnZz/7mXx9fXXllVe6/TkrLS214Wez0q87s719+3a3Pz/oG8xDoC8xFoEr8H4ErqpwU11drYyMDHl5edn3fPfcc49dfAD0FRMYMQ413uh6DugL5vrNLbfcossuu0yhoaGcdBciNAIMoNUW5sKDSR0D+HLmwp1pE2BSqi+99JK9+GBaOxEcAQ4tNzdX119/vRYtWiR/f39OE/AVdF8RNmHCBBsiGTJkiF544QXaogFfcDHaVBq599577bapNGLGO6afNqERoH9gHgJ9hbEIXIX3I3AFM0589tln9b///U9jx46185dmsaipXMn7YADupKWlRRdffLFtl2QWlcC1aE8DDAA/+clP9NZbb2nx4sVKTk529eEAA4JZpZqenq6pU6fqvvvu08SJE/XII4+4+rCAfsuUwC8uLtaUKVPk7e1tbyZo9Ze//MU+NitfABwZU05z5MiR2rVrF6cMOIyEhISDwryjR4+mtVOn6Ohou/K0qKioxzky2/Hx8fxcodcxD4G+xFgErsL7EbjCL3/5S1tt5NJLL9X48eP1ne98RzfeeKOdvwT6SteYgvEGXB0YycnJsYsYqTLieoRGgH7MpOvMRI1pq/HRRx9p6NChrj4kYECvHmlqanL1YQD91vz5821bJ7PCpetmVoCb8qjmsblwBeDI1NbWavfu3XYSGsChmbabO3bs6LHP9HU3VXrgCECb8LPpd9/9/azZNi0Ygd7CPARcgbEIXIX3I3CF+vp6eXr2vDRn5lzMez2gr5hrTSY40n28YdomrVixgvEG+iwwsnPnTn3wwQeKiorirLtLexozadp9ld2ePXvsxYfIyEilpqb2xSEAA7YUrClT9/rrryskJMTZSy4sLEwBAQGuPjyg3/rVr35lWwWYvzE1NTX239HHH3+s9957z9WHBvRb5u/MuHHjeuwLCgqyb9oP3A+gp1/84hdasGCBvdhdUFCgO+64w076mX6sAA7NrKacPXu2bU9jJotWrlypf/7zn/YGh5tuusmWKDchzhkzZujhhx9WXV2drr76ak4Reg3zEHAFxiJwFd6PwBXM2PGee+6x85amPc26dev00EMP6bvf/S7fEPTptVnTFun3v/+9RowYYUMkv/3tb22bpHPPPZfvBHrtZ88ssLrwwgu1du1a22HBVLfuuvZpnjcLKOAaHh1mCUEvMxfq5s2bd9B+M/nx5JNP9vaXBwYsDw+PQ+5/4okndNVVV/X58QADxTXXXGNT0oWFhTZkNWHCBN1yyy06+eSTXX1owIBywgknaNKkSfYiFYDDM2WFlyxZorKyMsXExGju3Ll2EnD48OGcNuALmAkiE/Y1q4vMJKUJSXz/+9/nnHXzt7/9TQ888ICdRDN/k03buJkzZ3KO0GuYh0B/wVgEfYX3I+hrZoGbuThvqoubNsHmIr1ZcHD77bdzsRR9em3WXB42i15McL+ystLOZTz66KO23S7QWz97d95552G7KixevNi+B8QgDo0AAAAAAAAAAAAAAACgf+nZOA0AAAAAAAAAAAAAAABugdAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAALghQiMAAAAAAAAAAAAAAABuiNAIAAAAAAAAAAAAAACAGyI0AgAAAAAAAAAAAAAA4IYIjQAAAAAAAAAAAAAAAMj9/H+iSBwh5UBI7wAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 2200x214.355 with 2 Axes>"
       ]
@@ -2819,7 +2819,7 @@
     "# Diagnostics ArviZ pour l'inference de rho et kappa\n",
     "print(\"Diagnostics de convergence MCMC (rho, kappa)\")\n",
     "print(\"=\" * 50)\n",
-    "summary_rho = az.summary(trace_rho, var_names=[\"rho\", \"kappa\"], ci_prob=0.89)\n",
+    "summary_rho = az.summary(trace_rho, var_names=[\"rho\", \"kappa\"], ci_prob=0.89, ci_kind=\"hdi\")\n",
     "print(summary_rho.to_string())\n",
     "\n",
     "ess = az.ess(trace_rho, var_names=[\"rho\", \"kappa\"])\n",
@@ -2834,7 +2834,7 @@
     "\n",
     "# ArviZ 1.x : plot_dist remplace plot_posterior\n",
     "plt.rcParams[\"figure.figsize\"] = (11, 4)\n",
-    "az.plot_dist(trace_rho, var_names=[\"rho\", \"kappa\"], ci_prob=0.89)\n",
+    "az.plot_dist(trace_rho, var_names=[\"rho\", \"kappa\"], ci_prob=0.89, ci_kind=\"hdi\")\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
@@ -2850,16 +2850,16 @@
    "id": "p15b-code-08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:01.798931Z",
-     "iopub.status.busy": "2026-09-08T01:23:01.797488Z",
-     "iopub.status.idle": "2026-09-08T01:23:02.706758Z",
-     "shell.execute_reply": "2026-09-08T01:23:02.706758Z"
+     "iopub.execute_input": "2026-09-11T11:59:38.949213Z",
+     "iopub.status.busy": "2026-09-11T11:59:38.948196Z",
+     "iopub.status.idle": "2026-09-11T11:59:41.429711Z",
+     "shell.execute_reply": "2026-09-11T11:59:41.427707Z"
     },
     "papermill": {
-     "duration": 0.931177,
-     "end_time": "2026-09-08T01:23:02.708147+00:00",
+     "duration": 2.523513,
+     "end_time": "2026-09-11T11:59:41.430723",
      "exception": false,
-     "start_time": "2026-09-08T01:23:01.776970+00:00",
+     "start_time": "2026-09-11T11:59:38.907210",
      "status": "completed"
     },
     "tags": []
@@ -2924,10 +2924,10 @@
    "id": "p15b-md-06",
    "metadata": {
     "papermill": {
-     "duration": 0.027718,
-     "end_time": "2026-09-08T01:23:02.760093+00:00",
+     "duration": 0.046541,
+     "end_time": "2026-09-11T11:59:41.518762",
      "exception": false,
-     "start_time": "2026-09-08T01:23:02.732375+00:00",
+     "start_time": "2026-09-11T11:59:41.472221",
      "status": "completed"
     },
     "tags": []
@@ -2944,16 +2944,16 @@
    "id": "p15b-code-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:02.818367Z",
-     "iopub.status.busy": "2026-09-08T01:23:02.818367Z",
-     "iopub.status.idle": "2026-09-08T01:23:03.168695Z",
-     "shell.execute_reply": "2026-09-08T01:23:03.167088Z"
+     "iopub.execute_input": "2026-09-11T11:59:41.654394Z",
+     "iopub.status.busy": "2026-09-11T11:59:41.653868Z",
+     "iopub.status.idle": "2026-09-11T11:59:42.553154Z",
+     "shell.execute_reply": "2026-09-11T11:59:42.548311Z"
     },
     "papermill": {
-     "duration": 0.378378,
-     "end_time": "2026-09-08T01:23:03.170336+00:00",
+     "duration": 0.969518,
+     "end_time": "2026-09-11T11:59:42.554946",
      "exception": false,
-     "start_time": "2026-09-08T01:23:02.791958+00:00",
+     "start_time": "2026-09-11T11:59:41.585428",
      "status": "completed"
     },
     "tags": []
@@ -3032,16 +3032,16 @@
    "id": "p15b-code-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:03.269403Z",
-     "iopub.status.busy": "2026-09-08T01:23:03.268860Z",
-     "iopub.status.idle": "2026-09-08T01:23:04.780907Z",
-     "shell.execute_reply": "2026-09-08T01:23:04.779891Z"
+     "iopub.execute_input": "2026-09-11T11:59:42.648411Z",
+     "iopub.status.busy": "2026-09-11T11:59:42.647842Z",
+     "iopub.status.idle": "2026-09-11T11:59:44.128618Z",
+     "shell.execute_reply": "2026-09-11T11:59:44.126606Z"
     },
     "papermill": {
-     "duration": 1.563064,
-     "end_time": "2026-09-08T01:23:04.781905+00:00",
+     "duration": 1.530321,
+     "end_time": "2026-09-11T11:59:44.129617",
      "exception": false,
-     "start_time": "2026-09-08T01:23:03.218841+00:00",
+     "start_time": "2026-09-11T11:59:42.599296",
      "status": "completed"
     },
     "tags": []
@@ -3113,10 +3113,10 @@
    "id": "p15b-md-07",
    "metadata": {
     "papermill": {
-     "duration": 0.039646,
-     "end_time": "2026-09-08T01:23:04.865407+00:00",
+     "duration": 0.039981,
+     "end_time": "2026-09-11T11:59:44.206956",
      "exception": false,
-     "start_time": "2026-09-08T01:23:04.825761+00:00",
+     "start_time": "2026-09-11T11:59:44.166975",
      "status": "completed"
     },
     "tags": []
@@ -3131,16 +3131,16 @@
    "id": "p15b-code-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:04.946919Z",
-     "iopub.status.busy": "2026-09-08T01:23:04.946919Z",
-     "iopub.status.idle": "2026-09-08T01:23:04.963594Z",
-     "shell.execute_reply": "2026-09-08T01:23:04.963083Z"
+     "iopub.execute_input": "2026-09-11T11:59:44.294714Z",
+     "iopub.status.busy": "2026-09-11T11:59:44.293703Z",
+     "iopub.status.idle": "2026-09-11T11:59:44.323301Z",
+     "shell.execute_reply": "2026-09-11T11:59:44.321293Z"
     },
     "papermill": {
-     "duration": 0.057565,
-     "end_time": "2026-09-08T01:23:04.964604+00:00",
+     "duration": 0.073926,
+     "end_time": "2026-09-11T11:59:44.324572",
      "exception": false,
-     "start_time": "2026-09-08T01:23:04.907039+00:00",
+     "start_time": "2026-09-11T11:59:44.250646",
      "status": "completed"
     },
     "tags": []
@@ -3275,10 +3275,10 @@
    "id": "p15b-md-08",
    "metadata": {
     "papermill": {
-     "duration": 0.031925,
-     "end_time": "2026-09-08T01:23:05.026963+00:00",
+     "duration": 0.042629,
+     "end_time": "2026-09-11T11:59:44.413080",
      "exception": false,
-     "start_time": "2026-09-08T01:23:04.995038+00:00",
+     "start_time": "2026-09-11T11:59:44.370451",
      "status": "completed"
     },
     "tags": []
@@ -3292,10 +3292,10 @@
    "id": "cell-29",
    "metadata": {
     "papermill": {
-     "duration": 0.032024,
-     "end_time": "2026-09-08T01:23:05.088953+00:00",
+     "duration": 0.041665,
+     "end_time": "2026-09-11T11:59:44.496174",
      "exception": false,
-     "start_time": "2026-09-08T01:23:05.056929+00:00",
+     "start_time": "2026-09-11T11:59:44.454509",
      "status": "completed"
     },
     "tags": []
@@ -3327,16 +3327,16 @@
    "id": "cell-30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T01:23:05.176804Z",
-     "iopub.status.busy": "2026-09-08T01:23:05.175305Z",
-     "iopub.status.idle": "2026-09-08T01:23:05.182857Z",
-     "shell.execute_reply": "2026-09-08T01:23:05.181830Z"
+     "iopub.execute_input": "2026-09-11T11:59:44.588106Z",
+     "iopub.status.busy": "2026-09-11T11:59:44.587110Z",
+     "iopub.status.idle": "2026-09-11T11:59:44.597136Z",
+     "shell.execute_reply": "2026-09-11T11:59:44.595126Z"
     },
     "papermill": {
-     "duration": 0.056377,
-     "end_time": "2026-09-08T01:23:05.183861+00:00",
+     "duration": 0.059142,
+     "end_time": "2026-09-11T11:59:44.599136",
      "exception": false,
-     "start_time": "2026-09-08T01:23:05.127484+00:00",
+     "start_time": "2026-09-11T11:59:44.539994",
      "status": "completed"
     },
     "tags": []
@@ -3381,10 +3381,10 @@
    "id": "cell-31",
    "metadata": {
     "papermill": {
-     "duration": 0.033644,
-     "end_time": "2026-09-08T01:23:05.249061+00:00",
+     "duration": 0.043046,
+     "end_time": "2026-09-11T11:59:44.681784",
      "exception": false,
-     "start_time": "2026-09-08T01:23:05.215417+00:00",
+     "start_time": "2026-09-11T11:59:44.638738",
      "status": "completed"
     },
     "tags": []
@@ -3477,14 +3477,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 44.86483,
-   "end_time": "2026-09-08T01:23:06.168587+00:00",
+   "duration": 92.64426,
+   "end_time": "2026-09-11T11:59:45.942110",
    "environment_variables": {},
    "exception": null,
    "input_path": "DecPyMC-2-Utility-Money.ipynb",
    "output_path": "DecPyMC-2-Utility-Money.ipynb",
    "parameters": {},
-   "start_time": "2026-09-08T01:22:21.303757+00:00",
+   "start_time": "2026-09-11T11:58:13.297850",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #15333

## Le défaut (seconde victime de #15156)

#15156 a migré `hdi_prob=0.89` → `ci_prob=0.89` **sans `ci_kind`**. En arviz 1.1, le défaut de `ci_kind` est `None`, que la bibliothèque résout en **`"eti"`** : l'intervalle de crédibilité affiché n'est plus un **HDI** mais un **ETI** — alors que la prose du notebook annonce un **HDI 89 %**.

C'est exactement le même défaut que celui corrigé par #15333 sur `DecPyMC-8`. La vérification d'audit faite là-bas a montré qu'un **second** notebook de la même migration est porteur de la dérive ; c'est celui-ci (issue #15592).

Ce qui rend ce cas plus vicieux que `DecPyMC-8` : **#15156 a mis à jour le commentaire de la cellule consommatrice pour qu'il colle à la sortie fausse.**

```python
# main — le commentaire et le code s'accordent... sur le mauvais intervalle
# Credible interval (ArviZ 1.x : colonnes eti89_lb/eti89_ub)
summary = az.summary(trace_risk, var_names=["theta"], ci_prob=0.89)
ci_lo = float(summary["eti89_lb"].iloc[0])
ci_hi = float(summary["eti89_ub"].iloc[0])
```

La cellule 51 (markdown), quinze cellules plus loin, dit toujours « contenue dans le **HDI 89%** ». La sortie contredit sa propre prose à distance — et le commentaire local, lui, donne raison à la sortie.

| | Source | Sorties committées |
|---|---|---|
| `origin/main` (post-#15156) | `ci_prob=0.89` ×3, `ci_kind` ×0 | `eti89_lb` / `eti89_ub` |
| **cette PR** | `ci_prob=0.89, ci_kind="hdi"` ×3 | **`hdi89_lb` / `hdi89_ub`** |

## Le correctif

Trois sites `ci_prob=` reçoivent `ci_kind="hdi"`, plus les deux lectures de colonnes en aval :

| Cellule | Nature du site | Modification |
|---|---|---|
| 36 | `az.summary` + 2 lectures `summary[...]` | `ci_kind="hdi"` ; commentaire et `hdi89_lb`/`hdi89_ub` |
| 52 | `az.summary` | `ci_kind="hdi"` |
| 52 | `az.plot_dist` (un `az.plot_posterior` renommé par #15156) | `ci_kind="hdi"` |

**Diff de source = 6 lignes, sur 2 cellules.** Vérifié par comparaison cellule à cellule contre `origin/main` : les 61 autres cellules ont une source **byte-identique**. Les 308 autres lignes de diff sont les **sorties ré-exécutées** (C.2 : une cellule code modifiée impose une ré-exécution complète ; les noms de colonnes changent, les outputs ne se retouchent pas à la main).

## Validation réelle (H.1, règle C.2)

- **Ré-exécution complète** kernel `pymc-arviz11` (arviz **1.1.0**, pymc 6.3.1, python 3.12) : **SUCCESS**, 28/28 cellules code, `execution_count` **1→28 séquentiels**, **0 sortie d'erreur**.
- Le `kernelspec` du notebook reste **`python3`** — inchangé, identique à `main`. (Le kernel `python3` du dépôt porte arviz 0.23.4, qui ne connaît pas `ci_prob` ; l'exécution passe par `pymc-arviz11`, seul porteur d'arviz 1.1. Le kernelspec committé n'est pas touché.)
- Colonnes d'intervalle après ré-exécution : **`hdi89_lb` / `hdi89_ub`** — cohérentes avec la prose « HDI 89 % ».
- Vérification faite sur le **blob commité** (`git show HEAD:<nb>`), pas seulement sur le working tree : 28 cellules, `execution_count` contigus, 0 erreur, 3 × `ci_kind="hdi"`, `hdi89_lb` présent.
- Les autres colonnes `eti89_*` résiduelles dans les sorties viennent de cellules **non touchées** qui n'ont jamais spécifié d'intervalle — elles ne sont pas concernées.

Le fichier est normalisé LF sans newline final, comme `main` (`.gitattributes` : `text: set`, `eol: lf` ; blob index et blob `main` = 0 CR, 3492 LF).

## Portée

1 fichier : `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb` (314 insertions / 314 suppressions : 6 lignes de source + sorties ré-exécutées).

La ré-exécution a régénéré dans le working tree les 9 PNG que le notebook écrit lui-même via `plt.savefig` (cellules 6, 9, 14, 20, 24, 30, 36, 38). Ces fichiers sont **non suivis sur `main`** et ne sont **pas** inclus dans cette PR : ils ne font pas partie du livrable.

## Notes d'organe (hors scope, non ouverts ici)

- **Aucun garde CI ne compare le nom d'intervalle des sorties à la prose du notebook.** C'est ce qui a laissé passer #15156 : le notebook s'exécute, passe tous les gates, et ment sur ce qu'il affiche. Un garde `(hdi|eti)N_(lb|ub)` vs mention `HDI` dans le markdown serait peu coûteux — signalé, pas implémenté ici (hors scope d'un fix de contenu).
- Les 5 autres notebooks de #15156 (`PyMC-01/06/13/14/15`) affichent aussi des colonnes `eti89_*` mais **ne revendiquent pas de HDI en prose** : rien ne prouve une incohérence chez eux. Ils restent à regarder si l'intention d'origine était HDI.

`Closes #15592`. `See #15333` (DecPyMC-8, même défaut, déjà corrigé). `See #15140` (EPIC fermée par #15156 — le pattern cassé `hdi_prob=` a bien disparu ; ce défaut-ci est d'une autre nature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
