### PR TITLE
fix(lean,#15629): Lean-1-Setup — encoding="utf-8" sur les 24 appels subprocess à pipe texte

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -5,10 +5,10 @@
    "id": "6ff81c19",
    "metadata": {
     "papermill": {
-     "duration": 0.004004,
-     "end_time": "2026-09-02T15:33:52.332169",
+     "duration": 0.008753,
+     "end_time": "2026-09-11T21:23:45.776592+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:52.328165",
+     "start_time": "2026-09-11T21:23:45.767839+00:00",
      "status": "completed"
     },
     "tags": []
@@ -73,10 +73,10 @@
    "id": "e6d4bff8",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-09-02T15:33:52.340676",
+     "duration": 0.004271,
+     "end_time": "2026-09-11T21:23:45.786266+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:52.337675",
+     "start_time": "2026-09-11T21:23:45.781995+00:00",
      "status": "completed"
     },
     "tags": []
@@ -121,10 +121,10 @@
    "id": "7c05c5e5",
    "metadata": {
     "papermill": {
-     "duration": 0.004516,
-     "end_time": "2026-09-02T15:33:52.349703",
+     "duration": 0.004648,
+     "end_time": "2026-09-11T21:23:45.795526+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:52.345187",
+     "start_time": "2026-09-11T21:23:45.790878+00:00",
      "status": "completed"
     },
     "tags": []
@@ -153,10 +153,10 @@
    "id": "5241b28010e04157",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-09-02T15:33:52.357703",
+     "duration": 0.003984,
+     "end_time": "2026-09-11T21:23:45.803874+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:52.353703",
+     "start_time": "2026-09-11T21:23:45.799890+00:00",
      "status": "completed"
     },
     "tags": []
@@ -185,16 +185,16 @@
    "id": "78848c0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:52.367211Z",
-     "iopub.status.busy": "2026-09-02T15:33:52.367211Z",
-     "iopub.status.idle": "2026-09-02T15:33:56.878782Z",
-     "shell.execute_reply": "2026-09-02T15:33:56.878782Z"
+     "iopub.execute_input": "2026-09-11T21:23:45.813149Z",
+     "iopub.status.busy": "2026-09-11T21:23:45.812771Z",
+     "iopub.status.idle": "2026-09-11T21:23:51.235801Z",
+     "shell.execute_reply": "2026-09-11T21:23:51.233307Z"
     },
     "papermill": {
-     "duration": 4.518096,
-     "end_time": "2026-09-02T15:33:56.879799",
+     "duration": 5.430473,
+     "end_time": "2026-09-11T21:23:51.237597+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:52.361703",
+     "start_time": "2026-09-11T21:23:45.807124+00:00",
      "status": "completed"
     },
     "tags": []
@@ -208,7 +208,7 @@
       "    DIAGNOSTIC DE L'ENVIRONNEMENT LEAN 4\n",
       "============================================================\n",
       "\n",
-      "Systeme: Windows 10\n",
+      "Systeme: Windows 11\n",
       "Architecture: AMD64\n",
       "\n"
      ]
@@ -220,8 +220,8 @@
       "------------------------------------------------------------\n",
       "Composant              Status       Version/Info\n",
       "------------------------------------------------------------\n",
-      "Python                [OK]         3.11.9\n",
-      "elan                  [OK]         elan 4.1.2 (58e8d545e 2025-05-26)\n",
+      "Python                [OK]         3.13.15\n",
+      "elan                  [OK]         elan 4.2.3 (b6cec7e10 2026-06-08)\n",
       "Lean 4                [OK]         Lean (version 4.33.1, x86_64-w64-windows\n",
       "lean4_jupyter         [OK]         0.0.2\n",
       "Kernel Jupyter        [OK]         lean4\n",
@@ -277,7 +277,7 @@
     "        try:\n",
     "            result = subprocess.run(\n",
     "                [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && elan --version\"],\n",
-    "                capture_output=True, text=True, timeout=10\n",
+    "                capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "            )\n",
     "            if result.returncode == 0:\n",
     "                version = result.stdout.strip().split('\\n')[0]\n",
@@ -289,7 +289,7 @@
     "    elan_path = shutil.which(\"elan\")\n",
     "    if elan_path:\n",
     "        try:\n",
-    "            result = subprocess.run([\"elan\", \"--version\"], capture_output=True, text=True, timeout=10)\n",
+    "            result = subprocess.run([\"elan\", \"--version\"], capture_output=True, text=True, timeout=10, encoding=\"utf-8\")\n",
     "            version = result.stdout.strip().split('\\n')[0] if result.returncode == 0 else \"unknown\"\n",
     "            return ComponentStatus(name=\"elan\", installed=True, version=version, path=elan_path)\n",
     "        except Exception as e:\n",
@@ -308,7 +308,7 @@
     "        try:\n",
     "            result = subprocess.run(\n",
     "                [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && lean --version\"],\n",
-    "                capture_output=True, text=True, timeout=10\n",
+    "                capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "            )\n",
     "            if result.returncode == 0:\n",
     "                version = result.stdout.strip().split('\\n')[0]\n",
@@ -320,7 +320,7 @@
     "    lean_path = shutil.which(\"lean\")\n",
     "    if lean_path:\n",
     "        try:\n",
-    "            result = subprocess.run([\"lean\", \"--version\"], capture_output=True, text=True, timeout=10)\n",
+    "            result = subprocess.run([\"lean\", \"--version\"], capture_output=True, text=True, timeout=10, encoding=\"utf-8\")\n",
     "            version = result.stdout.strip().split('\\n')[0] if result.returncode == 0 else \"unknown\"\n",
     "            return ComponentStatus(name=\"Lean 4\", installed=True, version=version, path=lean_path)\n",
     "        except Exception as e:\n",
@@ -360,7 +360,7 @@
     "    try:\n",
     "        result = subprocess.run(\n",
     "            [sys.executable, \"-m\", \"jupyter\", \"kernelspec\", \"list\", \"--json\"],\n",
-    "            capture_output=True, text=True, timeout=10\n",
+    "            capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0:\n",
     "            import json\n",
@@ -449,10 +449,10 @@
    "id": "32da08bb",
    "metadata": {
     "papermill": {
-     "duration": 0.004021,
-     "end_time": "2026-09-02T15:33:56.887831",
+     "duration": 0.007861,
+     "end_time": "2026-09-11T21:23:51.260337+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.883810",
+     "start_time": "2026-09-11T21:23:51.252476+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,16 +484,16 @@
    "id": "39b2473c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:56.898372Z",
-     "iopub.status.busy": "2026-09-02T15:33:56.898372Z",
-     "iopub.status.idle": "2026-09-02T15:33:56.921138Z",
-     "shell.execute_reply": "2026-09-02T15:33:56.921138Z"
+     "iopub.execute_input": "2026-09-11T21:23:51.279511Z",
+     "iopub.status.busy": "2026-09-11T21:23:51.278849Z",
+     "iopub.status.idle": "2026-09-11T21:23:51.317082Z",
+     "shell.execute_reply": "2026-09-11T21:23:51.315871Z"
     },
     "papermill": {
-     "duration": 0.029302,
-     "end_time": "2026-09-02T15:33:56.922156",
+     "duration": 0.05037,
+     "end_time": "2026-09-11T21:23:51.318015+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.892854",
+     "start_time": "2026-09-11T21:23:51.267645+00:00",
      "status": "completed"
     },
     "tags": []
@@ -562,9 +562,9 @@
     "                cmd = [\"bash\", \"-c\", bash_cmd]\n",
     "            \n",
     "            if shell and self.is_windows:\n",
-    "                result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, shell=True)\n",
+    "                result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, shell=True, encoding=\"utf-8\")\n",
     "            else:\n",
-    "                result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)\n",
+    "                result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, encoding=\"utf-8\")\n",
     "            \n",
     "            if result.returncode == 0:\n",
     "                self.log(f\"{description} - OK\", \"OK\")\n",
@@ -588,7 +588,7 @@
     "            try:\n",
     "                result = subprocess.run(\n",
     "                    [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && elan --version\"],\n",
-    "                    capture_output=True, text=True, timeout=5\n",
+    "                    capture_output=True, text=True, timeout=5, encoding=\"utf-8\"\n",
     "                )\n",
     "                if result.returncode == 0:\n",
     "                    self.log(\"elan deja installe\", \"OK\")\n",
@@ -620,7 +620,7 @@
     "            ps_command = f\"& '{escaped_path}' -NoPrompt:$true -DefaultToolchain none\"\n",
     "            cmd = [\"powershell\", \"-ExecutionPolicy\", \"Bypass\", \"-Command\", ps_command]\n",
     "            \n",
-    "            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)\n",
+    "            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, encoding=\"utf-8\")\n",
     "            os.unlink(script_path)\n",
     "            \n",
     "            if result.returncode == 0:\n",
@@ -640,7 +640,7 @@
     "        \"\"\"Installation elan sur Linux/macOS\"\"\"\n",
     "        try:\n",
     "            cmd = [\"sh\", \"-c\", \"curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none\"]\n",
-    "            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)\n",
+    "            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, encoding=\"utf-8\")\n",
     "            \n",
     "            if result.returncode == 0:\n",
     "                elan_bin = Path.home() / \".elan\" / \"bin\"\n",
@@ -662,7 +662,7 @@
     "            try:\n",
     "                result = subprocess.run(\n",
     "                    [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && lean --version\"],\n",
-    "                    capture_output=True, text=True, timeout=5\n",
+    "                    capture_output=True, text=True, timeout=5, encoding=\"utf-8\"\n",
     "                )\n",
     "                if result.returncode == 0:\n",
     "                    self.log(\"Lean 4 deja installe\", \"OK\")\n",
@@ -713,7 +713,7 @@
     "        \"\"\"Enregistre le kernel Lean dans Jupyter\"\"\"\n",
     "        # Verifier si un kernel lean existe deja\n",
     "        try:\n",
-    "            result = subprocess.run([sys.executable, \"-m\", \"jupyter\", \"kernelspec\", \"list\"], capture_output=True, text=True, timeout=10)\n",
+    "            result = subprocess.run([sys.executable, \"-m\", \"jupyter\", \"kernelspec\", \"list\"], capture_output=True, text=True, timeout=10, encoding=\"utf-8\")\n",
     "            if \"lean\" in result.stdout.lower():\n",
     "                self.log(\"Un kernel Lean est deja enregistre\", \"OK\")\n",
     "                return True\n",
@@ -724,7 +724,7 @@
     "        try:\n",
     "            result = subprocess.run(\n",
     "                [sys.executable, \"-m\", \"lean4_jupyter\", \"install\"],\n",
-    "                capture_output=True, text=True, timeout=60\n",
+    "                capture_output=True, text=True, timeout=60, encoding=\"utf-8\"\n",
     "            )\n",
     "            if result.returncode == 0:\n",
     "                self.log(\"Kernel enregistre avec succes\", \"OK\")\n",
@@ -811,10 +811,10 @@
    "id": "590f0c15",
    "metadata": {
     "papermill": {
-     "duration": 0.004063,
-     "end_time": "2026-09-02T15:33:56.930931",
+     "duration": 0.004002,
+     "end_time": "2026-09-11T21:23:51.326467+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.926868",
+     "start_time": "2026-09-11T21:23:51.322465+00:00",
      "status": "completed"
     },
     "tags": []
@@ -862,10 +862,10 @@
    "id": "d9f8d71e",
    "metadata": {
     "papermill": {
-     "duration": 0.004506,
-     "end_time": "2026-09-02T15:33:56.940945",
+     "duration": 0.003654,
+     "end_time": "2026-09-11T21:23:51.333805+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.936439",
+     "start_time": "2026-09-11T21:23:51.330151+00:00",
      "status": "completed"
     },
     "tags": []
@@ -891,16 +891,16 @@
    "id": "162f291d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:56.952151Z",
-     "iopub.status.busy": "2026-09-02T15:33:56.952151Z",
-     "iopub.status.idle": "2026-09-02T15:33:56.970730Z",
-     "shell.execute_reply": "2026-09-02T15:33:56.969883Z"
+     "iopub.execute_input": "2026-09-11T21:23:51.343618Z",
+     "iopub.status.busy": "2026-09-11T21:23:51.343333Z",
+     "iopub.status.idle": "2026-09-11T21:23:51.368804Z",
+     "shell.execute_reply": "2026-09-11T21:23:51.367484Z"
     },
     "papermill": {
-     "duration": 0.025106,
-     "end_time": "2026-09-02T15:33:56.970730",
+     "duration": 0.031361,
+     "end_time": "2026-09-11T21:23:51.369878+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.945624",
+     "start_time": "2026-09-11T21:23:51.338517+00:00",
      "status": "completed"
     },
     "tags": []
@@ -914,7 +914,7 @@
       "    AIDE-MEMOIRE : commande equivalente pour VOTRE machine\n",
       "================================================================\n",
       "\n",
-      "OS detecte : Windows (10, AMD64)\n",
+      "OS detecte : Windows (11, AMD64)\n",
       "\n",
       "Plateforme : Windows\n",
       "\n",
@@ -1038,10 +1038,10 @@
    "id": "87568df1",
    "metadata": {
     "papermill": {
-     "duration": 0.004007,
-     "end_time": "2026-09-02T15:33:56.979587",
+     "duration": 0.003659,
+     "end_time": "2026-09-11T21:23:51.377336+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.975580",
+     "start_time": "2026-09-11T21:23:51.373677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1061,16 +1061,16 @@
    "id": "e2362b95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:56.991672Z",
-     "iopub.status.busy": "2026-09-02T15:33:56.990665Z",
-     "iopub.status.idle": "2026-09-02T15:33:58.619472Z",
-     "shell.execute_reply": "2026-09-02T15:33:58.618465Z"
+     "iopub.execute_input": "2026-09-11T21:23:51.386701Z",
+     "iopub.status.busy": "2026-09-11T21:23:51.386418Z",
+     "iopub.status.idle": "2026-09-11T21:23:55.696020Z",
+     "shell.execute_reply": "2026-09-11T21:23:55.693811Z"
     },
     "papermill": {
-     "duration": 1.635816,
-     "end_time": "2026-09-02T15:33:58.620476",
+     "duration": 4.31682,
+     "end_time": "2026-09-11T21:23:55.697651+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:56.984660",
+     "start_time": "2026-09-11T21:23:51.380831+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1092,8 +1092,8 @@
      "text": [
       "Composant            Status       Version/Info\n",
       "------------------------------------------------------------\n",
-      "Python 3.8+          [OK]         3.11\n",
-      "elan                 [OK]         4.1.2\n",
+      "Python 3.8+          [OK]         3.13\n",
+      "elan                 [OK]         4.2.3\n",
       "Lean 4               [OK]         Lean (version 4.33.1, x86_64-w64-windows-gnu, commit 819816b2e0a3bf405af45ae5c7af2491d8f5bee6, Release)\n",
       "lean4_jupyter        [OK]         0.0.2\n",
       "Kernel Jupyter       [OK]         lean4\n",
@@ -1138,7 +1138,7 @@
     "    try:\n",
     "        result = subprocess.run(\n",
     "            [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && elan --version\"],\n",
-    "            capture_output=True, text=True, timeout=10\n",
+    "            capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0:\n",
     "            elan_version = result.stdout.strip().split()[1]\n",
@@ -1150,7 +1150,7 @@
     "    elan_path = shutil.which(\"elan\")\n",
     "    if elan_path:\n",
     "        try:\n",
-    "            result = subprocess.run([\"elan\", \"--version\"], capture_output=True, text=True, timeout=5)\n",
+    "            result = subprocess.run([\"elan\", \"--version\"], capture_output=True, text=True, timeout=5, encoding=\"utf-8\")\n",
     "            elan_version = result.stdout.strip().split()[1] if result.returncode == 0 else \"?\"\n",
     "            elan_ok = True\n",
     "        except:\n",
@@ -1165,7 +1165,7 @@
     "    try:\n",
     "        result = subprocess.run(\n",
     "            [\"bash\", \"-c\", \"source ~/.elan/env 2>/dev/null && lean --version\"],\n",
-    "            capture_output=True, text=True, timeout=10\n",
+    "            capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0:\n",
     "            lean_version = result.stdout.strip().split('\\n')[0]\n",
@@ -1177,7 +1177,7 @@
     "    lean_path = shutil.which(\"lean\")\n",
     "    if lean_path:\n",
     "        try:\n",
-    "            result = subprocess.run([\"lean\", \"--version\"], capture_output=True, text=True, timeout=5)\n",
+    "            result = subprocess.run([\"lean\", \"--version\"], capture_output=True, text=True, timeout=5, encoding=\"utf-8\")\n",
     "            lean_version = result.stdout.strip().split('\\n')[0] if result.returncode == 0 else \"?\"\n",
     "            lean_ok = True\n",
     "        except:\n",
@@ -1198,7 +1198,7 @@
     "kernel_ok = False\n",
     "kernel_name = \"\"\n",
     "try:\n",
-    "    result = subprocess.run([sys.executable, \"-m\", \"jupyter\", \"kernelspec\", \"list\"], capture_output=True, text=True, timeout=10)\n",
+    "    result = subprocess.run([sys.executable, \"-m\", \"jupyter\", \"kernelspec\", \"list\"], capture_output=True, text=True, timeout=10, encoding=\"utf-8\")\n",
     "    if \"lean\" in result.stdout.lower():\n",
     "        kernel_ok = True\n",
     "        for line in result.stdout.split('\\n'):\n",
@@ -1241,10 +1241,10 @@
    "id": "b9e6bb41",
    "metadata": {
     "papermill": {
-     "duration": 0.00816,
-     "end_time": "2026-09-02T15:33:58.637945",
+     "duration": 0.006652,
+     "end_time": "2026-09-11T21:23:55.712195+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.629785",
+     "start_time": "2026-09-11T21:23:55.705543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1277,10 +1277,10 @@
    "id": "c18c40b2",
    "metadata": {
     "papermill": {
-     "duration": 0.008664,
-     "end_time": "2026-09-02T15:33:58.655811",
+     "duration": 0.00566,
+     "end_time": "2026-09-11T21:23:55.721601+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.647147",
+     "start_time": "2026-09-11T21:23:55.715941+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1313,10 +1313,10 @@
    "id": "b3ddcf38",
    "metadata": {
     "papermill": {
-     "duration": 0.008039,
-     "end_time": "2026-09-02T15:33:58.672499",
+     "duration": 0.004262,
+     "end_time": "2026-09-11T21:23:55.730256+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.664460",
+     "start_time": "2026-09-11T21:23:55.725994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1341,16 +1341,16 @@
    "id": "341ed37b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:58.691481Z",
-     "iopub.status.busy": "2026-09-02T15:33:58.690481Z",
-     "iopub.status.idle": "2026-09-02T15:33:58.706516Z",
-     "shell.execute_reply": "2026-09-02T15:33:58.705984Z"
+     "iopub.execute_input": "2026-09-11T21:23:55.739249Z",
+     "iopub.status.busy": "2026-09-11T21:23:55.738960Z",
+     "iopub.status.idle": "2026-09-11T21:23:55.754032Z",
+     "shell.execute_reply": "2026-09-11T21:23:55.752988Z"
     },
     "papermill": {
-     "duration": 0.026853,
-     "end_time": "2026-09-02T15:33:58.707525",
+     "duration": 0.021143,
+     "end_time": "2026-09-11T21:23:55.754904+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.680672",
+     "start_time": "2026-09-11T21:23:55.733761+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1406,7 +1406,7 @@
     "        print(f\"[*] Clonage de repl depuis GitHub...\")\n",
     "        result = subprocess.run(\n",
     "            [\"git\", \"clone\", \"https://github.com/leanprover-community/repl\", str(repl_dir)],\n",
-    "            capture_output=True, text=True, timeout=60\n",
+    "            capture_output=True, text=True, timeout=60, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode != 0:\n",
     "            print(f\"[!] Erreur lors du clonage: {result.stderr[:200]}\")\n",
@@ -1420,7 +1420,7 @@
     "    result = subprocess.run(\n",
     "        [\"lake\", \"build\"],\n",
     "        cwd=str(repl_dir),\n",
-    "        capture_output=True, text=True, timeout=300\n",
+    "        capture_output=True, text=True, timeout=300, encoding=\"utf-8\"\n",
     "    )\n",
     "    if result.returncode != 0:\n",
     "        print(f\"[!] Erreur lors de la construction: {result.stderr[:200]}\")\n",
@@ -1472,10 +1472,10 @@
    "id": "5dde083b",
    "metadata": {
     "papermill": {
-     "duration": 0.007509,
-     "end_time": "2026-09-02T15:33:58.723623",
+     "duration": 0.004586,
+     "end_time": "2026-09-11T21:23:55.764028+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.716114",
+     "start_time": "2026-09-11T21:23:55.759442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1494,32 +1494,30 @@
    "id": "981fa813",
    "metadata": {
     "execution": {
-     "iopub.status.busy": "2026-09-05T13:09:45.072951Z",
-     "iopub.execute_input": "2026-09-05T13:09:45.073331Z",
-     "shell.execute_reply": "2026-09-05T13:09:45.088622Z",
-     "iopub.status.idle": "2026-09-05T13:09:45.090323Z"
+     "iopub.execute_input": "2026-09-11T21:23:55.773374Z",
+     "iopub.status.busy": "2026-09-11T21:23:55.773107Z",
+     "iopub.status.idle": "2026-09-11T21:23:55.783416Z",
+     "shell.execute_reply": "2026-09-11T21:23:55.782436Z"
     },
     "papermill": {
-     "duration": 0.030596,
-     "end_time": "2026-09-02T15:33:58.757220",
+     "duration": 0.016459,
+     "end_time": "2026-09-11T21:23:55.784300+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.726624",
+     "start_time": "2026-09-11T21:23:55.767841+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "============================================================\n",
       "    PATCH DU KERNEL LEAN4 POUR WINDOWS\n",
       "============================================================\n",
       "\n",
-      "[*] Patch de ~/AppData/Roaming/Python/Python313/site-packages/lean4_jupyter/kernel.py...\n",
-      "[+] Patch applique avec succes !\n",
-      "    Le kernel 'lean4' (Windows natif) est maintenant fonctionnel.\n",
+      "[OK] kernel.py deja patche: D:/dev/CoursIA/venv/Lib/site-packages/lean4_jupyter/kernel.py\n",
       "\n",
       "============================================================\n",
       "[OK] Kernel lean4 pret a l'emploi !\n",
@@ -1630,10 +1628,10 @@
    "id": "a8ce86b1",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-09-02T15:33:58.766239",
+     "duration": 0.005387,
+     "end_time": "2026-09-11T21:23:55.793633+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.761724",
+     "start_time": "2026-09-11T21:23:55.788246+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1656,16 +1654,16 @@
    "id": "ea71e7c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:33:58.777524Z",
-     "iopub.status.busy": "2026-09-02T15:33:58.777524Z",
-     "iopub.status.idle": "2026-09-02T15:34:02.641170Z",
-     "shell.execute_reply": "2026-09-02T15:34:02.640164Z"
+     "iopub.execute_input": "2026-09-11T21:23:55.805806Z",
+     "iopub.status.busy": "2026-09-11T21:23:55.805535Z",
+     "iopub.status.idle": "2026-09-11T21:24:01.431113Z",
+     "shell.execute_reply": "2026-09-11T21:24:01.430057Z"
     },
     "papermill": {
-     "duration": 3.870671,
-     "end_time": "2026-09-02T15:34:02.641677",
+     "duration": 5.631805,
+     "end_time": "2026-09-11T21:24:01.431974+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:33:58.771006",
+     "start_time": "2026-09-11T21:23:55.800169+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1679,7 +1677,13 @@
       "    DIAGNOSTIC ET CONFIGURATION KERNEL LEAN4 VIA WSL\n",
       "============================================================\n",
       "\n",
-      "[1/4] Verification de WSL...\n",
+      "[1/4] Verification de WSL...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "      [OK] WSL disponible\n",
       "\n",
       "[2/4] Verification de Lean dans WSL...\n"
@@ -1753,7 +1757,7 @@
     "    try:\n",
     "        result = subprocess.run(\n",
     "            [\"wsl.exe\", \"-d\", \"Ubuntu\", \"--\", \"bash\", \"-c\", \"echo -n $HOME\"],\n",
-    "            capture_output=True, text=True, timeout=10\n",
+    "            capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0 and result.stdout.strip().startswith(\"/\"):\n",
     "            return result.stdout.strip()\n",
@@ -1763,7 +1767,7 @@
     "    try:\n",
     "        result = subprocess.run(\n",
     "            [\"wsl.exe\", \"-d\", \"Ubuntu\", \"--\", \"whoami\"],\n",
-    "            capture_output=True, text=True, timeout=10\n",
+    "            capture_output=True, text=True, timeout=10, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0 and result.stdout.strip():\n",
     "            return f\"/home/{result.stdout.strip()}\"\n",
@@ -2039,10 +2043,10 @@
    "id": "9f3d4507",
    "metadata": {
     "papermill": {
-     "duration": 0.00454,
-     "end_time": "2026-09-02T15:34:02.650868",
+     "duration": 0.003801,
+     "end_time": "2026-09-11T21:24:01.439810+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:02.646328",
+     "start_time": "2026-09-11T21:24:01.436009+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2070,16 +2074,16 @@
    "id": "baaf4a4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-02T15:34:02.661645Z",
-     "iopub.status.busy": "2026-09-02T15:34:02.661645Z",
-     "iopub.status.idle": "2026-09-02T15:34:06.724084Z",
-     "shell.execute_reply": "2026-09-02T15:34:06.724084Z"
+     "iopub.execute_input": "2026-09-11T21:24:01.451235Z",
+     "iopub.status.busy": "2026-09-11T21:24:01.450949Z",
+     "iopub.status.idle": "2026-09-11T21:24:56.548115Z",
+     "shell.execute_reply": "2026-09-11T21:24:56.547187Z"
     },
     "papermill": {
-     "duration": 4.070182,
-     "end_time": "2026-09-02T15:34:06.725781",
+     "duration": 55.109829,
+     "end_time": "2026-09-11T21:24:56.553571+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:02.655599",
+     "start_time": "2026-09-11T21:24:01.443742+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2103,11 +2107,11 @@
       "Installation de Semantic Kernel...\n",
       "\n",
       "=== Verification ===\n",
-      "- python-dotenv 1.2.2\n",
-      "- openai 2.38.0\n",
-      "- anthropic 0.105.2\n",
-      "- matplotlib 3.10.9\n",
-      "- semantic-kernel 1.42.0\n",
+      "- python-dotenv 1.2.3\n",
+      "- openai 3.13.0\n",
+      "- anthropic 1.5.0\n",
+      "- matplotlib 3.11.2\n",
+      "- semantic-kernel 1.44.1\n",
       "\n",
       "=== Configuration terminee ===\n",
       "Le kernel Python 3 (WSL) est pret pour les notebooks Lean 7-8\n",
@@ -2171,7 +2175,7 @@
     "        [\"wsl\", \"-d\", \"Ubuntu\", \"bash\", script_wsl],\n",
     "        capture_output=True,\n",
     "        text=True,\n",
-    "        timeout=180  # 3 min pour semantic-kernel (gros package)\n",
+    "        timeout=180, encoding=\"utf-8\"  # 3 min pour semantic-kernel (gros package)\n",
     "    )\n",
     "\n",
     "    if result.returncode == 0:\n",
@@ -2203,7 +2207,7 @@
     "            [sys.executable, \"-m\", \"pip\", \"install\", \"--quiet\"] + missing,\n",
     "            capture_output=True,\n",
     "            text=True,\n",
-    "            timeout=180\n",
+    "            timeout=180, encoding=\"utf-8\"\n",
     "        )\n",
     "        if result.returncode == 0:\n",
     "            print(\"[OK] Packages installes avec succes\")\n",
@@ -2229,10 +2233,10 @@
    "id": "12b7cc45",
    "metadata": {
     "papermill": {
-     "duration": 0.005512,
-     "end_time": "2026-09-02T15:34:06.737301",
+     "duration": 0.013194,
+     "end_time": "2026-09-11T21:24:56.574751+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:06.731789",
+     "start_time": "2026-09-11T21:24:56.561557+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2279,10 +2283,10 @@
    "id": "87fdc737",
    "metadata": {
     "papermill": {
-     "duration": 0.007137,
-     "end_time": "2026-09-02T15:34:06.749531",
+     "duration": 0.00578,
+     "end_time": "2026-09-11T21:24:56.590226+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:06.742394",
+     "start_time": "2026-09-11T21:24:56.584446+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2368,10 +2372,10 @@
    "id": "b96f7760",
    "metadata": {
     "papermill": {
-     "duration": 0.009582,
-     "end_time": "2026-09-02T15:34:06.768057",
+     "duration": 0.006598,
+     "end_time": "2026-09-11T21:24:56.601831+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:06.758475",
+     "start_time": "2026-09-11T21:24:56.595233+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2425,10 +2429,10 @@
    "id": "42ff9202",
    "metadata": {
     "papermill": {
-     "duration": 0.00544,
-     "end_time": "2026-09-02T15:34:06.781484",
+     "duration": 0.004865,
+     "end_time": "2026-09-11T21:24:56.611227+00:00",
      "exception": false,
-     "start_time": "2026-09-02T15:34:06.776044",
+     "start_time": "2026-09-11T21:24:56.606362+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2518,7 +2522,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.15"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 72.839621,
+   "end_time": "2026-09-11T21:24:56.971728+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-1-Setup.ipynb",
+   "output_path": "Lean-1-Setup.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T21:23:44.132107+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2027:CoursIA — prev: DEEP/lean #15596

## Summary

Tranche 1 de #15629 : porter `encoding="utf-8"` explicite sur les **24 appels `subprocess` à pipe texte** de `Lean-1-Setup.ipynb`, puis **ré-exécuter** le notebook (C.2).

Le décodage des pipes de `subprocess.run(..., text=True)` suit la locale du process — cp1252 sous Windows. Toute sortie non-cp1252 (ℝ, ℕ, →, ✔) fait alors crasher le reader-thread : `res.stdout` devient `None`, et **papermill ne signale aucune cellule en erreur** parce que l'exception vit dans un *stream*, pas dans un output `error`. C'est l'incident vivant mesuré sur `Lean-21-MIMO-Detection-Flips` (6 cellules dégradées).

## Scope

| | |
|---|---|
| Fichiers | 1 — `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb` |
| Sites corrigés | 24, répartis sur 6 cellules code (4, 6, 11, 15, 19, 21) |
| Appels `wsl` | hors périmètre de cette tranche (rendus aux autres lanes, cf commentaire de claim sur l'issue) |

**Édition = chirurgie positionnelle ancrée sur l'AST.** L'insertion se fait après le **dernier argument** de l'appel (`max` des `end_col_offset` de `node.args + node.keywords`), jamais « avant la parenthèse fermante » : un commentaire de fin de liste contient lui-même une parenthèse et avalerait la virgule. Le reste du source des cellules est inchangé — le diff de source est exactement 24 insertions / 24 suppressions.

Contrôle : 0 appel `subprocess` à pipe texte sans `encoding=` ne subsiste dans le fichier (ré-inventaire AST après édition).

## Acceptance

| # | Critère de l'issue | État |
|---|---|---|
| 1 | Tout appel `subprocess` à pipe texte de la série porte `encoding="utf-8"` | **fait pour ce notebook** — les autres notebooks de la série restent à faire, un par PR |
| 2 | Outputs identiques avec et sans `PYTHONUTF8=1` dans l'env du lanceur | **prouvé** — cf ci-dessous |
| 3 | Série par série, un notebook par PR, chaque notebook modifié ré-exécuté | **respecté** — 1 notebook, ré-exécuté |

`See #15629` (livraison partielle : 1 notebook sur la série, l'issue reste ouverte).

## Preuve de ré-exécution

`papermill`, kernel `python3`, `--cwd` = dossier du notebook, deux runs complets :

| Run | Env du lanceur | Cellules code exécutées | Erreurs | `Exception in thread` |
|---|---|---|---|---|
| **E** | sans `PYTHONUTF8` | 8 / 8 (`execution_count` 1→8) | 0 | 0 |
| **F** | `PYTHONUTF8=1` | 8 / 8 (`execution_count` 1→8) | 0 | 0 |

```
########## E (sans PYTHONUTF8)  vs  F (avec PYTHONUTF8=1) ##########
E: 26 cellules | F: 26 cellules
cellules differentes: 0
--- detecteur ---
cellules a probleme: 0
```

Le détecteur couvre les trois surfaces : outputs `error`, `Exception in thread Thread-N (_readerthread)` dans les streams, et `execution_count is None`. Les sorties sont identiques **cellule par cellule** — la dépendance à la variable d'environnement du lanceur disparaît, c'est exactement l'acceptance 2.

Extrait de la cellule de vérification finale, run E :

```
Composant            Status       Version/Info
------------------------------------------------------------
Python 3.8+          [OK]         3.13
elan                 [OK]         4.2.3
Lean 4               [OK]         Lean (version 4.33.1, x86_64-w64-windows-gnu, ...)
lean4_jupyter        [OK]         0.0.2
Kernel Jupyter       [OK]         lean4
```

## Diagnostic dérive

Section due : la PR ré-exécute le notebook, donc les sorties **autres que** mes 6 cellules modifiées doivent s'expliquer.

**Cause (a) — env / kernel. Verdict : `CAUSE_DOCUMENTED_ONLY`.**

Comparaison HEAD → run E, cellule par cellule : 8 cellules diffèrent, dont **6 portent une modification de source** (4, 6, 11, 15, 19, 21). Les deux cellules **témoins** (source inchangée) qui bougent le font pour une raison d'environnement, pas de logique :

| Cellule | HEAD | Run E | Nature |
|---|---|---|---|
| 9 | `OS detecte : Windows (10, AMD64)` | `Windows (11, AMD64)` | version d'OS de la machine |
| 4 | `Python [OK] 3.11.9`, `elan 4.1.2`, `Systeme: Windows 10` | `3.13`, `4.2.3`, `Windows 11` | interpréteur + elan de la machine |
| 11 | `Python 3.8+ 3.11`, `elan 4.1.2` | `3.13`, `4.2.3` | idem |
| 17 | `Patch de ~/AppData/.../Python313/site-packages/...` | `kernel.py deja patche: D:/dev/CoursIA/venv/Lib/site-packages/...` | **quel** interpréteur a gagné la résolution de `lean4_jupyter` |
| 21 | `python-dotenv 1.2.2 … semantic-kernel 1.42.0` | `1.2.3 … 1.44.1` | `pip install` du notebook installe les versions courantes |

Aucune de ces dérives n'est produite par le correctif : elles documentent l'environnement courant, ce qui est le travail de ce notebook. `language_info.version` passe de `3.11.9` à `3.13.15` pour la même raison (le kernel qui a réellement exécuté).

Deux points relevés en passant, **hors périmètre de cette PR** :

- **Cellule 17** normalise `Path.home()` en `~` mais pas le cas « package résolu dans un venv hors du home » — d'où le chemin absolu ci-dessus. Pré-existant, cosmétique, sans identifiant de compte.
- Suivi ouvert : **#15644** — la détection de Lean en cellule 11 a `timeout=5` sur `lean --version` et un `except: pass` nu. Mesure : **8/30 `TimeoutExpired` sous charge**, taux **identique** avec et sans `PYTHONUTF8=1`, octets bruts décodables en utf-8 **et** cp1252. C'est un défaut **orthogonal** au correctif d'encodage, mais il rend une ré-exécution ponctuellement fausse (`Lean 4 [MANQUANT]` + consigne d'installation pour un composant présent). Il est la raison pour laquelle une comparaison « avec / sans `PYTHONUTF8` » sur ce notebook peut montrer une divergence de cellule 11 qui n'est **pas** imputable à la variable d'environnement.

## Réparation d'environnement nécessaire à la ré-exécution

La cellule 21 exige un venv WSL fonctionnel en `~/.python3-wsl-venv`. Il était **cassé et vide** (32 K, symlinks `python` seuls, ni `activate` ni `pip`) — séquelle probable de l'incident WSL du 04/09. Le script `scripts/setup_wsl_python.sh` ne le répare pas : sa garde `if [ ! -d "$VENV_PATH" ]` saute la création puisque le dossier existe, puis `source .../bin/activate` échoue.

- `python3 -m venv` ne fonctionne pas en WSL : `ensurepip` absent, paquet `python3.14-venv` non installé.
- `sudo` exige une authentification interactive sur cette machine (pas de sudoers NOPASSWD) — je n'ai donc pas pu installer le paquet.
- Réparation appliquée **sans sudo** : `~/.lean4-venv/bin/python3 -m venv ~/.python3-wsl-venv` (3.11.16 + pip 24.0). L'ancien dossier est mis de côté, **pas supprimé** : `~/.python3-wsl-venv.broken-20260911`.
- Reste à faire côté machine, hors PR : `sudo apt install python3-venv` pour que le venv système 3.14 soit recréable nativement.

La cellule 19 (déploiement du wrapper kernel WSL) échouait avec `--cwd` = racine du dépôt, parce qu'elle se replie sur `Path.cwd().parent` quand `__vsc_ipynb_file__` est absent (cas papermill). Avec `--cwd` = dossier du notebook, elle réussit et retrouve la sortie de HEAD (`[+] Wrapper robuste deploye`, `[+] Kernel cree`).

## Note lane-claim

Claim resserrée sur ce seul fichier (`[CLAIMED-AMEND] … -- paths: MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb`) : la claim initiale était epic-wide et bloquait la série. Le commentaire de claim porte les contraintes de ré-exécution mesurées des autres notebooks (dont `Lean-3b`, qui exige `cwd = …/Lean/formal_logic_lean` et un lake **froid**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
