### PR TITLE
fix(nits,#14705): voie 3 B.0 — élargir la borne nommeur au coordinateur (LIFT_OVERRIDE_LOGINS)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -2904,7 +2904,10 @@ def collect_followup_lifts(pr_data: dict, cutoff: datetime,
     Une phrase de l'auteur de la PR ne leve pas la reserve d'un tiers
     (voie 1 close pour lui, #11145), mais un report nomme avant merge est
     un geste delibere que B.0 credite — l'auteur de la PR est explicitement
-    ouvert comme nommeur (borne #13563).
+    ouvert comme nommeur (borne #13563). #14705 elargit au coordinateur
+    (``LIFT_OVERRIDE_LOGINS``) : B.0 est son gate, et un report se falsifie
+    en n'ouvrant pas l'issue — ce que les conditions 1-6 verifient deja —
+    pas en se declarant.
 
     `issue_info=None` coupe la voie — `analyse()` reste pur pour les tests
     (aucun appel reseau n'y est tolere). Retourne des tuples
@@ -3859,7 +3862,12 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                              and _lift_eligible(lifter, login, lift_body, body)
                              for (t, lifter, lift_body) in explicit_lifts)
                       # #14218 conditions 5+6 — voir commentaire `followup_lifts`
-                      or any(when < t < cutoff and namer in (login, pr_author)
+                      # #14705 — le coordinateur est un nommeur credite : la
+                      # voie 3 REPORT (elle n'affirme pas la reserve traitee),
+                      # et B.0 est le gate du coordinateur.
+                      or any(when < t < cutoff
+                             and (namer in (login, pr_author)
+                                  or namer in LIFT_OVERRIDE_LOGINS)
                              and when < info.created_at
                              and _issue_references_pr(info, pr_number)
                              for (t, namer, info) in followup_lifts))
@@ -3888,8 +3896,13 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                     # garantie — l'issue existe et fut creee AVANT le cutoff —
                     # et reste ouverte a l'auteur : un report nomme avant
                     # merge est un geste delibere que B.0 credite. Borne
-                    # nommeur (c.705) : {auteur du blocage, auteur de la PR}.
-                    or any(when < t < cutoff and namer in (login, pr_author)
+                    # nommeur (c.705) : {auteur du blocage, auteur de la PR}
+                    # ; #14705 y ajoute le coordinateur (LIFT_OVERRIDE_LOGINS)
+                    # — B.0 est son gate, et un report se falsifie en n'ouvrant
+                    # pas l'issue, ce que les conditions 1-6 verifient deja.
+                    or any(when < t < cutoff
+                           and (namer in (login, pr_author)
+                                or namer in LIFT_OVERRIDE_LOGINS)
                            and when < info.created_at
                            and _issue_references_pr(info, pr_number)
                            for (t, namer, info) in followup_lifts)):
@@ -3907,7 +3920,11 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
                   when < t < cutoff and _lift_eligible(lift_author, login, lift_body, body)
                   for (t, lift_author, lift_body) in explicit_lifts
               ) or _approved_lifts_reserve(login, when, pr_author)
-              or any(when < t < cutoff and namer in (login, pr_author)
+              # #14705 — meme elargissement nommeur que les deux surfaces
+              # voie 3 ci-dessus (reserve Hermes, blocage).
+              or any(when < t < cutoff
+                     and (namer in (login, pr_author)
+                          or namer in LIFT_OVERRIDE_LOGINS)
                      and when < info.created_at
                      and _issue_references_pr(info, pr_number)
                      for (t, namer, info) in followup_lifts)):

--- a/scripts/tests/test_check_unaddressed_nits_followup.py
+++ b/scripts/tests/test_check_unaddressed_nits_followup.py
@@ -430,3 +430,108 @@ def test_14218_mutation_si_predicat_retire_les_fp_rougissent():
         # mutation representative, et on documente la borne.
     finally:
         mod._issue_references_pr = saved
+
+
+# --- #14705 — voie 3 ouverte au coordinateur (B.0 est son gate) -----------------
+#
+# Cas fondateur : #14673 (réserve Hermes du 2026-09-04, report #14704 nommé
+# par myia-ai-01). Toutes les conditions de substance passaient ; seule
+# l'identité du nommeur échouait (`namer='myia-ai-01'` hors
+# `(login, pr_author)`), et le merge a dû passer par `[OVERRIDE] lane` — la
+# porte d'arbitrage EXCEPTIONNEL — pour un report que B.0 prévoit comme voie
+# ORDINAIRE.
+#
+# La borne nommeur garde sa raison d'être sur les voies 1/2 (se lever
+# soi-même n'est pas répondre, #11145/#12798) ; elle ne transpose pas à la
+# voie 3, qui affirme le CONTRAIRE — la réserve n'est pas traitée, elle est
+# reportée. Un report se falsifie en n'ouvrant pas l'issue ; les conditions
+# 1-6 (#14218) le vérifient côté serveur. L'identité du nommeur n'y ajoute
+# rien — sauf à retirer au coordinateur la seule voie que B.0 lui donne.
+
+_PR_14705 = 14673  # la PR réelle du cas fondateur
+
+REPORT_COORD = {
+    "author": {"login": "myia-ai-01"},
+    "createdAt": at(12),
+    "body": "Le nit d'attribution est reporte sciemment sur l'issue #500.",
+}
+
+
+def test_14705_coordinateur_leve_reserve_hermes():
+    """Le cas mesuré (#14673) : réserve Hermes, pr-auteur == jsboige,
+    nommeur == coordinateur, issue ouverte postérieure référençant la PR —
+    lève SANS [OVERRIDE]."""
+    res = run([REPORT_COORD], reviews=[HERMES_NIT],
+              issue_info=resolver(ISSUE_OK, pr_number=_PR_14705),
+              number=_PR_14705)
+    assert res["blocked"] is False, (
+        "Un report nommé par le coordinateur satisfaisant les conditions 1-6 "
+        "doit lever la réserve sans [OVERRIDE] (#14705).")
+
+
+def test_14705_coordinateur_leve_blocage():
+    """Surface blocage : même élargissement nommeur (borne c.705 + #14705)."""
+    block = {"author": {"login": "myia-po-2025"}, "createdAt": at(10),
+             "body": "[BLOCAGE] lane myia-po-2025:CoursIA — l'attribution "
+                     "est fausse, pas de merge sans correctif."}
+    res = run([block, REPORT_COORD],
+              issue_info=resolver(ISSUE_OK, pr_number=_PR_14705),
+              number=_PR_14705)
+    assert res["blocked"] is False, (
+        "La voie 3 d'un blocage doit créditer le report du coordinateur.")
+
+
+def test_14705_coordinateur_leve_changes_requested():
+    """Surface re-review CHANGES_REQUESTED : même élargissement nommeur."""
+    cr = {"author": {"login": "hermes-bot"}, "state": "CHANGES_REQUESTED",
+          "submittedAt": at(10),
+          "body": "CHANGES_REQUESTED: 2 edge cases non couverts."}
+    res = run([REPORT_COORD], reviews=[cr],
+              issue_info=resolver(ISSUE_OK, pr_number=_PR_14705),
+              number=_PR_14705)
+    assert res["blocked"] is False, (
+        "La voie 3 d'un CHANGES_REQUESTED doit créditer le report du "
+        "coordinateur.")
+
+
+def test_14705_tiers_non_coordinateur_ne_leve_pas():
+    """Contrôle négatif (acceptance #14705) : un compte tiers QUELCONQUE (ni
+    nit-auteur, ni pr-auteur, ni coordinateur) ne lève toujours pas —
+    l'élargissement AJOUTE le coordinateur à la borne, il ne la supprime pas."""
+    third = dict(REPORT, author={"login": "myia-po-2025"})
+    res = run([USER_NIT, third],
+              issue_info=resolver(ISSUE_OK, pr_number=_PR_14705),
+              number=_PR_14705)
+    assert res["blocked"] is True, (
+        "Un tiers non coordinateur ne doit pas lever via la voie 3.")
+
+
+def test_14705_coordinateur_conditions_toujours_exigees():
+    """L'élargissement ne court-circuite pas les conditions 1-6 : un report du
+    coordinateur sur une issue qui ne RÉFÉRENCE PAS la PR ne lève pas."""
+    unrelated = make_issue(
+        _PR_14705, datetime(2026, 8, 14, 11, 0, tzinfo=timezone.utc),
+        title="Inspection du lundi", body="Quelques notes sans rapport.")
+    resolver_unrelated = lambda n: unrelated if n == 500 else None
+    res = run([USER_NIT, REPORT_COORD], issue_info=resolver_unrelated,
+              number=_PR_14705)
+    assert res["blocked"] is True, (
+        "Le coordinateur reste soumis à la condition 6 (l'issue doit citer "
+        "la PR) : l'identité ne remplace pas la substance.")
+
+
+def test_14705_mutation_sans_constante_les_fp_rougissent():
+    """Mutation (précédent #14218) : `LIFT_OVERRIDE_LOGINS` vidé -> les
+    contrôles positifs coordinateur rougissent. Prouve que les tests
+    #14705 valident la borne coordinateur, pas un vert par hasard."""
+    saved = mod.LIFT_OVERRIDE_LOGINS
+    try:
+        mod.LIFT_OVERRIDE_LOGINS = set()
+        res = run([REPORT_COORD], reviews=[HERMES_NIT],
+                  issue_info=resolver(ISSUE_OK, pr_number=_PR_14705),
+                  number=_PR_14705)
+        assert res["blocked"] is True, (
+            "Sans LIFT_OVERRIDE_LOGINS, le report coordinateur ne doit plus "
+            "lever — sinon les tests #14705 ne testent pas la borne.")
+    finally:
+        mod.LIFT_OVERRIDE_LOGINS = saved


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/docs #15577

## Le défaut (cas mesuré #14673 / #14704)

La voie 3 de B.0 — « une **issue de suivi ouverte et nommée AVANT le merge** (reportée sciemment) » — **ne pouvait pas être exercée par le coordinateur**. Les 3 surfaces voie 3 de `check_unaddressed_nits.py` créditaient un report uniquement quand le nommeur est l'auteur du nit ou l'auteur de la PR (borne c.705, élargie une fois à l'auteur de la PR par #13563 — jamais au coordinateur).

Sur #14673 (réserve Hermes du 2026-09-04, issue de suivi #14704) : toutes les conditions de substance passaient (cond. 5 « issue créée après la réserve » ✓, cond. 6 « référence la PR » ✓, fenêtre ✓), seule l'identité échouait (`namer='myia-ai-01'`, `login='jsboige'`, `pr_author='jsboige'`). `collect_followup_lifts` **collectait bien** le report — c'est la borne d'identité appliquée dans `analyse()` qui le jetait. Conséquence : merge passé par `[OVERRIDE] lane` (porte d'arbitrage **exceptionnel**) pour un report que B.0 prévoit comme voie **ordinaire**.

## Pourquoi la garde ne transpose pas

La borne d'auteur existe pour une bonne raison sur les voies 1 et 2 : **se lever soi-même la réserve d'un tiers n'est pas y répondre** (#11145, #12798). Cette raison ne transpose pas à la voie 3 : une voie-1 *affirme que la réserve est traitée* (d'où la borne), une voie-3 *affirme le contraire* — la réserve est **reportée, tracée, datée**. Un report se falsifie en n'ouvrant pas l'issue, et cela, les conditions 1-6 (#14218) le vérifient déjà côté serveur (issue réelle, ouverte, postérieure à la réserve, référençant la PR).

## Le correctif

Les 3 sites voie 3 reçoivent `or namer in LIFT_OVERRIDE_LOGINS` — réutilisation de la constante existante qui nomme le coordinateur pour l'override, **aucune surface neuve**. Les voies 1 et 2 gardent leur borne d'auteur **inchangée**.

| Site | Surface | Lignes |
|---|---|---|
| `analyse`, réserve Hermes / re-review | `lifted = (...)` | ~l.3857 |
| `analyse`, blocage (#13495) | `elif kind == "BLOCK"` | ~l.3885 |
| `analyse`, nit en commentaire/review COMMENTED | `elif (...)` | ~l.3906 |

```python
or any(when < t < cutoff
       and (namer in (login, pr_author) or namer in LIFT_OVERRIDE_LOGINS)
       and when < info.created_at
       and _issue_references_pr(info, pr_number)
       for (t, namer, info) in followup_lifts))
```

Docstring de `collect_followup_lifts` et commentaires de site mis à jour (#14705 cité).

## Validation

- `scripts/tests/test_check_unaddressed_nits_followup.py` : **31/31** (25 existants + 6 nouveaux).
- Les 5 autres fichiers du script : **493/493** — les gardes voies 1/2 (#11145/#12798), trappe coordinateur #13495, dismissal, hold, mention, unevaluated restent vertes.

### Acceptance #14705 → tests

| Critère d'acceptance | Test |
|---|---|
| Report nommé par `myia-ai-01`, conditions 1-6 → lève sans `[OVERRIDE]` | `test_14705_coordinateur_leve_reserve_hermes` (le cas mesuré #14673) + les 2 autres surfaces (`_leve_blocage`, `_leve_changes_requested`) |
| Contrôle négatif : tiers quelconque ne lève pas | `test_14705_tiers_non_coordinateur_ne_leve_pas` (bystander ≠ coordinateur) + `test_voie3_bystander_ne_leve_pas` existant |
| Contrôle négatif 2 : voies 1/2 fermées à l'auto-levée | 493/493 sur les fichiers existants (dont `test_trappe_refusee_pour_lauteur_de_la_pr`) |
| Cas mesuré : nit-auteur == pr-auteur == `jsboige`, nommeur == `myia-ai-01`, issue postérieure référençant la PR → lève | `test_14705_coordinateur_leve_reserve_hermes` |
| Mutation : si la borne coordinateur est retirée, les tests rougissent | `test_14705_mutation_sans_constante_les_fp_rougissent` (`LIFT_OVERRIDE_LOGINS` vide → le report coordinateur ne lève plus) |

Un 7ᵉ garde inattendu s'est révélé utile : `test_14705_coordinateur_conditions_toujours_exigees` — le coordinateur reste soumis à la condition 6 (l'issue doit citer la PR) : l'élargissement d'identité ne remplace pas la substance.

Closes #14705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
