### PR TITLE
feat(catalog,#15606): le générateur émet son compte d'exclusions par motif

### DIFF
--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -574,6 +574,37 @@ pour le fallback Playwright + execution **via QC Cloud** (`mcp__qc-mcp-lite__*`)
 `fix_catalog_drift.py` : regeneration du catalogue (`COURSE_CATALOG.generated.json`,
 marqueurs `<!-- CATALOG-STATUS:START -->...:END -->`).
 
+**Regle d'exclusion du scan** (#15606) : le generateur n'indexe PAS tout
+l'arbre — l'ecart arbre/catalogue est structurel et deliberé. Le scan itere
+les repertoires de serie sous `MyIA.AI.Notebooks/` puis ecarte chaque notebook
+sous le PREMIER motif applicable, dans cet ordre de précédence :
+
+1. `git_non_tracke` — fichier non suivi par git (quand `--git-tracked-only`,
+   le mode du cron) ;
+2. `suffixe_executed` — stem finissant par `_executed` ;
+3. `segment_exclu:<segment>` — un segment du chemin est dans `EXCLUDE_ALWAYS`
+   (`.ipynb_checkpoints`, `obj`, `bin`, `__pycache__`, `.git`) ;
+4. `pedagogical:<motif>` — le chemin relatif a la serie CONTIENT un substring
+   de `EXCLUDE_PEDAGOGICAL` (`research`, `archive`, `_archive`, `_archives`,
+   `_output`, `output`, `partner-course`, `examples`) ;
+5. `serie_exclue:<nom>` — serie entiere dans `EXCLUDE_ALWAYS` ou cachée (dot).
+6. `racine_non_parcourue` — un `.ipynb` pose directement a la racine de
+   `MyIA.AI.Notebooks/` n'est jamais visite (le scan itere les series, pas
+   les fichiers racine ; `GradeBook.ipynb` est l'instance vivante) ;
+7. `json_illisible` — notebook que `analyze_notebook` ne peut pas parser.
+
+Le generateur EMET ce compte a chaque run (`excluded N <motif>` par ligne,
+visible dans les logs de `catalog-cron.yml`) : la reconciliation
+`arbre = indexes + exclus par motif` se fait par construction, sans document
+humain a maintenir. Toute alarme « catalogue incomplet » doit d'abord
+confronter ce compte — un notebook absent du catalogue ET d'aucun motif est
+seulement alors un vrai oubli. Mesure de reference (2026-09-11, origin/main,
+attribution deterministic par tri des motifs) : 1254 ipynb trackes =
+1136 indexes + 117 `pedagogical:*` (98 research, 8 _archive, 6 examples,
+3 partner-course, 2 output) + 1 racine_non_parcourue. Le catalogue commis
+(1130) est en retard de 6 sur ce compte (notebooks du jour non encore
+ingeres par le cron de 16:00 — rattrapes au tick suivant).
+
 **Regle HARD catalog-pr-hygiene R1** : JAMAIS regenerer le catalogue sur
 une branche feature (propriete de l'automatisation). Qui regenere alors :
 

--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -29,6 +29,7 @@ import re
 import subprocess
 import sys
 import unicodedata
+from collections import Counter
 from pathlib import Path
 from urllib.parse import quote
 
@@ -1233,37 +1234,77 @@ def scan_all_notebooks(
     series_filter: str | None = None,
     git_meta: dict | None = None,
     git_tracked_only: bool = False,
+    exclusions: Counter[str] | None = None,
 ) -> list[dict]:
-    """Scan all notebooks and return catalog entries."""
+    """Scan all notebooks and return catalog entries.
+
+    Quand ``exclusions`` est fourni (un ``collections.Counter``), chaque
+    notebook écarté du catalogue y est compté sous son motif exact, dans
+    l'ordre de précédence réel des règles du scan — pour que l'écart
+    arbre/catalogue se réconcilie par construction et qu'aucune alarme
+    « catalogue incomplet » ne puisse confondre une exclusion voulue avec
+    un notebook oublié (#15606 point 2). La règle est documentée dans
+    scripts/notebook_tools/README.md (section Catalogue).
+    """
     tracked = _git_tracked_files() if git_tracked_only else None
     entries = []
     dirs = sorted(NOTEBOOKS_DIR.iterdir()) if not series_filter else [
         NOTEBOOKS_DIR / series_filter
     ]
 
+    def _count(motif: str, nb_path: Path) -> None:
+        if exclusions is not None:
+            exclusions[motif] += 1
+
     for series_dir in dirs:
         if not series_dir.is_dir():
             continue
         if series_dir.name in EXCLUDE_ALWAYS or series_dir.name.startswith("."):
+            for nb_path in sorted(series_dir.rglob("*.ipynb")):
+                if tracked and str(nb_path.relative_to(REPO_ROOT)).replace("\\", "/") not in tracked:
+                    continue
+                _count(f"serie_exclue:{series_dir.name}", nb_path)
             continue
 
         for nb_path in sorted(series_dir.rglob("*.ipynb")):
-            rel = str(nb_path.relative_to(REPO_ROOT)).replace("\\", "/")
-            if tracked and rel not in tracked:
+            if tracked and str(nb_path.relative_to(REPO_ROOT)).replace("\\", "/") not in tracked:
+                _count("git_non_tracke", nb_path)
                 continue
             if pedagogical and nb_path.stem.endswith("_executed"):
+                _count("suffixe_executed", nb_path)
                 continue
             parts = nb_path.relative_to(series_dir).parts
-            if any(part in EXCLUDE_ALWAYS for part in parts):
+            always_part = next(
+                (part for part in parts if part in EXCLUDE_ALWAYS), None
+            )
+            if always_part is not None:
+                _count(f"segment_exclu:{always_part}", nb_path)
                 continue
             if pedagogical and any(
                 exc in str(nb_path.relative_to(series_dir))
                 for exc in EXCLUDE_PEDAGOGICAL
             ):
+                motif = next(
+                    exc for exc in sorted(EXCLUDE_PEDAGOGICAL)
+                    if exc in str(nb_path.relative_to(series_dir))
+                )
+                _count(f"pedagogical:{motif}", nb_path)
                 continue
             entry = analyze_notebook(nb_path, pedagogical, git_meta=git_meta)
             if entry:
                 entries.append(entry)
+            else:
+                _count("json_illisible", nb_path)
+
+    # Le scan itère les RÉPERTOIRES de série : un .ipynb posé directement à la
+    # racine de MyIA.AI.Notebooks/ n'est jamais visité (#15606 — GradeBook.ipynb
+    # est l'instance vivante). Compté sous son propre motif pour que la
+    # réconciliation arbre/catalogue ne laisse aucun écart inexpliqué.
+    if exclusions is not None and not series_filter:
+        for nb_path in sorted(NOTEBOOKS_DIR.glob("*.ipynb")):
+            if tracked and str(nb_path.relative_to(REPO_ROOT)).replace("\\", "/") not in tracked:
+                continue
+            exclusions["racine_non_parcourue"] += 1
 
     return entries
 
@@ -1521,6 +1562,7 @@ def main():
     )
     args = parser.parse_args()
 
+    scan_exclusions: Counter[str] = Counter()
     pedagogical = not args.all
     git_meta = build_git_metadata()
     forensic_meta = build_forensic_metadata()
@@ -1538,7 +1580,19 @@ def main():
     entries = scan_all_notebooks(
         pedagogical=pedagogical, series_filter=args.series,
         git_meta=git_meta, git_tracked_only=args.git_tracked_only,
+        exclusions=scan_exclusions,
     )
+
+    # Compte des exclusions par motif (#15606 point 2) : la règle d'exclusion
+    # du scan est ÉMISE à chaque run pour que l'écart arbre/catalogue se
+    # réconcilie sans document humain — la réponse ne se périme pas.
+    total_excl = sum(scan_exclusions.values())
+    print(
+        f"Scan: {len(entries)} notebooks indexes, "
+        f"{total_excl} exclus par la regle (cf scripts/notebook_tools/README.md, Catalogue)"
+    )
+    for motif, n in sorted(scan_exclusions.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  excluded {n:>4}  {motif}")
 
     # Preserve curated git fields from origin/main for entries not
     # touched on the current branch (prevents stale-branch blanching)

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -8,6 +8,7 @@ classify_maturity.
 import json
 import sys
 import tempfile
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -1919,6 +1920,123 @@ class TestGenerateMarkdownReport:
             "#quarto-document-content table { display: block; overflow-x: auto; }"
             in report
         )
+
+
+# --- scan_all_notebooks : compte des exclusions par motif (#15606 point 2) ---
+
+def _write_nb(path: Path, cells=None) -> None:
+    """Write a minimal valid notebook at path (parents created)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {"cells": cells if cells is not None else [], "metadata": {}}
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+class TestScanExclusions:
+    """L'écart arbre/catalogue doit se réconcilier par construction :
+    chaque notebook écarté est compté sous son motif exact, dans l'ordre
+    de précédence réel des règles du scan."""
+
+    def test_reconciliation_par_motif(self, tmp_path, monkeypatch):
+        import generate_catalog as gc
+
+        root = tmp_path / "MyIA.AI.Notebooks"
+        monkeypatch.setattr(gc, "NOTEBOOKS_DIR", root)
+        # Une série saine : 1 gardé + 1 par motif d'exclusion.
+        _write_nb(root / "SerieA" / "keep.ipynb")
+        _write_nb(root / "SerieA" / "research" / "r.ipynb")
+        _write_nb(root / "SerieA" / "deep" / "_archive" / "a.ipynb")
+        _write_nb(root / "SerieA" / "old_executed.ipynb")
+        _write_nb(root / "SerieA" / ".ipynb_checkpoints" / "c.ipynb")
+        # Racine : jamais parcourue (le scan itère les séries).
+        _write_nb(root / "GradeBook-like.ipynb")
+        # Série entière exclue.
+        _write_nb(root / "obj" / "serie-exclue.ipynb")
+        # JSON illisible : analyze_notebook rend None.
+        bad = root / "SerieA" / "broken.ipynb"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("{not json", encoding="utf-8")
+
+        exclusions = Counter()
+        entries = gc.scan_all_notebooks(exclusions=exclusions)
+
+        assert [e["path"] for e in entries] == ["SerieA/keep.ipynb"]
+        assert exclusions == Counter({
+            "pedagogical:research": 1,
+            "pedagogical:_archive": 1,
+            "suffixe_executed": 1,
+            "segment_exclu:.ipynb_checkpoints": 1,
+            "racine_non_parcourue": 1,
+            "serie_exclue:obj": 1,
+            "json_illisible": 1,
+        })
+
+    def test_precedence_premiere_regle_gagnante(self, tmp_path, monkeypatch):
+        """Un notebook cumulant plusieurs motifs (research/ + _executed)
+        est compté sous le PREMIER motif applicable — suffixe avant substring."""
+        import generate_catalog as gc
+
+        root = tmp_path / "MyIA.AI.Notebooks"
+        monkeypatch.setattr(gc, "NOTEBOOKS_DIR", root)
+        _write_nb(root / "SerieA" / "research" / "both_executed.ipynb")
+
+        exclusions = Counter()
+        gc.scan_all_notebooks(exclusions=exclusions)
+        assert exclusions == Counter({"suffixe_executed": 1})
+
+    def test_git_non_tracke_seulement_avec_le_flag(self, tmp_path, monkeypatch):
+        import generate_catalog as gc
+
+        root = tmp_path / "MyIA.AI.Notebooks"
+        monkeypatch.setattr(gc, "NOTEBOOKS_DIR", root)
+        monkeypatch.setattr(gc, "REPO_ROOT", tmp_path)
+        _write_nb(root / "SerieA" / "a.ipynb")
+        _write_nb(root / "SerieA" / "b.ipynb")
+        # _git_tracked_files mocké : SEULEMENT a.ipynb est suivi.
+        monkeypatch.setattr(
+            gc, "_git_tracked_files",
+            lambda: {"MyIA.AI.Notebooks/SerieA/a.ipynb"},
+        )
+
+        # Sans le flag : rien de filtré, aucune exclusion.
+        exclusions = Counter()
+        entries = gc.scan_all_notebooks(exclusions=exclusions)
+        assert len(entries) == 2 and not exclusions
+
+        # Avec --git-tracked-only : b.ipynb compté sous son motif.
+        exclusions = Counter()
+        entries = gc.scan_all_notebooks(
+            git_tracked_only=True, exclusions=exclusions
+        )
+        assert [e["path"] for e in entries] == ["SerieA/a.ipynb"]
+        assert exclusions == Counter({"git_non_tracke": 1})
+
+    def test_motif_substring_deterministe(self, tmp_path, monkeypatch):
+        """Un chemin contenant plusieurs substrings de EXCLUDE_PEDAGOGICAL
+        est attribué au motif le plus spécifique (tri déterministe), pas a
+        l'ordre d'itération du set."""
+        import generate_catalog as gc
+
+        root = tmp_path / "MyIA.AI.Notebooks"
+        monkeypatch.setattr(gc, "NOTEBOOKS_DIR", root)
+        # "_archive" contient aussi "archive" : "_archive" (trié avant) gagne.
+        _write_nb(root / "SerieA" / "x_archive_y" / "n.ipynb")
+
+        exclusions = Counter()
+        gc.scan_all_notebooks(exclusions=exclusions)
+        assert exclusions == Counter({"pedagogical:_archive": 1})
+
+    def test_sans_compteur_comportement_inchange(self, tmp_path, monkeypatch):
+        """Sans le paramètre exclusions, le scan rend exactement ce qu'avant
+        (signature additive : les appelants existants ne changent pas)."""
+        import generate_catalog as gc
+
+        root = tmp_path / "MyIA.AI.Notebooks"
+        monkeypatch.setattr(gc, "NOTEBOOKS_DIR", root)
+        _write_nb(root / "SerieA" / "keep.ipynb")
+        _write_nb(root / "SerieA" / "research" / "r.ipynb")
+
+        entries = gc.scan_all_notebooks()
+        assert [e["path"] for e in entries] == ["SerieA/keep.ipynb"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/research-code #15627

Quoi: le générateur de catalogue émet à chaque run son compte d'exclusions PAR MOTIF — l'écart arbre/catalogue devient réconciliable par construction (point 2 de #15606), et la règle d'exclusion est nommée dans le README du générateur.

Preuve: `pytest scripts/notebook_tools/tests/test_generate_catalog.py` = **193 passed** (188 existants + 5 nouveaux) ; run réel du générateur avec les flags exacts du cron (`--json-only --git-tracked-only`, sortie scratchpad hors repo) : `Scan: 1136 notebooks indexes, 118 exclus par la regle`, décomposé 98 `pedagogical:research` + 8 `_archive` + 6 `examples` + 3 `partner-course` + 2 `output` + 1 `racine_non_parcourue` ; réconciliation complète mesurée firsthand sur origin/main : **1254 ipynb trackés = 1136 indexés + 117 exclus substring + 1 racine jamais parcourue**.

Perimetre: `scripts/notebook_tools/generate_catalog.py` (paramètre additif `exclusions` de `scan_all_notebooks` + émission dans `main()` ; `rel` git calculé paresseusement — il ne servait qu'au filtre tracked), `scripts/notebook_tools/README.md` (§Catalogue : règle + précédence + mesure de référence), `scripts/notebook_tools/tests/test_generate_catalog.py` (+5 tests). AUCUNE régén du catalogue sur la branche (règle catalog-pr-hygiene HARD 1 : `COURSE_CATALOG.generated.*` byte-identiques à main — non touchés).

## Le défaut que ceci ferme

L'écart arbre/catalogue est structurel (le scan exclut délibérément research/archive/partner-course/examples/output, les `_executed`, les segments `EXCLUDE_ALWAYS`) mais cette règle n'était écrite **nulle part** : chaque run de cron pouvait relancer une fausse alarme « catalogue incomplet », et aucun auditeur ne pouvait distinguer une exclusion voulue d'un notebook réellement oublié (#15606 point 2). Le geste demandé par l'issue : « la faire **émettre par le générateur lui-même** (un compte `excluded: N` par motif), pour que la réponse ne se périme pas ».

## Le mécanisme

`scan_all_notebooks(..., exclusions: Counter[str] | None = None)` — signature additive, les deux appelants existants (main + tests) inchangés par défaut. Chaque notebook écarté est compté sous le PREMIER motif applicable dans l'ordre de précédence réel du scan : `git_non_tracke` (si `--git-tracked-only`), `suffixe_executed`, `segment_exclu:<segment>`, `pedagogical:<motif>` (attribution déterministe par tri — un chemin contenant `partner-course` ET `examples` est attribué une seule fois, au motif trié en tête), `serie_exclue:<nom>`, `racine_non_parcourue`, `json_illisible` (le `return None` de `analyze_notebook`, invisible jusqu'ici). La racine `MyIA.AI.Notebooks/*.ipynb` n'est jamais visitée par design (le scan itère les répertoires de série — `GradeBook.ipynb` est l'instance vivante) : comptée sous son propre motif pour que la réconciliation ne laisse AUCUN écart inexpliqué. `main()` imprime le compte à chaque run — visible dans les logs de `catalog-cron.yml` et `catalog-drift.yml`, y compris en `--check`.

## Tests (5 nouveaux, arbre synthétique, `NOTEBOOKS_DIR` monkeypatché)

| Test | Gate |
|---|---|
| reconciliation_par_motif | un arbre plantant chaque motif rend le compte EXACT attendu et un seul entrée indexée |
| precedence_premiere_regle_gagnante | chemin cumulant `research/` + `_executed` compté sous `suffixe_executed` (l'ordre du scan, pas un choix de test) |
| git_non_tracke_seulement_avec_le_flag | sans le flag : zéro exclusion ; avec : `b.ipynb` compté sous `git_non_tracke` (`_git_tracked_files` mocké) |
| motif_substring_deterministe | `_archive` (trié avant `archive`) attribue le chemin multi-motifs une seule fois |
| sans_compteur_comportement_inchange | sans le paramètre, le scan rend exactement les mêmes entrées qu'avant |

## Mesure de référence (2026-09-11, origin/main@d14b1ac098)

1254 ipynb trackés = 1136 indexés + 117 `pedagogical:*` + 1 `racine_non_parcourue`. Le catalogue commis (1130 entrées) est en retard de 6 sur ce compte : les 6 notebooks du jour (GameTheory-02c/06f, App-18c, Lean-3b, SL-12b, SL-13) ajoutés après la base de la régén 16:00 — rattrapés au tick suivant du cron, ce n'est PAS une exclusion.

Les points 1 (plafond contents 1 MiB) et 3 (compte GameTheory) de #15606 sont mesurés et rapportés sur le fil de l'issue — le point 3 se réconcilie sans changement (marqueur `pedagogical_count: 98` = catalogue 98 ; l'écart résiduel vs arbre 100 = les 2 notebooks GameTheory en retard cron ci-dessus), le point 1 (énumération des consommateurs `contents`) est un sujet séparé s'il appelle un correctif.

See #15606 (contribution partielle : point 2 livré, points 1 et 3 mesurés/réconciliés sur le fil).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
