### PR TITLE
fix(ml,#15293): probe #15099 -- arm Qwen3-8B + jugement N-aire des arms

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/probe_15099_dapo_grpo.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/probe_15099_dapo_grpo.py
@@ -215,6 +215,15 @@ def build_trainer(
     cfg = GRPOConfig(
         output_dir=str(RUNS_ROOT / f"{model_key}_seed{seed}" / "trainer_out"),
         seed=seed,
+        # device_map explicite, jamais "auto". Sous 4-bit SANS
+        # llm_int8_enable_fp32_cpu_offload, le chemin d'offload d'accelerate est
+        # mort par construction : des qu'un module part sur CPU, le quantizer bnb
+        # leve « Some modules are dispatched on the CPU or the disk » AVANT tout
+        # entrainement -- mesure sur l'arm 8B (#15293), qui tient pourtant sur 8 Go
+        # (5,78 GiB, 4717,9 M parametres tous sur cuda:0) et echouait sur "auto".
+        # Forcer le GPU rend l'echec honnete : un modele qui ne tient pas OOM au
+        # lieu de lever une erreur opaque.
+        model_init_kwargs=dict(device_map={"": 0}),
         max_steps=steps,  # cap NON lineaire (lecon #13596)
         learning_rate=2e-5,
         warmup_steps=5,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/probe_15099_dapo_grpo.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/probe_15099_dapo_grpo.py
@@ -18,6 +18,7 @@ Dataset : BytedTsinghua-SIA/DAPO-Math-17k (cache HF local, 1 791 700 lignes =
 from __future__ import annotations
 
 import argparse
+import itertools
 import json
 import math
 import re
@@ -51,6 +52,15 @@ MODELS: dict[str, dict[str, str]] = {
     "qwen35": {
         "path_glob": "models--Qwen--Qwen3.5-0.8B/snapshots/*",
         "label": "Qwen3.5-0.8B",
+    },
+    # Etage >= 8-9B demande par #15293 (review user de #15249 : le casting
+    # 0.8B/2B est errone pour un exercice de raisonnement mathematique).
+    # Poids deja en cache local sur po-2024 — l'arm ne demande aucun
+    # telechargement, ce que la disponibilite intermittente de huggingface.co
+    # rend necessaire (cf corps de PR).
+    "qwen3_8b": {
+        "path_glob": "models--Qwen--Qwen3-8B/snapshots/*",
+        "label": "Qwen3-8B",
     },
 }
 
@@ -402,9 +412,7 @@ def mode_summarize() -> int:
     axes[1].set_xlabel("step")
     axes[0].legend(fontsize=7)
 
-    if "minicpm5" in summary["per_model"] and "qwen35" in summary["per_model"]:
-        mini, qwen = summary["per_model"]["minicpm5"], summary["per_model"]["qwen35"]
-
+    if len(summary["per_model"]) >= 2:
         def curves_healthy(model_key: str) -> bool:
             rl = [r for r in loaded if r["model_key"] == model_key]
             improved = all(r["post_eval"]["reward_mean"] > r["pre_eval"]["reward_mean"] for r in rl)
@@ -421,19 +429,39 @@ def mode_summarize() -> int:
                         no_collapse = False
             return improved and no_collapse
 
-        mini_ok = curves_healthy("minicpm5")
-        qwen_ok = curves_healthy("qwen35")
-        disjoint = (mini["delta_mean"] - mini["delta_std"]
-                    > qwen["delta_mean"] + qwen["delta_std"])
-        beats = bool(mini_ok and disjoint)
-        summary["verdict"] = {
-            "mini_curves_healthy": mini_ok,
-            "qwen_curves_healthy": qwen_ok,
-            "delta_intervals_disjoint": disjoint,
-            "beats": beats,
-            "rule": ("BEATS si courbes MiniCPM5 saines (post>pre par seed, pas d'effondrement de longueur) "
-                     "ET delta eval moyen > qwen avec intervalles ±1std disjoints (≥2 seeds par modèle)"),
-        }
+        health = {k: curves_healthy(k) for k in summary["per_model"]}
+
+        # La comparaison est desormais N-aire : #15293 demande de rejouer le
+        # harnais au-dela de 2B et de dire si le classement tient a cette
+        # echelle. Une paire codee en dur interdisait de lire l'etage >= 8-9B.
+        pairs: dict[str, Any] = {}
+        for a, b in itertools.combinations(sorted(summary["per_model"]), 2):
+            pa, pb = summary["per_model"][a], summary["per_model"][b]
+            disjoint = (pa["delta_mean"] - pa["delta_std"]
+                        > pb["delta_mean"] + pb["delta_std"])
+            pairs[f"{a}_vs_{b}"] = {
+                "curves_healthy": {a: health[a], b: health[b]},
+                "delta_intervals_disjoint": disjoint,
+                "beats": bool(health[a] and disjoint),
+                "higher_delta": a if pa["delta_mean"] > pb["delta_mean"] else b,
+                "rule": (f"BEATS si courbes {MODELS[a]['label']} saines (post>pre par seed, "
+                         "pas d'effondrement de longueur) ET delta eval moyen > "
+                         f"{MODELS[b]['label']} avec intervalles +-1std disjoints (>=2 seeds par modele)"),
+            }
+        summary["pairs"] = pairs
+
+        # Forme historique conservee telle quelle (m19) : la re-execution du
+        # summarize sur les runs deja committes doit rendre le meme verdict.
+        if "minicpm5_vs_qwen35" in pairs:
+            legacy = pairs["minicpm5_vs_qwen35"]
+            summary["verdict"] = {
+                "mini_curves_healthy": health["minicpm5"],
+                "qwen_curves_healthy": health["qwen35"],
+                "delta_intervals_disjoint": legacy["delta_intervals_disjoint"],
+                "beats": legacy["beats"],
+                "rule": ("BEATS si courbes MiniCPM5 saines (post>pre par seed, pas d'effondrement de longueur) "
+                         "ET delta eval moyen > qwen avec intervalles ±1std disjoints (≥2 seeds par modèle)"),
+            }
     fig.tight_layout()
     png = REPO_RESULTS / "curves.png"
     fig.savefig(png, dpi=130)


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2024:CoursIA — prev: MED/test #15543

`See #15293` (contribution partielle — l'acceptance n'est **pas** atteinte : un seul backbone ≥ 8-9B est instrumenté, et la mesure à cette échelle n'est pas encore un verdict de classement).

## Ce que #15293 demande

Rejouer le harnais `probe_15099_dapo_grpo.py` (GRPO + QLoRA sur DAPO-Math-17k) sur des backbones **≥ 8-9B**, protocole inchangé, et dire si le classement observé à 0.8B/2B tient à cette échelle. L'issue désigne po-2024 comme cible de routage (« 8-9B QLoRA → routing po-2024/ai-01 (24 Go) »).

## Deux verrous du harnais, et un troisième trouvé à l'exécution

1. **`MODELS` ne portait que 0.8B/2B.** Aucune arm ≥ 8-9B n'était instanciable, quel que soit le run produit.
2. **`mode_summarize` codait la paire en dur** (`minicpm5`/`qwen35`) : un troisième arm n'aurait été ni jugé, ni lisible.
3. **Découvert en exécutant l'arm 8B : le modèle ne se chargeait pas, alors qu'il tient sur la carte.** Sous 4-bit **sans** `llm_int8_enable_fp32_cpu_offload`, le chemin d'offload d'accelerate est **mort par construction** — dès qu'un module part sur CPU, le quantizer bnb lève `ValueError: Some modules are dispatched on the CPU or the disk` **avant tout entraînement**. Le défaut n'était pas la capacité, mais `device_map="auto"`.

## Changements (1 fichier, +53 / −16)

- **`MODELS["qwen3_8b"]`** — arm Qwen3-8B. Poids **déjà en cache local** sur po-2024 (`models--Qwen--Qwen3-8B/snapshots/b968826d9c46dd6066d109eabc6255188de91218`, 16 Go) : l'arm ne déclenche aucun téléchargement.
- **`GRPOConfig(model_init_kwargs=dict(device_map={"": 0}))`** — on force le GPU au lieu de laisser accelerate calculer `"auto"`. Un modèle qui ne tient réellement pas **OOM** désormais, au lieu de lever une erreur opaque qui pointait la mauvaise cause.
- **`mode_summarize` juge N-aire** — `itertools.combinations(sorted(...), 2)`, verdict par paire publié dans `summary["pairs"]` (`curves_healthy`, `delta_intervals_disjoint`, `beats`, `higher_delta`, `rule`), le `rule` nommant les deux labels comparés.
- **Forme historique préservée byte-identique** — `summary["verdict"]` (mini/qwen) est reconstruit depuis `pairs["minicpm5_vs_qwen35"]`, mêmes clés, mêmes valeurs. La ré-exécution du `summarize` sur les runs m19 déjà committés doit rendre le verdict identique ; c'est ce qui rend le changement non régressif.

## Mesures

**Le 8B tient sur la RTX 3070 8 Go — chargé et forcé sur `cuda:0`** (chargement nu, hors trainer, config 4-bit nf4 + double quant exactement celle du probe) :

| Grandeur | Valeur |
|---|---|
| Paramètres sur `cuda:0` | **4717,9 M** (aucun sur CPU) |
| Pic alloué (torch) | **5,75 GiB** |
| Empreinte réelle | **5,78 GiB** |
| VRAM libre avant / après | 6,96 GiB / **1,18 GiB** |

Avant le correctif, le même chargement échouait en `ValueError: Some modules are dispatched on the CPU or the disk` — donc **la cause annoncée par l'erreur était fausse** : ce n'était pas un manque de VRAM, c'était l'auto-dispatch.

**Dataset DAPO-Math-17k : récupéré**, par un chemin qui a son intérêt — `hf download` échouait (`Error: Local entry not found. [WinError 10054]`, **avec un code de sortie 0**, ce qui rend un chaînage `&&` trompeur) alors que `curl -L -C -` sur l'URL `resolve/main` a servi les **285,5 MiB** d'un trait à **14,1 Mo/s**. Le chemin CLI/métadonnées était en panne, pas le CDN de données. Le fichier a été posé dans le cache HF standard (`blobs/<sha256>` + `snapshots/<rev>/…` + `refs/main`, révision `65877096c24ffa7abc4e4fa5edb95cf3413a5674`), et la résolution du script (`find_hf_snapshot`) vérifiée sur place.

**Vérification du harnais** :

| Preuve | Résultat |
|---|---|
| `probe_15099_dapo_grpo.py selftest` | **10/10 pass** |
| `--model {minicpm5,qwen35,qwen3_8b}` + résolution de snapshot | OK |
| Fixture synthétique 3 arms × 2 seeds sur `mode_summarize` | **OK** — 3 paires jugées, clés du verdict historique inchangées, `beats is True`, paire d'échelle `minicpm5_vs_qwen3_8b` jugée |
| Smoke 8B end-to-end sur la RTX 3070 (mode `smoke`, seed 0) | **en cours** — poussé après le correctif `device_map`, le modèle est chargé et le run tourne à 100 % d'utilisation GPU / 8009 MiB sur 8192. Le résultat sera reporté ici. |
| Catalogue byte-identique à `main` | oui (`git diff origin/main...HEAD`, 1 fichier) |

Le vérificateur de fixture est un script de scratchpad (hors dépôt) : il charge le script par `importlib`, pointe `REPO_RESULTS` sur un `mkdtemp`, écrit des runs synthétiques et exerce le chemin de jugement. Il ne touche ni au GPU ni au dataset.

## Ce que la PR ne fait pas

- **Pas de verdict de classement à l'échelle ≥ 8-9B** : le smoke valide le chemin end-to-end (chargement, génération, reward, éval), il ne produit pas un verdict multi-seed. L'acceptance de #15293 (≥ 4 seeds × ≥ 2 backbones) reste due.
- **Pas de `Closes #15293`.**

## Collision de chemin

**#15531** (`myia-po-2026`, `feature/15294-accessibility-baseline`, **OPEN**) modifie le **même fichier** (+343/−24) pour #15294 (mode `baseline`), notamment `MODELS` et `mode_selftest`. Aucun chevauchement fonctionnel avec cette PR, mais **l'une des deux devra être rebasée** après le merge de l'autre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
