### PR TITLE
feat(training,#15639): tranche 4B de la sonde VRAM — Qwen3-4B FIT a 4,096 GiB sur 8 Go

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_4b.jsonl
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_4b.jsonl
@@ -1,0 +1,1 @@
+{"model": "Qwen/Qwen3-4B", "torch": "2.13.0+cu126", "gpu": "NVIDIA GeForce RTX 3070 Laptop GPU", "vram_total_gb": 8.0, "status": "FIT", "load_s": 91.1, "train_s": 61.4, "sec_per_step": 20.5, "max_vram_allocated_gb": 4.096, "max_vram_reserved_gb": 5.0, "steps_done": 3, "error": null}


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2024:CoursIA — prev: MED/test #15543

## Summary

Tranche 4B de l'échelle demandée par le concern user sur #15634 (issue de suivi : #15639). Le même instrument que #15634 (`vram_wall_probe.py`, recipe QLoRA GRPO PT_11d exacte), exécuté sur le RTX 3070 Laptop 8 Go.

Mesure de ce cycle : **Qwen/Qwen3-4B — FIT, 4,096 GiB alloués (5,0 réservés), 20,5 s/step** (load 91 s, 3 steps).

## Campagne complète à date (RTX 3070 8 Go, recipe PT_11d)

| Modèle | Statut | VRAM max allouée | s/step |
|---|---|---|---|
| Qwen3.5-0.8B | FIT | 2,938 GiB | 21,6 |
| Qwen3-1.7B | FIT | 2,744 GiB | 15,9 |
| Qwen3-2B | FIT | 3,884 GiB | 17,3 |
| **Qwen3-4B** | **FIT** | **4,096 GiB** | **20,5** |

Lecture : l'enveloppe est **quasi plate de 2B à 4B** (+0,21 GiB pour +2B de paramètres) — confirmation directe de la thèse de #15634 : sous QLoRA GRPO, l'enveloppe est dominée par les logits (vocabulaire × G=8 × complétion 96) et les activations, pas par les poids quantifiés. Le mur 8 Go de la petite carte n'est pas atteint à 4B, qui consomme la moitié de la carte.

## Portée

- Fichier ajouté : `MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_4b.jsonl` (une ligne, sortie brute de l'instrument — aucun chiffre recopié à la main).
- L'instrument lui-même est dans **#15634** (branche `feature/pt-vram-wall-probe`) — cette PR ne livre que la donnée de la tranche 4B, pour ne pas dupliquer le fichier instrument entre deux PR ouvertes.
- Tranches restantes de #15639, libres : **7B sur 16 Go** (po-2025 règle thermique / po-2026 VRAM partagée) et **9B-14B sur 4090** (ai-01, précédent `ict25a_scaleup_grpo.py`).

## Validation

- Sonde exécutée localement ce cycle sur GPU libre (nvidia-smi : 0/8192 MiB avant lancement), sous-processus unique, sortie brute ci-dessus.
- Aucun notebook touché ; catalogue byte-identique à main ; un seul fichier dans le diff.

See #15639 · See #15634 · Part of #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
