### PR TITLE
feat(slides,#11508): S2-ia-exploratoire — detrame 14 comment-trapped images

### DIFF
--- a/slides/S2-ia-exploratoire-symbolique/slides.md
+++ b/slides/S2-ia-exploratoire-symbolique/slides.md
@@ -41,7 +41,7 @@ layout: cover
   - Comment utiliser les données et l'expérience ?
 - Application: le langage naturel
 
-<!-- Image: images/img_001.jpg -->
+<img src="./images/img_001.jpg" alt="Panorama des approches de l'IA : probabiliste, multi-agents, apprentissage, langage naturel" style="display:block; margin:10px auto; width:100%; max-height:40px; object-fit:contain; margin:2px auto -34px;">
 
 
 
@@ -98,7 +98,7 @@ layout: cover
 - **Théorie du contrôle** : Maximiser une fonction objective dans le temps
 - **Linguistique** : Représentation de connaissances, grammaire
 
-<!-- Image: images/img_002.png -->
+<img src="./images/img_002.png" alt="Disciplines fondatrices de l'IA : psychologie, informatique, théorie du contrôle, linguistique" style="display:block; margin:10px auto; width:100%; max-height:165px; object-fit:contain; margin:2px auto -34px;">
 
 
 ---
@@ -121,7 +121,7 @@ layout: cover
 - **2000s** : Data mining, reconnaissances, apprentissage bayésien, web sémantique
 - **2010s** : Big data, deep learning, chatbots, smart contracts, cloud, architectures hybrides
 
-<!-- Image: images/img_003.png -->
+<img src="./images/img_003.png" alt="Chronologie de l'IA des années 1990 aux années 2010 : agents, data mining, deep learning" style="display:block; margin:10px auto; max-width:100%;">
 
 
 ---
@@ -171,7 +171,7 @@ layout: cover
   - **Fonction d'agent: de l'historique des perceptions (percepts) vers les actions:**
     - [f: P* A]
 
-<!-- Image: images/img_006.png -->
+<img src="./images/img_006.png" alt="Fonction d'agent : de l'historique des perceptions vers les actions" style="display:block; margin:10px auto; width:100%; max-height:285px; object-fit:contain; margin:2px auto -34px;">
 
 
 
@@ -275,7 +275,7 @@ layout: cover
 
 # Environnement de tâche (exemples)
 
-<!-- Image: images/img_013.png -->
+<img src="./images/img_013.png" alt="Agents et environnements de tâche : capteurs en entrée, effecteurs en sortie, exemples" style="display:block; margin:10px auto; max-width:100%;">
 
 
 
@@ -343,7 +343,7 @@ layout: cover
 - **Compromis**
   - Flexibilité vs complexité
 
-<!-- Image: images/img_016.png -->
+<img src="./images/img_016.png" alt="Niveaux de représentation de l'environnement : atomique, factorisée, structurée" style="display:block; margin:10px auto; max-width:100%;">
 
 
 
@@ -412,7 +412,7 @@ layout: section
   - e.g., Arad, Sibiu, Fagaras, Bucharest
   - Solution optimale = cout minimal
 
-<!-- Image: images/img_018.png -->
+<img src="./images/img_018.png" alt="Formulation d'un problème : actions de conduite entre villes et coût de chemin" style="display:block; margin:10px auto; width:100%; max-height:48px; object-fit:contain; margin:2px auto -34px;">
 
 <!-- Illustration : carte de Roumanie avec chemins explores par A* -->
 
@@ -518,7 +518,7 @@ layout: two-cols
 - **Principe**
   - On tri les nœuds en ordre décroissant de désirabilité
 
-<!-- Image: images/img_025.png -->
+<img src="./images/img_025.png" alt="Exploration informée : fonction d'évaluation développant les nœuds les plus désirables" style="display:block; margin:10px auto; width:100%; max-height:100px; object-fit:contain; margin:2px auto -34px;">
 
 <!-- Demo : comparaison visuelle Greedy vs A* sur PathFinding.js -->
 
@@ -573,8 +573,8 @@ layout: two-cols
     - Phénotype
     - Fonction d'adaptation
 
-<!-- Image: images/img_028.png -->
-<!-- Image: images/img_029.png -->
+<img src="./images/img_028.png" alt="Combinaison d'algorithmes et d'intelligence naturelle — figure 1 de 2" style="display:inline-block; margin:0 6px -34px; max-height:70px; object-fit:contain; max-width:47%; vertical-align:middle;">
+<img src="./images/img_029.png" alt="Combinaison d'algorithmes et d'intelligence naturelle — figure 2 de 2" style="display:inline-block; margin:0 6px -34px; max-height:70px; object-fit:contain; max-width:47%; vertical-align:middle;">
 
 <!-- Demo : visualisation convergence dans le notebook GeneticSharp -->
 
@@ -618,7 +618,7 @@ layout: two-cols
 - **Techniques probabilistes**
   - Expectiminimax, méthodes de Monte-Carlo
 
-<!-- Image: images/img_030.png -->
+<img src="./images/img_030.png" alt="Panorama des techniques de résolution, dont les techniques probabilistes" style="display:block; margin:10px auto; width:100%; max-height:110px; object-fit:contain; margin:2px auto -34px;">
 
 
 ---
@@ -637,7 +637,7 @@ layout: two-cols
   - Permet l'utilisation de méthodes générales
     - plus puissantes que les algorithmes standards d'exploration
 
-<!-- Image: images/img_031.png -->
+<img src="./images/img_031.png" alt="Problème de satisfaction de contraintes : formulation standard d'exploration" style="display:block; margin:10px auto; width:100%; max-height:185px; object-fit:contain; margin:2px auto -34px;">
 
 
 ---
@@ -695,8 +695,8 @@ layout: two-cols
   - Contrainte de rupture de symétrie
     - ex: ordre alphabétique: NT<SA<WA
 
-<!-- Image: images/img_036.png -->
-<!-- Image: images/img_037.png -->
+<img src="./images/img_036.png" alt="Symétries en coloration de graphe : n! permutations équivalentes — figure 1 de 2" style="display:inline-block; margin:0 6px -34px; max-height:90px; object-fit:contain; max-width:47%; vertical-align:middle;">
+<img src="./images/img_037.png" alt="Symétries en coloration de graphe : n! permutations équivalentes — figure 2 de 2" style="display:inline-block; margin:0 6px -34px; max-height:90px; object-fit:contain; max-width:47%; vertical-align:middle;">
 
 
 ---


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA — prev: MED/test #15543

Tranche L4 supplementaire de l'EPIC slides #11508 : **S2-ia-exploratoire-symbolique**, meme classe de defaut et meme methodologie que la tranche 04-probabilites (#15608). Les 14 images `<!-- Image: images/img_NNN.ext -->` piegees en commentaires deviennent de vraies balises `<img>` avec alt descriptif FR, mises en page sans debordement du canvas.

## Livrable

`slides/S2-ia-exploratoire-symbolique/slides.md` — 14 balises converties :

| Groupe | Images | Rendu |
|---|---|---|
| Blocs simples (11) | img_001, 002, 003, 006, 013, 016, 018, 025, 030, 031 | `display:block; width:100%; max-height:<budget>px; object-fit:contain` |
| Rangées de 2 (2 paires) | img_028+029, img_036+037 | `display:inline-block; max-width:47%; max-height:<budget>px; object-fit:contain` |

Alt descriptifs FR derives du contexte declare de chaque slide (ex. img_025 : « Exploration informée : fonction d'évaluation développant les nœuds les plus désirables »). Les paires consecutives forment une seule rangee inline, figures 1/2 et 2/2 nommees dans l'alt.

## Validation (organes, relances apres le dernier commit)

**Refs images** — `scan_slides_image_refs.py --repo <worktree> --deck S2-ia-exploratoire-symbolique` : avant 40 actives / **14 COMMENT_TRAPPED** ; apres **54/54 actives (100 %), 0 piegee, 0 MARP_ONLY, 0 orpheline**.

**Composition** — `scan_slidev_composition.py` (canvas 980x552, serveur Slidev sur le deck transforme, baseline = `git show origin/main` servie a part) :

| Mesure | base origin/main | apres cette PR |
|---|---|---|
| slides hors_canvas | 14 (pre-existants) | 14 (identiques, INTRODUCED = []) |
| chevauchements | 0 | 0 |

Attribution : les 9 slides nouvellement flagrees par l'ajout des images (debordement 17-26 px de la boite du div `slidev-layout`, produit du `padding-bottom:32px` + hauteur d'image) sont **rentrees dans le canvas** par deux gestes cumules : budgets de hauteur (11 images) puis `margin-bottom:-34px` sur les 11 images en fin de slide (l'image est l'element le plus bas ; la marge negative annule le padding invisible du conteneur — contenu visible mesure `content_bottom <= 546 < 552`, rien de rogne). `INTRODUCED = []` mesure sur scan final.

**Verification visuelle non revendiquee** (lane content-machine, pas vision) : la validation est instrumentale (DOM mesure via Playwright : bbox du div layout, bottoms des enfants, tailles naturelles des images) — voir #15608 pour le meme protocole.

See #11508 (contribution partielle a l'EPIC : tranche S2 ; restent S1-argumentation, 07-elargissements, S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
