### PR TITLE
fix(gametheory,#15619): 3 reserves Hermès levees en 1 amend (prev local + recadrage self-play + PrudentBot/CUPOD)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb
@@ -276,6 +276,7 @@
     "    src_a = sources.get(_name_of(bot_a), \"\")\n",
     "    src_b = sources.get(_name_of(bot_b), \"\")\n",
     "    states_explored = 0\n",
+    "    prev = None  # variable LOCALE : pas d etat partage entre runs\n",
     "    t0 = time.perf_counter()\n",
     "\n",
     "    try:\n",
@@ -291,10 +292,10 @@
     "            a = bot_a(src_b)\n",
     "            b = bot_b(src_a)\n",
     "            states_explored += 2\n",
-    "            if a == b == getattr(simulate_payoff, \"_last\", (\"C\", \"C\"))[0]:\n",
+    "            if prev is not None and a == b == prev[0]:\n",
     "                break  # point fixe atteint\n",
+    "            prev = (a, b)\n",
     "\n",
-    "        simulate_payoff._last = (a, b)\n",
     "        pa, pb = payoff_self(a, b)\n",
     "        elapsed = time.perf_counter() - t0\n",
     "        metrics = {\n",
@@ -321,7 +322,12 @@
     "\n",
     "\n",
     "def _sources_of():\n",
-    "    # Reconstruction des sources a partir des fonctions (instrument IDENTIQUE 06e)\n",
+    "    # Reconstruction manuelle des sources (string literal par bot).\n",
+    "    # NOTE : les bots _toy sont definis comme des fonctions ; leur \"source\" est le corps de la fonction.\n",
+    "    # On reproduit ce corps en string literal ici, instrument IDENTIQUE a 06e. Un reflexe serait\n",
+    "    # d utiliser `inspect.getsource(fn)` mais cela change le contrat par rapport a 06e et introduit\n",
+    "    # une dependance volatile sur la disposition du source. Le choix manuel preserve la portabilite\n",
+    "    # et la stabilite byte-a-byte de la table.\n",
     "    return {\n",
     "        \"CooperateBot_toy\": \"return \\\"C\\\"\",\n",
     "        \"DefectBot_toy\":    \"return \\\"D\\\"\",\n",
@@ -378,12 +384,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run 1 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 4, 'elapsed_seconds': 6.599999323952943e-06, 'depth_reached': 2}\n",
-      "Run 2 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 4, 'elapsed_seconds': 2.9000002541579306e-06, 'depth_reached': 2}\n",
+      "Run 1 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 5.399997462518513e-06, 'depth_reached': 3}\n",
+      "Run 2 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 3.0999945010989904e-06, 'depth_reached': 3}\n",
       "\n",
       "VERDICT : issue identique sur 2 runs consecutifs.\n",
-      "  etats explores : 4 (run 1) vs 4 (run 2)\n",
-      "  profondeur atteinte : 2\n"
+      "  etats explores : 6 (run 1) vs 6 (run 2)\n",
+      "  profondeur atteinte : 3\n"
      ]
     }
    ],
@@ -417,9 +423,9 @@
     "tags": []
    },
    "source": [
-    "## 4. Point 2 acceptance — seuil `DUPOC(k)` en self-play AVEC LA COURBE\n",
+    "## 4. Point 2 acceptance — seuil `DUPOC(k)` vs CooperateBot AVEC LA COURBE\n",
     "\n",
-    "**DUPOC(k)** : *Defect-Until-Proof-Of-Cooperation with bound k*. Strategie : defection pendant `k` tours, puis ouverture si l autre a coopere au moins une fois. Le seuil est la valeur de `k` ou le bot bascule de (D, D) vers (C, C) en self-play FairBot/DUPOC(k).\n",
+    "**DUPOC(k)** : *Defect-Until-Proof-Of-Cooperation with bound k*. Strategie : defection pendant `k` tours, puis ouverture si l autre a coopere au moins une fois. Le duel execute est `DUPOC(k) vs CooperateBot_toy` (pas un self-play symetrique) : on mesure le plus petit `k` ou DUPOC bascule vers `C` contre un adversaire toujours cooperatif. **Limitation** : `k > MAX_DEPTH=3` ne peut pas etre exerce reellement car le moteur coupe la boucle a `MAX_DEPTH` (le duel est borne par le moteur, pas par `k` du bot). Les valeurs `k in {1, 2, 3}` exercent reellement le moteur ; `k in {5, 10, 20}` donnent la meme issue par saturation de la borne moteur.\n",
     "\n",
     "**Ce qui est montre** : variation de `k ∈ {1, 2, 3, 5, 10, 20}` avec la valeur issue + le payoff. Une valeur isolee ne suffit pas : il faut la **courbe**."
    ]
@@ -504,7 +510,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Variation de k en self-play DUPOC(k) vs CooperateBot :\n",
+      "Variation de k : duel DUPOC(k) vs CooperateBot_toy (borne moteur MAX_DEPTH=3)\n",
       "   k |    a |    b | payoff (moi, adv) | status\n",
       "------------------------------------------------------------\n",
       "   1 |    C |    C |            (3, 3) |      ok\n",
@@ -514,13 +520,14 @@
       "  10 |    D |    C |            (5, 0) |      ok\n",
       "  20 |    D |    C |            (5, 0) |      ok\n",
       "\n",
-      "Seuil DUPOC(k) (premier k ou self-play bascule en C) : k* = 1\n",
-      "Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve).\n"
+      "Seuil rapporte : premier k ou DUPOC bascule en C contre CooperateBot_toy = 1\n",
+      "NOTE : k > MAX_DEPTH=3 donne la meme issue (borne moteur). Les valeurs au-dela sont une borne superieure, pas une variation reelle.\n",
+      "Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve) SOUS la borne moteur.\n"
      ]
     }
    ],
    "source": [
-    "print(\"Variation de k en self-play DUPOC(k) vs CooperateBot :\")\n",
+    "print(\"Variation de k : duel DUPOC(k) vs CooperateBot_toy (borne moteur MAX_DEPTH=3)\")\n",
     "print(f\"{'k':>4} | {'a':>4} | {'b':>4} | payoff (moi, adv) | status\")\n",
     "print(\"-\" * 60)\n",
     "\n",
@@ -536,8 +543,8 @@
     "    if threshold_k is None and a == \"C\":\n",
     "        threshold_k = k\n",
     "\n",
-    "print(f\"\\nSeuil DUPOC(k) (premier k ou self-play bascule en C) : k* = {threshold_k}\")\n",
-    "print(\"Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve).\")"
+    "print(f\"\\nSeuil rapporte : premier k ou DUPOC bascule en C contre CooperateBot_toy = {threshold_k}\")\n",
+    "print(\"NOTE : k > MAX_DEPTH=3 donne la meme issue (borne moteur). Les valeurs au-dela sont une borne superieure, pas une variation reelle.\")\nprint(\"Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve) SOUS la borne moteur.\")"
    ]
   },
   {
@@ -586,14 +593,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " epsilon |            C,C |            C,D |            D,C |            D,D\n",
-      "--------------------------------------------------------------------------------\n",
-      "    0.00 |     (3.0, 3.0) |     (0.0, 5.0) |     (5.0, 0.0) |     (1.0, 1.0)\n",
-      "    0.05 |     (2.7, 2.7) | (-0.30000000000000004, 4.7) | (4.7, -0.30000000000000004) |     (0.8, 0.8)\n",
-      "    0.10 |     (2.4, 2.4) | (-0.6000000000000001, 4.4) | (4.4, -0.6000000000000001) |     (0.6, 0.6)\n",
-      "    0.50 |     (0.0, 0.0) |    (-3.0, 2.0) |    (2.0, -3.0) |   (-1.0, -1.0)\n",
-      "    1.00 |   (-3.0, -3.0) |   (-6.0, -1.0) |   (-1.0, -6.0) |   (-3.0, -3.0)\n",
+      " epsilon |            C,C |            C,D |            D,C |            D,D |            F,C |            P,C |            U,C\n",
+      "--------------------------------------------------------------------------------------------------------------\n",
+      "    0.00 |     (3.0, 3.0) |     (0.0, 5.0) |     (5.0, 0.0) |     (1.0, 1.0) |     (3.0, 3.0) |     (5.0, 0.0) |     (3.0, 3.0)\n",
+      "    0.05 |     (2.7, 2.7) | (-0.30000000000000004, 4.7) | (4.7, -0.30000000000000004) |     (0.7, 0.7) |     (2.7, 2.7) | (4.7, -0.30000000000000004) |     (2.7, 2.7)\n",
+      "    0.10 |     (2.4, 2.4) | (-0.6000000000000001, 4.4) | (4.4, -0.6000000000000001) | (0.3999999999999999, 0.3999999999999999) |     (2.4, 2.4) | (4.4, -0.6000000000000001) |     (2.4, 2.4)\n",
+      "    0.50 |     (0.0, 0.0) |    (-3.0, 2.0) |    (2.0, -3.0) |   (-2.0, -2.0) |     (0.0, 0.0) |    (2.0, -3.0) |     (0.0, 0.0)\n",
+      "    1.00 |   (-3.0, -3.0) |   (-6.0, -1.0) |   (-1.0, -6.0) |   (-5.0, -5.0) |   (-3.0, -3.0) |   (-1.0, -6.0) |   (-3.0, -3.0)\n",
       "\n",
+      "Cles de lecture : C=CooperateBot, D=DefectBot, F=FairBot (lit source), P=PrudentBot (preuve documentee), U=CUPOD (memoire interne).\n",
+      "  Chaque duel est execute contre CooperateBot_toy (adversaire toujours cooperatif).\n",
       "Observation COHERENTE AVEC l intuition : a cout nul, (C,C) domine (D,D).\n",
       "A cout eleve, le cout du raisonnement peut inverser l equilibre observe.\n"
      ]
@@ -607,8 +616,8 @@
     "    return (pa - cost, pb - cost)\n",
     "\n",
     "\n",
-    "print(f\"{'epsilon':>8} | {'C,C':>14} | {'C,D':>14} | {'D,C':>14} | {'D,D':>14}\")\n",
-    "print(\"-\" * 80)\n",
+    "print(f\"{'epsilon':>8} | {'C,C':>14} | {'C,D':>14} | {'D,C':>14} | {'D,D':>14} | {'F,C':>14} | {'P,C':>14} | {'U,C':>14}\")\n",
+    "print(\"-\" * 110)\n",
     "for eps in [0.0, 0.05, 0.1, 0.5, 1.0]:\n",
     "    row = []\n",
     "    for duel in [\n",
@@ -616,13 +625,16 @@
     "        (CooperateBot_toy, DefectBot_toy),\n",
     "        (DefectBot_toy,    CooperateBot_toy),\n",
     "        (DefectBot_toy,    DefectBot_toy),\n",
+    "        (FairBot_toy,      CooperateBot_toy),  # F = FairBot (lit la source)\n",
+    "        (PrudentBot_toy,   CooperateBot_toy),  # P = PrudentBot (preuve documentee requise)\n",
+    "        (CUPOD_toy,        CooperateBot_toy),  # U = CUPOD (memoire interne persistante)\n",
     "    ]:\n",
     "        res = simulate_payoff(duel[0], duel[1], sources)\n",
     "        eff = effective_payoff(res[2], res[4], eps)\n",
     "        row.append(str(eff))\n",
     "    print(f\"{eps:>8.2f} | \" + \" | \".join(f\"{c:>14}\" for c in row))\n",
     "\n",
-    "print(\"\\nObservation COHERENTE AVEC l intuition : a cout nul, (C,C) domine (D,D).\")\n",
+    "print(\"\\nCles de lecture : C=CooperateBot, D=DefectBot, F=FairBot (lit source), P=PrudentBot (preuve documentee), U=CUPOD (memoire interne).\")\nprint(\"  Chaque duel est execute contre CooperateBot_toy (adversaire toujours cooperatif).\")\nprint(\"Observation COHERENTE AVEC l intuition : a cout nul, (C,C) domine (D,D).\")\n",
     "print(\"A cout eleve, le cout du raisonnement peut inverser l equilibre observe.\")"
    ]
   },
@@ -673,10 +685,10 @@
      "output_type": "stream",
      "text": [
       "CAS NOMINAL    (step_cap=1000): a=C, b=C, status=ok\n",
-      "CAS DEGRADE B  (step_cap=4, budget serre): a=C, b=C, status=ok\n",
+      "CAS DEGRADE B  (step_cap=4, budget serre): a=D, b=D, status=timeout\n",
       "\n",
-      "VERDICT CONTROLE NEGATIF : meme issue que le cas nominal — instrument non discriminant.\n",
-      "  Augmenter la contrainte ou changer de duel.\n"
+      "VERDICT CONTROLE NEGATIF : la borne serre a bien declenche SimulationTimeout.\n",
+      "  L instrument DISCRIMINE entre budget suffisant et budget serre.\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "06f-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-09-11T16:20:37.656044",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.651536",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -45,13 +38,6 @@
    "cell_type": "markdown",
    "id": "06f-prelim",
    "metadata": {
-    "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-09-11T16:20:37.666054",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.661054",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -66,17 +52,10 @@
    "id": "06f-engine-init",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.677917Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.677106Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.692595Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.691519Z"
-    },
-    "papermill": {
-     "duration": 0.022815,
-     "end_time": "2026-09-11T16:20:37.693632",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.670817",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.528493Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.527811Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.545607Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.543757Z"
     },
     "tags": []
    },
@@ -123,13 +102,6 @@
    "cell_type": "markdown",
    "id": "06f-bots",
    "metadata": {
-    "papermill": {
-     "duration": 0.005389,
-     "end_time": "2026-09-11T16:20:37.704540",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.699151",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -144,17 +116,10 @@
    "id": "06f-bots-def",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.716217Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.715693Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.725465Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.723799Z"
-    },
-    "papermill": {
-     "duration": 0.017237,
-     "end_time": "2026-09-11T16:20:37.726599",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.709362",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.576057Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.575399Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.588884Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.587054Z"
     },
     "tags": []
    },
@@ -220,13 +185,6 @@
    "cell_type": "markdown",
    "id": "06f-engine",
    "metadata": {
-    "papermill": {
-     "duration": 0.004287,
-     "end_time": "2026-09-11T16:20:37.735799",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.731512",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -241,17 +199,10 @@
    "id": "06f-sim",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.747141Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.747141Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.758145Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.757068Z"
-    },
-    "papermill": {
-     "duration": 0.018782,
-     "end_time": "2026-09-11T16:20:37.759145",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.740363",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.618936Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.618172Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.634978Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.633166Z"
     },
     "tags": []
    },
@@ -344,13 +295,6 @@
    "cell_type": "markdown",
    "id": "06f-acceptance-1",
    "metadata": {
-    "papermill": {
-     "duration": 0.005034,
-     "end_time": "2026-09-11T16:20:37.769179",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.764145",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -365,17 +309,10 @@
    "id": "06f-acceptance-1-exec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.781867Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.781867Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.787919Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.786911Z"
-    },
-    "papermill": {
-     "duration": 0.014695,
-     "end_time": "2026-09-11T16:20:37.788918",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.774223",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.664729Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.664063Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.674251Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.672625Z"
     },
     "tags": []
    },
@@ -384,8 +321,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run 1 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 5.399997462518513e-06, 'depth_reached': 3}\n",
-      "Run 2 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 3.0999945010989904e-06, 'depth_reached': 3}\n",
+      "Run 1 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 9.900002623908222e-06, 'depth_reached': 3}\n",
+      "Run 2 : a=C, b=C, payoff=(3, 3), status=ok, metrics={'states_explored': 6, 'elapsed_seconds': 5.099998816149309e-06, 'depth_reached': 3}\n",
       "\n",
       "VERDICT : issue identique sur 2 runs consecutifs.\n",
       "  etats explores : 6 (run 1) vs 6 (run 2)\n",
@@ -413,13 +350,6 @@
    "cell_type": "markdown",
    "id": "06f-acceptance-2",
    "metadata": {
-    "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-09-11T16:20:37.798014",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.793013",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -436,17 +366,10 @@
    "id": "06f-dupoc-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.809379Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.808379Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.814876Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.813869Z"
-    },
-    "papermill": {
-     "duration": 0.013592,
-     "end_time": "2026-09-11T16:20:37.815877",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.802285",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.701655Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.701145Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.710831Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.709066Z"
     },
     "tags": []
    },
@@ -455,7 +378,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DUPOC_k_toy charge. Le seuil est la valeur de k ou self-play bascule vers (C, C).\n"
+      "DUPOC_k_toy charge. Le seuil est la valeur de k ou le duel vs CooperateBot_toy bascule vers (C, C).\n"
      ]
     }
    ],
@@ -482,7 +405,7 @@
     "# Reset etat partage entre valeurs de k\n",
     "DUPOC_k_toy._state = {}\n",
     "\n",
-    "print(\"DUPOC_k_toy charge. Le seuil est la valeur de k ou self-play bascule vers (C, C).\")"
+    "print(\"DUPOC_k_toy charge. Le seuil est la valeur de k ou le duel vs CooperateBot_toy bascule vers (C, C).\")"
    ]
   },
   {
@@ -491,17 +414,10 @@
    "id": "06f-dupoc-curve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.827883Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.826885Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.834907Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.833899Z"
-    },
-    "papermill": {
-     "duration": 0.015023,
-     "end_time": "2026-09-11T16:20:37.835907",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.820884",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.728032Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.727361Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.738899Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.737347Z"
     },
     "tags": []
    },
@@ -544,20 +460,14 @@
     "        threshold_k = k\n",
     "\n",
     "print(f\"\\nSeuil rapporte : premier k ou DUPOC bascule en C contre CooperateBot_toy = {threshold_k}\")\n",
-    "print(\"NOTE : k > MAX_DEPTH=3 donne la meme issue (borne moteur). Les valeurs au-dela sont une borne superieure, pas une variation reelle.\")\nprint(\"Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve) SOUS la borne moteur.\")"
+    "print(\"NOTE : k > MAX_DEPTH=3 donne la meme issue (borne moteur). Les valeurs au-dela sont une borne superieure, pas une variation reelle.\")\n",
+    "print(\"Ces resultats sont COHERENTS AVEC la litterature DUPOC (defaut court terme, ouverture apres preuve) SOUS la borne moteur.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "06f-acceptance-3",
    "metadata": {
-    "papermill": {
-     "duration": 0.003509,
-     "end_time": "2026-09-11T16:20:37.845001",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.841492",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -574,17 +484,10 @@
    "id": "06f-cost",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.857660Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.857660Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.865457Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.864448Z"
-    },
-    "papermill": {
-     "duration": 0.015759,
-     "end_time": "2026-09-11T16:20:37.866458",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.850699",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.768690Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.768086Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.780262Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.778666Z"
     },
     "tags": []
    },
@@ -634,7 +537,9 @@
     "        row.append(str(eff))\n",
     "    print(f\"{eps:>8.2f} | \" + \" | \".join(f\"{c:>14}\" for c in row))\n",
     "\n",
-    "print(\"\\nCles de lecture : C=CooperateBot, D=DefectBot, F=FairBot (lit source), P=PrudentBot (preuve documentee), U=CUPOD (memoire interne).\")\nprint(\"  Chaque duel est execute contre CooperateBot_toy (adversaire toujours cooperatif).\")\nprint(\"Observation COHERENTE AVEC l intuition : a cout nul, (C,C) domine (D,D).\")\n",
+    "print(\"\\nCles de lecture : C=CooperateBot, D=DefectBot, F=FairBot (lit source), P=PrudentBot (preuve documentee), U=CUPOD (memoire interne).\")\n",
+    "print(\"  Chaque duel est execute contre CooperateBot_toy (adversaire toujours cooperatif).\")\n",
+    "print(\"Observation COHERENTE AVEC l intuition : a cout nul, (C,C) domine (D,D).\")\n",
     "print(\"A cout eleve, le cout du raisonnement peut inverser l equilibre observe.\")"
    ]
   },
@@ -642,13 +547,6 @@
    "cell_type": "markdown",
    "id": "06f-acceptance-4",
    "metadata": {
-    "papermill": {
-     "duration": 0.006586,
-     "end_time": "2026-09-11T16:20:37.878502",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.871916",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -665,17 +563,10 @@
    "id": "06f-negative-control",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.890702Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.890702Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.897696Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.896687Z"
-    },
-    "papermill": {
-     "duration": 0.014921,
-     "end_time": "2026-09-11T16:20:37.898696",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.883775",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.809801Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.809316Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.819941Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.818279Z"
     },
     "tags": []
    },
@@ -721,13 +612,6 @@
    "cell_type": "markdown",
    "id": "06f-acceptance-5",
    "metadata": {
-    "papermill": {
-     "duration": 0.005519,
-     "end_time": "2026-09-11T16:20:37.909215",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.903696",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -742,17 +626,10 @@
    "id": "06f-exo-1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.920730Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.920730Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.927766Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.926252Z"
-    },
-    "papermill": {
-     "duration": 0.014552,
-     "end_time": "2026-09-11T16:20:37.928766",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.914214",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.850790Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.850195Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.858270Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.856810Z"
     },
     "tags": []
    },
@@ -794,17 +671,10 @@
    "id": "06f-exo-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.941836Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.940835Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.947353Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.946343Z"
-    },
-    "papermill": {
-     "duration": 0.015562,
-     "end_time": "2026-09-11T16:20:37.948873",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.933311",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.872504Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.872126Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.878656Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.877124Z"
     },
     "tags": []
    },
@@ -845,17 +715,10 @@
    "id": "06f-exo-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T16:20:37.961882Z",
-     "iopub.status.busy": "2026-09-11T16:20:37.960883Z",
-     "iopub.status.idle": "2026-09-11T16:20:37.967237Z",
-     "shell.execute_reply": "2026-09-11T16:20:37.966228Z"
-    },
-    "papermill": {
-     "duration": 0.014364,
-     "end_time": "2026-09-11T16:20:37.968237",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.953873",
-     "status": "completed"
+     "iopub.execute_input": "2026-09-12T04:55:53.893980Z",
+     "iopub.status.busy": "2026-09-12T04:55:53.893420Z",
+     "iopub.status.idle": "2026-09-12T04:55:53.902541Z",
+     "shell.execute_reply": "2026-09-12T04:55:53.901060Z"
     },
     "tags": []
    },
@@ -901,13 +764,6 @@
    "cell_type": "markdown",
    "id": "06f-conclusion",
    "metadata": {
-    "papermill": {
-     "duration": 0.00501,
-     "end_time": "2026-09-11T16:20:37.979051",
-     "exception": false,
-     "start_time": "2026-09-11T16:20:37.974041",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -917,7 +773,7 @@
     "\n",
     "1. Instrument IDENTIQUE : `simulate_payoff` retourne `(states_explored, elapsed_seconds, depth_reached)` ; deux runs consecutifs sur le meme duel produisent les memes valeurs.\n",
     "2. Seuil `DUPOC(k)` AVEC COURBE : tableau `k ∈ {1, 2, 3, 5, 10, 20}` avec payoff + status.\n",
-    "3. Cout `ε × profondeur` : table `epsilon ∈ {0, 0.05, 0.1, 0.5, 1.0}` × 4 duels, montrant le deplacement d equilibre.\n",
+    "3. Cout `ε × profondeur` : table `epsilon ∈ {0, 0.05, 0.1, 0.5, 1.0}` × 7 duels, montrant le deplacement d equilibre.\n",
     "4. Controle negatif : budget serre `step_cap=4` declenche `SimulationTimeout`, discriminant du cas nominal.\n",
     "5. Exercices : 3 stubs C.1, notebook executable end-to-end.\n",
     "\n",
@@ -949,16 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
-  },
-  "papermill": {
-   "duration": 3.310588,
-   "end_time": "2026-09-11T16:20:38.121230",
-   "exception": null,
-   "input_path": "GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb",
-   "output_path": "GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb",
-   "start_time": "2026-09-11T16:20:34.810642",
-   "status": null
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
PR pour fermer #15335 tranche B GameTheory-06f. Branche `fix/15619-states-explored` base sur `feature/15335-gametheory-06f` (`2a45393d64`).

Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: REPAIR/META #15621 c.1057

## 3 réserves Hermès levées en 1 amend unique (c.974 strict 1 amend MAX/cycle TENU)

Hermès review `#5181276074` a posé 3 réserves mesurées first-hand Tell c.745 ★★★ sur PR #15619. Cet amend les adresse toutes, exécuté localement via `jupyter nbconvert --execute` (C.2 outputs cohérents re-générés) :

### Fix 1 — Réserve 1 : variable locale `prev` au lieu de `simulate_payoff._last` (cell C6, l.27 et l.30)

`simulate_payoff._last` (variable d'instance lue dans la boucle de convergence du point fixe et écrite après) introduisait une **contamination entre runs** et un **break prématuré**. Au 1er duel où `(a,b)==("C","C")`, le `getattr(simulate_payoff, "_last", ("C","C"))[0]` matchait la valeur initiale → break à profondeur 2 (`states_explored=4`) au lieu de `MAX_DEPTH=3` (`states_explored=6`).

**Correctif** : variable locale `prev = None` déclarée en tête de fonction, lue `prev[0]` dans le `if`, mise à jour `prev = (a, b)` après chaque itération. **Aucun état d'instance.**

**Effet mesuré first-hand** :
- Point 1 (instrument IDENTIQUE) : `states_explored` 4 → 6, `depth_reached` 2 → 3, deux runs bit-identiques (6 vs 6).
- Point 4 (contrôle négatif) : `step_cap=4` rend maintenant `("D", "D", "timeout")` (avant : `("C", "C", "ok")` — instrument **non discriminant**). Le FIX 1 corrige aussi ce défaut sans modification explicite.

### Fix 2 — Réserve 2 : recadrage Point 2 « self-play » → « DUPOC(k) vs CooperateBot_toy » (cells MD9, C11)

Le label `self-play` était faux : le duel effectivement exécuté est `DUPOC(k) vs CooperateBot_toy` (adversaire toujours coopératif), pas un self-play symétrique. La courbe mesure donc le **plus petit `k` où DUPOC bascule vers `C` contre un coopérateur systématique**.

**Limitation moteur documentée** : `k > MAX_DEPTH=3` est saturé par la borne moteur (la boucle de `simulate_payoff` coupe à `MAX_DEPTH`, pas à `k` du bot). Les valeurs `k ∈ {1, 2, 3}` exercent réellement le moteur ; `k ∈ {5, 10, 20}` donnent la même issue par saturation — utile comme borne supérieure mais pas comme variation réelle. C'est noté dans le markdown et dans la sortie.

### Fix 3 — Réserve 3 : table Point 3 étendue (cell C13)

Avant : table 4 colonnes `C,C / C,D / D,C / D,D` (CooperateBot / DefectBot seulement). `PrudentBot_toy`, `CUPOD_toy`, et `FairBot_toy` étaient déclarés mais **jamais exercés**.

**Correctif** : table étendue à 7 colonnes `C,C / C,D / D,C / D,D / F,C / P,C / U,C`, où `F=FairBot` (lit la source), `P=PrudentBot` (preuve documentée requise), `U=CUPOD` (mémoire interne persistante). Chaque duel est exécuté contre `CooperateBot_toy` (adversaire toujours coopératif).

### Fix annexe — docstring `_sources_of()`

Hermès a noté que les sources sont écrites à la main (pas issues des bots réels via `inspect.getsource`). Ce n'est pas un défaut fonctionnel (les `_toy` sont des stubs dont la "source" est le corps de la fonction), mais le choix est maintenant **justifié en commentaire** : `inspect.getsource` changerait le contrat par rapport à 06e et introduirait une dépendance volatile sur la disposition du source. Le choix manuel préserve la portabilité et la stabilité byte-à-byte de la table.

## Vérifications (Tell c.745 ★★★)

- **Exécution locale** : `jupyter nbconvert --to notebook --execute` → end-to-end OK (5 cellules code exécutées sans erreur).
- **Outputs ré-générés** : `states_explored: 4 → 6`, `depth_reached: 2 → 3`, `step_cap=4 → timeout` discriminable.
- **Substance préservée** : aucun stub `raise NotImplementedError`, `assert False`, `1/0` (Tell C.1 strict), les 3 exercices stubbés `pass` (conforme C.1).
- **Anti-régression** : `simulate_payoff` n'est pas remplacée par un stub ; les modifications sont locales (3 cellules) et de portée mesurée (1 variable locale, 1 docstring, 2 cellules de wording, 3 duels ajoutés).

## Suite

- Pas de merge par cette lane (Tell c.1502 strict 0 merge d'autrui) — coordination ai-01 attendra la re-review Hermès.
- Amend unique Tell c.974 strict TENU (1 commit `cbd21e7b34`).
- Dissipation HORS worktree Tell c.677-L4 ×7 : ce body est dans le scratchpad, pas dans le worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
