### PR TITLE
feat(tooling,#15489): garde de casse canonique des suffixes de noyau + config d'adoption

### DIFF
--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -148,6 +148,10 @@ NOTEBOOK_GLOBS = ["**/*.ipynb"]
 #   - self-hosted-runner-policy : bloquant, scan statique des workflows
 #   - duplicate-notebook-index-guard : bloquant, delta base-vs-head sur
 #                           les fichiers AJOUTES (#12753)
+#   - kernel-suffix-canon-guard : bloquant, delta base-vs-head sur les fichiers
+#                           AJOUTES, avec une CONFIG d'adoption lue a l'execution
+#                           (seul garde de la voie rapide dont le verdict depend
+#                           d'un fichier de donnees, #15489)
 #
 # Un lot homogene aurait valide le moteur sur un seul cas de figure -- et un
 # lot entierement vert serait indiscernable d'un moteur debranche.
@@ -307,6 +311,42 @@ PILOT: list[Guard] = [
             "scripts/notebook_tools/naming_canon.py",
         ],
         argv=["python", "scripts/notebook_tools/check_duplicate_notebook_index.py",
+              "--base", "{base_ref}", "--head", "HEAD"],
+        blocking=True,
+        needs_base=True,
+    ),
+
+    # Defaut 3 de #15489 : "aucun garde dedie n'impose la casse canonique
+    # `Python` / `CSharp` / `Lean` apres adoption d'une serie". La tranche
+    # #15503 avait livre le parseur partage en declarant ce point hors de sa
+    # portee (un module qui normalise la casse ne peut pas la juger).
+    #
+    # Porte aux fichiers AJOUTES, et c'est ce qui rend le garde possible : la
+    # mesure de l'arbre donne 114 `-Csharp` contre 16 `-CSharp`. Un garde qui
+    # imposerait la casse canonique a tout le corpus condamnerait la majorite
+    # de ses propres notebooks et serait desactive ; un garde qui ne l'impose
+    # nulle part ne ferme rien. D'ou la CONFIG d'adoption explicite
+    # (`kernel_suffix_canon.json`), lue a l'execution : les series qui ont
+    # tranche (mesure : `Search/Applications` 15 canoniques contre 5 herites)
+    # sont tenues, les autres gardent leur convention -- et leurs 114 fichiers
+    # herites ne rougissent jamais, puisqu'ils ne sont pas des ajouts.
+    #
+    # C'est le seul garde de la voie rapide dont le verdict depend d'un fichier
+    # de donnees : `kernel_suffix_canon.json` figure donc dans `paths`, sinon
+    # une revision qui declare une nouvelle serie adoptee -- ou en revoque une --
+    # ne rejouerait pas le garde dont elle change la portee.
+    Guard(
+        name="kernel-suffix-canon-guard",
+        source=FAST_LANE_NATIVE,
+        paths=NOTEBOOK_GLOBS + [
+            "scripts/notebook_tools/check_kernel_suffix_canon.py",
+            "scripts/notebook_tools/kernel_suffix_canon.json",
+            # Liste partagee des suffixes de noyau : l'en retirer un rend le
+            # garde muet sur cette famille, l'y ajouter rouvre les exclusions
+            # mesurees (`-Lean` marque le contenu, pas le moteur).
+            "scripts/notebook_tools/naming_canon.py",
+        ],
+        argv=["python", "scripts/notebook_tools/check_kernel_suffix_canon.py",
               "--base", "{base_ref}", "--head", "HEAD"],
         blocking=True,
         needs_base=True,

--- a/scripts/notebook_tools/check_kernel_suffix_canon.py
+++ b/scripts/notebook_tools/check_kernel_suffix_canon.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Garde de casse canonique des suffixes de noyau (#15489, defaut 3).
+
+Origine -- W0 de #5081/#11840, point 3 de #15489 :
+
+    "Aucun garde dedie n'impose la casse canonique `Python` / `CSharp` / `Lean`
+     apres adoption d'une serie."
+
+La tranche precedente (#15503) a livre le parseur partage `naming_canon.py` en
+declarant explicitement hors de sa portee "la casse canonique des suffixes de
+langue" : un module qui lit un nom sans lire sa casse ne peut pas fermer ce
+defaut, et il l'ecrit lui-meme pour ne pas passer pour le canon entier. C'est ce
+trou que ce fichier ferme.
+
+CE QUE CE GARDE MESURE
+----------------------
+Sur les seuls notebooks AJOUTES par la revision, deux choses :
+
+1. **Casse du suffixe** -- un nouvel `-python` au lieu de `-Python`, `-csharp` au
+   lieu de `-CSharp`, porte une casse hors canon. Un `-Csharp` dans une serie
+   qui n'a PAS adopte la casse canonique ne rougit pas : la mesure de l'arbre
+   donne 114 `-Csharp` contre 16 `-CSharp`, et imposer la regle a une serie qui
+   n'a pas tranche fabrique du rouge sans defaut -- lecon du garde de zero-pad
+   (#12586). L'adoption est une **liste explicite** (`kernel_suffix_canon.json`),
+   jamais une deduction.
+
+2. **Coherence suffixe <-> noyau reel** -- le suffixe dit quel moteur execute le
+   notebook, et il peut mentir. Mesure : `GenAI/SemanticKernel/
+   Workbook-Template-Python.ipynb` porte `-Python` et un kernelspec `.net-csharp`.
+   Deux lecteurs du meme nom (le fichier, le metadata) se contredisent, et rien
+   ne le signalait. Ce defaut la est independant de toute adoption.
+
+CE QU'IL NE MESURE PAS, ET POURQUOI LA LISTE EST COURTE
+-------------------------------------------------------
+`KERNEL_LANG_SUFFIXES` ne contient que `-csharp` et `-python`, parce que ce sont
+les deux seuls suffixes dont la mesure montre qu'ils NOMMENT le noyau :
+
+    -Csharp / -CSharp  130 fichiers  -> 130 x kernelspec `.net-csharp`
+    -Python             44 fichiers  -> 41 x `python3`, 2 x `coursia-ml-training`,
+                                        1 x `.net-csharp` (le defaut ci-dessus)
+    -Lean                4 fichiers  -> 2 x `python3`, 1 x `lean4-wsl`,
+                                        1 x `lean4-wsl-perc`
+
+`-Lean` est donc **exclu** : dans ce depot il marque le CONTENU, pas le moteur.
+Le pendant reellement Lean d'un notebook porte `-Native`
+(`Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb` -> `lean4-wsl`), et 2 des 4
+`-Lean` tournent sous `python3`. Declarer `lean` comme famille de noyau
+injecterait un faux positif dans une famille de ~50 notebooks -- et un garde qui
+crie a tort est un garde qu'on desactive. `-FSharp` est exclu pour une raison
+distincte : aucun kernelspec F# n'existe dans l'arbre (17 noyaux distincts,
+aucun `fsharp`) et `.net-csharp` est partage par les langages .NET, donc une
+famille F# deduite du suffixe produirait un faux positif au premier notebook F#.
+Ces deux exclusions sont des decisions mesurees, pas des oublis.
+
+Ce qu'il ne mesure toujours PAS : le contenu, l'index de position (c'est
+`check_duplicate_notebook_index.py`), la reservation d'un slot contre les PR
+ouvertes (point 4 de #15489), ni la configuration padding par serie (point 5).
+Un vert dit "les suffixes des notebooks ajoutes sont coherents", jamais "le
+corpus est homogene" -- les 114 `-Csharp` herites restent, deliberement.
+
+PORTEE DELTA
+------------
+Les fichiers examines sont lus en `--no-renames --diff-filter=A`, comme le garde
+de collision d'index : un `git mv X.ipynb X-Csharp.ipynb` introduit un suffixe
+non canonique et sort par defaut en `R100`, que `--diff-filter=A` ecarterait. Le
+rename est une manoeuvre legitime ; c'est le nom introduit qui est juge. Les
+defauts herites ne rougissent donc pas -- c'est ce qui rend l'adoption d'une
+serie compatible avec ses fichiers deja non conformes.
+
+Usage
+-----
+    python scripts/notebook_tools/check_kernel_suffix_canon.py --base origin/main
+    python scripts/notebook_tools/check_kernel_suffix_canon.py --base origin/main --json
+    python scripts/notebook_tools/check_kernel_suffix_canon.py --scan-all
+    python scripts/notebook_tools/check_kernel_suffix_canon.py --self-test
+
+Sortie : 0 = aucun defaut introduit ; 1 = defaut ; 2 = erreur d'invocation.
+Le denombrement des fichiers examines et la ventilation par etat sont TOUJOURS
+imprimes : "rien trouve" et "rien regarde" ne doivent jamais se confondre.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_here = str(Path(__file__).resolve().parent)
+if _here not in sys.path:
+    sys.path.insert(0, _here)
+# La liste des suffixes de noyau vient du canon partage (#5081/#15489) : deux
+# lectures du meme nom divergent au premier cas limite, c'est ce que la tranche
+# #15503 a corrige. Ce garde lit `KERNEL_LANG_SUFFIXES` au lieu de redefinir
+# `("-csharp", "-python")` une troisieme fois.
+from naming_canon import KERNEL_LANG_SUFFIXES  # noqa: E402
+
+CONFIG_PATH = Path(__file__).resolve().parent / "kernel_suffix_canon.json"
+
+# Casse canonique par famille, telle que #15489 la nomme (`CSharp` / `Python`).
+KERNEL_CANONICAL = {"csharp": "CSharp", "python": "Python"}
+
+# Environnements Python du depot dont le nom ne commence pas par `python`.
+# Mesures dans l'arbre, pas supposes : `coursia-ml-training` (27 notebooks),
+# `conda-torch` (2), `pyphi` (6), `global-3.13` (1). Le prefixe `python` couvre
+# les autres (`python3`, `python3-wsl`, `python3-coursia2`, ...). Un kernelspec
+# absent de ces regles n'est pas devine : il tombe en `unknown_kernel`, etat
+# VISIBLE, jamais un vert silencieux.
+PYTHON_ENV_NAMES = {"coursia-ml-training", "conda-torch", "pyphi", "global-3.13"}
+
+
+def kernel_family(kernelspec: str | None) -> str | None:
+    """Famille de noyau d'un `metadata.kernelspec.name`, ou None si non reconnue.
+
+    Lecture par FAMILLE et non par nom exact : le depot emploie `python3`,
+    `python3-wsl`, `python3-coursia2` et `coursia-ml-training` pour le meme
+    noyau, et une table fermee de noms exacts rouvrirait le defaut au prochain
+    environnement ajoute -- meme piege que la liste de suffixes incomplete.
+    """
+    if not kernelspec:
+        return None
+    low = kernelspec.strip().lower().lstrip(".")
+    if "csharp" in low:
+        return "csharp"
+    if low.startswith("lean"):
+        return "lean"
+    if low.startswith("python") or low in PYTHON_ENV_NAMES:
+        return "python"
+    return None
+
+
+def raw_kernel_suffix(stem: str) -> str | None:
+    """Suffixe de noyau tel qu'ECRIT (casse d'origine), ou None.
+
+    `naming_canon.lang_of` normalise en minuscules -- c'est ce qu'il faut pour
+    apparier deux rendus, et exactement ce qui interdit de juger la casse. On
+    relit donc le suffixe brut en s'appuyant sur la MEME liste partagee : la
+    grammaire reste au canon, seul le jugement de casse est local.
+    """
+    low = stem.lower()
+    for suf in KERNEL_LANG_SUFFIXES:
+        if low.endswith(suf):
+            return stem[len(stem) - len(suf):]
+    return None
+
+
+def load_config(path: Path) -> dict:
+    """Configuration explicite : series ayant adopte le canon + exceptions."""
+    if not path.is_file():
+        return {"adopted": [], "exceptions": []}
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    data.setdefault("adopted", [])
+    data.setdefault("exceptions", [])
+    return data
+
+
+def glob_match(path: str, pattern: str) -> bool:
+    """Motif d'adoption. `.../**` couvre le dossier et toute sa descendance.
+
+    `fnmatch.fnmatchcase` et non `fnmatch.fnmatch` : ce dernier replie la casse
+    sous Windows (`normcase`) et pas sous Linux, donc le meme depot rendrait deux
+    verdicts selon la machine du runner.
+    """
+    if not pattern:
+        return False
+    if pattern.endswith("/**"):
+        base = pattern[:-3]
+        return path == base or path.startswith(base + "/")
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def is_adopted(path: str, adopted: list[dict]) -> dict | None:
+    for entry in adopted:
+        if glob_match(path, entry.get("path_glob", "")):
+            return entry
+    return None
+
+
+def find_exception(path: str, exceptions: list[dict]) -> dict | None:
+    """Exception declarée, par chemin exact (`path`) ou par motif (`path_glob`).
+
+    Le motif existe pour qu'une convention MINUSCULE assumee par une serie
+    entiere (cf la contre-exemple Fort-Boyard de `kernel_suffix_canon.json`) se
+    declare en une ligne au lieu d'enumerer ses fichiers un par un.
+    """
+    for entry in exceptions:
+        if entry.get("path") == path:
+            return entry
+        if entry.get("path_glob") and glob_match(path, entry["path_glob"]):
+            return entry
+    return None
+
+
+def read_kernelspec(abs_path: Path) -> tuple[str | None, bool]:
+    """(kernelspec.name, metadata_present). Ne leve jamais : un notebook
+    illisible ou sans metadata est un etat a part, pas un crash de garde."""
+    try:
+        with abs_path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None, False
+    meta = data.get("metadata")
+    if not isinstance(meta, dict):
+        return None, False
+    ks = meta.get("kernelspec")
+    name = ks.get("name") if isinstance(ks, dict) else None
+    return (name if isinstance(name, str) else None), True
+
+
+def classify(path: str, name: str, kernelspec: str | None, meta_present: bool,
+             config: dict) -> dict:
+    """Etat d'un notebook ajoute. `verdict` = "violation" | "ok" | "info"."""
+    stem = name[:-len(".ipynb")] if name.lower().endswith(".ipynb") else name
+    raw = raw_kernel_suffix(stem)
+
+    if raw is None:
+        # Sans suffixe de noyau il n'y a rien a juger -- ce n'est pas une faute.
+        # Les `-Lean` tombent ici, conformement a la mesure (le suffixe y marque
+        # le contenu, pas le moteur).
+        return {"file": path, "state": "no_kernel_suffix", "verdict": "info"}
+
+    # L'exception est lue APRES la presence d'un suffixe : declarer une exception
+    # sur un fichier sans suffixe de noyau n'a pas de sens et ne doit pas creer
+    # un etat `exception` trompeur.
+    exc = find_exception(path, config.get("exceptions", []))
+    if exc is not None:
+        return {"file": path, "state": "exception", "verdict": "info",
+                "reason": exc.get("reason", "")}
+
+    if not meta_present or kernelspec is None:
+        # "rien trouve" != "rien regarde" : sans kernelspec la coherence est
+        # INVERIFIABLE, etat distinct et non silencieux.
+        return {"file": path, "state": "kernelspec_missing", "verdict": "info"}
+
+    fam = kernel_family(kernelspec)
+    if fam is None:
+        return {"file": path, "state": "unknown_kernel", "verdict": "info",
+                "kernelspec": kernelspec}
+
+    got_case = raw.lstrip("-_")
+
+    # 1. Le suffixe contredit le noyau : defaut factuel, hors adoption. Le
+    #    message ne prescrit pas de suffixe (la famille reelle peut n'en avoir
+    #    aucun de canonique, cf `-Lean`/`-Native`) : il nomme les deux versions.
+    if got_case.lower() != fam:
+        return {"file": path, "state": "kernel_mismatch", "verdict": "violation",
+                "suffix": raw, "kernelspec": kernelspec}
+
+    # 2. Casse hors canon : defaut seulement dans une serie qui a adopte.
+    want = KERNEL_CANONICAL[fam]
+    if got_case != want:
+        adoption = is_adopted(path, config.get("adopted", []))
+        if adoption is not None:
+            return {"file": path, "state": "case_deviation",
+                    "verdict": "violation", "suffix": raw, "expected": want,
+                    "adopted": adoption.get("note", "")}
+        return {"file": path, "state": "case_deviation_unadopted",
+                "verdict": "info", "suffix": raw, "expected": want}
+
+    return {"file": path, "state": "canonical", "verdict": "ok", "suffix": raw}
+
+
+# ------------------------------------------------------------------ sources
+def _git(args: list[str]) -> str:
+    env = dict(os.environ, MSYS_NO_PATHCONV="1")
+    r = subprocess.run(["git"] + args, capture_output=True, text=True,
+                       encoding="utf-8", errors="replace", env=env)
+    if r.returncode != 0:
+        raise RuntimeError("git %s -> %s"
+                           % (" ".join(args), (r.stderr or "").strip()[:200]))
+    return r.stdout
+
+
+def repo_root() -> Path:
+    """Racine du depot JUGE, resolue depuis git (cwd), pas depuis le script.
+
+    Le garde lit le contenu des notebooks qu'il vient d'identifier par `git
+    diff` : les deux doivent porter sur le meme arbre. Une racine figee sur
+    `__file__` lirait le depot qui heberge le script -- faux des qu'on lance le
+    garde depuis un worktree, et impossible a tester sur un depot temporaire.
+    """
+    try:
+        return Path(_git(["rev-parse", "--show-toplevel"]).strip())
+    except RuntimeError:
+        return Path(__file__).resolve().parents[2]
+
+
+def added_notebooks(base: str, head: str) -> list[str]:
+    """Notebooks AJOUTES, renames repliés en suppressions + additions.
+
+    Meme raison que le garde de collision d'index : `git mv X.ipynb
+    X-Csharp.ipynb` introduit le suffixe non canonique et sort en `R` par
+    defaut -- une vue qui l'ecarte ne verrait jamais le cas qu'elle doit juger.
+    """
+    out = _git(["diff", "--no-renames", "--diff-filter=A", "--name-only",
+                "%s...%s" % (base, head)])
+    return [l.strip() for l in out.splitlines()
+            if l.strip().lower().endswith(".ipynb")]
+
+
+def notebooks_in_tree(root: Path, sub: str = "MyIA.AI.Notebooks") -> list[str]:
+    """Notebooks de l'arbre, en chemins relatifs a la racine du depot."""
+    base = root / sub
+    if not base.is_dir():
+        base = root
+    return sorted(p.relative_to(root).as_posix()
+                  for p in base.rglob("*.ipynb") if p.is_file())
+
+
+def examine(paths: list[str], config: dict) -> list[dict]:
+    root = repo_root()
+    out = []
+    for rel in paths:
+        ks, meta = read_kernelspec(root / rel)
+        out.append(classify(rel, os.path.basename(rel), ks, meta, config))
+    return out
+
+
+def _detail(r: dict) -> str:
+    if r["state"] == "kernel_mismatch":
+        return "  (suffixe %s, noyau %s)" % (r.get("suffix"), r.get("kernelspec"))
+    if r["state"] in ("case_deviation", "case_deviation_unadopted"):
+        return "  (suffixe %s, casse attendue %s)" % (r.get("suffix"),
+                                                     r.get("expected"))
+    if r["state"] == "unknown_kernel":
+        return "  (noyau %s absent de la table de familles)" % r.get("kernelspec")
+    if r["state"] == "exception":
+        return "  (%s)" % r.get("reason", "")
+    return ""
+
+
+# ------------------------------------------------------------------ self-test
+_SUFFIX_CASES = [
+    ("-CSharp", "-CSharp"), ("-Csharp", "-Csharp"), ("-csharp", "-csharp"),
+    ("-Python", "-Python"), ("-python", "-python"),
+    # Hors canon de noyau : `-Lean` marque le contenu (mesure), `_en` est un
+    # sibling i18n (#4980). Les deux doivent ressortir None -- c'est la
+    # contre-epreuve des deux exclusions mesurees.
+    ("-Lean", None), ("-FSharp", None), ("_en", None), ("-Native", None),
+    ("", None),
+]
+_FAMILY_CASES = [
+    (".net-csharp", "csharp"), ("python3", "python"),
+    ("python3-wsl", "python"), ("python3-coursia2", "python"),
+    ("coursia-ml-training", "python"), ("conda-torch", "python"),
+    ("pyphi", "python"), ("global-3.13", "python"),
+    ("lean4-wsl", "lean"), ("lean4", "lean"), ("lean4-wsl-perc", "lean"),
+    ("", None), (None, None), ("smartcontracts", None),
+]
+
+
+def self_test() -> int:
+    ko = 0
+    print("--- suffixe brut de noyau (casse preservee) ---")
+    for suffix, want in _SUFFIX_CASES:
+        stem = "04-Item" + suffix
+        got = raw_kernel_suffix(stem)
+        ok = got == want
+        ko += 0 if ok else 1
+        print("  %-4s %-22s -> %-9s (attendu %s)"
+              % ("OK" if ok else "KO", stem, got, want))
+    print("--- famille de noyau ---")
+    for ks, want in _FAMILY_CASES:
+        got = kernel_family(ks)
+        ok = got == want
+        ko += 0 if ok else 1
+        print("  %-4s %-24s -> %-9s (attendu %s)"
+              % ("OK" if ok else "KO", ks, got, want))
+    total = len(_SUFFIX_CASES) + len(_FAMILY_CASES)
+    print("")
+    print("%s : %d cas, %d echec(s)" % ("ECHEC" if ko else "SUCCES", total, ko))
+    return 1 if ko else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Refuser un notebook ajoute dont le suffixe de noyau porte "
+                    "une casse non canonique (serie adoptee) ou contredit le "
+                    "noyau reel (#15489 defaut 3).")
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--head", default="HEAD")
+    ap.add_argument("--config", default=str(CONFIG_PATH),
+                    help="configuration d'adoption (defaut : celle livree)")
+    ap.add_argument("--scan-all", action="store_true",
+                    help="census de tout l'arbre au lieu du delta (mesure de "
+                         "baseline ; sort en 1 si l'arbre porte des ecarts, y "
+                         "compris herites)")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.self_test:
+        return self_test()
+
+    config = load_config(Path(a.config))
+
+    if a.scan_all:
+        paths = notebooks_in_tree(repo_root())
+        source = "arbre complet"
+    else:
+        try:
+            paths = added_notebooks(a.base, a.head)
+        except RuntimeError as e:
+            print("ERREUR git : %s" % e, file=sys.stderr)
+            return 2
+        source = "%s...%s" % (a.base, a.head)
+
+    results = examine(paths, config)
+    violations = [r for r in results if r["verdict"] == "violation"]
+    by_state: dict[str, int] = {}
+    for r in results:
+        by_state[r["state"]] = by_state.get(r["state"], 0) + 1
+
+    if a.json:
+        print(json.dumps({
+            "source": source,
+            "examined": len(results),
+            "violations": violations,
+            "states": by_state,
+            "adopted": config.get("adopted", []),
+        }, indent=2, ensure_ascii=False))
+        return 1 if violations else 0
+
+    print("notebooks examines : %d   (source %s)" % (len(results), source))
+    if not results:
+        print("VERDICT: OK -- aucun notebook ajoute, rien a verifier.")
+        return 0
+    print("etats : " + ", ".join("%s=%d" % kv for kv in sorted(by_state.items())))
+    for r in results:
+        # `no_kernel_suffix` est l'etat par defaut du corpus (86 %) : le lister
+        # noierait les etats qui, eux, demandent un regard. Il reste denombre
+        # ci-dessus, donc "rien a juger" ne se confond pas avec "rien regarde".
+        if r["verdict"] != "ok" and r["state"] != "no_kernel_suffix":
+            print("   [%s] %s%s" % (r["state"], r["file"], _detail(r)))
+    if by_state.get("no_kernel_suffix"):
+        print("   (no_kernel_suffix : %d fichier(s) sans suffixe de noyau -- "
+              "aucun moteur annonce, rien a juger, non listes)"
+              % by_state["no_kernel_suffix"])
+    if not violations:
+        print("VERDICT: OK -- aucun defaut de suffixe sur les notebooks ajoutes.")
+        return 0
+    print("")
+    print("VERDICT: SUFFIXE DE NOYAU NON CONFORME (%d)" % len(violations))
+    print("")
+    print("Un suffixe de noyau dit quel moteur execute le notebook ; le nom du "
+          "fichier et son metadata ne doivent pas se contredire.")
+    print("- `case_deviation` : le nom porte la bonne langue, la mauvaise casse "
+          "-> un rename suffit.")
+    print("- `kernel_mismatch` : le suffixe et le kernelspec divergent -> "
+          "verifier quel noyau a REELLEMENT produit les sorties (regle C.2)")
+    print("  avant de renommer : corriger le nom sans re-executer fabrique une "
+          "preuve d'execution qui ne correspond plus au fichier.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/kernel_suffix_canon.json
+++ b/scripts/notebook_tools/kernel_suffix_canon.json
@@ -1,0 +1,19 @@
+{
+  "_role": "Configuration d'adoption du garde check_kernel_suffix_canon.py (#15489 defaut 3). L'adoption est EXPLICITE et par serie : le garde est en portee delta (il ne juge que les notebooks ajoutes), donc declarer une serie adoptee n'invalide aucun de ses fichiers herites — cela dit seulement qu'a partir d'ici, un nouveau fichier de cette serie porte la casse canonique.",
+  "_canon": "Casse canonique pour les suffixes de noyau : -CSharp (famille csharp) et -Python (famille python). Nommee par #15489 lui-meme. -Lean n'est PAS un suffixe de noyau dans ce depot (il marque le contenu ; le pendant Lean porte -Native) et aucune famille fsharp n'existe — cf la docstring du garde.",
+  "_how_to_extend": "Ajouter une entree dans 'adopted' avec un 'path_glob' (suffixe '/**' = dossier et descendance) et une 'note' citant la MESURE qui justifie l'adoption. Ne jamais elargir un glob sans re-mesurer : une serie qui n'a pas tranche ne doit pas rougir.",
+  "_no_wide_glob_please": "Ne PAS remplacer les globs ci-dessous par 'MyIA.AI.Notebooks/**'. Contre-exemple mesure : GenAI/CaseStudies/Fort-Boyard et GenAI/SemanticKernel portent 'fort-boyard-python.ipynb' / 'fort-boyard-csharp.ipynb', c'est-a-dire des suffixes de langue EN MINUSCULES, comme convention de nommage assumee de ces notebooks. L'adoption repo-wide les rougirait a tort. Les 114 '-Csharp' herites (GameTheory, Sudoku, Tweety, Search/Part1-2, SymbolicLearning, SMT/Z3-API, Planners) sont eux aussi hors perimetre : aucune de ces series n'a tranche.",
+  "adopted": [
+    {
+      "path_glob": "MyIA.AI.Notebooks/Search/Applications/**",
+      "note": "Serie convergée sur -CSharp : mesure de l'arbre 15 '-CSharp' contre 5 '-Csharp' parmi ses notebooks suffixes d'une langue. 13 des 15 canoniques portent une accretion b/c, c'est-a-dire sont les side-tracks les plus recemment ajoutes (App-1b, -2b, -3b, -4b, -7b, -9b, -10b, -11b, -13b, -15b, -18b, -20b, -14c) alors que les 5 herites (App-6, App-8, App-16, App-19, App-17b) sont majoritairement des notebooks primaires. La convention a donc ete adoptee par les ajouts, ce qui est exactement la portee du garde.",
+      "measured": "2026-09-11, arbre origin/main d14b1ac098"
+    },
+    {
+      "path_glob": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/**",
+      "note": "Serie convergee sur -CSharp : 1 '-CSharp' (SW-13-Reasoners-CSharp.ipynb) contre 0 '-Csharp'. Echantillon mince (n=1) — assume : la seule forme presente est la canonique, il n'y a donc aucune divergence a preserver.",
+      "measured": "2026-09-11, arbre origin/main d14b1ac098"
+    }
+  ],
+  "exceptions": []
+}

--- a/scripts/notebook_tools/naming_canon.py
+++ b/scripts/notebook_tools/naming_canon.py
@@ -24,7 +24,10 @@ Il ne certifie **pas** : la casse canonique des suffixes de langue (`Python` /
 `CSharp` / `Lean`), la reservation d'un slot contre les PR ouvertes, ni la
 configuration par serie du zero-pad. Ce sont les points 3 a 5 de #15489, laisses
 hors de cette tranche — les revendiquer ici sans les implementer ferait passer un
-module partiel pour le canon entier.
+module partiel pour le canon entier. Le point 3 est depuis livre par
+`check_kernel_suffix_canon.py`, qui lit `KERNEL_LANG_SUFFIXES` ci-dessous : le
+canon fournit la LISTE des suffixes de noyau, le garde juge leur casse. Un
+module ne peut pas juger la casse d'un nom qu'il vient de normaliser.
 
 REGLE DE NON-REGRESSION — extraction a comportement constant
 ------------------------------------------------------------
@@ -38,10 +41,30 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+# Suffixes de NOYAU : ceux dont la mesure de l'arbre montre qu'ils NOMMENT le
+# moteur qui execute le notebook. Sous-ensemble extrait de LANG_SUFFIXES pour que
+# le garde de casse (#15489 defaut 3) ne juge que ceux-la -- `_en`/`_fr` sont des
+# siblings i18n (#4980) et `-Lean` un marqueur de contenu ; leur imposer une
+# "casse canonique de noyau" n'a pas de sens.
+#
+#   130 x -Csharp/-CSharp -> 130 x `.net-csharp`
+#    44 x -Python         ->  41 x `python3`, 2 x `coursia-ml-training`,
+#                              1 x `.net-csharp` (le defaut, cf le garde)
+#
+# `-Lean` est volontairement ABSENT : dans ce depot il marque le contenu, pas le
+# moteur. Le pendant reellement Lean porte `-Native`
+# (`Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb` -> `lean4-wsl`) et 2 des 4
+# `-Lean` tournent sous `python3`. Le declarer comme noyau ferait crier le garde
+# a tort sur ~50 notebooks de `SymbolicAI/Lean`. `-FSharp` est absent aussi :
+# aucun kernelspec F# n'existe dans l'arbre et `.net-csharp` est partage par les
+# langages .NET. Exclusions mesurees, pas oublis.
+KERNEL_LANG_SUFFIXES = ("-csharp", "-python")
+
 # Suffixes marquant un rendu ALTERNATIF du meme item, pas un item concurrent.
-# -Csharp / -Python : paires de langage (GameTheory/SocialChoice).
-# _en / _fr / -en / -fr : siblings i18n (#4980).
-LANG_SUFFIXES = ("-csharp", "-python", "_en", "-en", "_fr", "-fr")
+# = les noyaux ci-dessus + le rendu Lean (sibling de contenu) + les siblings
+# i18n (#4980). Ceux-la servent a APPARIER deux rendus (`strip_lang`), jamais a
+# juger un moteur.
+LANG_SUFFIXES = KERNEL_LANG_SUFFIXES + ("-lean", "_en", "-en", "_fr", "-fr")
 
 # Index en tete de nom : un ou plusieurs nombres separes par . ou -, suivis d'un
 # separateur puis du titre. On capture TOUS les niveaux : "04-1" et non "04".

--- a/scripts/tests/test_check_kernel_suffix_canon.py
+++ b/scripts/tests/test_check_kernel_suffix_canon.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Tests du garde de casse canonique des suffixes de noyau (#15489, defaut 3).
+
+Deux pieges sont tendus a ce garde, et chaque test en couvre un :
+
+1. **Crier a tort.** La mesure de l'arbre donne 114 `-Csharp` contre 16 `-CSharp` :
+   si le garde rougissait sur tout `-Csharp` il condamnerait la majorite du
+   corpus et serait desactive dans la semaine. Les negatifs -- casse heritee hors
+   serie adoptee, convention minuscule assumee (`-python` + noyau python),
+   suffixe absent, `-Lean` -- sont donc aussi importants que les positifs.
+
+2. **Se taire a tort.** Un garde qui ne denombre pas ce qu'il a regarde rend le
+   meme verdict sur "tout est conforme" et sur "je n'ai rien lu". Chaque test
+   assert donc un ETAT nomme dans la sortie, pas seulement un code retour.
+
+Les scenarios tournent contre un **vrai depot git temporaire** : le defaut
+d'origine (#5081) etait un angle mort de la vue `git diff` -- un `git mv` vers
+une casse non canonique sort en `R100`, invisible sous `--diff-filter=A`. Le
+dernier test exige donc d'abord que Git classe bien le commit en rename, faute de
+quoi il ne reproduirait plus la condition du defaut et passerait au vert a vide.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = (Path(__file__).resolve().parent.parent / "notebook_tools"
+           / "check_kernel_suffix_canon.py")
+
+ADOPTED = "MyIA.AI.Notebooks/Search/Applications"
+
+
+def _git(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git"] + list(args), cwd=str(repo), capture_output=True,
+                       text=True, encoding="utf-8", errors="replace")
+    if r.returncode != 0:
+        raise AssertionError("git %s -> %s"
+                             % (" ".join(args), r.stderr.strip()[:200]))
+    return r.stdout
+
+
+def _notebook(kernelspec: str | None = "python3", with_kernelspec: bool = True) -> str:
+    """Notebook minimal valide, kernelspec absent ou nomme."""
+    meta: dict = {}
+    if with_kernelspec:
+        meta["kernelspec"] = {"name": kernelspec, "display_name": kernelspec or "",
+                              "language": "python"}
+    return json.dumps({"cells": [], "metadata": meta,
+                       "nbformat": 4, "nbformat_minor": 5}, indent=1) + "\n"
+
+
+def _write(repo: Path, rel: str, body: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def _write_config(repo: Path, adopted_globs: list[str],
+                  exceptions: list[dict] | None = None) -> Path:
+    cfg = repo / "kernel_suffix_canon.test.json"
+    cfg.write_text(json.dumps({
+        "adopted": [{"path_glob": g, "note": "test"} for g in adopted_globs],
+        "exceptions": exceptions or [],
+    }, indent=1), encoding="utf-8")
+    return cfg
+
+
+def _init_repo(repo: Path) -> str:
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "config", "diff.renames", "true")
+    _write(repo, ADOPTED + "/CSP/App-5-Timetabling-CSharp.ipynb",
+           _notebook(".net-csharp"))
+    _write(repo, "MyIA.AI.Notebooks/GameTheory/GameTheory-04-Nash.ipynb",
+           _notebook(".net-csharp"))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def _run_guard(repo: Path, cfg: Path, base: str | None = None) -> subprocess.CompletedProcess:
+    args = [sys.executable, str(_SCRIPT), "--config", str(cfg)]
+    if base is None:
+        args += ["--scan-all"]
+    else:
+        args += ["--base", base, "--head", "HEAD"]
+    return subprocess.run(args, cwd=str(repo), capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+
+
+class TestCaseCanonInAdoptedSeries(unittest.TestCase):
+    """Acceptance #15489 defaut 3 : la casse canonique est imposee la ou la serie
+    a adopte, et seulement la."""
+
+    def test_positive_new_lowercase_csharp_in_adopted_series_reddens(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            _write(repo, ADOPTED + "/CSP/App-21-Foo-Csharp.ipynb",
+                   _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "new notebook, casse hors canon")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 1,
+                             "un nouveau -Csharp dans une serie adoptee doit rougir\n"
+                             + r.stdout + r.stderr)
+            self.assertIn("case_deviation", r.stdout)
+            self.assertIn("App-21-Foo-Csharp.ipynb", r.stdout)
+            self.assertIn("attendue CSharp", r.stdout)
+
+    def test_negative_canonical_case_in_adopted_series_stays_green(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            _write(repo, ADOPTED + "/CSP/App-22-Bar-CSharp.ipynb",
+                   _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "new notebook, casse canonique")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("canonical=1", r.stdout)
+
+    def test_negative_legacy_case_outside_adopted_series_stays_green(self):
+        """Le corpus herite ne doit pas etre condamne : c'est la raison d'etre du
+        perimetre delta, et la lecon du garde de zero-pad (#12586)."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            _write(repo, "MyIA.AI.Notebooks/GameTheory/GameTheory-28-Foo-Csharp.ipynb",
+                   _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "nouveau -Csharp dans une serie non adoptee")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("case_deviation_unadopted=1", r.stdout)
+
+    def test_negative_assumed_lowercase_python_series_stays_green(self):
+        """Forme Fort-Boyard : `-python` minuscule comme convention assumee d'une
+        serie entiere (paire `fort-boyard-python` / `fort-boyard-csharp`)."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            _write(repo, "MyIA.AI.Notebooks/GenAI/Fort-Boyard/fort-boyard-python.ipynb",
+                   _notebook("python3"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "convention minuscule assumee")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("case_deviation_unadopted=1", r.stdout)
+
+
+class TestKernelCoherence(unittest.TestCase):
+    """Le suffixe dit quel moteur execute le notebook. S'il ment, c'est un defaut
+    factuel -- independant de toute adoption de casse."""
+
+    def test_positive_python_suffix_on_csharp_kernel_reddens(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            # Hors serie adoptee : la violation vient de la coherence, pas de la
+            # casse. Le controle n'a de valeur que si le perimetre est neutre ici.
+            _write(repo, "MyIA.AI.Notebooks/GenAI/Workbook-Template-Python.ipynb",
+                   _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "suffixe en desaccord avec le noyau")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+            self.assertIn("kernel_mismatch", r.stdout)
+            self.assertIn(".net-csharp", r.stdout)
+
+    def test_negative_csharp_suffix_on_csharp_kernel_stays_green(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [])
+            _write(repo, "MyIA.AI.Notebooks/GenAI/Notebook-CSharp.ipynb",
+                   _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "coherent")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("canonical=1", r.stdout)
+
+    def test_lean_suffix_is_not_treated_as_a_kernel_suffix(self):
+        """Contre-epreuve d'une exclusion MESUREE : `-Lean` marque le contenu, pas
+        le moteur (le pendant Lean porte `-Native` ; 2 des 4 `-Lean` tournent sous
+        `python3`). Si quelqu'un remet `-lean` dans KERNEL_LANG_SUFFIXES, ce test
+        rougit et le renvoie a la mesure."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [])
+            _write(repo, "MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Foo-Lean.ipynb",
+                   _notebook("python3"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "suffixe de contenu, pas de noyau")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("no_kernel_suffix=1", r.stdout)
+            self.assertNotIn("kernel_mismatch", r.stdout)
+
+
+class TestDistinctStates(unittest.TestCase):
+    """'rien trouve' et 'rien regarde' ne doivent jamais partager la meme sortie."""
+
+    def test_no_suffix_is_reported_not_silent(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [])
+            _write(repo, "MyIA.AI.Notebooks/GameTheory/GameTheory-29-Plain.ipynb",
+                   _notebook("python3"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "rendu unique, sans suffixe de noyau")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("no_kernel_suffix=1", r.stdout)
+            self.assertIn("notebooks examines : 1", r.stdout)
+
+    def test_missing_kernelspec_is_a_distinct_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [])
+            _write(repo, "MyIA.AI.Notebooks/GameTheory/GameTheory-30-NoKs-CSharp.ipynb",
+                   _notebook(with_kernelspec=False))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "metadata sans kernelspec")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0,
+                             "un kernelspec absent est INVERIFIABLE, pas fautif\n"
+                             + r.stdout + r.stderr)
+            self.assertIn("kernelspec_missing=1", r.stdout)
+
+    def test_exception_suppresses_a_violation(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            rel = ADOPTED + "/CSP/App-23-Excused-Csharp.ipynb"
+            cfg = _write_config(repo, [ADOPTED + "/**"],
+                                [{"path": rel, "reason": "derive documentee"}])
+            _write(repo, rel, _notebook(".net-csharp"))
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "derive declaree")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("exception=1", r.stdout)
+
+    def test_denominator_is_printed_when_nothing_was_added(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("notebooks examines : 0", r.stdout)
+
+    def test_scan_all_reports_the_whole_tree(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            r = _run_guard(repo, cfg, None)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("notebooks examines : 2", r.stdout)
+
+
+class TestRenameAwareness(unittest.TestCase):
+    """Le defaut d'origine est un angle mort de la vue `git diff` : un rename sort
+    en `R100` et `--diff-filter=A` l'ecarte. Le garde lit en `--no-renames`."""
+
+    def test_rename_to_noncanonical_case_in_adopted_series_reddens(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            base = _init_repo(repo)
+            cfg = _write_config(repo, [ADOPTED + "/**"])
+            _git(repo, "mv",
+                 ADOPTED + "/CSP/App-5-Timetabling-CSharp.ipynb",
+                 ADOPTED + "/CSP/App-5-Timetabling-Csharp.ipynb")
+            _git(repo, "commit", "-qm", "rename vers une casse hors canon")
+
+            # Sans rename classe par Git, le test ne reproduirait plus le defaut
+            # et passerait au vert sur un garde aveugle.
+            status = _git(repo, "diff", "--name-status", base, "HEAD")
+            self.assertIn("R", status,
+                          "Git ne classe pas ce commit en rename : le controle "
+                          "positif ne reproduit plus la condition du defaut.")
+
+            r = _run_guard(repo, cfg, base)
+            self.assertEqual(r.returncode, 1,
+                             "un rename vers une casse non canonique dans une "
+                             "serie adoptee doit rougir\n" + r.stdout + r.stderr)
+            self.assertIn("case_deviation", r.stdout)
+            self.assertIn("App-5-Timetabling-Csharp.ipynb", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15503

## Résumé

Défaut 3 de **#15489** (EPIC #5081, sécuriser les renames) : *« aucun garde dédié n'impose la casse canonique `Python` / `CSharp` / `Lean` après adoption d'une série »*. La tranche précédente (#15503) a livré le parseur partagé `naming_canon.py` en déclarant explicitement ce point **hors de sa portée** — un module qui normalise la casse en minuscules ne peut pas la juger. C'est ce trou que cette PR ferme. **Aucun notebook renommé, aucun rename de contenu** : c'est une tranche de garde, de config et de tests.

## Ce que le garde mesure

Sur les seuls notebooks **ajoutés** par la révision (`--no-renames --diff-filter=A`) :

1. **Casse du suffixe** — un nouvel `-Csharp` / `-python` hors canon.
2. **Cohérence suffixe ↔ noyau réel** — le suffixe dit quel moteur exécute le notebook, et il peut mentir. Mesure de l'arbre : `GenAI/SemanticKernel/Workbook-Template-Python.ipynb` porte `-Python` et un `kernelspec` `.net-csharp`. Deux lecteurs du même nom se contredisent, et rien ne le signalait.

Huit états distincts, jamais confondus : `canonical`, `case_deviation`, `case_deviation_unadopted`, `kernel_mismatch`, `no_kernel_suffix`, `kernelspec_missing`, `unknown_kernel`, `exception`. Le dénominateur est **toujours** imprimé — « rien trouvé » et « rien regardé » ne partagent pas la même sortie.

## La mesure a tranché deux exclusions

`KERNEL_LANG_SUFFIXES` ne contient que `-csharp` et `-python`, parce que ce sont les deux seuls suffixes dont la mesure montre qu'ils **nomment le moteur** :

| Suffixe | Fichiers | Kernelspec mesuré |
|---|---|---|
| `-Csharp` / `-CSharp` | 130 | 130 × `.net-csharp` |
| `-Python` | 44 | 41 × `python3`, 2 × `coursia-ml-training`, **1 × `.net-csharp`** (le défaut ci-dessus) |
| `-Lean` | 4 | 2 × `python3`, 1 × `lean4-wsl`, 1 × `lean4-wsl-perc` |

- **`-Lean` exclu** : dans ce dépôt il marque le **contenu**, pas le moteur. Le pendant réellement Lean porte `-Native` (`Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb` → `lean4-wsl`), et 2 des 4 `-Lean` tournent sous `python3`. Le déclarer comme famille de noyau ferait crier le garde à tort sur ~50 notebooks de `SymbolicAI/Lean` — et un garde qui crie à tort est un garde qu'on désactive.
- **`-FSharp` exclu** : aucun kernelspec F# n'existe dans l'arbre (17 noyaux distincts, aucun `fsharp`) et `.net-csharp` est partagé par les langages .NET, donc une famille F# déduite du suffixe produirait un faux positif au premier notebook F#.

Ces deux exclusions sont des décisions mesurées, et le self-test les épingle comme **contre-épreuves** : si quelqu'un remet `-lean` dans la liste noyau, le test rougit et le renvoie à la mesure.

## Pourquoi l'adoption est une config explicite

La mesure de l'arbre donne **114 `-Csharp` contre 16 `-CSharp`**. Un garde qui imposerait la casse canonique à tout le corpus condamnerait la majorité de ses propres notebooks et serait désactivé dans la semaine ; un garde qui ne l'impose nulle part ne ferme rien. D'où `kernel_suffix_canon.json` : une **liste d'adoption par série**, groundée sur la mesure, et un garde en **portée delta** — les notebooks hérités en `-Csharp` ne rougissent jamais, puisqu'ils ne sont pas des ajouts. C'est exactement la leçon du garde de zero-pad (#12586) : une règle imposée à une série qui n'a pas tranché fabrique du rouge sans défaut.

Deux séries ont tranché, et sont déclarées :

- `Search/Applications/**` — **15 `-CSharp` contre 5 `-Csharp`** parmi ses notebooks suffixés d'une langue. 13 des 15 canoniques portent une accrétion `b`/`c`, c'est-à-dire sont les side-tracks les plus récemment ajoutés, alors que les 5 hérités sont majoritairement des notebooks primaires : la convention a été adoptée **par les ajouts**, ce qui est précisément la portée du garde.
- `SymbolicAI/SemanticWeb/**` — 1 `-CSharp` contre 0 `-Csharp` (échantillon mince, assumé : la seule forme présente est la canonique, il n'y a aucune divergence à préserver).

Le config documente aussi le **contre-exemple qui interdit une adoption repo-wide** : `GenAI/CaseStudies/Fort-Boyard` et `GenAI/SemanticKernel` portent `fort-boyard-python.ipynb` / `fort-boyard-csharp.ipynb`, soit des suffixes **en minuscules comme convention de nommage assumée**. Un glob `MyIA.AI.Notebooks/**` les rougirait à tort.

## Preuves

| Preuve | Résultat |
|---|---|
| Self-test du garde | `SUCCES : 24 cas, 0 echec(s)` |
| Tests du garde (dépôt git temporaire) | **13 passed** — dont le rename que `--diff-filter=A` seul ne voit pas |
| Baseline « collision d'index » (gardes existants) | `SUCCES : 23 cas` — **inchangé** |
| Baseline « zero-pad + collision » | **15 passed** — **inchangé** |
| Census arbre complet | 1254 examinés → `canonical=59, case_deviation=5, case_deviation_unadopted=112, kernel_mismatch=1, no_kernel_suffix=1077` |
| Voie rapide | `fast-lane.py --dry-run --only kernel-suffix-canon-guard` → `exit 0` |

Le rename est testé en **vrai dépôt git** parce que c'est le défaut d'origine classique (#5081) : un `git mv` vers une casse hors canon sort en `R100`. Le test commence par vérifier que Git classe bien le commit en rename — sans cette assertion il passerait au vert sur un garde aveugle et ne contrôlerait rien.

La régression a été vérifiée avant/après : `LANG_SUFFIXES` gagne `-lean`, ce qui change `strip_lang` / `lang_of`, donc les deux gardes existants ont été rejoués et leurs baselines sont **identiques**. Preuve par mesure, pas par raisonnement : les notebooks `-Lean` de l'arbre n'ont pas d'index de position (`index_key = None`) et n'ont pas de voisin de même index, donc aucun verdict de collision ne change.

## Périmètre

Exactement les fichiers ci-dessous, rien d'autre : aucun notebook touché, aucun workflow CI, le catalogue byte-identique à `main`.

| Fichier | Δ |
|---|---|
| `scripts/notebook_tools/check_kernel_suffix_canon.py` | nouveau (garde) |
| `scripts/notebook_tools/kernel_suffix_canon.json` | nouveau (config d'adoption) |
| `scripts/tests/test_check_kernel_suffix_canon.py` | nouveau (13 tests) |
| `scripts/notebook_tools/naming_canon.py` | `KERNEL_LANG_SUFFIXES` extrait, `LANG_SUFFIXES` + `-lean` |
| `scripts/ci/fast_lane_registry.py` | enregistrement du garde |

## Détail technique

- `scripts/notebook_tools/check_kernel_suffix_canon.py` — garde (`--base` / `--head` / `--config` / `--scan-all` / `--json` / `--self-test`, exit 0/1/2). Sa racine de dépôt est résolue par `git rev-parse --show-toplevel` et non par `__file__` : un garde qui lit le contenu des notebooks doit lire l'arbre qu'il juge (faux depuis un worktree, impossible à tester sur un dépôt temporaire).
- `scripts/notebook_tools/kernel_suffix_canon.json` — adoption + exceptions (par chemin ou par motif), avec les mesures citées.
- `scripts/notebook_tools/naming_canon.py` — `KERNEL_LANG_SUFFIXES` (sous-ensemble noyau) extrait et `LANG_SUFFIXES` étendu de `-lean`.
- `scripts/tests/test_check_kernel_suffix_canon.py` — 13 tests.
- `scripts/ci/fast_lane_registry.py` — enregistrement bloquant, delta base-vs-head ; le config figure dans `paths` (seul garde de la voie rapide dont le verdict dépend d'un fichier de données : une révision qui déclare une série adoptée doit rejouer le garde dont elle change la portée).

## Résiduel

Défauts **4** (réservation d'un slot contre les PR ouvertes) et **5** (configuration padding par série) de #15489 restent ouverts — cette PR ne les revendique pas.

See #15489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
