### PR TITLE
fix(tooling,#14983): check_output_flood -- definition morte de _nb dans self_test + coquille

### DIFF
--- a/scripts/notebook_tools/check_output_flood.py
+++ b/scripts/notebook_tools/check_output_flood.py
@@ -174,12 +174,6 @@ def self_test(cwd=None):
     """
     failures = []
 
-    def _nb(cells):
-        return {"cells": [{"cell_type": "code", "id": kid,
-                           "outputs": [{"output_type": "stream", "text": "."}
-                                       for _ in range(n)]}
-                          for kid, n in cells]}
-
     def _nb(code_cells, added=False):
         """Build a synthetic notebook from [(id, outputs)]; None base = added."""
         return None if added else {

--- a/scripts/notebook_tools/tests/test_check_output_flood.py
+++ b/scripts/notebook_tools/tests/test_check_output_flood.py
@@ -68,7 +68,7 @@ def test_index_shift_not_misattributed():
     got = analyze(base([("a", 3000)]), nb([("zz", 10), ("a", 3000)]))
     assert got["cells"] == []
     # TOTAL keeps the pure-ratchet semantics: the notebook went 3000 -> 3010,
-    # both abovs TOTAL_CAP, so the total axis fires (same as the sibling's
+    # both above TOTAL_CAP, so the total axis fires (same as the sibling's
     # 0 -> N = regression). This is NOT an index-shift artifact.
     assert got["regressed"] is True
     assert got["total"] == {"base": 3000, "head": 3010, "delta": 10}


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2026:CoursIA — prev: MED/docs #15577

## Objet

Les deux nits tracés par #14983 (relevés par Hermes sur la review de #14959, mesurés par le coordinateur avant merge). Vérifiés **toujours présents** sur `origin/main` `d14b1ac09` avant d'écrire — l'issue avait 0 commentaire, donc jamais claimée.

**1. Définition morte** — `scripts/notebook_tools/check_output_flood.py`, `self_test()` : la première `_nb(cells)` était écrasée par celle déclarée juste après. Les sept témoins s'exécutaient donc déjà sur la version survivante (`[{}] * n`), pas sur les sorties `stream` typées que la définition morte laissait croire.

Ce que ce **n'est pas** : un contrôle positif éteint. La version survivante produit des sorties comptées — le témoin `3 -> 3018` lèverait sinon. Le contrat était bien exercé. Ce qui était cassé, c'est la **lisibilité** du self-test : un lecteur qui veut savoir sur quoi vit le contrat lisait la mauvaise définition — exactement la confusion qu'un `self_test` existe pour ne pas produire.

**2. Coquille** — `tests/test_check_output_flood.py` : `abovs` → `above` (commentaire de `test_index_shift_not_misattributed`). L'issue citait `scripts/tests/…` ; le fichier vit en réalité sous `scripts/notebook_tools/tests/…` depuis le déplacement — chemin corrigé ici.

## Preuve — contrôle positif avant/après

C'est la suppression de la définition qui doit être validée, pas le témoin :

```
AVANT  : python scripts/notebook_tools/check_output_flood.py --self-test
         replay 954d1cd7fef5: 1 notebooks, CELL flood 1, TOTAL delta +372
         SELF-TEST OK: witnesses matched, benign growth silent, replay fires

APRÈS  : python scripts/notebook_tools/check_output_flood.py --self-test
         replay 954d1cd7fef5: 1 notebooks, CELL flood 1, TOTAL delta +372
         SELF-TEST OK: witnesses matched, benign growth silent, replay fires
```

Sortie **identique** avant/après ⇒ la définition supprimée était bien morte. `grep -c "def _nb"` = 1 après le diff.

```
python -m pytest scripts/notebook_tools/tests/test_check_output_flood.py -q
10 passed
```

## Diff

```
scripts/notebook_tools/check_output_flood.py            | 6 ------
scripts/notebook_tools/tests/test_check_output_flood.py | 2 +-
2 files changed, 1 insertion(+), 7 deletions(-)
```

Aucune modification de comportement : le contrat du ratchet, ses seuils et ses témoins sont inchangés ; seul du code mort et un commentaire disparaissent.

Closes #14983

🤖 Generated with [Claude Code](https://claude.com/claude-code)