### PR TITLE
fix(ci,#15621): pr-gate-missing -- collecteur et consommateur partagent une seule forme (+ 3 labels jamais crees)

### DIFF
--- a/scripts/pr_gate_missing.py
+++ b/scripts/pr_gate_missing.py
@@ -56,10 +56,15 @@ LABEL_DEFAULT = "pr-gate-missing"
 LABEL_BOT_DEFAULT = "pr-gate-missing-bot"
 LABEL_COLOR = "b60205"  # red -- "invisible required-context blocker, needs a push"
 LABEL_BOT_COLOR = "d93f0b"  # orange -- "structural bot case (GITHUB_TOKEN anti-recursion)"
-LABEL_DESC = ("PR gate absent du rollup: contexte requis jamais rapporte -- "
-              "PR verrouillee malgre des checks verts (#10928)")
-LABEL_BOT_DESC = ("PR du bot sans PR gate: structural (push GITHUB_TOKEN ne cree "
-                  "pas de workflow run) -- merge admin ou push humain (#10928)")
+# GitHub rejette toute description de label de plus de 100 caracteres, et
+# `ensure_label` avalait ce refus (mesure #15621 : 108 c ici, 121 c et 145 c
+# plus bas -- les trois labels etaient absents du depot tandis que le sweep
+# lisait `mode=apply`). La limite est epinglee par
+# `test_label_descriptions_within_github_limit` : elles derivent facilement.
+LABEL_DESC = ("PR gate absent du rollup: contexte requis jamais rapporte, "
+              "PR bloquee, checks verts (#10928)")
+LABEL_BOT_DESC = ("PR du bot sans PR gate: un push GITHUB_TOKEN ne cree pas "
+                  "de workflow run -- merge admin (#10928)")
 
 # Issue #14477 (cause 5, mesuree 2026-09-03 sur #14220) : une PR en conflit
 # avec main ne recoit AUCUN run `pull_request` -- GitHub ne calcule pas de
@@ -68,9 +73,8 @@ LABEL_BOT_DESC = ("PR du bot sans PR gate: structural (push GITHUB_TOKEN ne cree
 # aucun run). Label distinct : le remede n'est pas un push, c'est un conflit.
 LABEL_CONFLICT_DEFAULT = "pr-gate-conflict"
 LABEL_CONFLICT_COLOR = "fdd0a2"  # saumon -- "PR dirty, remede = resoudre le conflit"
-LABEL_CONFLICT_DESC = ("PR gate absent car la PR est en conflit avec main "
-                       "(mergeable_state=dirty) -- aucun run pull_request tant "
-                       "que le conflit n'est pas resolu (#14477)")
+LABEL_CONFLICT_DESC = ("PR gate absent: PR en conflit avec main, aucun run "
+                       "pull_request tant que le conflit dure (#14477)")
 
 # The exact check-run name posted by pr_gate.py --self-name "PR gate" and
 # required by main's branch protection. Renaming here silently detaches the
@@ -346,7 +350,8 @@ def list_open_prs(repo: str) -> list[dict]:
     pulls = _gh_rows([
         "api", f"repos/{repo}/pulls?state=open&per_page=100", "--paginate",
         "--jq", '.[] | {number, draft: .draft, base: .base.ref, '
-                'author: .user.login, sha: .head.sha}',
+                'author: .user.login, labels: [.labels[] | {name}], '
+                'sha: .head.sha}',
     ])
     out: list[dict] = []
     for p in pulls:
@@ -357,14 +362,36 @@ def list_open_prs(repo: str) -> list[dict]:
                 "--jq", "[.check_runs[].name]",
             ]) or []
             rollup = [{"name": n} for n in names]
-        out.append({
-            "number": p["number"],
-            "base_ref_name": p.get("base"),
-            "is_draft": bool(p.get("draft")),
-            "author_login": p.get("author") or "",
-            "statusCheckRollup": rollup,
-        })
+        out.append(classify_input(p["number"], p.get("base"), p.get("draft"),
+                                  p.get("author"), rollup, p.get("labels")))
     return out
+
+
+def classify_input(number: int, base: str | None, draft: object,
+                   author: str | None, rollup: list[dict],
+                   labels: list | None = None) -> dict:
+    """La SEULE forme d'entree de ``classify()`` -- produite ici, pas ailleurs.
+
+    Le collecteur et le consommateur ont diverge (#15621) : ``list_open_prs``
+    s'est mis a emettre des cles plates a la migration REST (#14488) pendant que
+    ``main`` continuait de relire des cles GraphQL (``baseRefName``,
+    ``isDraft``, ``author``). Chaque ``.get()`` rendait son defaut, donc
+    ``excluded_base``, ``draft`` et ``bot_missing`` etaient inatteignables --
+    mesure en production : ``excluded_base: 0``, ``draft: 0`` sur 60 PRs
+    ouvertes, dont 5 stackees et 2 drafts, classees ``missing`` a la place.
+
+    Une seule fabrique, utilisee par le collecteur ET epinglee par les tests :
+    un re-mappage ulterieur dans ``main`` fait rougir la suite au lieu de
+    desactiver silencieusement trois verdicts.
+    """
+    return {
+        "number": number,
+        "base_ref_name": base,
+        "is_draft": bool(draft),
+        "author_login": author or "",
+        "statusCheckRollup": rollup or [],
+        "labels": labels or [],
+    }
 
 
 def enrich_candidate(repo: str, number: int) -> dict:
@@ -413,14 +440,35 @@ def enrich_candidate(repo: str, number: int) -> dict:
     }
 
 
+def _gh_write(args: list[str], what: str) -> bool:
+    """Run one gh WRITE, reporting a refusal instead of swallowing it.
+
+    Mesure #15621 : `ensure_label` passait a `gh label create` une description de
+    108 c (les deux autres faisaient 121 c et 145 c), au-dessus de la limite
+    GitHub de 100. Le label n'etait jamais cree, `mode=apply` continuait de lire
+    vert, et chaque `--add-label` en aval echouait pour la meme raison. Avec
+    `check=False` + `capture_output=True`, ces refus ne laissaient AUCUNE trace :
+    le log du sweep annoncait sept PRs signalees sans qu'aucun de ses trois
+    labels n'existe.
+
+    L'organe est advisory et ne doit pas faire tomber le sweep : il SIGNALE, il
+    ne leve pas. Retourne True quand l'ecriture a ete acceptee.
+    """
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True,
+                          check=False, encoding="utf-8")
+    if proc.returncode == 0:
+        return True
+    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    print(f"[pr-gate-missing] WARNING {what} refused (gh exit {proc.returncode}): "
+          f"{detail[0] if detail else 'no output'}", file=sys.stderr)
+    return False
+
+
 def ensure_label(repo: str, name: str, color: str, desc: str, dry_run: bool) -> None:
     if dry_run:
         return
-    subprocess.run(
-        ["gh", "label", "create", name, "--repo", repo,
-         "--color", color, "--description", desc, "--force"],
-        capture_output=True, text=True, check=False, encoding="utf-8",
-    )
+    _gh_write(["label", "create", name, "--repo", repo, "--color", color,
+               "--description", desc, "--force"], f"label create {name!r}")
 
 
 def has_label(pr: dict, name: str) -> bool:
@@ -430,19 +478,15 @@ def has_label(pr: dict, name: str) -> bool:
 def apply_label(repo: str, number: int, name: str, dry_run: bool) -> None:
     if dry_run:
         return
-    subprocess.run(
-        ["gh", "pr", "edit", str(number), "--repo", repo, "--add-label", name],
-        capture_output=True, text=True, check=False, encoding="utf-8",
-    )
+    _gh_write(["pr", "edit", str(number), "--repo", repo, "--add-label", name],
+              f"add-label {name!r} on #{number}")
 
 
 def remove_label(repo: str, number: int, name: str, dry_run: bool) -> None:
     if dry_run:
         return
-    subprocess.run(
-        ["gh", "pr", "edit", str(number), "--repo", repo, "--remove-label", name],
-        capture_output=True, text=True, check=False, encoding="utf-8",
-    )
+    _gh_write(["pr", "edit", str(number), "--repo", repo, "--remove-label", name],
+              f"remove-label {name!r} on #{number}")
 
 
 def existing_comment(repo: str, number: int) -> int | None:
@@ -489,10 +533,8 @@ def _remediate_for(repo: str, number: int, extra: dict, verdict: str,
 def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
     if dry_run:
         return
-    subprocess.run(
-        ["gh", "pr", "comment", str(number), "--repo", repo, "--body", body],
-        capture_output=True, text=True, check=False, encoding="utf-8",
-    )
+    _gh_write(["pr", "comment", str(number), "--repo", repo, "--body", body],
+              f"comment on #{number}")
 
 
 def labeled_prs(repo: str, label: str) -> dict[int, bool]:
@@ -548,14 +590,10 @@ def main(argv: list[str] | None = None) -> int:
 
     for pr in prs:
         number = pr["number"]
-        enriched = {
-            "number": number,
-            "base_ref_name": pr.get("baseRefName"),
-            "is_draft": pr.get("isDraft", False),
-            "author_login": (pr.get("author") or {}).get("login", ""),
-            "statusCheckRollup": pr.get("statusCheckRollup") or [],
-            "labels": (pr.get("labels") or []),
-        }
+        # Le collecteur livre DEJA la forme d'entree de classify() (#15621 :
+        # ce bloc la reconstruisait avec des cles GraphQL que list_open_prs
+        # n'emet pas, desactivant excluded_base / draft / bot_missing).
+        enriched = pr
         verdict, why = classify(enriched)
         counts[verdict] = counts.get(verdict, 0) + 1
 

--- a/scripts/pr_gate_missing.py
+++ b/scripts/pr_gate_missing.py
@@ -50,7 +50,6 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Iterable
 
 LABEL_DEFAULT = "pr-gate-missing"
 LABEL_BOT_DEFAULT = "pr-gate-missing-bot"
@@ -537,6 +536,21 @@ def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
               f"comment on #{number}")
 
 
+def retract_comment(repo: str, comment_id: int, body: str, dry_run: bool) -> None:
+    """Rewrite one PR-gate-missing comment in place (PATCH, idempotent).
+
+    Hermes #15621 (c.16h54, point 3) : le commentaire marque laisse par un faux
+    positif de classification affirmait des proprietes non mesurees (« auteur :
+    (pas une PR bot) », « investigation manuelle ») -- le laisser tel quel
+    fabrique du travail de coordination pour une cause triviale et design.
+    """
+    if dry_run:
+        return
+    _gh_write(["api", f"repos/{repo}/issues/comments/{comment_id}",
+               "-X", "PATCH", "-f", f"body={body}"],
+              f"retract comment {comment_id}")
+
+
 def labeled_prs(repo: str, label: str) -> dict[int, bool]:
     """Map PR number -> has-label for all open PRs carrying ``label``.
 
@@ -613,10 +627,13 @@ def main(argv: list[str] | None = None) -> int:
             if number in labeled_conflict:
                 remove_label(repo, number, args.label_conflict, args.dry_run)
                 print(f"  #{number:<6} has_gate   {why}  (conflict label retracted)")
-        elif verdict == "draft":
-            pass  # quiet -- the common non-defect case
-        else:  # excluded_base
-            pass  # quiet -- PRs targeting a feature branch never see PR gate
+        elif verdict in ("draft", "excluded_base"):
+            # Hermes #15621 (c.16h54, point 3) : la retombee de label n'existait
+            # que sur `has_gate` -- une PR signee « missing » par l'ancien
+            # collapse de forme puis correctement reclassee gardait son label et
+            # son commentaire FAUX a vie. Retrait symetrique, idempotent.
+            _retract_reclassified(repo, number, verdict, why, args,
+                                  labeled, labeled_bot, labeled_conflict)
 
     print(f"[pr-gate-missing] done: {counts} causes={causes}")
     return 0
@@ -633,6 +650,46 @@ def _comment_body(remediation: str, cause_line: str = "") -> str:
         parts += ["", cause_line]
     parts.append(COMMENT_MARKER_END)
     return "\n".join(parts)
+
+
+def _retraction_body(verdict: str, why: str) -> str:
+    # SANS marqueurs, volontairement : une PR qui redevient `missing` (retarget
+    # vers main, sortie du draft) doit obtenir une remediation FRAICHE --
+    # `existing_comment` ne doit plus trouver ce commentaire retracte, sinon
+    # il resterait muet sur un vrai defaut futur.
+    return "\n".join([
+        "## Retracte -- cette PR n'est pas un cas « PR gate absent »",
+        "",
+        f"Classe `{verdict}` : {why}.",
+        "Le signalement precedent etait un artefact du defaut de forme #15621",
+        "(classification figee sur `missing`). Aucune action requise.",
+    ])
+
+
+def _retract_reclassified(repo: str, number: int, verdict: str, why: str,
+                          args: object, labeled: dict, labeled_bot: dict,
+                          labeled_conflict: dict) -> None:
+    """Idempotent retraction of a misclassification's artifacts.
+
+    Symetrique au `has_gate` ci-dessus, mais la reecriture du commentaire est
+    en plus : pour `has_gate` le commentaire reste en historique (le retrait du
+    label EST le signal de resolution), alors qu'ici le commentaire laisse par
+    le faux positif affirmait des proprietes non mesurees. Le check des
+    commentaires est INCONDITIONNEL (pas seulement si un label est present) :
+    pendant l'episode 404 des labels (mesure #15621, defaut 2), les
+    commentaires ont ete postes alors qu'aucun label n'a jamais ete cree.
+    """
+    for present, label in ((number in labeled, args.label),
+                           (number in labeled_bot, args.label_bot),
+                           (number in labeled_conflict, args.label_conflict)):
+        if present:
+            remove_label(repo, number, label, args.dry_run)
+            print(f"  #{number:<6} {verdict:<8} {why}  (label {label} retracted)")
+    comment_id = existing_comment(repo, number)
+    if comment_id is not None:
+        retract_comment(repo, comment_id, _retraction_body(verdict, why),
+                        args.dry_run)
+        print(f"  #{number:<6} {verdict:<8} {why}  (comment retracted)")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pr_gate_missing.py
+++ b/scripts/tests/test_pr_gate_missing.py
@@ -5,6 +5,13 @@ The ``classify`` and ``rollup_names`` functions are network-free; ``main`` (the
 gh wiring) is exercised end-to-end in CI dry-runs, not here. These fixtures
 encode the verdicts measured firsthand on the #10928 sample (2026-08-14):
 
+  - (#15621) the fixtures below build the classify() input BY HAND -- which is
+    exactly how three verdicts stayed unreachable for weeks: the collector had
+    been migrated to REST keys while main() kept reading GraphQL ones, and a
+    hand-built fixture cannot notice that. The `#15621` section at the end
+    therefore feeds classify() with the COLLECTOR'S OUTPUT (patched gh), never
+    with a hand-built dict.
+
   - #10902 : rollup = 5 CodeQL checks only, no ``PR gate`` -> missing
   - #10558 : same rollup, author app/github-actions -> bot_missing (structural)
   - #10898 : same shape before the re-push -> missing; after the re-push the
@@ -17,15 +24,25 @@ encode the verdicts measured firsthand on the #10928 sample (2026-08-14):
 
 import sys
 import os
+import io
+from contextlib import redirect_stderr
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pr_gate_missing import (  # noqa: E402
     classify,
+    classify_input,
     rollup_names,
+    list_open_prs,
+    has_label,
     GATE_NAME,
+    LABEL_BOT_DESC,
+    LABEL_CONFLICT_DESC,
+    LABEL_DESC,
     prescribe,
     remediation_for,
+    _gh_write,
     REMEDIATION_CONFLICT,
     REMEDIATION_SKIP_CI,
 )
@@ -217,3 +234,133 @@ def test_unknown_names_the_measurements():
     assert "pas determinee" in remedy
     assert "git merge" not in remedy
     assert "commit-tree" not in remedy
+
+
+# ---------------------------------------------------------------------------
+# (#15621) le collecteur et le consommateur partagent UNE seule forme
+#
+# Ces tests alimentent classify() avec la SORTIE du collecteur -- jamais avec un
+# dict ecrit a la main. C'est la difference qui compte : les fixtures ci-dessus
+# construisaient la forme attendue par le consommateur, donc elles sont restees
+# vertes pendant que le producteur, migre en REST (#14488), emettait
+# `base_ref_name` / `is_draft` / `author_login` la ou main() relisait
+# `baseRefName` / `isDraft` / `author`. Trois verdicts etaient des lors
+# inatteignables, et la production le montrait : `excluded_base: 0`,
+# `draft: 0` sur 60 PRs ouvertes (run 34621731008).
+# ---------------------------------------------------------------------------
+
+
+def _collector_row(number=1, base="main", draft=False, author="jsboige",
+                   labels=None):
+    """Une ligne exactement telle que le flux gh de `list_open_prs` la rend.
+
+    `labels` porte la forme de l'API REST (`[{"name": ...}]`), pas des chaines :
+    c'est la forme que `has_label()` lit, et la garder identique a celle du
+    payload REST evite un second dialecte.
+    """
+    return {
+        "number": number,
+        "draft": draft,
+        "base": base,
+        "author": author,
+        "labels": labels or [],
+        "sha": "sha%d" % number,
+    }
+
+
+def _collector_output(rows, check_run_names=("PR gate",)):
+    """`list_open_prs` sur un flux gh simule -- aucun appel reseau."""
+    with mock.patch("pr_gate_missing._gh_rows", lambda args: rows), \
+         mock.patch("pr_gate_missing._gh_json",
+                    lambda args: list(check_run_names)):
+        return list_open_prs("jsboige/CoursIA")
+
+
+def test_collector_output_excludes_non_main_base():
+    # Verdict inatteignable avant le fix : 5 PRs stackees ouvertes a la mesure
+    # (dont #15620) etaient classees `missing` avec cause `unknown`.
+    rows = _collector_output([_collector_row(15620, base="fix/15489-x")])
+    verdict, why = classify(rows[0])
+    assert verdict == "excluded_base", why
+
+
+def test_collector_output_excludes_drafts():
+    rows = _collector_output([_collector_row(15334, draft=True)])
+    verdict, why = classify(rows[0])
+    assert verdict == "draft", why
+
+
+def test_collector_output_flags_bot_pr_structurally():
+    rows = _collector_output([_collector_row(10558, author="app/github-actions")],
+                             check_run_names=("CodeQL",))
+    verdict, why = classify(rows[0])
+    assert verdict == "bot_missing", why
+
+
+def test_collector_output_carries_author_and_labels():
+    # Le symptome visible du defaut : le commentaire imprimait « auteur : » vide
+    # (vu sur #15620), et `labels` n'etait pas collecte du tout -- donc
+    # has_label() etait toujours faux et le remappage vers pr-gate-conflict
+    # impossible.
+    rows = _collector_output(
+        [_collector_row(4, author="jsboige",
+                        labels=[{"name": "pr-gate-missing"}])],
+        check_run_names=("CodeQL",))
+    assert classify(rows[0])[0] == "missing"
+    assert rows[0]["author_login"] == "jsboige"
+    assert has_label(rows[0], "pr-gate-missing")
+    assert not has_label(rows[0], "pr-gate-conflict")
+
+
+def test_classify_input_is_the_only_shape():
+    # Epingle le contrat : toucher a `classify_input` sans mettre a jour
+    # classify() (ou l'inverse) fait rougir ici au lieu de desactiver un verdict
+    # en silence.
+    row = classify_input(7, "main", False, "jsboige", [{"name": GATE_NAME}],
+                         [{"name": "pr-gate-missing"}])
+    assert set(row) == {"number", "base_ref_name", "is_draft",
+                        "author_login", "statusCheckRollup", "labels"}
+    assert row["labels"] == [{"name": "pr-gate-missing"}]
+    assert classify(row)[0] == "has_gate"
+
+
+def test_label_descriptions_within_github_limit():
+    # GitHub refuse une description de plus de 100 caracteres. Mesure #15621 :
+    # 108 / 121 / 145 -- `gh label create` echouait, l'echec etait avale, et les
+    # trois labels etaient absents du depot (404) alors que le sweep lisait
+    # `mode=apply` sept jours de suite.
+    for name, desc in (("pr-gate-missing", LABEL_DESC),
+                       ("pr-gate-missing-bot", LABEL_BOT_DESC),
+                       ("pr-gate-conflict", LABEL_CONFLICT_DESC)):
+        assert len(desc) <= 100, "%s: %d caracteres" % (name, len(desc))
+
+
+def _gh_proc(returncode, stderr=""):
+    class _Proc:
+        pass
+    p = _Proc()
+    p.returncode = returncode
+    p.stderr = stderr
+    p.stdout = ""
+    return p
+
+
+def test_write_failure_is_reported_not_swallowed():
+    # Critere d'acceptation 3 : un refus de gh n'est plus silencieux.
+    err = io.StringIO()
+    with mock.patch("pr_gate_missing.subprocess.run",
+                    lambda *a, **k: _gh_proc(1, "description is too long\n")), \
+         redirect_stderr(err):
+        ok = _gh_write(["label", "create", "pr-gate-missing"], "label create")
+    assert ok is False
+    assert "WARNING" in err.getvalue()
+    assert "too long" in err.getvalue()
+
+
+def test_write_success_stays_quiet():
+    err = io.StringIO()
+    with mock.patch("pr_gate_missing.subprocess.run",
+                    lambda *a, **k: _gh_proc(0)), redirect_stderr(err):
+        ok = _gh_write(["label", "create", "pr-gate-missing"], "label create")
+    assert ok is True
+    assert err.getvalue() == ""

--- a/scripts/tests/test_pr_gate_missing.py
+++ b/scripts/tests/test_pr_gate_missing.py
@@ -31,6 +31,7 @@ from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pr_gate_missing import (  # noqa: E402
+    main,
     classify,
     classify_input,
     rollup_names,
@@ -43,8 +44,9 @@ from pr_gate_missing import (  # noqa: E402
     prescribe,
     remediation_for,
     _gh_write,
+    COMMENT_MARKER_START,
+    COMMENT_MARKER_END,
     REMEDIATION_CONFLICT,
-    REMEDIATION_SKIP_CI,
 )
 
 
@@ -364,3 +366,73 @@ def test_write_success_stays_quiet():
         ok = _gh_write(["label", "create", "pr-gate-missing"], "label create")
     assert ok is True
     assert err.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# (#15621, Hermes point 3) la reclassee retracte ses artefacts faux
+# ---------------------------------------------------------------------------
+
+
+def _run_main(pr_row, labeled_map=None, comment_id=None):
+    """Drive main() in apply mode with every network touch patched.
+
+    The retraction path for `excluded_base`/`draft` is WIRLING (labels map +
+    comment lookup + writes), invisible to a classify()-only test -- the same
+    blind spot that let the GraphQL/REST mismatch live for weeks.
+    """
+    labeled_map = labeled_map or {}
+    with mock.patch("pr_gate_missing.ensure_label", lambda *a, **k: None), \
+         mock.patch("pr_gate_missing.list_open_prs", lambda repo: [pr_row]), \
+         mock.patch("pr_gate_missing.labeled_prs",
+                    lambda repo, label: labeled_map.get(label, {})), \
+         mock.patch("pr_gate_missing.existing_comment",
+                    lambda repo, number: comment_id), \
+         mock.patch("pr_gate_missing.remove_label") as remove, \
+         mock.patch("pr_gate_missing.retract_comment") as retract, \
+         mock.patch("pr_gate_missing.apply_label") as apply_l, \
+         mock.patch("pr_gate_missing.post_comment") as post:
+        rc = main(["--repo", "jsboige/CoursIA"])
+    return rc, remove, retract, apply_l, post
+
+
+def test_reclassified_pr_loses_label_and_false_comment():
+    # #15620 telle que mesuree par Hermes : stackee (base != main), classee
+    # `missing` par le collapse de forme, label + commentaire faux poses.
+    row = classify_input(15620, "fix/15489-kernel-suffix-canon-guard", False,
+                         "jsboige", [], [{"name": "pr-gate-missing"}])
+    rc, remove, retract, apply_l, post = _run_main(
+        row, labeled_map={"pr-gate-missing": {15620: True}}, comment_id=42)
+    assert rc == 0
+    assert remove.call_count == 1
+    assert remove.call_args[0] == ("jsboige/CoursIA", 15620,
+                                   "pr-gate-missing", False)
+    assert retract.call_count == 1
+    repo, cid, body, dry = retract.call_args[0]
+    assert (repo, cid, dry) == ("jsboige/CoursIA", 42, False)
+    # La retraction est SANS marqueurs : une rechute reelle doit reposter une
+    # remediation fraiche, pas rester muette sur un commentaire retracte.
+    assert COMMENT_MARKER_START not in body and COMMENT_MARKER_END not in body
+    assert "excluded_base" in body
+    assert apply_l.call_count == 0 and post.call_count == 0
+
+
+def test_reclassified_draft_retracts_too():
+    row = classify_input(15334, "main", True, "jsboige", [],
+                         [{"name": "pr-gate-conflict"}])
+    rc, remove, retract, _, _ = _run_main(
+        row, labeled_map={"pr-gate-conflict": {15334: True}}, comment_id=None)
+    assert rc == 0
+    assert remove.call_count == 1
+    assert remove.call_args[0][2] == "pr-gate-conflict"
+    assert retract.call_count == 0  # pas de commentaire marque -> rien a reecrire
+
+
+def test_retraction_is_idempotent():
+    # Deuxieme passage : plus de label, plus de commentaire -> aucun geste.
+    row = classify_input(15609, "feature/15479-ict-torch-hooks", False,
+                         "jsboige", [])
+    rc, remove, retract, apply_l, post = _run_main(row)
+    assert rc == 0
+    assert remove.call_count == 0
+    assert retract.call_count == 0
+    assert apply_l.call_count == 0 and post.call_count == 0


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15620

## Résumé

`scripts/pr_gate_missing.py` — l'organe advisory de #10928, exécuté **horairement en `mode=apply`** par `pr-gate-stale-sweep.yml` — ne réalisait pas le contrat qu'il documente. Deux défauts mesurés, de même nature : **un échec silencieux**. Aucun changement de la détection elle-même.

## Défaut 1 — le collecteur et le consommateur ne partageaient pas la même forme

`list_open_prs()` a été migré en REST (#14488, le rollup GraphQL renvoie 504 sur ce dépôt) et émet des **clés plates** — `base_ref_name`, `is_draft`, `author_login`. Mais `main()` reconstruisait l'entrée de `classify()` en relisant des **clés GraphQL** — `baseRefName`, `isDraft`, `author` — **absentes de ces dicts**. Chaque `.get()` rendait donc son défaut, et les trois premiers verdicts de `classify()` étaient **structurellement inatteignables**.

| Verdict | Mesure |
|---|---|
| `excluded_base` (base != main) | **jamais**. 5 PRs ouvertes ont une base != main : #15620, #15609, #15605, #15600, #15548 — toutes classées `missing`, cause `unknown`, avec un commentaire demandant une « investigation manuelle » à la coordination |
| `draft` (non mergeable : bruit) | **jamais**. 2 drafts ouvertes : #15610, #15334 |
| `bot_missing` (push GITHUB_TOKEN) | **jamais** (0 PR bot ouverte à la mesure : latent) |

Symptôme visible dans le commentaire posté, constaté sur #15620 : le champ auteur était **vide** — « auteur : (pas une PR bot) ».

Défaut connexe : `labels` n'était **pas collecté du tout**, donc `has_label()` était toujours faux — le remappage du label générique vers `pr-gate-conflict` ne pouvait pas se déclencher.

**Pourquoi les tests ne l'attrapaient pas.** Les fixtures existantes construisent l'entrée de `classify()` **à la main** — c'est-à-dire la forme que le **consommateur** attend, pas celle que le **producteur** émet. Un dict écrit à la main ne peut pas remarquer qu'un producteur a changé de dialecte. Le docstring du fichier de tests le disait lui-même : *« `main` (the gh wiring) is exercised end-to-end in CI dry-runs, not here »* — et le dry-run CI ne compare les verdicts à **aucune** attente.

## Défaut 2 — les trois labels n'étaient jamais créés (échec avalé)

```
gh api repos/jsboige/CoursIA/labels/pr-gate-missing   ->  HTTP 404
```

Les trois labels (`pr-gate-missing`, `pr-gate-missing-bot`, `pr-gate-conflict`) sont **absents** du dépôt, alors que le run tourne en `mode=apply` et appelle `ensure_label()` au démarrage.

**Cause mesurée.** Le dépôt porte 190 labels et la plus longue description fait **97** caractères. Les trois descriptions du module faisaient **108**, **121** et **145** — au-dessus de la limite GitHub de 100. `gh label create` échouait, et `check=False` + `capture_output=True` rendaient ce refus **invisible** : le log du sweep annonçait sept PRs signalées sans qu'aucun de ses trois labels n'existe.

**Portée.** Le docstring du module déclare : *« The actionable payload is the set of labeled PRs and their comments, NEVER the green conclusion »*. La moitié « labels » de cette charge utile n'existait pas, et `gh pr list --label pr-gate-missing` renvoyait `[]`.

## Correctifs

| Fichier | Changement |
|---|---|
| `scripts/pr_gate_missing.py` | `classify_input()` : fabrique **unique** de la forme d'entrée de `classify()`, utilisée par le collecteur et épinglée par les tests |
| `scripts/pr_gate_missing.py` | `main()` consomme la sortie du collecteur **telle quelle** — plus de re-mappage |
| `scripts/pr_gate_missing.py` | `labels` collecté, dans la forme du payload REST (`[{"name": ...}]`) pour ne pas ouvrir un second dialecte |
| `scripts/pr_gate_missing.py` | descriptions ramenées à 92 / 96 / 97 caractères |
| `scripts/pr_gate_missing.py` | `_gh_write()` : une écriture refusée est **signalée** sur stderr (non bloquant — l'organe reste advisory et ne doit pas faire tomber le sweep) |
| `scripts/pr_gate_missing.py` | commit 2 (Hermes point 3) : `_retract_reclassified()` — retrait **symétrique** des trois labels + **réécriture** du commentaire marqué pour une PR reclassée `excluded_base`/`draft` ; la réécriture est **sans marqueurs** pour qu'une rechute réelle reposte une remédiation fraîche |
| `scripts/tests/test_pr_gate_missing.py` | 10 tests — dont ceux qui alimentent `classify()` avec la **sortie du collecteur**, jamais avec un dict écrit à la main, et 3 qui pilotent `main()` en mode apply (réseaux patchés) : retrait label+commentaire, cas `draft`, idempotence (second passage = zéro geste) |

## Preuve

Le dry-run porte sur **le même pool vivant** que le run de production (60 PRs ouvertes) :

| | production (avant) | dry-run (après) |
|---|---|---|
| `missing` | **7** | **0** |
| `excluded_base` | **0** | **5** |
| `draft` | **0** | **2** |
| `bot_missing` | 0 | 0 |
| `has_gate` | 53 | **53** (inchangé) |

Les 7 PRs signalées étaient donc **7 faux positifs**, résolus en 5 `excluded_base` + 2 `draft` — exactement les PRs mesurées indépendamment. Le chemin légitime (`has_gate`) ne bouge pas : critère d'acceptation 4 tenu par la mesure, pas par un raisonnement.

| Preuve | Résultat |
|---|---|
| Suite de tests du module | **29 passed** (19 existants inchangés + 10 nouveaux) — relancée après le commit 2 |
| Dry-run pool vivant (60 PRs) | `{'missing': 0, 'bot_missing': 0, 'has_gate': 53, 'draft': 2, 'excluded_base': 5}` |
| `jq` des labels vérifié sur l'API réelle | `labels: [{"name": "lane-claim-absent"}]` — la forme que `has_label()` lit |
| Run de production 34621731008 | `excluded_base: 0`, `draft: 0` sur 60 PRs (constat de départ) |
| Label `pr-gate-missing` | HTTP 404 ; dépôt : 190 labels, description max 97 c |

Le `jq` est vérifié **contre l'API réelle** et non seulement contre les fixtures : c'est précisément le trou que cette PR ferme, il aurait été incohérent de le rouvrir pour ma propre correction.

## Commit 2 — le complément Hermes (point 3 du commentaire c.16h54)

La vérification firsthand d'Hermes po-2026 a nommé un **troisième effet** que le correctif de forme ne couvrait pas : la retombée de label n'existait que sur `has_gate` — une PR signalée « missing » par l'ancien collapse de forme, puis correctement reclassée, gardait son label et son commentaire **faux à vie**. Et ce commentaire affirmait des propriétés non mesurées (« auteur : (pas une PR bot) » avec un auteur vide, « investigation manuelle » pour une cause triviale et **par design**).

Le commit 2 traite la transition `missing → excluded_base|draft` comme un retrait idempotent, symétriquement au `has_gate` : les trois labels sont retirés si présents, et le commentaire marqué est **réécrit** (`PATCH` via `gh api`) en note de rétraction honnête. Le check du commentaire est **inconditionnel** (pas seulement si un label est présent) : pendant l'épisode 404 des labels, les commentaires ont été postés alors qu'aucun label n'a jamais été créé. La note de rétraction ne porte **pas** les marqueurs — une PR qui redevient `missing` (retarget vers `main`, sortie du draft) doit obtenir une remédiation fraîche, pas rester muette sur un commentaire rétracté.

Dry-run vivant après le commit 2 (76 PRs ouvertes, lecture seule) :

```
[pr-gate-missing] done: {'missing': 2, 'bot_missing': 0, 'has_gate': 65, 'draft': 2, 'excluded_base': 7} causes={'cause_retarget': 2}
  #15620 excluded_base (comment retracted)   #15610 draft (comment retracted)
  #15609 excluded_base (comment retracted)   #15605 excluded_base (comment retracted)   #15334 draft (comment retracted)
```

Les 2 `missing` restants sont de **vrais** défauts — #15600 et #15548, retargetées vers `main` après le merge de leur base, gate jamais re-rendu (`cause_retarget`, remède commit-tree déjà prescrit par `prescribe()`). C'est le premier recensement où **tout** ce qui est signalé est réel.

## Périmètre

Deux fichiers, aucun workflow, aucun label créé par cette PR, catalogue byte-identique à `main` :

| Fichier | Δ |
|---|---|
| `scripts/pr_gate_missing.py` | `+140/-45` |
| `scripts/tests/test_pr_gate_missing.py` | `+220/-1` |

## Ce que cette PR ne fait pas

- Elle ne corrige **pas** la cause 5 de #14477 ni `prescribe()` : le remède par cause fonctionne (mesuré : `cause_conflict: 1`, `cause_unknown: 6` sur le pool vivant).
- Elle ne crée **pas** les trois labels elle-même : c'est `ensure_label()` qui les créera à la prochaine passe horaire, désormais avec des descriptions acceptées et un refus signalé s'il survient. Vérifiable au prochain sweep.
- ~~Les 7 PRs déjà commentées gardent leur commentaire faux.~~ **Résolu par le commit 2** : la prochaine passe horaire du sweep réécrira leurs commentaires en note de rétraction (mesuré en dry-run ci-dessus). Pas de nettoyage manuel hors périmètre — c'est l'organe qui se corrige, traçable dans le log du sweep.

Closes #15621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

