### PR TITLE
feat(guard,#15489): portee explicite du zero-pad par registre de series migrees (defaut 5)

### DIFF
--- a/.github/workflows/series-naming-gate.yml
+++ b/.github/workflows/series-naming-gate.yml
@@ -1,29 +1,46 @@
 name: series-naming-gate
 
-# Garde de convention zero-pad de la serie GameTheory (#11840, #12586).
+# Garde de convention zero-pad des series ayant ADOPTE la numerotation a deux
+# chiffres (#11840, #12586, #15489).
 #
 # La tranche 1 (#12241) a zero-pade 30 notebooks ; six side-tracks au chiffre
 # unique sont arrives sur main ENTRE sa review et son merge -- un invariant
 # verifie a l'instant t n'est pas une propriete du livrable. Ce garde rend la
-# tranche 3 impossible : il rougit des qu'un GameTheory-<chiffre unique>
+# tranche 3 impossible : il rougit des qu'un `<Serie>-<chiffre unique>`
 # apparait, cote PR comme cote push.
 #
-# Portee : la serie GameTheory SEULEMENT (la seule zero-padee a ce jour, scope
-# fige par #12586). Ne pas l'etendre a une autre serie sans avoir mesure si
-# elle a une convention arretee -- une regle imposee a une serie qui n'a pas
-# tranche fabrique du rouge sans defaut.
+# PORTEE = LISTE EXPLICITE (#15489, defaut 5). Le job lance le garde SANS
+# argument : le garde lit alors `scripts/notebook_tools/zero_pad_series.json`
+# et scanne chaque serie declaree. La liste vit la, pas ici -- les `paths:`
+# ci-dessous n'en sont qu'un MIROIR, et un test de parite
+# (`scripts/tests/test_check_series_zero_pad.py`) rougit si le miroir et le
+# registre divergent.
+#
+# Ne jamais ajouter une serie aux `paths:` sans l'avoir declaree au registre :
+# le critere d'admission est mesure (la serie prouve son padding ET ne porte
+# aucune violation sur son arbre entier). Une regle imposee a une serie qui
+# n'a pas tranche fabrique du rouge sans defaut -- 20 familles sont dans ce
+# cas, et le registre les nomme pour qu'on ne les ajoute pas par megarde.
 
 # ABSORBE PAR LA VOIE RAPIDE sur `pull_request` (#12567, tranche 1) : le
-# verdict PR est rendu par `fast-lane-shadow.yml` (check-run nomme
-# `zero-pad guard (GameTheory serie)`, meme nom que ce job). Ce fichier
-# garde `push` (couverture post-merge) et `workflow_dispatch`. Les `paths:`
-# d'origine vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE1).
+# verdict PR est rendu par `fast-lane-shadow.yml` (check-run de meme nom que
+# ce job). Ce fichier garde `push` (couverture post-merge) et
+# `workflow_dispatch`. Les `paths:` d'origine vivent dans
+# `scripts/ci/fast_lane_registry.py` (TRANCHE1).
 
 on:
   push:
     branches: [ main ]
     paths:
       - 'MyIA.AI.Notebooks/GameTheory/**'
+      - 'MyIA.AI.Notebooks/GenAI/FineTuning/**'
+      - 'MyIA.AI.Notebooks/IIT/**'
+      - 'MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/**'
+      - 'MyIA.AI.Notebooks/Probas/PyMC/**'
+      - 'MyIA.AI.Notebooks/Search/Part1-Foundations/**'
+      - 'MyIA.AI.Notebooks/Search/Part4-Metaheuristics/**'
+      - 'MyIA.AI.Notebooks/Sudoku/**'
+      - 'scripts/notebook_tools/zero_pad_series.json'
       - 'scripts/notebook_tools/check_series_zero_pad.py'
   workflow_dispatch:
 
@@ -43,7 +60,7 @@ concurrency:
 
 jobs:
   zero-pad-scan:
-    name: "zero-pad guard (GameTheory serie)"
+    name: "zero-pad guard (series declarees)"
     # Route vers la jambe Linux auto-hebergee (#13378 tranche 5, decision ai-01
     # 2026-09-02) : garde Python pur, sans secret. La garde same-repo ci-dessous
     # saute les PRs de fork (pr_gate.py compte `skipped` comme OK) : aucun code de
@@ -59,12 +76,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: "Fail si un GameTheory-<chiffre unique> apparait"
+      - name: "Fail si un <Serie>-<chiffre unique> apparait dans une serie declaree"
         run: |
           if ! python scripts/notebook_tools/check_series_zero_pad.py; then
             echo ""
-            echo "::error::Un fichier GameTheory-<chiffre unique> est apparu dans la serie."
+            echo "::error::Un fichier <Serie>-<chiffre unique> est apparu dans une serie declaree zero-padee."
             echo "Convention #11840 : numero a DEUX chiffres (GameTheory-03a, -08d, -26 valides ; -3a, -8d non)."
             echo "Renommer (git mv) vers la forme zero-padee, puis mettre a jour README + navlinks -- cf #12241 (tranche 1) et #12586 (tranche 2)."
+            echo "Si la serie vient d'adopter le padding, l'inscrire dans scripts/notebook_tools/zero_pad_series.json (critere d'admission : cf _criterion)."
             exit 1
           fi

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -351,14 +351,27 @@ TRANCHE1: list[Guard] = [
         blocking=True,
         absorbed=True,
     ),
-    # Forme 2 : scan globs, bloque sur convention zero-pad GameTheory
-    # (#11840/#12586). Source : series-naming-gate.yml (job affiche
-    # `zero-pad guard (GameTheory serie)`).
+    # Forme 2 : scan globs, bloque sur la convention zero-pad des series
+    # DECLAREES (#11840/#12586, portee explicite #15489 defaut 5). Source :
+    # series-naming-gate.yml (job affiche `zero-pad guard (series declarees)`).
+    # Les globs ci-dessous MIROITENT `scripts/notebook_tools/zero_pad_series.json`
+    # -- le garde est lance sans argument et lit le registre, mais la voie
+    # rapide doit savoir quand le declencher sans lire le JSON au chargement
+    # (ce module ne fait AUCUNE E/S, cf son docstring). Un test de parite
+    # rougit si le miroir et le registre divergent.
     Guard(
-        name="zero-pad guard (GameTheory serie)",
+        name="zero-pad guard (series declarees)",
         source="series-naming-gate.yml",
         paths=[
             "MyIA.AI.Notebooks/GameTheory/**",
+            "MyIA.AI.Notebooks/GenAI/FineTuning/**",
+            "MyIA.AI.Notebooks/IIT/**",
+            "MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/**",
+            "MyIA.AI.Notebooks/Probas/PyMC/**",
+            "MyIA.AI.Notebooks/Search/Part1-Foundations/**",
+            "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/**",
+            "MyIA.AI.Notebooks/Sudoku/**",
+            "scripts/notebook_tools/zero_pad_series.json",
             "scripts/notebook_tools/check_series_zero_pad.py",
             "scripts/notebook_tools/naming_canon.py",
             ".github/workflows/series-naming-gate.yml",

--- a/scripts/notebook_tools/check_series_zero_pad.py
+++ b/scripts/notebook_tools/check_series_zero_pad.py
@@ -1,4 +1,4 @@
-"""Garde de convention zero-pad d'une serie de notebooks (#11840, #12586).
+"""Garde de convention zero-pad d'une serie de notebooks (#11840, #12586, #15489).
 
 Une serie qui a tranche sa numerotation a deux chiffres (GameTheory : 01..26,
 side-tracks en lettres 03a/08d) doit y rester. Six side-tracks au chiffre
@@ -14,11 +14,62 @@ d'un second chiffre. Les formes valides ne matchent pas :
     GameTheory-26-...   (deux chiffres)
     GameTheory-04c-...  (deux chiffres + lettre de side-track)
 
-Portee volontairement ETROITE : la serie passee en argument, GameTheory par
-defaut (la seule zero-padee a ce jour). Ne pas l'etendre a une autre serie
-sans avoir mesure si elle a une convention arretee -- une regle imposee a une
-serie qui n'a pas tranche fabrique du rouge sans defaut (scope fige par
-#12586).
+PORTEE : REGISTRE EXPLICITE, JAMAIS UN DEFAUT (#15489, defaut 5)
+--------------------------------------------------------------
+L'issue est explicite -- "check_series_zero_pad.py doit rester opt-in par
+series migrees ; une activation globale avant cartographie creerait un mur
+rouge inutilisable" -- et son acceptance demande "Padding active par liste
+explicite de series migrees, avec tests de non-regression sur familles non
+encore adoptees".
+
+Avant cette tranche, la portee vivait dans deux defauts argparse
+(`--series-dir` = GameTheory, `--prefix` = GameTheory) et une phrase de
+docstring. C'etait une convention de fait : non datee, non justifiee, et
+invisible a tout controle automatique -- rien ne distinguait "GameTheory est
+la seule serie zero-padee" (vrai en #12586) de "GameTheory est la seule
+serie zero-padee" (faux depuis que sept autres l'ont adopte en silence).
+La portee vit desormais dans `zero_pad_series.json`, ou chaque serie est
+nommee, datee, mesuree et justifiee.
+
+Le critere d'admission a DEUX moities, et les deux sont mesurees :
+
+  (a) la serie PROUVE son padding -- au moins un fichier dont le numero porte
+      un zero de tete (`01`, `04a`). Une serie qui ne porte que des numeros
+      >= 10 n'a rien adopte : elle n'a simplement aucun numero a un chiffre,
+      donc son etat ne dit rien de sa convention. Sept familles sont dans ce
+      cas et restent hors registre ;
+  (b) la serie ne porte AUCUNE violation sur son arbre ENTIER. C'est ce qui
+      distingue ce garde du garde de casse canonique des suffixes (#15489
+      defaut 3) : celui-la est DELTA (`--diff-filter=A`) et peut donc
+      declarer une serie en laissant ses fichiers herites non conformes.
+      Ici le scan est whole-tree (`rglob` recursif), donc declarer une serie
+      non migree rougit des dizaines de fichiers d'un seul coup -- le mur
+      rouge que l'issue interdit. La mesure du 2026-09-11 en denombre 20.
+
+Ces 20 familles et leurs comptes sont conserves dans le registre sous
+`_not_declared`, pour que la liste ne soit pas "elargie" par inadvertance :
+chaque ligne y porte le nombre de fichiers qui rougiraient.
+
+CE QUE CE GARDE NE FAIT PAS
+---------------------------
+Il ne migre aucune serie : renommer les fichiers d'une famille est une
+tranche a part, avec ses README et ses navlinks. Il ne verifie pas non plus
+que le registre est "complet" -- l'absence d'une serie n'est pas un defaut,
+c'est le regime par defaut (opt-in).
+
+Usage
+-----
+    python scripts/notebook_tools/check_series_zero_pad.py
+        -> scanne TOUTES les series du registre (c'est l'invocation CI)
+
+    python scripts/notebook_tools/check_series_zero_pad.py --series-dir <d> --prefix <P>
+        -> scanne une seule serie (surcharge explicite, prime sur le registre)
+
+    python scripts/notebook_tools/check_series_zero_pad.py --json
+    python scripts/notebook_tools/check_series_zero_pad.py --list-series
+
+Sortie : 0 = aucune violation ; 1 = violation(s) ; 2 = erreur d'invocation
+(dont un repertoire declare absent du disque, qui est un defaut du registre).
 """
 
 from __future__ import annotations
@@ -37,6 +88,11 @@ if _here not in sys.path:
     sys.path.insert(0, _here)
 from naming_canon import parse_name  # noqa: E402
 
+#: Registre des series ayant adopte le zero-pad. Vit a cote de l'organe : le
+#: registre et le garde qui le lit ne doivent pas pouvoir deriver l'un de
+#: l'autre sans que le diff le montre.
+REGISTRY_PATH = Path(__file__).resolve().parent / "zero_pad_series.json"
+
 
 def violations(series_dir: Path, prefix: str = "GameTheory") -> list[dict]:
     """Fichiers de la serie dont le numero n'est PAS zero-pade.
@@ -47,6 +103,10 @@ def violations(series_dir: Path, prefix: str = "GameTheory") -> list[dict]:
     LONGUEUR du numero et non sur un motif du nom complet -- un motif local
     re-encode la grammaire du canon, et deux encodages divergent au premier cas
     limite (c'est ce que #15489 corrige).
+
+    Le balayage est RECURSIF : un sous-dossier non declare compte. C'est
+    volontaire -- l'arbre entier d'une serie declaree est sous la convention,
+    sans quoi une sous-serie pourrait deriver sans que le garde le voie.
     """
     out: list[dict] = []
     for path in sorted(series_dir.rglob(f"{prefix}-*")):
@@ -64,46 +124,186 @@ def violations(series_dir: Path, prefix: str = "GameTheory") -> list[dict]:
     return out
 
 
+def load_registry(path: Path | None = None) -> list[dict]:
+    """Series declarees zero-padees, telles que lues dans le registre.
+
+    Leve ``RegistryError`` si le registre est illisible ou malforme : un
+    registre casse doit faire echouer l'organe, jamais le rendre muet en
+    retombant sur une portee vide (une portee vide rend 0 violation, donc un
+    vert -- le pire des modes de defaillance pour un garde).
+    """
+    path = path or REGISTRY_PATH
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RegistryError(f"registre illisible : {path} ({exc})") from exc
+    except json.JSONDecodeError as exc:
+        raise RegistryError(f"registre malforme : {path} ({exc})") from exc
+
+    adopted = raw.get("adopted")
+    if not isinstance(adopted, list) or not adopted:
+        raise RegistryError(
+            f"registre sans section 'adopted' non vide : {path}")
+
+    out: list[dict] = []
+    for entry in adopted:
+        if not isinstance(entry, dict):
+            raise RegistryError(f"entree de registre non-objet : {entry!r}")
+        series, directory = entry.get("series"), entry.get("dir")
+        if not series or not directory:
+            raise RegistryError(
+                f"entree de registre sans 'series'/'dir' : {entry!r}")
+        out.append({"series": series, "dir": directory,
+                    "note": entry.get("note", "")})
+    return out
+
+
+class RegistryError(Exception):
+    """Le registre est absent, illisible, malforme, ou pointe dans le vide."""
+
+
+def _resolve(directory: str) -> Path:
+    p = Path(directory)
+    return p if p.is_absolute() else REPO_ROOT / p
+
+
+def _scan_registry(entries: list[dict]) -> tuple[list[dict], list[str]]:
+    """Scanne chaque serie declaree. Rend (rapport par serie, repertoires absents).
+
+    Un repertoire declare absent n'est PAS silencieusement ignore : le registre
+    nomme des series qui doivent exister, et une serie declaree disparue est un
+    defaut du registre, pas une raison de rendre un vert.
+    """
+    report: list[dict] = []
+    missing: list[str] = []
+    for entry in entries:
+        series_dir = _resolve(entry["dir"])
+        if not series_dir.is_dir():
+            missing.append(entry["dir"])
+            continue
+        found = violations(series_dir, entry["series"])
+        report.append({"series": entry["series"], "dir": entry["dir"],
+                       "count": len(found), "violations": found})
+    return report, missing
+
+
+def _emit_text(report: list[dict]) -> None:
+    for block in report:
+        for v in block["violations"]:
+            print(f"VIOLATION {block['series']} {v['file']}")
+    for block in report:
+        state = "OK" if not block["count"] else f"{block['count']} violation(s)"
+        print(f"[zero-pad] {block['series']:<12} {block['dir']} : {state}")
+
+
+def _summarize(report: list[dict]) -> str:
+    total = sum(b["count"] for b in report)
+    clean = [b["series"] for b in report if not b["count"]]
+    dirty = [f"{b['series']} ({b['count']})" for b in report if b["count"]]
+    parts = [f"{len(report)} serie(s) declaree(s), {total} violation(s)"]
+    if clean:
+        parts.append("conformes : " + ", ".join(clean))
+    if dirty:
+        parts.append("a corriger : " + ", ".join(dirty))
+    return "[zero-pad] " + " | ".join(parts)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Echoue si un fichier de la serie porte un numero "
-                    "non zero-pade (convention NN, #11840/#12586).")
-    parser.add_argument("--series-dir", default="MyIA.AI.Notebooks/GameTheory",
-                        help="repertoire de la serie (relatif a la racine du depot)")
+        description="Echoue si un fichier d'une serie DECLAREE zero-padee "
+                    "porte un numero non zero-pade (convention NN, #11840/"
+                    "#12586). Sans argument, scanne les series du registre "
+                    "explicite (#15489 defaut 5).")
+    parser.add_argument("--series-dir", default=None,
+                        help="surcharge : repertoire d'UNE serie (relatif a la "
+                             "racine du depot). Omettez-le pour scanner le "
+                             "registre entier.")
     parser.add_argument("--prefix", default="GameTheory",
-                        help="prefixe des fichiers de la serie")
+                        help="prefixe des fichiers, avec --series-dir "
+                             "(defaut : GameTheory, forme historique)")
+    parser.add_argument("--registry", default=None,
+                        help=f"chemin du registre (defaut : {REGISTRY_PATH.name})")
+    parser.add_argument("--list-series", action="store_true",
+                        help="liste les series declarees et sort")
     parser.add_argument("--json", action="store_true",
                         help="sortie machine-readable")
     args = parser.parse_args(argv)
 
-    series_dir = Path(args.series_dir)
-    if not series_dir.is_absolute():
-        series_dir = REPO_ROOT / series_dir
-    if not series_dir.is_dir():
-        print(f"[zero-pad] repertoire introuvable : {series_dir}",
-              file=sys.stderr)
+    if args.list_series:
+        try:
+            entries = load_registry(Path(args.registry) if args.registry else None)
+        except RegistryError as exc:
+            print(f"[zero-pad] {exc}", file=sys.stderr)
+            return 2
+        for e in entries:
+            print(f"{e['series']}\t{e['dir']}")
+        return 0
+
+    # --- Mode surcharge : une seule serie, forme historique ----------------
+    if args.series_dir is not None:
+        series_dir = _resolve(args.series_dir)
+        if not series_dir.is_dir():
+            print(f"[zero-pad] repertoire introuvable : {series_dir}",
+                  file=sys.stderr)
+            return 2
+        found = violations(series_dir, args.prefix)
+        if args.json:
+            print(json.dumps({
+                "schema": 2,
+                "mode": "series",
+                "series_dir": args.series_dir,
+                "prefix": args.prefix,
+                "count": len(found),
+                "violations": found,
+            }, ensure_ascii=False, indent=1))
+        else:
+            for v in found:
+                print(f"VIOLATION {v['file']}")
+        if found:
+            print(f"[zero-pad] {len(found)} fichier(s) au chiffre unique -- la "
+                  f"convention {args.prefix}-NN exige deux chiffres "
+                  f"(side-tracks valides : {args.prefix}-03a, -08d).",
+                  file=sys.stderr)
+            return 1
+        if not args.json:
+            print(f"[zero-pad] OK : aucun {args.prefix}-<chiffre unique> "
+                  f"dans {series_dir}")
+        return 0
+
+    # --- Mode registre : c'est l'invocation CI -----------------------------
+    try:
+        entries = load_registry(Path(args.registry) if args.registry else None)
+    except RegistryError as exc:
+        print(f"[zero-pad] {exc}", file=sys.stderr)
         return 2
 
-    found = violations(series_dir, args.prefix)
+    report, missing = _scan_registry(entries)
+    for d in missing:
+        print(f"[zero-pad] serie declaree introuvable sur le disque : {d}",
+              file=sys.stderr)
+
+    total = sum(b["count"] for b in report)
     if args.json:
         print(json.dumps({
-            "series_dir": args.series_dir,
-            "prefix": args.prefix,
-            "count": len(found),
-            "violations": found,
+            "schema": 2,
+            "mode": "registry",
+            "series": report,
+            "count": total,
+            "violations": [dict(v, series=b["series"])
+                           for b in report for v in b["violations"]],
+            "missing_dirs": missing,
         }, ensure_ascii=False, indent=1))
     else:
-        for v in found:
-            print(f"VIOLATION {v['file']}")
-    if found:
-        print(f"[zero-pad] {len(found)} fichier(s) au chiffre unique -- la "
-              f"convention {args.prefix}-NN exige deux chiffres "
-              f"(side-tracks valides : {args.prefix}-03a, -08d).",
-              file=sys.stderr)
+        _emit_text(report)
+        print(_summarize(report))
+
+    if missing:
+        return 2
+    if total:
+        print(f"[zero-pad] {total} fichier(s) au chiffre unique dans des "
+              f"series declarees -- la convention exige deux chiffres "
+              f"(side-track valide : GameTheory-03a).", file=sys.stderr)
         return 1
-    if not args.json:
-        print(f"[zero-pad] OK : aucun {args.prefix}-<chiffre unique> "
-              f"dans {args.series_dir}")
     return 0
 
 

--- a/scripts/notebook_tools/zero_pad_series.json
+++ b/scripts/notebook_tools/zero_pad_series.json
@@ -1,0 +1,83 @@
+{
+  "_role": "Series ayant ADOPTE la numerotation a deux chiffres (zero-pad). Lu par check_series_zero_pad.py -- defaut 5 de #15489 : la portee du garde est une liste EXPLICITE, jamais un defaut argparse.",
+  "_criterion": "Deux moities, toutes deux mesurees. (a) La serie PROUVE son padding : au moins un fichier dont le numero porte un zero de tete (`01`, `04a`). Une serie qui ne porte que des numeros >= 10 n'a rien adopte -- elle n'a simplement aucun numero a un chiffre, donc son etat ne dit rien de sa convention. (b) La serie ne porte AUCUNE violation sur son arbre ENTIER, sous-dossiers compris (le scan du garde est recursif). Ce second critere distingue ce garde du garde de casse canonique des suffixes (#15489 defaut 3), qui est DELTA et peut donc declarer une serie en laissant ses fichiers herites non conformes ; ici declarer une serie non migree rougit des dizaines de fichiers d'un coup.",
+  "_why_explicit": "Le defaut 5 de #15489 dit exactement ceci : `check_series_zero_pad.py` doit rester opt-in par series MIGREES, une activation globale avant cartographie creant un mur rouge inutilisable. Avant ce registre, la portee vivait dans deux defauts argparse (`--series-dir` = GameTheory, `--prefix` = GameTheory) et une phrase de docstring -- une convention de fait, non datee, non justifiee, invisible a tout controle automatique. La docstring affirmait encore que GameTheory etait 'la seule zero-padee a ce jour' alors que sept autres series l'avaient adopte en silence.",
+  "_measured": "2026-09-11, sur origin/main, par balayage de l'arbre (`parse_name` du canon #5081, hors /.lake/ et /_peters/). Chaque entree ci-dessous a ensuite ete revalidee par l'organe lui-meme en mode registre : `python scripts/notebook_tools/check_series_zero_pad.py` rend exit 0 sur main.",
+  "_how_to_extend": "Ajouter une entree UNIQUEMENT apres avoir mesure, sur la serie candidate : (a) au moins un nom zero-pade, et (b) zero fichier au chiffre unique sur l'arbre ENTIER. Puis relancer `python scripts/notebook_tools/check_series_zero_pad.py` -- exit 0 obligatoire sur main, et le test de parite verifie que le workflow et la fast lane citent le meme repertoire que cette entree. Migrer une serie (renommer ses fichiers) est une tranche a part, avec ses README et ses navlinks.",
+  "_not_declared": {
+    "_why": "Cartographie de la meme mesure, conservee ici pour que personne ne les ajoute 'pour elargir la couverture' : chacune de ces familles fabriquerait aujourd'hui le mur rouge que l'issue interdit. Les declarer demande d'abord de les MIGRER.",
+    "unproven_no_leading_zero": [
+      "App -- Search/Applications/Search (4 numeros, tous >= 10 : aucun zero de tete, donc aucune preuve d'adoption)",
+      "MGS -- Search/Part4-Metaheuristics/MGS-vs-mealpy (10, tous >= 10)",
+      "Planners -- SymbolicAI/Planners/04-NeuroSymbolic (4, tous >= 10)",
+      "SC -- SymbolicAI/SmartContracts/03-Foundry-Testing (3, tous >= 10)",
+      "SC -- SymbolicAI/SmartContracts/04-Privacy-Cryptography (3, tous >= 10)",
+      "SC -- SymbolicAI/SmartContracts/05-Alternative-Chains (5, tous >= 10)",
+      "SC -- SymbolicAI/SmartContracts/06-Real-World (5, tous >= 10)"
+    ],
+    "would_red_on_activation": [
+      "Tweety -- SymbolicAI/Tweety (28 violations)",
+      "ML -- ML/ML.Net (20)",
+      "CSP -- Search/Part2-CSP (18)",
+      "App -- Search/Applications/CSP (17)",
+      "SW -- SymbolicAI/SemanticWeb (17)",
+      "SL -- SymbolicAI/SymbolicLearning (17)",
+      "Lean -- SymbolicAI/Lean (11)",
+      "Infer -- Probas/Infer (10)",
+      "ICT -- IIT/ICT-Series (9)",
+      "DecPyMC -- Probas/DecisionTheory/PyMC (9)",
+      "Planners -- SymbolicAI/Planners/02-Classical (8)",
+      "Planners -- SymbolicAI/Planners/01-Foundation (6)",
+      "Planners -- SymbolicAI/Planners/03-Advanced (6)",
+      "SC -- SymbolicAI/SmartContracts/02-Solidity-Advanced (5)",
+      "SC -- SymbolicAI/SmartContracts/00-Foundations (4)",
+      "SC -- SymbolicAI/SmartContracts/01-Solidity-Foundation (4)",
+      "DoWhy -- Probas/DecisionTheory/Causal-Bridges (2)",
+      "App -- Search/Applications/Hybrid (2)",
+      "RL -- RL (1 -- a UN fichier pres ; de toutes les familles, la plus proche d'une adoption)",
+      "Planners -- SymbolicAI/Planners/00-Environment (1)"
+    ]
+  },
+  "adopted": [
+    {
+      "series": "GameTheory",
+      "dir": "MyIA.AI.Notebooks/GameTheory",
+      "note": "Serie fondatrice du garde (#11840/#12241). 48 noms zero-pades, 44 numeros a deux chiffres non pades (GameTheory-26)."
+    },
+    {
+      "series": "FT",
+      "dir": "MyIA.AI.Notebooks/GenAI/FineTuning",
+      "note": "7 noms zero-pades, aucun numero >= 10."
+    },
+    {
+      "series": "IIT",
+      "dir": "MyIA.AI.Notebooks/IIT",
+      "note": "5 noms zero-pades. La sous-serie ICT-Series (IIT/ICT-Series) ne porte PAS le prefixe IIT : elle est une famille distincte, non adoptee, et n'entre pas dans ce scan."
+    },
+    {
+      "series": "DecInfer",
+      "dir": "MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer",
+      "note": "9 noms zero-pades, 1 numero a deux chiffres."
+    },
+    {
+      "series": "PyMC",
+      "dir": "MyIA.AI.Notebooks/Probas/PyMC",
+      "note": "9 noms zero-pades, 10 numeros a deux chiffres. A ne pas confondre avec Probas/DecisionTheory/PyMC (DecPyMC), famille distincte."
+    },
+    {
+      "series": "Search",
+      "dir": "MyIA.AI.Notebooks/Search/Part1-Foundations",
+      "note": "31 noms zero-pades. Part2-CSP (18 violations) et Part4-Metaheuristics sont des series DISTINCTES, traitees separement -- c'est pourquoi le repertoire declare est le sous-dossier et non Search/."
+    },
+    {
+      "series": "MGS",
+      "dir": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics",
+      "note": "12 noms zero-pades, 13 numeros a deux chiffres. Le sous-dossier MGS-vs-mealpy tombe dans ce scan recursif mais ne porte aucun numero a un chiffre, donc il ne rougit pas."
+    },
+    {
+      "series": "Sudoku",
+      "dir": "MyIA.AI.Notebooks/Sudoku",
+      "note": "19 noms zero-pades, 19 numeros a deux chiffres. Le pendant Python de la serie suit la meme convention."
+    }
+  ]
+}

--- a/scripts/tests/test_check_series_zero_pad.py
+++ b/scripts/tests/test_check_series_zero_pad.py
@@ -3,18 +3,34 @@
 Les cas sont construits sur les formes REELLES de la serie GameTheory :
 zero-pades valides (03a, 08d, 26), chiffre unique invalide (3a, 8d, 8-).
 Le lookahead est la piece delicate -- chaque forme a son test.
+
+Deuxieme volet (#15489, defaut 5) : la PORTEE du garde est une liste explicite
+(`zero_pad_series.json`), lue quand le garde est lance sans argument -- c'est
+l'invocation CI. Les tests de parite qui suivent verrouillent le fait que les
+deux miroirs de cette liste (workflow `paths:` + garde de la voie rapide) ne
+peuvent pas deriver du registre : sans eux, la duplication serait silencieuse,
+et c'est precisement le silence que cette tranche supprime.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "notebook_tools"))
 
-from check_series_zero_pad import main, violations  # noqa: E402
+from check_series_zero_pad import (  # noqa: E402
+    REGISTRY_PATH,
+    REPO_ROOT,
+    RegistryError,
+    load_registry,
+    main,
+    violations,
+)
 
 
 @pytest.fixture
@@ -97,3 +113,220 @@ def test_main_json_shape(series: Path, capsys):
 
 def test_main_repertoire_introuvable():
     assert main(["--series-dir", "Nulle/Part"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Portee explicite (#15489, defaut 5) -- le registre, ses modes d'echec, et ses
+# deux miroirs.
+# ---------------------------------------------------------------------------
+
+def _registry(tmp_path: Path, entries: list[dict], name: str = "reg.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps({"adopted": entries}), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def two_series(tmp_path: Path) -> tuple[Path, Path]:
+    """Deux series sur disque : une propre (zero-padee), une en violation."""
+    clean = tmp_path / "Clean"
+    clean.mkdir()
+    (clean / "Alpha-01-X.ipynb").write_text("x", encoding="utf-8")
+    (clean / "Alpha-12-Y.ipynb").write_text("x", encoding="utf-8")
+    dirty = tmp_path / "Dirty"
+    dirty.mkdir()
+    (dirty / "Beta-7-Bad.ipynb").write_text("x", encoding="utf-8")
+    return clean, dirty
+
+
+def test_registre_declare_des_series_qui_existent():
+    """Le registre du depot ne doit nommer que des repertoires reels.
+
+    Un registre qui pointe dans le vide n'est pas un detail cosmetique : le
+    garde rendrait 2 en CI, et le rouge accuserait le depot au lieu du
+    registre.
+    """
+    for entry in load_registry():
+        assert (REPO_ROOT / entry["dir"]).is_dir(), entry["dir"]
+
+
+def test_registre_aujourd_hui_vert_sur_l_arbre_reel(capsys):
+    """L'invocation CI (sans argument) doit rendre 0 sur main.
+
+    C'est la preuve d'admission des 8 series declarees : le critere du
+    registre affirme "zero violation sur l'arbre entier", et ce test le
+    verifie sur l'arbre reel plutot que de faire confiance a la note.
+    """
+    assert main([]) == 0
+    out = capsys.readouterr().out
+    assert "0 violation(s)" in out
+
+
+def test_registre_scanne_toutes_les_series_declarees(two_series, tmp_path,
+                                                     capsys):
+    clean, _ = two_series
+    reg = _registry(tmp_path, [{"series": "Alpha", "dir": str(clean)}])
+    assert main(["--registry", str(reg), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "registry"
+    assert [s["series"] for s in payload["series"]] == ["Alpha"]
+
+
+def test_famille_non_declaree_n_est_jamais_scannee(two_series, tmp_path,
+                                                   capsys):
+    """Non-regression du point d'acceptance : une famille NON adoptee ne doit
+    pas rougir. `Dirty` porte Beta-7 (chiffre unique) et n'est pas declaree :
+    le mode registre l'ignore completement."""
+    clean, dirty = two_series
+    reg = _registry(tmp_path, [{"series": "Alpha", "dir": str(clean)}])
+    assert main(["--registry", str(reg)]) == 0
+    out = capsys.readouterr().out
+    assert "Dirty" not in out and "Beta" not in out
+
+
+def test_serie_declaree_en_violation_rougit(two_series, tmp_path, capsys):
+    """Le pendant du test precedent : declarer une serie non migree DOIT
+    rougir. Sans ce test, le garde pourrait rendre 0 en ne scannant rien --
+    c'est le mode de defaillance qu'un registre introduit."""
+    _, dirty = two_series
+    reg = _registry(tmp_path, [{"series": "Beta", "dir": str(dirty)}])
+    assert main(["--registry", str(reg)]) == 1
+    assert "Beta-7-Bad.ipynb" in capsys.readouterr().out
+
+
+def test_serie_declaree_absente_rend_2(tmp_path, capsys):
+    """Une serie declaree disparue est un defaut du REGISTRE, pas un vert."""
+    reg = _registry(tmp_path, [{"series": "Fantome",
+                                "dir": str(tmp_path / "nulle-part")}])
+    assert main(["--registry", str(reg)]) == 2
+    assert "introuvable" in capsys.readouterr().err
+
+
+def test_registre_absent_rend_2_pas_vert(tmp_path, capsys):
+    """Le mode de defaillance a interdire : un registre illisible qui rendrait
+    0 en scannant zero serie."""
+    assert main(["--registry", str(tmp_path / "absent.json")]) == 2
+    assert "illisible" in capsys.readouterr().err
+
+
+def test_registre_malforme_rend_2(tmp_path, capsys):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ pas du json", encoding="utf-8")
+    assert main(["--registry", str(bad)]) == 2
+    assert "malforme" in capsys.readouterr().err
+
+
+def test_registre_sans_adopted_rend_2(tmp_path, capsys):
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({"adopted": []}), encoding="utf-8")
+    assert main(["--registry", str(empty)]) == 2
+    assert "adopted" in capsys.readouterr().err
+
+
+def test_surcharge_explicite_prime_sur_le_registre(two_series, capsys):
+    """`--series-dir` reste la forme historique et doit continuer de marcher
+    seule, registre du depot ou non : c'est ce qui garde les autres tests de
+    ce fichier valides."""
+    clean, _ = two_series
+    assert main(["--series-dir", str(clean), "--prefix", "Alpha"]) == 0
+    _, dirty = two_series
+    assert main(["--series-dir", str(dirty), "--prefix", "Beta"]) == 1
+    assert "Beta-7-Bad.ipynb" in capsys.readouterr().out
+
+
+def test_json_registre_forme_stable(two_series, tmp_path, capsys):
+    """Forme JSON stable pour consommation CI (acceptance de #15489)."""
+    _, dirty = two_series
+    reg = _registry(tmp_path, [{"series": "Beta", "dir": str(dirty)}])
+    assert main(["--registry", str(reg), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) >= {"schema", "mode", "series", "count", "violations",
+                            "missing_dirs"}
+    assert payload["schema"] == 2
+    assert payload["count"] == 1
+    assert payload["violations"][0]["series"] == "Beta"
+    assert payload["series"][0]["count"] == 1
+
+
+def test_json_serie_unique_porte_encore_les_cles_historiques(series: Path,
+                                                             capsys):
+    (series / "GameTheory-3f-Bad.ipynb").write_text("x", encoding="utf-8")
+    assert main(["--series-dir", str(series), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "series"
+    assert payload["prefix"] == "GameTheory"
+    assert payload["count"] == 1
+
+
+def test_list_series(capsys):
+    assert main(["--list-series"]) == 0
+    lines = [l for l in capsys.readouterr().out.splitlines() if l.strip()]
+    assert len(lines) == len(load_registry()) == 8
+    assert any(l.startswith("GameTheory\t") for l in lines)
+
+
+# --- Parite registre <-> miroirs -------------------------------------------
+#
+# Le registre est la source de verite ; le workflow et la voie rapide en
+# portent une copie. Ces tests rendent la duplication VERIFIEE : sans eux,
+# ajouter une serie au registre laisserait les deux miroirs muets, et le
+# garde ne serait declenche par rien pour cette serie.
+
+def _workflow_push_paths() -> list[str]:
+    doc = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/series-naming-gate.yml")
+        .read_text(encoding="utf-8"))
+    # PyYAML 1.1 lit la cle `on` comme le booleen True.
+    on = doc.get("on", doc.get(True))
+    return on["push"]["paths"]
+
+
+def _fast_lane_paths() -> list[str]:
+    sys.path.insert(0, str(REPO_ROOT / "scripts/ci"))
+    import fast_lane_registry as flr
+
+    guards = [g for lst in vars(flr).values()
+              if isinstance(lst, list)
+              for g in lst
+              if getattr(g, "source", None) == "series-naming-gate.yml"]
+    assert len(guards) == 1, "garde zero-pad introuvable ou duplique"
+    return list(guards[0].paths)
+
+
+@pytest.mark.parametrize("mirror", [_workflow_push_paths, _fast_lane_paths],
+                         ids=["workflow-paths", "fast-lane-guard"])
+def test_miroir_couvre_chaque_serie_declaree(mirror):
+    """Chaque serie du registre doit apparaitre dans les deux miroirs, sinon le
+    garde ne se declenche pas quand cette serie change."""
+    paths = mirror()
+    for entry in load_registry():
+        assert f"{entry['dir']}/**" in paths, (
+            f"{entry['series']} declaree mais absente du miroir : {entry['dir']}")
+    assert "scripts/notebook_tools/zero_pad_series.json" in paths, (
+        "le registre lui-meme doit declencher le garde")
+
+
+@pytest.mark.parametrize("mirror", [_workflow_push_paths, _fast_lane_paths],
+                         ids=["workflow-paths", "fast-lane-guard"])
+def test_miroir_sans_serie_orpheline(mirror):
+    """L'inverse : aucun miroir ne doit citer une serie non declaree. C'est ce
+    qui empeche d'elargir la portee en editant le YAML sans passer par le
+    critere d'admission mesure."""
+    declared = {e["dir"] for e in load_registry()}
+    for path in mirror():
+        if path.startswith("MyIA.AI.Notebooks/") and path.endswith("/**"):
+            assert path[:-3] in declared, (
+                f"{path} n'est pas une serie declaree au registre")
+
+
+def test_fast_lane_garde_nomme_la_portee_reelle():
+    """Le nom du check-run ne doit pas mentir sur la portee (une portee
+    'GameTheory serie' pour huit series serait un proxy faux)."""
+    sys.path.insert(0, str(REPO_ROOT / "scripts/ci"))
+    import fast_lane_registry as flr
+
+    guard = next(g for lst in vars(flr).values() if isinstance(lst, list)
+                 for g in lst
+                 if getattr(g, "source", None) == "series-naming-gate.yml")
+    assert "GameTheory" not in guard.name
+    assert REGISTRY_PATH.name not in guard.argv  # lit le registre via son defaut


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15622

## Résumé

Défaut 5 de #15489 : « `check_series_zero_pad.py` doit rester opt-in par séries migrées ; une activation globale avant cartographie créerait un mur rouge inutilisable. » Son acceptance demande « Padding activé par **liste explicite** de séries migrées, avec tests de non-régression sur familles non encore adoptées ».

Avant cette PR, la portée du garde tenait à deux défauts `argparse` (`--series-dir` = GameTheory, `--prefix` = GameTheory) et à une phrase de docstring. C'était une convention de fait : non datée, non justifiée, et **invisible à tout contrôle automatique**. Sa docstring affirmait encore que GameTheory était « la seule zéro-padée à ce jour » — vrai en #12586, faux depuis que sept autres séries l'ont adopté en silence.

## Mesure firsthand avant d'écrire une ligne

`origin/main@d14b1ac098`, balayage de l'arbre par `parse_name` du canon #5081 (hors `/.lake/` et `/_peters/`) :

| Catégorie | # | Détail |
|---|---|---|
| Séries qui **prouvent** le zéro-pad et sont propres | **8** | GameTheory (48 pad), FT (7), IIT (5), DecInfer (9), PyMC (9), Search/Part1-Foundations (31), MGS (12), Sudoku (19) |
| Séries **sans aucun zéro de tête** (non prouvées) | 7 | App/Search (4 numéros, tous ≥ 10), MGS-vs-mealpy, Planners/04, 4× SC |
| Familles qui **rougiraient** si activées | **20** | Tweety 28, ML 20, CSP 18, App/CSP 17, SW 17, SL 17, Lean 11, Infer 10, ICT 9, DecPyMC 9, Planners 8/6/6, SC 5/4/4, DoWhy 2, App/Hybrid 2, **RL 1**, Planners/00 1 |

`RL` est à **un** fichier de l'adoption — la famille la plus proche du seuil. Le registre la nomme, avec son compte, pour qu'on ne la déclare pas avant de l'avoir migrée.

## Le critère d'admission, en deux moitiés mesurées

1. **La série prouve son padding** : au moins un fichier dont le numéro porte un zéro de tête (`01`, `04a`). Une série qui ne porte que des numéros ≥ 10 n'a rien adopté — elle n'a simplement aucun numéro à un chiffre, donc son état ne dit rien de sa convention. Les 7 familles ci-dessus sont exclues pour cette raison précise.
2. **La série ne porte aucune violation sur son arbre entier** (sous-dossiers compris : le scan est `rglob` récursif).

La moitié 2 est ce qui distingue ce garde du garde de casse canonique des suffixes (#15616) : celui-là est **delta** (`--diff-filter=A`) et peut donc déclarer une série en laissant ses fichiers hérités non conformes. Ici le scan est **whole-tree**, donc déclarer une série non migrée rougit des dizaines de fichiers d'un coup — exactement le mur rouge que l'issue interdit.

## Correctifs

| Fichier | Δ | Changement |
|---|---|---|
| `scripts/notebook_tools/zero_pad_series.json` | +83/-0 | **nouveau** — registre : 8 séries déclarées (nommées, datées, mesurées) + critère + les 20 familles sous `_not_declared` avec leur compte |
| `scripts/notebook_tools/check_series_zero_pad.py` | +232/-32 | sans argument → scanne le registre (invocation CI) ; `--series-dir` reste la surcharge d'une série ; `--registry`, `--list-series` ; `RegistryError` |
| `scripts/tests/test_check_series_zero_pad.py` | +234/-1 | 18 tests — modes d'échec du registre, critère discriminant, parité registre ↔ miroirs |
| `scripts/ci/fast_lane_registry.py` | +17/-4 | garde renommé `zero-pad guard (series declarees)` + `paths` miroir du registre |
| `.github/workflows/series-naming-gate.yml` | +31/-13 | `paths:` miroir du registre + en-tête corrigé (ne dit plus « GameTheory SEULEMENT ») |

**Modes d'échec fermés.** Un registre illisible, malformé, vide (`adopted: []`), ou déclarant un répertoire absent rend **2** — jamais 0. Un garde qui rendrait vert en ne scannant rien serait le pire mode de défaillance qu'un registre introduit, et il est explicitement testé.

## Preuve

| Preuve | Résultat |
|---|---|
| Registre en mode CI sur l'arbre réel | **exit 0**, `8 serie(s) declaree(s), 0 violation(s)` |
| Sonde négative — famille non déclarée (`Tweety`) déclarée de force | **exit 1**, violations nommées (le critère discrimine, ce n'est pas un tampon) |
| Suite `test_check_series_zero_pad.py` | **29 passed** (11 existants inchangés + 18 nouveaux) |
| Suite voie rapide + identité des check-runs absorbés | **86 passed** |
| `check_absorbed_check_run_identity.py` | `OK -- 16 gardes absorbes byte-identiques a leur source` (le renommage est vérifié par l'organe lui-même) |
| Test de parité **muté** (série ajoutée au registre seul) | **2 failed** — puis restauré, 29 passed |

La mutation du test de parité est la preuve qui compte : sans elle, on ne saurait pas si ces tests peuvent rougir. Ajouter une série au registre sans toucher les deux miroirs fait échouer `test_miroir_couvre_chaque_serie_declaree` dans les deux configs (workflow et voie rapide), et l'inverse est verrouillé par `test_miroir_sans_serie_orpheline`.

Le renommage du check-run était sûr, vérifié avant de le faire : `required_status_checks.contexts = ["PR gate"]` seulement, `rulesets: []`. Aucun autre nom de check-run n'est requis par la protection de branche.

## Ce que cette PR ne fait pas

- Elle **ne migre aucune série** : renommer les fichiers d'une famille est une tranche à part, avec ses README et ses navlinks. Les 20 familles restent rouges tant qu'elles ne sont pas migrées — c'est voulu, et leurs comptes sont dans le registre.
- Elle **ne déclare pas** les 7 familles « non prouvées » : leur état ne prouve rien, et les déclarer créerait une règle sans objet mesurable.
- Elle ne touche **aucun** notebook, catalogue ou traduction générée.
- Défaut 6 de l'issue (`check_link_label_agreement.py`) reste hors périmètre, comme l'issue le demande elle-même.

See #15489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
