### PR TITLE
feat(training,#15639): tranche 8B de la sonde VRAM — Qwen3-8B FIT a 7,406 GiB sur 8 Go

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_8b.jsonl
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_8b.jsonl
@@ -1,0 +1,1 @@
+{"model": "Qwen/Qwen3-8B", "torch": "2.13.0+cu126", "gpu": "NVIDIA GeForce RTX 3070 Laptop GPU", "vram_total_gb": 8.0, "status": "FIT", "load_s": 151.3, "train_s": 77.5, "sec_per_step": 25.8, "max_vram_allocated_gb": 7.406, "max_vram_reserved_gb": 8.172, "steps_done": 3, "error": null}


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2024:CoursIA — prev: MED/test #15543

## Summary

Tranche 8B de l'échelle de #15639, sur le RTX 3070 Laptop 8 Go — la strate qui devait établir le **mur nominal de la petite carte**, après la platitude mesurée de 0.8B à 4B. Même instrument, recipe QLoRA GRPO PT_11d exacte (QLoRA 4-bit nf4 double-quant, LoRA r=8 all-proj, `num_generations=8`, batch 8, accum 4, complétion 96, gradient checkpointing, bf16, beta=0), sous-processus dédié.

**Qwen/Qwen3-8B : FIT — 7,406 GiB alloués (8,172 réservés), 25,8 s/step** (load 151 s, 3 steps).

## Campagne complète (RTX 3070 8 Go, recipe PT_11d)

| Modèle | Statut | VRAM max allouée | s/step |
|---|---|---|---|
| Qwen3.5-0.8B | FIT | 2,938 GiB | 21,6 |
| Qwen3-1.7B | FIT | 2,744 GiB | 15,9 |
| Qwen3-2B | FIT | 3,884 GiB | 17,3 |
| Qwen3-4B | FIT | 4,096 GiB | 20,5 |
| **Qwen3-8B** | **FIT** | **7,406 GiB** | **25,8** |

## Lecture — et sa réserve honnête

1. **L'enveloppe n'est pas plate indéfiniment.** De 4B à 8B elle passe de 4,096 à 7,406 GiB (+3,31 GiB pour +4B de paramètres) : c'est le premier palier où la croissance des poids quantifiés (~2,3 GiB pour 4B→8B en 4-bit) redevient visible à côté du terme logits/activations qui dominait jusque-là.

2. **« FIT » signifie ici « pas d'OOM », pas « à l'aise ».** La mesure réserve **8,172 GiB pour une carte de 8,0 GiB** : sur Windows/WDDM, le pic a donc pu s'appuyer sur la mémoire partagée hôte. Le 25,8 s/step (contre 20,5 à 4B) porte probablement une partie de ce coût d'échange. Un FIT sur une carte native (Linux, VRAM non partageable) au même palier serait à re-mesurer — c'est exactement ce que la tranche 16 Go/24 Go de #15639 tranchera.

3. **Conséquence pour la campagne** : le mur de la petite carte n'est **pas** atteint à 8B sous cette recipe ; il faut la strate suivante (14B) ou une carte native pour le situer. C'est un résultat utile : la contrainte de la petite carte n'est pas « on ne peut pas dépasser 2B » mais « au-delà de 4B on travaille à l'arête ».

## Portée

- Fichier ajouté : `MyIA.AI.Notebooks/GenAI/PostTraining/_measurements/vram_probe_results_2026-09-11_8b.jsonl` (sortie brute de l'instrument ; aucun chiffre recopié à la main).
- L'instrument (`vram_wall_probe.py`) est livré par **#15634** ; cette PR ne porte que la donnée de la tranche, pour ne pas dupliquer le fichier instrument entre PRs ouvertes.
- Tranche restante de #15639 : **16 Go / 24 Go** (po-2025 règle thermique, po-2026 VRAM partagée, ai-01 4090).

## Validation

- Sonde exécutée localement ce cycle, GPU vérifié libre avant lancement (`nvidia-smi` : 0/8192 MiB), OOM isolé par sous-processus.
- Aucun notebook touché ; catalogue byte-identique à main ; un seul fichier dans le diff.

See #15639 · See #15634 · Part of #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
