### PR TITLE
feat(ict,#15479): torch hook binding for causal engine — pre-hook edits, paired interchange, sidecar records (tranche 2)

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -85,10 +85,14 @@ jobs:
           # origin/main@5302d974aa, CI-confirme run 34307798875). Rootdir herite du
           # pyproject.toml d'ICT-Series/ (pip install -e . rend le package ict/
           # importable depuis n'importe quel cwd).
-          - suite-name: "tests/ (55)"
+          # Floor 1046 -> 1071 : +25 items hooks torch du moteur causal
+          # (#15479 tranche 2, tests/test_causal_hooks.py -- importorskip
+          # FONCTION-niveau : comptes a la collecte meme sans torch, skips a
+          # l'execution seulement, convention test_jlens_traces.py).
+          - suite-name: "tests/ (56)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series
             test-args: tests
-            test-floor: 1046
+            test-floor: 1071
           # ict/tests/ : 42 strates package (85 - 43 consolides dans tests/,
           # #9478) -> 670 items collectes (le "strates == collection" d'origine
           # est tombe : le parametrize est devenu massif ici aussi ; compte mesure
@@ -98,10 +102,12 @@ jobs:
           # (mode prepend, neutralise --import-mode=importlib) s'applique -- sinon
           # test_reversibility_budget / test_time_arrow n'executent jamais
           # (sys.path.insert module-level ignore sous importlib).
+          # Floor 670 -> 692 : +22 items coeur numpy du moteur causal
+          # (#15479 tranche 1, ict/tests/test_causal_engine.py).
           - suite-name: "ict/tests/ (42 package)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests
             test-args: .
-            test-floor: 670
+            test-floor: 692
 
     steps:
       - uses: actions/checkout@v4

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/causal_hooks.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/causal_hooks.py
@@ -1,0 +1,468 @@
+"""Hooks torch du Causal Intervention Engine (#15479, tranche 2/n, Epic #15475).
+
+Ce module confine torch/transformers (convention de la serie : ``ict/`` reste
+numpy-only, les scripts d'extraction et d'application portent le GPU/torch --
+cf ``extract_sae_traces.py``). Il relie une :class:`~ict.causal_engine.InterventionSpec`
+a un module torch vivant via un **forward pre-hook** : l'activation d'entree du
+module designe EST le panneau (T, d) -- ou (B, T, d), lot diffuse -- sur lequel
+les cinq operations du contrat v1 s'appliquent.
+
+Correspondance bijective avec le coeur numpy : pour chaque operation unaire
+(ablate/clamp/steer/patch), ``apply_spec_to_tensor`` reproduit exactement
+``ict.causal_engine.apply_intervention`` (equivalence testee bit a bit en
+float64, ``tests/test_causal_hooks.py``). L'operation ``interchange`` exige le
+**protocole capture-puis-ecriture** (classe :class:`PairedInterchange`) : un
+pre-hook ne voit chaque activation qu'une fois par forward, donc un echange
+bilateral ne peut PAS se jouer dans un forward unique -- on capture la tranche
+des deux runs apparies (2 forwards), puis on ecrit chacun avec la tranche de
+l'autre (2 forwards). En tensor units, l'ecriture d'un cote d'interchange EST
+un patch par la tranche empirique du run apparie — c'est litteralement ce que
+fait ``interchange_panels`` cote par cote.
+
+Captures : le hook enregistre le panneau complet avant/apres edition (numpy,
+CPU) ET la tranche cible (etat). Un forward hook optionnel capte la sortie du
+module (point de lecture readout, ex. sortie du LayerNorm vise) — les deux
+points de capture pre/post de la decision de design 2026-09-11T12:25Z.
+``hook_record`` assemble ensuite un ``InterventionRecord`` sidecar complet
+(domage general calcule par le coeur numpy, verdict selectivite, empreintes
+avant/apres) sans jamais stocker les panneaux dans l'enregistrement.
+
+Compatibilite transformers : ``attach_intervention`` resout le module par son
+nom ``named_modules()`` — n'importe quel ``nn.Module`` (bloc GPT2, couche
+LayerNorm interne, sae hook module...) est adressable. La traduction
+instrument-space (residual -> latent SAE : encode, editer, decoder) est
+explicitement HORS de ce module : elle appartient a la couche lentille
+(ex ``extract_sae_traces.py``), le champ ``tensor_space`` de la spec documente
+l'espace dans lequel positions/features sont lus.
+
+Determinisme : aucun RNG ici. Les seules nondeterminismes possibles viennent
+du modele lui-meme ; les tests s'appuient sur des modeles jouets seeds et des
+comparaisons bit a bit en float64.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+# Le package ``ict/`` reste numpy-only : l'importer ici ne fait PAS entrer torch
+# dans la bibliotheque — c'est ce script qui confine torch (cf docstring).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from ict.causal_engine import (  # noqa: E402  (necessairement apres sys.path)
+    InterventionRecord,
+    InterventionSpec,
+    artifact_sha256,
+    damage_metrics,
+    selectivity_verdict,
+)
+
+__all__ = [
+    "InterventionHook",
+    "InterventionHandle",
+    "PairedInterchange",
+    "apply_spec_to_tensor",
+    "attach_intervention",
+    "forward_with_spec",
+    "hook_record",
+    "resolve_module",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Resolution de cible : nom de module -> nn.Module
+# --------------------------------------------------------------------------- #
+
+def resolve_module(model: torch.nn.Module, module_name: str) -> torch.nn.Module:
+    """Resout un module par son chemin ``named_modules()`` (compatible transformers).
+
+    Echoue en nommant quelques modules disponibles — jamais un KeyError muet.
+    """
+    modules = dict(model.named_modules())
+    if module_name not in modules:
+        available = sorted(name for name in modules if name)
+        shown = ", ".join(available[:10]) + ("…" if len(available) > 10 else "")
+        raise ValueError(
+            f"module {module_name!r} introuvable dans le modele — "
+            f"disponibles: {shown}"
+        )
+    return modules[module_name]
+
+
+# --------------------------------------------------------------------------- #
+# Application tensor : miroir torch du coeur numpy
+# --------------------------------------------------------------------------- #
+
+def _validate_shape(t: torch.Tensor, spec: InterventionSpec) -> None:
+    if t.dim() not in (2, 3):
+        raise ValueError(
+            f"activation {tuple(t.shape)} : le moteur edite des panneaux (T, d) "
+            f"ou (B, T, d), rien d'autre"
+        )
+    T, d = t.shape[-2], t.shape[-1]
+    if spec.positions:
+        bad = min(spec.positions) if min(spec.positions) < 0 else (
+            max(spec.positions) if max(spec.positions) >= T else None
+        )
+        if bad is not None:
+            raise ValueError(
+                f"position {bad} hors activation T={T} — la spec ne peut pas "
+                f"s'appliquer a ce panneau (pas de troncature silencieuse)"
+            )
+    if spec.features:
+        bad = min(spec.features) if min(spec.features) < 0 else (
+            max(spec.features) if max(spec.features) >= d else None
+        )
+        if bad is not None:
+            raise ValueError(
+                f"feature {bad} hors dimension d={d} — la spec ne peut pas "
+                f"s'appliquer a ce panneau (pas de troncature silencieuse)"
+            )
+
+
+def _target_index(t: torch.Tensor, spec: InterventionSpec) -> tuple[Any, ...]:
+    rows = torch.tensor(list(spec.positions), dtype=torch.long, device=t.device)
+    cols = torch.tensor(list(spec.features), dtype=torch.long, device=t.device)
+    if t.dim() == 2:
+        return (rows[:, None], cols)
+    return (slice(None), rows[:, None], cols)  # (B, T, d) : diffuse sur le lot
+
+
+def _donor_tensor(
+    donor: Any, t: torch.Tensor, spec: InterventionSpec
+) -> torch.Tensor:
+    """Coerce le donneur (torch / numpy / tuple de lignes) vers (n_positions, n_features)."""
+    values = torch.as_tensor(np.asarray(donor), dtype=t.dtype, device=t.device)
+    expected = (len(spec.positions), len(spec.features))
+    if tuple(values.shape) != expected:
+        raise ValueError(
+            f"donneur de forme {tuple(values.shape)} != cible {expected} "
+            f"(positions x features)"
+        )
+    return values
+
+
+def apply_spec_to_tensor(
+    t: torch.Tensor, spec: InterventionSpec, *, donor: Any = None
+) -> torch.Tensor:
+    """Applique la spec au tensor d'activation — clone, ne mute JAMAIS l'entree.
+
+    Miroir torch de ``ict.causal_engine.apply_intervention`` (equivalence bit a
+    bit testee). Cible vide (bras intact du Gate 24) : identite PAR LA MEME VOIE
+    (clone retourne sans edition). ``interchange`` exige ``donor`` : la tranche
+    capturee du run apparie — le protocole bilateral vit dans
+    :class:`PairedInterchange`.
+    """
+    _validate_shape(t, spec)
+    out = t.clone()
+    if not spec.positions or not spec.features:
+        return out  # bras intact : meme voie de code, aucune edition
+    idx = _target_index(out, spec)
+    if spec.operation == "ablate":
+        out[idx] = torch.zeros((), dtype=t.dtype, device=t.device)
+    elif spec.operation == "clamp":
+        dvec = torch.tensor(spec.direction, dtype=t.dtype, device=t.device)
+        out[idx] = spec.dose * dvec
+    elif spec.operation == "steer":
+        dvec = torch.tensor(spec.direction, dtype=t.dtype, device=t.device)
+        unit = dvec / dvec.norm()
+        out[idx] = out[idx] + spec.dose * unit
+    elif spec.operation == "patch":
+        source = donor if donor is not None else spec.donor
+        if source is None:
+            raise ValueError("patch exige un donneur (valeurs empiriques)")
+        out[idx] = _donor_tensor(source, out, spec)
+    elif spec.operation == "interchange":
+        if donor is None:
+            raise ValueError(
+                "interchange exige le donneur capture du run apparie — "
+                "protocole PairedInterchange.capture puis .write, "
+                "jamais une ecriture directe"
+            )
+        out[idx] = _donor_tensor(donor, out, spec)
+    else:  # pragma: no cover - l'enum est ferme, InterventionSpec a deja valide
+        raise ValueError(f"operation {spec.operation!r} hors contrat v1")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Hooks
+# --------------------------------------------------------------------------- #
+
+def _first_tensor(args: tuple[Any, ...]) -> torch.Tensor | None:
+    for a in args:
+        if isinstance(a, torch.Tensor):
+            return a
+    return None
+
+
+def _slice_of(panel: np.ndarray, spec: InterventionSpec) -> np.ndarray:
+    rows, cols = list(spec.positions), list(spec.features)
+    if panel.ndim == 2:
+        return panel[rows][:, cols]
+    return panel[:, rows][:, :, cols]
+
+
+class InterventionHook:
+    """Forward pre-hook qui applique une spec a l'activation d'entree d'un module.
+
+    A chaque forward : capture le panneau avant (numpy CPU), edite via
+    :func:`apply_spec_to_tensor`, capture le panneau/tranche apres, et
+    REMPLACE les entrees positionnelles du module par la version editee
+    (contrat des pre-hooks torch : un retour non-None remplace ``args``).
+    L'entree d'origine n'est jamais mutee.
+
+    Captures (ecrasees a chaque forward) :
+      ``panel_before``/``panel_after``  panneaux complets (T, d) ou (B, T, d) ;
+      ``state_before``/``state_after``  tranche cible (l'etat du canal etat).
+    """
+
+    def __init__(self, spec: InterventionSpec, *, donor: Any = None) -> None:
+        self.spec = spec
+        self.donor = donor
+        self.panel_before: np.ndarray | None = None
+        self.panel_after: np.ndarray | None = None
+        self.state_before: np.ndarray | None = None
+        self.state_after: np.ndarray | None = None
+        self.calls = 0
+
+    def __call__(
+        self, module: torch.nn.Module, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        t = _first_tensor(args)
+        if t is None:
+            raise RuntimeError(
+                f"aucun tensor dans les entrees positionnelles de "
+                f"{type(module).__name__} — le hook du moteur causal ne sait "
+                f"pas ou editer (appels kwargs uniquement non supportes)"
+            )
+        _validate_shape(t, self.spec)
+        self.panel_before = t.detach().cpu().numpy().copy()
+        edited = apply_spec_to_tensor(t, self.spec, donor=self.donor)
+        self.panel_after = edited.detach().cpu().numpy().copy()
+        if self.spec.positions and self.spec.features:
+            self.state_before = _slice_of(self.panel_before, self.spec)
+            self.state_after = _slice_of(self.panel_after, self.spec)
+        else:
+            self.state_before = np.zeros((0, 0))
+            self.state_after = np.zeros((0, 0))
+        self.calls += 1
+        return tuple(edited if a is t else a for a in args)
+
+
+class _PostCaptureHook:
+    """Forward hook passif : capte la sortie du module (point de lecture readout)."""
+
+    def __init__(self) -> None:
+        self.readout: np.ndarray | None = None
+
+    def __call__(
+        self, module: torch.nn.Module, args: tuple[Any, ...], output: Any
+    ) -> None:
+        t = output if isinstance(output, torch.Tensor) else _first_tensor(
+            output if isinstance(output, tuple) else ()
+        )
+        self.readout = t.detach().cpu().numpy().copy() if t is not None else None
+
+
+class InterventionHandle:
+    """Poignee de detachement + vues sur les captures d'une intervention attachee."""
+
+    def __init__(
+        self,
+        module_name: str,
+        hook: InterventionHook,
+        post: _PostCaptureHook | None = None,
+    ) -> None:
+        self.module_name = module_name
+        self.hook = hook
+        self.post = post
+        self._removables: list[Any] = []
+
+    @property
+    def panel_before(self) -> np.ndarray | None:
+        return self.hook.panel_before
+
+    @property
+    def panel_after(self) -> np.ndarray | None:
+        return self.hook.panel_after
+
+    @property
+    def state_before(self) -> np.ndarray | None:
+        return self.hook.state_before
+
+    @property
+    def state_after(self) -> np.ndarray | None:
+        return self.hook.state_after
+
+    @property
+    def readout(self) -> np.ndarray | None:
+        return self.post.readout if self.post is not None else None
+
+    def remove(self) -> None:
+        for removable in self._removables:
+            removable.remove()
+        self._removables.clear()
+
+
+def attach_intervention(
+    model: torch.nn.Module,
+    module_name: str,
+    spec: InterventionSpec,
+    *,
+    donor: Any = None,
+    capture_post: bool = True,
+) -> InterventionHandle:
+    """Attache spec (pre-hook d'edition + post-hook de lecture) sur un module nomme."""
+    module = resolve_module(model, module_name)
+    hook = InterventionHook(spec, donor=donor)
+    handle = InterventionHandle(module_name, hook)
+    handle._removables.append(module.register_forward_pre_hook(hook))
+    if capture_post:
+        post = _PostCaptureHook()
+        handle.post = post
+        handle._removables.append(module.register_forward_hook(post))
+    return handle
+
+
+def forward_with_spec(
+    model: torch.nn.Module,
+    module_name: str,
+    model_input: torch.Tensor,
+    spec: InterventionSpec,
+    *,
+    donor: Any = None,
+    capture_post: bool = True,
+) -> tuple[torch.Tensor, InterventionHandle]:
+    """Un forward sous ``no_grad`` avec la spec attachee, hooks retires apres.
+
+    Point d'entree independant de l'endpoint : le consommateur (notebook,
+    extraction GPU) fournit le modele, le nom de module et l'entree ; le
+    moteur applique et capture. Retourne (sortie du modele, poignee dont les
+    captures survivent au detachement).
+    """
+    handle = attach_intervention(
+        model, module_name, spec, donor=donor, capture_post=capture_post
+    )
+    try:
+        with torch.no_grad():
+            output = model(model_input)
+    finally:
+        handle.remove()
+    return output, handle
+
+
+# --------------------------------------------------------------------------- #
+# Protocole interchange : capture-puis-ecriture
+# --------------------------------------------------------------------------- #
+
+class _SliceCaptureHook:
+    """Pre-hook passif : stocke panneau + tranche cible d'un run (phase capture)."""
+
+    def __init__(self, parent: "PairedInterchange", which: str) -> None:
+        self.parent = parent
+        self.which = which
+
+    def __call__(
+        self, module: torch.nn.Module, args: tuple[Any, ...]
+    ) -> None:
+        t = _first_tensor(args)
+        if t is None:
+            raise RuntimeError(
+                f"aucun tensor dans les entrees de {type(module).__name__} "
+                f"— capture interchange impossible"
+            )
+        _validate_shape(t, self.parent.spec)
+        panel = t.detach().cpu().numpy().copy()
+        self.parent.panels[self.which] = panel
+        self.parent.slices[self.which] = _slice_of(panel, self.parent.spec)
+        return None  # passthrough : la capture ne change RIEN au forward
+
+
+class PairedInterchange:
+    """Protocole capture-puis-ecriture pour l'operation interchange sur modele vivant.
+
+    Un pre-hook voit chaque activation une fois par forward : un echange
+    bilateral ne peut pas se jouer en un forward. Protocole en 4 forwards :
+
+        cap_a = pair.capture("a")   # forward run A -> buffer (passthrough)
+        cap_b = pair.capture("b")   # forward run B -> buffer (passthrough)
+        wr_a  = pair.write("a")     # forward run A -> ecrit la tranche de B
+        wr_b  = pair.write("b")     # forward run B -> ecrit la tranche de A
+
+    Les hooks de capture s'enregistrent comme les autres
+    (``module.register_forward_pre_hook(pair.capture("a"))``). Les hooks
+    d'ecriture sont des :class:`InterventionHook` complets (panneaux avant/
+    apres captes) donc ``hook_record`` fonctionne sur chaque cote de l'echange.
+    Ecrire avant d'avoir capture les deux runs echoue avec un diagnostic nomme.
+    """
+
+    def __init__(self, spec: InterventionSpec) -> None:
+        if spec.operation != "interchange":
+            raise ValueError(
+                f"PairedInterchange est le protocole d'interchange, pas de "
+                f"{spec.operation!r}"
+            )
+        self.spec = spec
+        self.slices: dict[str, np.ndarray] = {}
+        self.panels: dict[str, np.ndarray] = {}
+
+    def capture(self, which: str) -> _SliceCaptureHook:
+        if which not in ("a", "b"):
+            raise ValueError("which doit etre 'a' ou 'b'")
+        return _SliceCaptureHook(self, which)
+
+    def write(self, which: str) -> InterventionHook:
+        if which not in ("a", "b"):
+            raise ValueError("which doit etre 'a' ou 'b'")
+        missing = [w for w in ("a", "b") if w not in self.slices]
+        if missing:
+            raise ValueError(
+                f"protocole interchange : capture les DEUX runs avant d'ecrire "
+                f"(captures manquantes: {missing})"
+            )
+        other = "b" if which == "a" else "a"
+        return InterventionHook(self.spec, donor=self.slices[other])
+
+
+# --------------------------------------------------------------------------- #
+# Enregistrement sidecar depuis les captures du hook
+# --------------------------------------------------------------------------- #
+
+def hook_record(
+    handle: InterventionHandle | InterventionHook,
+    *,
+    verdict: str = "",
+    **alignment_extra: str,
+) -> InterventionRecord:
+    """Assemble un InterventionRecord sidecar depuis les captures d'un hook.
+
+    Le dommage general et le verdict sont calcules par le coeur numpy sur les
+    panneaux captes ; les empreintes couvrent les panneaux complets.
+    L'enregistrement ne STOCKE pas les panneaux (ils vivent dans le trace store
+    du contrat de trace). Requiert un panneau 2-D (T, d) — reduire au lot
+    unitaire avant d'enregistrer un forward diffuse (B, T, d).
+    """
+    hook = handle.hook if isinstance(handle, InterventionHandle) else handle
+    if hook.panel_before is None or hook.panel_after is None:
+        raise ValueError(
+            "aucune capture — attacher le hook et executer un forward AVANT "
+            "d'enregistrer"
+        )
+    if hook.panel_before.ndim != 2:
+        raise ValueError(
+            f"enregistrement sidecar sur panneau (T, d) — panneau capture de "
+            f"{hook.panel_before.ndim} dims : reduire au lot unitaire (B=1) "
+            f"avant hook_record"
+        )
+    damage = damage_metrics(hook.panel_before, hook.panel_after, hook.spec)
+    return InterventionRecord(
+        spec=hook.spec,
+        alignment=hook.spec.alignment(**alignment_extra),
+        sha_before=artifact_sha256(hook.panel_before),
+        sha_after=artifact_sha256(hook.panel_after),
+        damage=damage,
+        verdict=verdict or selectivity_verdict(damage),
+    )

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_causal_hooks.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_causal_hooks.py
@@ -1,0 +1,440 @@
+"""Tests des hooks torch du moteur causal (Epic #15475, grain #15479 tranche 2).
+
+Couvre ``scripts/causal_hooks.py`` — le confinement torch du moteur — sur des
+modeles jouets CPU deterministes (LayerNorm + Linear, seeds fixes, float64
+pour la parite bit a bit avec le coeur numpy). Aucune capture GPU : torch est
+importe paresseusement via ``pytest.importorskip`` DANS chaque test (convention
+``test_jlens_traces.py``) pour que la collecte reste verte sur un env sans
+torch (CI ICT py3.9 sans torch : les tests comptent au floor-guard et sautent
+a l'execution, jamais a la collecte).
+
+Gates :
+  1. (Miroir numpy) ``apply_spec_to_tensor`` == ``apply_intervention`` bit a
+     bit pour les 4 operations unaires ; interchange == cote de
+     ``interchange_panels``.
+  2. (Non-mutation + remplacement) le tensor d'entree n'est JAMAIS mute ; le
+     forward hooked == edition manuelle puis forward propre (bit a bit).
+  3. (Validation forte) position/feature hors panneau, donneur de mauvaise
+     forme, module inconnu, absence de tensor : chaque echec NOMME sa cause.
+  4. (Controles through-hooks) sham de clamp = write-back = identite ; bras
+     intact Gate 24 = identite PAR LA MEME VOIE ; cible aleatoire appariee
+     passe par le meme chemin d'application.
+  5. (Captures) panneaux/tranche avant-apres, point de lecture readout post.
+  6. (Protocole interchange) capture-puis-ecriture echange exactement les
+     tranches ; ecrire avant de capturer echoue avec diagnostic.
+  7. (Sidecar) ``hook_record`` produit un enregistrement complet (verdict,
+     empreintes distinctes, JSON serialisable).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict.causal_engine import (  # noqa: E402
+    InterventionSpec,
+    apply_intervention,
+    build_gate24_family,
+    interchange_panels,
+    random_target_matched,
+    sham_of,
+)
+
+D = 8
+T = 6
+
+
+def _torch():
+    return pytest.importorskip("torch")
+
+
+def _spec(operation: str, **overrides) -> InterventionSpec:
+    """Spec de reference sur le panneau jouet (T=6, d=8), champs par defaut sains."""
+    base = dict(
+        operation=operation,
+        instrument="synthetic",
+        layer=0,
+        positions=(1, 2),
+        features=(4, 5),
+        dose=2.0,
+        direction=(1.0, 0.0) if operation in ("clamp", "steer") else None,
+        donor=((1.5, -2.5), (-3.5, 4.5)) if operation == "patch" else None,
+        run="hook-run",
+        seed=11,
+    )
+    if operation == "interchange":
+        base["paired_run"] = "hook-run-paired"
+    base.update(overrides)
+    return InterventionSpec(**base)
+
+
+def _panel(seed: int = 7) -> np.ndarray:
+    return np.random.default_rng(seed).normal(size=(T, D))
+
+
+def _model():
+    """Modele jouet deterministe : LayerNorm(d) puis Linear(d, d), float64."""
+    torch = _torch()
+    torch.manual_seed(0)
+    model = torch.nn.Sequential(
+        torch.nn.LayerNorm(D, dtype=torch.float64),
+        torch.nn.Linear(D, D, dtype=torch.float64),
+    )
+    model.eval()
+    return model
+
+
+def _x(panel: np.ndarray):
+    torch = _torch()
+    return torch.tensor(panel, dtype=torch.float64)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 1 : miroir numpy bit a bit
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("operation", ["ablate", "clamp", "steer", "patch"])
+def test_tensor_mirror_bitwise_equals_numpy_core(operation):
+    """apply_spec_to_tensor reproduit apply_intervention exactement (float64)."""
+    _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    panel = _panel()
+    spec = _spec(operation)
+    got = apply_spec_to_tensor(_x(panel), spec).numpy()
+    want = apply_intervention(panel, spec)
+    assert got.dtype == want.dtype
+    assert np.array_equal(got, want)
+
+
+def test_interchange_tensor_equals_one_side_of_interchange_panels():
+    """L'ecriture d'un cote d'interchange == le cote correspondant du coeur numpy."""
+    _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    a, b = _panel(1), _panel(2)
+    spec = _spec("interchange")
+    donor = b[np.ix_(list(spec.positions), list(spec.features))]
+    got = apply_spec_to_tensor(_x(a), spec, donor=donor).numpy()
+    want_a, _ = interchange_panels(a, b, spec)
+    assert np.array_equal(got, want_a)
+
+
+def test_empty_target_identity_same_code_path():
+    """Cible vide (bras intact) : clone non edite PAR LA MEME VOIE."""
+    torch = _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    panel = _panel()
+    spec = _spec("clamp", positions=(), features=(), direction=None)
+    got = apply_spec_to_tensor(_x(panel), spec)
+    assert torch.equal(got, _x(panel))
+    assert got is not _x(panel)  # copie, pas un alias
+
+
+def test_batched_activation_broadcasts_over_batch():
+    """(B, T, d) : l'edition s'applique a chaque element du lot, hors cible intact."""
+    torch = _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    batch = np.stack([_panel(1), _panel(2)])
+    spec = _spec("clamp")
+    got = apply_spec_to_tensor(torch.tensor(batch), spec).numpy()
+    for b in range(2):
+        want = apply_intervention(batch[b], spec)
+        assert np.array_equal(got[b], want)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 2 : non-mutation, remplacement d'entrees, equivalence forward
+# --------------------------------------------------------------------------- #
+
+def test_input_tensor_never_mutated_by_hook():
+    torch = _torch()
+    from scripts.causal_hooks import attach_intervention
+
+    model = _model()
+    x = _x(_panel())
+    snapshot = x.clone()
+    spec = _spec("clamp")
+    handle = attach_intervention(model, "0", spec)
+    try:
+        with torch.no_grad():
+            model(x)
+    finally:
+        handle.remove()
+    assert torch.equal(x, snapshot)
+
+
+def test_hooked_forward_equals_manual_edit_then_clean_forward():
+    """Le pre-hook REMPLACE l'entree : hooked(x) == model(edite(x)) bit a bit."""
+    torch = _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor, forward_with_spec
+
+    model = _model()
+    x = _x(_panel())
+    spec = _spec("clamp")
+    hooked, _ = forward_with_spec(model, "0", x, spec, capture_post=False)
+    manual = model(apply_spec_to_tensor(x, spec))
+    assert torch.equal(hooked, manual)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 3 : validation forte, diagnostics nommes
+# --------------------------------------------------------------------------- #
+
+def test_position_and_feature_out_of_range_fail_loudly():
+    _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    x = _x(_panel())
+    with pytest.raises(ValueError, match="position .* hors activation T=6"):
+        apply_spec_to_tensor(x, _spec("clamp", positions=(99,)))
+    with pytest.raises(ValueError, match="feature .* hors dimension d=8"):
+        apply_spec_to_tensor(x, _spec("clamp", features=(99,), direction=(1.0,)))
+
+
+def test_donor_wrong_shape_fails_with_both_shapes():
+    _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    x = _x(_panel())
+    bad = np.zeros((3, 2))  # cible (2, 2)
+    with pytest.raises(ValueError, match=r"donneur de forme \(3, 2\) != cible \(2, 2\)"):
+        apply_spec_to_tensor(x, _spec("patch", donor=bad))
+
+
+def test_interchange_without_donor_refuses_direct_write():
+    _torch()
+    from scripts.causal_hooks import apply_spec_to_tensor
+
+    with pytest.raises(ValueError, match="protocole PairedInterchange"):
+        apply_spec_to_tensor(_x(_panel()), _spec("interchange"))
+
+
+def test_hook_without_tensor_argument_fails_loudly():
+    torch = _torch()
+    from scripts.causal_hooks import InterventionHook
+
+    hook = InterventionHook(_spec("clamp"))
+    with pytest.raises(RuntimeError, match="aucun tensor"):
+        hook(torch.nn.LayerNorm(D), ())
+
+
+def test_attach_unknown_module_names_available_candidates():
+    _torch()
+    from scripts.causal_hooks import attach_intervention
+
+    with pytest.raises(ValueError, match="disponibles"):
+        attach_intervention(_model(), "couche-inexistante", _spec("clamp"))
+
+
+# --------------------------------------------------------------------------- #
+# Gate 4 : controles through-hooks
+# --------------------------------------------------------------------------- #
+
+def test_clamp_sham_write_back_is_identity_through_hook():
+    """Sham de clamp = write-back de la tranche originale : sortie identique."""
+    torch = _torch()
+    from scripts.causal_hooks import forward_with_spec
+
+    model = _model()
+    panel = _panel()
+    x = _x(panel)
+    sham = sham_of(_spec("clamp"), panel)
+    assert sham.operation == "patch"
+    sham_out, handle = forward_with_spec(model, "0", x, sham)
+    clean = model(x)
+    assert torch.equal(sham_out, clean)
+    assert sham.control_ref == "sham-of-clamp(write-back)"
+
+
+def test_gate24_intact_arm_identity_same_path_target_differs():
+    """Bras intact : identite PAR LA MEME VOIE ; bras cible : sortie modifiee."""
+    torch = _torch()
+    from scripts.causal_hooks import forward_with_spec
+
+    model = _model()
+    x = _x(_panel())
+    spec = _spec("clamp")
+    norms = np.abs(np.random.default_rng(1).normal(1.0, 0.01, size=D))
+    control = random_target_matched(
+        _panel(), spec, feature_norms=norms,
+        feature_freqs=np.full(D, 0.5), rel_tol=1.5,
+    )
+    family = build_gate24_family(spec, control)
+    intact_out, _ = forward_with_spec(model, "0", x, family["intact"], capture_post=False)
+    assert torch.equal(intact_out, model(x))
+    target_out, _ = forward_with_spec(model, "0", x, family["target"], capture_post=False)
+    assert not torch.equal(target_out, model(x))
+
+
+def test_random_matched_control_applies_through_same_hook_path():
+    """Le controle aleatoire apparie traverse le meme chemin d'application."""
+    torch = _torch()
+    from scripts.causal_hooks import forward_with_spec
+
+    model = _model()
+    x = _x(_panel())
+    spec = _spec("clamp")
+    norms = np.abs(np.random.default_rng(2).normal(1.0, 0.05, size=D))
+    control = random_target_matched(
+        _panel(), spec, feature_norms=norms,
+        feature_freqs=np.full(D, 0.5), rel_tol=0.5,
+    )
+    clean = model(x)
+    target_out, _ = forward_with_spec(model, "0", x, spec, capture_post=False)
+    control_out, _ = forward_with_spec(model, "0", x, control, capture_post=False)
+    # le controle est une VRAIE intervention (meme nombre de features, autres
+    # indices) : il change la sortie, autrement que la cible
+    assert not torch.equal(control_out, clean)
+    assert not torch.equal(control_out, target_out)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 5 : captures pre/post
+# --------------------------------------------------------------------------- #
+
+def test_state_capture_before_after_slices():
+    """state_before = tranche du panneau d'entree ; state_after = tranche editee."""
+    _torch()
+    from scripts.causal_hooks import forward_with_spec
+
+    model = _model()
+    panel = _panel()
+    x = _x(panel)
+    spec = _spec("clamp", dose=3.0, direction=(0.0, 1.0))
+    _, handle = forward_with_spec(model, "0", x, spec)
+    rows, cols = list(spec.positions), list(spec.features)
+    assert np.array_equal(handle.state_before, panel[rows][:, cols])
+    want_after = np.tile(np.array([0.0, 3.0]), (len(rows), 1))
+    assert np.array_equal(handle.state_after, want_after)
+    assert np.array_equal(handle.panel_before, panel)
+
+
+def test_post_capture_readout_point():
+    """capture_post=True : le post-hook capte la sortie du module vise."""
+    torch = _torch()
+    from scripts.causal_hooks import forward_with_spec
+
+    model = _model()
+    x = _x(_panel())
+    spec = _spec("clamp", positions=(), features=(), direction=None)  # intact
+    with torch.no_grad():
+        expected = model[0](x).numpy()
+    _, handle = forward_with_spec(model, "0", x, spec)
+    assert np.array_equal(handle.readout, expected)
+    # et l'edition a bien traverse : state_after vide = rien n'a change
+    assert handle.state_after.shape == (0, 0)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 6 : protocole interchange capture-puis-ecriture
+# --------------------------------------------------------------------------- #
+
+def test_paired_interchange_swaps_exactly():
+    """4 forwards (capture x2, ecriture x2) == interchange_panels du coeur."""
+    torch = _torch()
+    from scripts.causal_hooks import PairedInterchange
+
+    model = _model()
+    a, b = _panel(1), _panel(2)
+    spec = _spec("interchange")
+    pair = PairedInterchange(spec)
+
+    with torch.no_grad():
+        # un hook de capture A LA FOIS : laisse "a" enregistre pendant le
+        # forward de b, il re-capturerait b dans le buffer de a
+        ha = model[0].register_forward_pre_hook(pair.capture("a"))
+        model(_x(a))
+        ha.remove()
+        hb = model[0].register_forward_pre_hook(pair.capture("b"))
+        model(_x(b))
+        hb.remove()
+    assert np.array_equal(pair.panels["a"], a)
+    assert np.array_equal(pair.panels["b"], b)
+
+    h_a = model[0].register_forward_pre_hook(pair.write("a"))
+    with torch.no_grad():
+        out_a = model(_x(a))
+    h_a.remove()
+    h_b = model[0].register_forward_pre_hook(pair.write("b"))
+    with torch.no_grad():
+        out_b = model(_x(b))
+    h_b.remove()
+
+    # chaque cote correspond EXACTEMENT au coeur numpy interchange_panels
+    want_a, want_b = interchange_panels(a, b, spec)
+    assert torch.equal(out_a, model(_x(want_a)))
+    assert torch.equal(out_b, model(_x(want_b)))
+
+
+def test_write_before_both_captures_fails_with_diagnostic():
+    _torch()
+    from scripts.causal_hooks import PairedInterchange
+
+    pair = PairedInterchange(_spec("interchange"))
+    with pytest.raises(ValueError, match="capture les DEUX runs"):
+        pair.write("a")
+
+
+def test_paired_interchange_rejects_non_interchange_spec():
+    _torch()
+    from scripts.causal_hooks import PairedInterchange
+
+    with pytest.raises(ValueError, match="pas de 'clamp'"):
+        PairedInterchange(_spec("clamp"))
+
+
+# --------------------------------------------------------------------------- #
+# Gate 7 : enregistrement sidecar depuis les captures
+# --------------------------------------------------------------------------- #
+
+def test_hook_record_full_sidecar():
+    """hook_record : verdict selectivite, empreintes distinctes, JSON serialisable."""
+    _torch()
+    from scripts.causal_hooks import forward_with_spec, hook_record
+
+    model = _model()
+    x = _x(_panel())
+    spec = _spec("clamp")
+    _, handle = forward_with_spec(model, "0", x, spec, capture_post=False)
+    rec = hook_record(handle, model="toy-model")
+    assert rec.verdict == "selective"
+    assert rec.damage["off_target_rel"] == 0.0  # hors cible intact bit a bit
+    assert rec.sha_before != rec.sha_after
+    payload = rec.to_json()
+    assert '"clamp"' in payload
+    assert '"toy-model"' in payload
+    assert rec.alignment["instrument"] == "synthetic"
+
+
+def test_hook_record_without_capture_fails():
+    _torch()
+    from scripts.causal_hooks import InterventionHook, hook_record
+
+    with pytest.raises(ValueError, match="aucune capture"):
+        hook_record(InterventionHook(_spec("clamp")))
+
+
+def test_hook_record_rejects_batched_panel():
+    """Panneau (B, T, d) : l'enregistrement sidecar exige le lot unitaire."""
+    torch = _torch()
+    from scripts.causal_hooks import attach_intervention, hook_record
+
+    model = _model()
+    batch = np.stack([_panel(1), _panel(2)])
+    x = torch.tensor(batch)
+    spec = _spec("clamp")
+    handle = attach_intervention(model, "0", spec)
+    try:
+        with torch.no_grad():
+            model(x)
+    finally:
+        handle.remove()
+    with pytest.raises(ValueError, match="lot unitaire"):
+        hook_record(handle)


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2023:CoursIA — prev: DEEP/research-code #15599

See #15479 (tranche 2/n, Epic #15475). **Empilée sur #15599** (base = branche du parent, tranche 1 = cœur numpy) — retarget automatique sur `main` à son merge.

## Livrable

| Fichier | Contenu |
|---|---|
| `ICT-Series/scripts/causal_hooks.py` (nouveau, ~470 l.) | confinement torch du moteur : `apply_spec_to_tensor` (miroir bit a bit du cœur numpy), `InterventionHook` (pre-hook qui remplace l'entrée du module), `attach_intervention`/`forward_with_spec` (résolution par `named_modules()`, compatible transformers), `PairedInterchange` (protocole capture-puis-écriture), `hook_record` (sidecar `InterventionRecord` depuis les captures) |
| `ICT-Series/tests/test_causal_hooks.py` (nouveau, 25 tests) | gates miroir/non-mutation/validation/contrôles-through-hooks/captures/protocole/sidecar, modèles jouets float64 CPU deterministes |
| `.github/workflows/ict-tests.yml` | floors relevés dans la même PR (mandat du workflow) : `tests/` 1046→1071 (+25), `ict/tests/` 670→692 (+22 = tranche 1), label `tests/ (56)` |

## Décisions de design

1. **Interchange = capture-puis-écriture (4 forwards)** : un pre-hook voit chaque activation une fois par forward — l'échange bilateral ne peut PAS se jouer en un forward. Capture A, capture B, écriture de A avec la tranche de B, écriture de B avec la tranche de A. En tensor units, un côté d'interchange EST un patch par la tranche empirique du run apparié (exactement `interchange_panels` côté par côté). Écrire avant d'avoir capturé les deux runs échoue avec diagnostic nommé.
2. **Édition par remplacement, jamais par mutation** : le pre-hook retourne les args remplacés (contrat torch) ; le tensor d'entrée d'origine n'est jamais muté (testé bit a bit).
3. **Captures pré/post** : panneaux complets + tranche cible avant/après (canal état), post-hook optionnel sur la sortie du module (point de lecture readout) — les deux points de capture de la décision de design 2026-09-11T12:25Z.
4. **Panneaux (T,d) et (B,T,d)** : l'édition diffuse sur le lot ; l'enregistrement sidecar exige le lot unitaire (B=1) — refus nommé sinon.
5. **Traduction instrument-space HORS scope** : residual → latent SAE (encode/édite/décode) appartient à la couche lentille (`extract_sae_traces.py`) ; `tensor_space` documente l'espace lu.

## Vérification

- `pytest tests/test_causal_hooks.py` : **25 passed** (torch 2.8.0+cu126, CPU) — parité bit a bit avec le cœur numpy en float64 (ablate/clamp/steer/patch/interchange), sham write-back identité bit a bit, bras intact Gate 24 identité PAR LA MÊME VOIE.
- Régression complète : `tests/` **1075 passed** (426.67 s), `ict/tests/` **692 passed** (120.28 s).
- Collection floor-guard : 1075/692 collectés localement ; floors CI = 1071 (base CI 1046 + 25) et 692. Les 25 tests torch sont collectés même sans torch (`importorskip` au niveau FONCTION, convention `test_jlens_traces.py`) : comptés au floor, sautés à l'exécution seulement sur la CI ICT py3.9 sans torch.
- `flake8` silencieux sur les deux nouveaux fichiers.

## Résiduel nommé (tranches suivantes de #15479)

- (b) notebook consommateur français exécuté (≥3 exos, verdict falsifiable sur banc synthétique) ;
- (c) câblage `trace_contract` au merge de #15525 (import gardé déjà en place dans le cœur) ;
- (d) endpoints multi-lentilles à l'échelle réelle (SAE latent-space via la couche lentille).

🤖 Generated with [Claude Code](https://claude.com/claude-code)