### PR TITLE
feat(lean,#15635): schema de motifs et de reactions Life, valide par replay (tranche 1+2)

### DIFF
--- a/docs/lean/life-components-schema.md
+++ b/docs/lean/life-components-schema.md
@@ -1,0 +1,154 @@
+# Schéma de motifs et de réactions de Game of Life — tranche 1+2 de #15635
+
+Le moteur cellulaire de #15571 cherche un motif en énumérant des cellules dans
+une boîte, puis en encodant son évolution en SAT. Son espace de recherche croît
+avec la surface, la période et la cardinalité, et il ignore tout ce que la
+communauté Life sait déjà des briques connues (still lifes, catalyseurs,
+oscillateurs, collisions de gliders, tronçons de pistes Herschel).
+
+Cette tranche ajoute la couche **symbolique** qui manquait : un format
+machine-readable pour décrire des *motifs/composants* et des *réactions*, avec
+la propriété qui la rend utile — **aucune métadonnée déclarée n'est acceptée sur
+confiance**. Chaque champ numérique est re-dérivé par replay dans le moteur Life
+du dépôt (`scripts/lean/life_synthesize.py`) et comparé à ce que le document
+prétend. Un écart est un refus, pas un avertissement.
+
+Le module est [`scripts/lean/life_components.py`](../../scripts/lean/life_components.py) ;
+le catalogue curé est [`scripts/lean/life_components_fixture.json`](../../scripts/lean/life_components_fixture.json).
+
+## Ce que la tranche couvre — et ce qu'elle ne couvre pas
+
+| Section de #15635 | État |
+|---|---|
+| §1 schéma minimal versionné (motifs + réactions) | **livré** |
+| §2 catalogue reproductible réduit, rejoué indépendamment | **livré** |
+| §3 générateur de contraintes compositionnelles | hors tranche |
+| §4 démonstrateur multi-composants + ablations de pruning | hors tranche |
+
+Le schéma porte les champs que #15635 nomme pour §1, mais **tous ne sont pas
+encore validés mécaniquement** — la distinction est explicite ci-dessous.
+
+## Motif : ce qui est mesuré
+
+Un motif déclare son identifiant, sa provenance, ses cellules canoniques, sa
+règle, sa période, sa translation par période, sa population, sa boîte initiale,
+son enveloppe sur un cycle et ses symétries autorisées. Sont **recalculés par
+replay** puis comparés :
+
+- la **période** — la plus petite `p` telle que `evolve^p T` soit `T` à
+  translation près (une période déclarée trop grande est refusée : elle n'est pas
+  la période du motif, c'est un de ses multiples) ;
+- la **translation** par période, et par conséquent la direction et la vitesse ;
+- la **population**, la **boîte initiale**, l'**enveloppe** sur un cycle ;
+- la **catégorie** (`still_life` / `oscillator` / `spaceship`), dérivée de la
+  période et de la translation plutôt que crue sur parole ;
+- la **forme canonique** des cellules (translation ramenée à l'origine, liste
+  triée) ;
+- les **phases** déclarées, si le document en porte.
+
+Le champ `rule` n'accepte que `B3/S23` : c'est la seule règle que le moteur du
+dépôt implémente, et prétendre en valider une autre serait une preuve non
+fournie.
+
+## Canonicalisation : normaliser sans fusionner
+
+Deux formes sont « le même objet » si l'une s'obtient à partir de l'autre par
+une symétrie **qui préserve son vecteur de translation**. Cette restriction
+n'est pas cosmétique : sous le groupe diédral complet, les quatre orientations
+d'un glider se confondraient, et la direction de vol — précisément ce qu'une
+réaction compositionnelle doit contraindre — disparaîtrait.
+
+| Translation | Symétries admissibles |
+|---|---|
+| `(0, 0)` (still life, oscillateur) | groupe diédral complet |
+| `(1, -1)` (glider du dépôt) | `T`, `D2` |
+| `(-1, -1)` (`glider_mirror`) | `T`, `D1` |
+| `(-2, 0)` (`lwss`) | `T`, `My` |
+
+Conséquence testée : `glider` et `glider_mirror` ont la même forme à une
+réflexion près mais des translations opposées — `same_object` répond **faux**.
+Déclarer une symétrie inadmissible est un refus.
+
+## Réaction : ce qui est mesuré
+
+Une réaction déclare ses réactifs et produits (placements de motifs, ou cellules
+brutes quand le produit n'est pas un objet catalogué), ses ports, son décalage
+temporel, son temps de stabilisation, sa région occupée, ses zones de clearance,
+sa nature et sa provenance. Sont **recalculés par replay de l'évolution jointe** :
+
+- le **produit** : l'état à `t = stabilization_time` doit égaler exactement le
+  produit déclaré, et être **stable** (`step(état) == état`). Une réaction dont
+  le produit est mobile est hors du domaine de ce validateur — c'est une limite
+  assumée, pas un silence ;
+- les **zones de clearance** : aucune cellule vivante ne doit y passer, à aucun
+  pas de la fenêtre. C'est le contrôle négatif de l'absence d'interaction
+  parasite ;
+- la **région occupée** : boîte englobante de tout ce qui a vécu pendant la
+  fenêtre ;
+- la **nature** (`consumable` / `reusable` / `catalytic`) : mesurée par survie
+  d'un réactif dans l'état final, à translation près.
+
+Les **ports** sont validés structurellement (nom, direction non nulle, position
+dans la région occupée). Leur *sémantique de compatibilité* — quel port de quel
+composant peut en rencontrer un autre, à quelle phase — appartient à §3 et n'est
+pas prétendue ici.
+
+## Le catalogue curé
+
+Six motifs et trois réactions, tous **rejoués** à chaque validation :
+
+| Motif | Catégorie | Période | Translation | Population | Enveloppe |
+|---|---|---:|---|---:|---|
+| `block` | still_life | 1 | `(0, 0)` | 4 | 2×2 |
+| `blinker` | oscillator | 2 | `(0, 0)` | 3 | 3×3 |
+| `toad` | oscillator | 2 | `(0, 0)` | 6 | 4×4 |
+| `glider` | spaceship | 4 | `(1, -1)` | 5 | 3×3 |
+| `glider_mirror` | spaceship | 4 | `(-1, -1)` | 5 | 3×3 |
+| `lwss` | spaceship | 4 | `(-2, 0)` | 9 | 5×4 |
+
+| Réaction | Nature | Stabilisation | Produit mesuré |
+|---|---|---:|---|
+| `glider_pair_annihilation` | consumable | 12 | vide (annihilation complète) |
+| `glider_pair_two_blocks` | consumable | 5 | deux `block` |
+| `block_catalyses_glider` | catalytic | 43 | 12 cellules, le `block` survit parmi les débris |
+
+La troisième réaction est délibérément **non triviale** : le produit n'est pas la
+forme du réactif, donc « le bloc survit » est une mesure qui discrimine. Un cas
+où le produit serait exactement la forme du catalyseur serait vrai par
+construction et ne prouverait rien.
+
+## Provenance : trois natures d'information, distinguées
+
+Le critère 8 de #15635 demande de ne pas confondre trois choses. Le catalogue
+les sépare champ par champ :
+
+1. **Faits importés** — la nomenclature et l'existence des objets (`block`,
+   `blinker`, `toad`, `lwss`) viennent de sources Life explicites, nommées dans
+   le champ `provenance.source`. Les objets mathématiques eux-mêmes sont du
+   domaine public ; ce qui est « importé » est le nom, pas une donnée.
+2. **Propriétés revalidées** — période, translation, population, enveloppe,
+   produit, stabilisation, clearance, survie. Elles ne sont pas importées : elles
+   sont mesurées par le moteur du dépôt, à chaque exécution. Le `glider` n'est
+   même pas importé du tout : il est celui que `life_synthesize.py` redécouvre
+   par énumération bornée (Loi II, EPIC #12205).
+3. **Choix de conception propres à CoursIA** — le format du schéma, la règle
+   d'admissibilité des symétries, l'exigence de stabilité du produit, la
+   convention de placement des phases (forme normalisée placée à l'offset
+   déclaré). Ces choix sont des décisions, pas des faits, et sont énoncés ici
+   comme tels.
+
+## Reproduction
+
+```
+python scripts/lean/life_components.py --fixture scripts/lean/life_components_fixture.json
+python scripts/lean/life_components.py --fixture scripts/lean/life_components_fixture.json --json
+python -m pytest scripts/lean/tests/test_life_components.py -q
+```
+
+Le validateur sort `0` si toutes les métadonnées déclarées correspondent au
+replay, `1` sinon, avec le champ fautif nommé. Les tests falsifient une
+métadonnée à la fois (période, translation, population, boîte, enveloppe,
+catégorie, symétrie, phases, vitesse, provenance, produit, stabilisation,
+clearance, nature, région, ports, version de schéma) et exigent le refus.
+
+See #15635 · See #15571 · See #12205

--- a/scripts/lean/README.md
+++ b/scripts/lean/README.md
@@ -325,3 +325,28 @@ mais reçoit des paths POSIX-style en entrée (`REPO_ROOT=/c/...`). Bug mesuré 
 
 Voir aussi : `lean-wdac-olean-wholesale-copy.md`, `lean-knot-build-windows-cache.md`,
 `lean-rc1-convergence-method.md` dans `~/.claude/projects/c--dev-CoursIA-2/memory/`.
+
+## `life_components.py` — le schéma symbolique au-dessus du moteur cellulaire (tranche 1+2 de #15635)
+
+Le moteur cellulaire (`life_synthesize.py`, `life_synthesize_sat.py`) cherche un
+motif en énumérant des cellules. Il ignore ce que la communauté Life sait déjà
+des briques connues. Ce module ajoute la couche **symbolique** : un format
+versionné pour décrire des *motifs/composants* et des *réactions*, validé par
+**replay** dans le moteur du dépôt plutôt que par confiance dans les
+métadonnées déclarées.
+
+```
+python scripts/lean/life_components.py --fixture scripts/lean/life_components_fixture.json
+python -m pytest scripts/lean/tests/test_life_components.py -q
+```
+
+Le validateur sort `0` si période, translation, population, boîte, enveloppe,
+catégorie, symétries, phases, produit, stabilisation, clearance et nature
+correspondent au replay ; `1` sinon, en nommant le champ fautif. Deux règles de
+fond : une symétrie n'est admissible que si elle **préserve le vecteur de
+translation** (sinon les quatre orientations d'un glider se confondraient), et
+une réaction dont le produit déclaré ne correspond pas à l'évolution jointe de
+ses réactifs est refusée.
+
+Document complet (périmètre, ce qui est mesuré vs déclaré, provenance des faits,
+limites assumées) : [`docs/lean/life-components-schema.md`](../../docs/lean/life-components-schema.md).

--- a/scripts/lean/life_components.py
+++ b/scripts/lean/life_components.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""Schema versionne de motifs et de reactions de Game of Life (tranche 1+2 de #15635).
+
+Ce module ajoute la couche **symbolique** que le moteur cellulaire de #15571
+n'a pas : un format machine-readable pour decrire des *motifs/composants*
+(still lifes, oscillateurs, spaceships, conduits) et des *reactions*
+(reactifs -> produits), avec une **validation par replay** dans le moteur Life
+du depot (`life_synthesize`) plutot qu'une confiance dans les metadonnees
+declarees.
+
+La regle est celle de #15635, section 1 : « Chaque champ inconnu reste explicite
+(`null`/absent documente), jamais invente. » Un motif dont la periode, la
+translation, la population ou l'enveloppe declaree ne correspond pas a son
+evolution reelle est **refuse** ; une reaction dont le produit declare ne
+correspond pas a l'evolution jointe de ses reactifs est **refusee**.
+
+Ce que cette tranche livre (criteres 1 et 2 de #15635) :
+
+  * un schema versionne motifs + reactions, avec validation et tests de donnees
+    invalides ;
+  * un catalogue (fixture) cure, source, et **rejoue** : aucune metadonnee
+    declaree n'est acceptee sur confiance ;
+  * une canonicalisation par translation/rotation/reflexion qui **ne fusionne
+    pas** des objets non equivalents (un glider qui monte n'est pas un glider
+    qui descend).
+
+Hors scope de cette tranche (tranches suivantes de #15635) : le generateur de
+contraintes compositionnelles, les mecanismes de pruning et le demonstrateur
+multi-composants.
+
+Usage :
+    python scripts/lean/life_components.py --fixture scripts/lean/life_components_fixture.json
+    python scripts/lean/life_components.py --fixture <path> --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from life_synthesize import Cell, Grid, evolve, normalize, step  # noqa: E402
+
+SCHEMA_VERSION = "1.0.0"
+CONWAY_RULE = "B3/S23"
+
+# Reglages de surete de la mesure : un motif dont la periode ou la translation
+# depasse ces bornes n'est pas « mesure », il est « hors du domaine de l'organe ».
+MAX_PERIOD = 64
+MAX_TRANSLATION = 16
+
+# Operations de symetrie. Une symetrie n'est *admissible* pour un motif que si
+# elle preserve son vecteur de translation : sinon elle echangerait deux objets
+# non equivalents (un glider nord-est contre un glider sud-est).
+SYMMETRY_OPS: dict[str, Any] = {
+    "T": lambda c: [(x, y) for (x, y) in c],
+    "R90": lambda c: [(y, -x) for (x, y) in c],
+    "R180": lambda c: [(-x, -y) for (x, y) in c],
+    "R270": lambda c: [(-y, x) for (x, y) in c],
+    "Mx": lambda c: [(-x, y) for (x, y) in c],
+    "My": lambda c: [(x, -y) for (x, y) in c],
+    "D1": lambda c: [(y, x) for (x, y) in c],
+    "D2": lambda c: [(-y, -x) for (x, y) in c],
+}
+FULL_DIHEDRAL = ("T", "R90", "R180", "R270", "Mx", "My", "D1", "D2")
+
+
+class SchemaError(ValueError):
+    """Un document ne respecte pas le schema, ou declare un fait faux."""
+
+
+def _apply_symmetry(name: str, translation: tuple[int, int]) -> tuple[int, int]:
+    """Image du vecteur de translation par la symetrie nommee."""
+    (x, y) = SYMMETRY_OPS[name]([(translation[0], translation[1])])[0]
+    return (x, y)
+
+
+def admissible_symmetries(translation: tuple[int, int]) -> tuple[str, ...]:
+    """Symetries qui preservent la direction de deplacement du motif."""
+    return tuple(s for s in FULL_DIHEDRAL if _apply_symmetry(s, translation) == translation)
+
+
+def canonical_form(
+    cells: Iterable[Cell], symmetries: Sequence[str] = ("T",)
+) -> tuple[Cell, ...]:
+    """Forme canonique : minimum lexicographique sur les symetries autorisees.
+
+    Le groupe applique est `symmetries`, jamais le groupe complet : passer
+    `FULL_DIHEDRAL` a un spaceship fusionnerait ses quatre directions de vol.
+    """
+    grid = set(cells)
+    if not grid:
+        return ()
+    best: tuple[Cell, ...] | None = None
+    for name in symmetries:
+        if name not in SYMMETRY_OPS:
+            raise SchemaError(f"symetrie inconnue : {name!r}")
+        cand = normalize(set(SYMMETRY_OPS[name](list(grid))))
+        if best is None or cand < best:
+            best = cand
+    assert best is not None
+    return best
+
+
+def same_object(a: Iterable[Cell], b: Iterable[Cell]) -> bool:
+    """Deux formes sont-elles le MEME objet, au sens de leurs translations ?
+
+    Deux objets ne sont compares que si leurs symetries admissibles coincident :
+    un glider nord-est et un glider nord-ouest ont la meme forme a une reflexion
+    pres, mais des translations differentes -- les fusionner ferait disparaitre
+    la direction de vol, qui est precisement ce qu'une reaction doit contraindre.
+    """
+    ta = measure_motif(a).translation
+    tb = measure_motif(b).translation
+    if admissible_symmetries(ta) != admissible_symmetries(tb):
+        return False
+    return canonical_form(a, admissible_symmetries(ta)) == canonical_form(b, admissible_symmetries(tb))
+
+
+def bounding_box(cells: Iterable[Cell]) -> tuple[int, int]:
+    """Largeur x hauteur de la boite englobante (cellules supposees canoniques)."""
+    grid = set(cells)
+    if not grid:
+        return (0, 0)
+    return (max(x for x, _ in grid) + 1, max(y for _, y in grid) + 1)
+
+
+def _translation_between(origin: Grid, image: Grid) -> tuple[int, int]:
+    """Translation qui envoie `origin` sur `image` (memes formes canoniques)."""
+    ox = min(x for x, _ in origin); oy = min(y for _, y in origin)
+    ix = min(x for x, _ in image); iy = min(y for _, y in image)
+    return (ix - ox, iy - oy)
+
+
+@dataclass(frozen=True)
+class MeasuredMotif:
+    """Ce que le moteur mesure reellement pour une forme cellulaire."""
+
+    period: int
+    translation: tuple[int, int]
+    population: int
+    box: tuple[int, int]
+    envelope: tuple[int, int]
+    phases: dict[int, tuple[Cell, ...]]
+    kind: str
+
+
+def measure_motif(cells: Iterable[Cell], max_period: int = MAX_PERIOD) -> MeasuredMotif:
+    """Mesure periode, translation, population, boite et enveloppe par replay.
+
+    C'est l'oracle de la tranche : toute metadonnee declaree dans le catalogue
+    est comparee a cette mesure.
+    """
+    seq = [tuple(c) for c in cells]
+    grid = set(seq)
+    if not grid:
+        raise SchemaError("motif vide : la forme canonique n'a aucune cellule")
+    if len(grid) != len(seq):
+        raise SchemaError("cellules dupliquees : la forme n'est pas un ensemble")
+
+    base = normalize(grid)
+    for period in range(1, max_period + 1):
+        image = evolve(period, grid)
+        if normalize(image) == base:
+            translation = _translation_between(grid, image)
+            if max(abs(translation[0]), abs(translation[1])) > MAX_TRANSLATION:
+                raise SchemaError(
+                    f"translation {translation} hors domaine (>{MAX_TRANSLATION})"
+                )
+            phases = {k: normalize(evolve(k, grid)) for k in range(period)}
+            acc: Grid = set()
+            for phase in phases.values():
+                acc |= set(phase)
+            if translation != (0, 0):
+                kind = "spaceship"
+            elif period == 1:
+                kind = "still_life"
+            else:
+                kind = "oscillator"
+            return MeasuredMotif(
+                period=period,
+                translation=translation,
+                population=len(grid),
+                box=bounding_box(base),
+                envelope=bounding_box(acc),
+                phases=phases,
+                kind=kind,
+            )
+    raise SchemaError(f"forme non periodique dans {max_period} generations")
+
+
+# --------------------------------------------------------------------------
+# Schema : provenance, motif, reaction
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source: str
+    license: str
+    retrieved: str
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "license": self.license,
+            "retrieved": self.retrieved,
+            "note": self.note,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Provenance":
+        for key in ("source", "license", "retrieved"):
+            if not data.get(key):
+                raise SchemaError(f"provenance : champ {key!r} manquant")
+        return cls(
+            source=str(data["source"]),
+            license=str(data["license"]),
+            retrieved=str(data["retrieved"]),
+            note=data.get("note"),
+        )
+
+
+@dataclass(frozen=True)
+class Motif:
+    """Motif/composant : la forme, ses invariants mesures, sa provenance."""
+
+    id: str
+    kind: str
+    period: int
+    phase: str
+    translation_step: tuple[int, int]
+    population: int
+    box: tuple[int, int]
+    envelope: tuple[int, int]
+    rule: str
+    symmetries: tuple[str, ...]
+    provenance: Provenance
+    cells: tuple[Cell, ...]
+    rle: str | None = None
+    phases: dict[int, tuple[Cell, ...]] | None = None
+    direction: tuple[int, int] | None = None
+    speed: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "period": self.period,
+            "translation": list(self.translation_step),
+            "population": self.population,
+            "box": list(self.box),
+            "envelope": list(self.envelope),
+            "rule": self.rule,
+            "symmetries": list(self.symmetries),
+            "provenance": self.provenance.to_dict(),
+            "cells": [list(c) for c in self.cells],
+            "rle": self.rle,
+            "phases": (
+                None
+                if self.phases is None
+                else {str(k): [list(c) for c in v] for k, v in sorted(self.phases.items())}
+            ),
+            "direction": None if self.direction is None else list(self.direction),
+            "speed": self.speed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Motif":
+        for key in (
+            "id", "kind", "period", "translation", "population", "box",
+            "envelope", "rule", "symmetries", "provenance", "cells",
+        ):
+            if key not in data:
+                raise SchemaError(f"motif {data.get('id')!r} : champ {key!r} manquant")
+        return cls(
+            id=str(data["id"]),
+            kind=str(data["kind"]),
+            period=int(data["period"]),
+            phase=str(data.get("phase", "unknown")),
+            translation_step=tuple(data["translation"]),  # type: ignore[arg-type]
+            population=int(data["population"]),
+            box=tuple(data["box"]),  # type: ignore[arg-type]
+            envelope=tuple(data["envelope"]),  # type: ignore[arg-type]
+            rule=str(data["rule"]),
+            symmetries=tuple(data["symmetries"]),
+            provenance=Provenance.from_dict(data["provenance"]),
+            cells=tuple(tuple(c) for c in data["cells"]),  # type: ignore[misc]
+            rle=data.get("rle"),
+            phases=(
+                None
+                if data.get("phases") is None
+                else {int(k): tuple(tuple(c) for c in v) for k, v in data["phases"].items()}
+            ),
+            direction=(
+                None if data.get("direction") is None else tuple(data["direction"])
+            ),
+            speed=None if data.get("speed") is None else float(data["speed"]),
+        )
+
+
+@dataclass(frozen=True)
+class Placement:
+    motif_id: str
+    offset: tuple[int, int]
+    phase: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"motif_id": self.motif_id, "offset": list(self.offset), "phase": self.phase}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Placement":
+        if "motif_id" not in data or "offset" not in data:
+            raise SchemaError("placement : 'motif_id' et 'offset' sont requis")
+        return cls(
+            motif_id=str(data["motif_id"]),
+            offset=tuple(data["offset"]),  # type: ignore[arg-type]
+            phase=int(data.get("phase", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class Port:
+    name: str
+    offset: tuple[int, int]
+    direction: tuple[int, int]
+    phase: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "offset": list(self.offset),
+            "direction": list(self.direction),
+            "phase": self.phase,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Port":
+        for key in ("name", "offset", "direction", "phase"):
+            if key not in data:
+                raise SchemaError(f"port : champ {key!r} manquant")
+        return cls(
+            name=str(data["name"]),
+            offset=tuple(data["offset"]),  # type: ignore[arg-type]
+            direction=tuple(data["direction"]),  # type: ignore[arg-type]
+            phase=int(data["phase"]),
+        )
+
+
+@dataclass(frozen=True)
+class Reaction:
+    id: str
+    reactants: tuple[Placement, ...]
+    products: tuple[Placement, ...]
+    ports: tuple[Port, ...]
+    temporal_offset: int
+    stabilization_time: int
+    occupied_region: tuple[int, int, int, int] | None
+    clearance: tuple[tuple[int, int, int, int], ...]
+    nature: str
+    spatial_transform: str | None
+    preconditions: tuple[str, ...]
+    effects: tuple[str, ...]
+    provenance: Provenance
+    product_cells: tuple[Cell, ...] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "reactants": [p.to_dict() for p in self.reactants],
+            "products": [p.to_dict() for p in self.products],
+            "product_cells": (
+                None if self.product_cells is None else [list(c) for c in self.product_cells]
+            ),
+            "ports": [p.to_dict() for p in self.ports],
+            "temporal_offset": self.temporal_offset,
+            "stabilization_time": self.stabilization_time,
+            "occupied_region": (
+                None if self.occupied_region is None else list(self.occupied_region)
+            ),
+            "clearance": [list(r) for r in self.clearance],
+            "nature": self.nature,
+            "spatial_transform": self.spatial_transform,
+            "preconditions": list(self.preconditions),
+            "effects": list(self.effects),
+            "provenance": self.provenance.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Reaction":
+        for key in (
+            "id", "reactants", "ports", "temporal_offset", "stabilization_time",
+            "clearance", "nature", "preconditions", "effects", "provenance",
+        ):
+            if key not in data:
+                raise SchemaError(f"reaction {data.get('id')!r} : champ {key!r} manquant")
+        return cls(
+            id=str(data["id"]),
+            reactants=tuple(Placement.from_dict(p) for p in data["reactants"]),
+            products=tuple(Placement.from_dict(p) for p in data.get("products", [])),
+            ports=tuple(Port.from_dict(p) for p in data["ports"]),
+            temporal_offset=int(data["temporal_offset"]),
+            stabilization_time=int(data["stabilization_time"]),
+            occupied_region=(
+                None
+                if data.get("occupied_region") is None
+                else tuple(data["occupied_region"])  # type: ignore[arg-type]
+            ),
+            clearance=tuple(tuple(r) for r in data["clearance"]),  # type: ignore[misc]
+            nature=str(data["nature"]),
+            spatial_transform=data.get("spatial_transform"),
+            preconditions=tuple(data["preconditions"]),
+            effects=tuple(data["effects"]),
+            provenance=Provenance.from_dict(data["provenance"]),
+            product_cells=(
+                None
+                if data.get("product_cells") is None
+                else tuple(tuple(c) for c in data["product_cells"])  # type: ignore[misc]
+            ),
+        )
+
+
+@dataclass
+class Catalog:
+    motifs: dict[str, Motif] = field(default_factory=dict)
+    reactions: dict[str, Reaction] = field(default_factory=dict)
+
+    def motif(self, motif_id: str) -> Motif:
+        try:
+            return self.motifs[motif_id]
+        except KeyError:
+            raise SchemaError(f"motif inconnu du catalogue : {motif_id!r}") from None
+
+
+# --------------------------------------------------------------------------
+# Validation par replay
+# --------------------------------------------------------------------------
+
+
+def validate_motif(motif: Motif) -> MeasuredMotif:
+    """Rejoue le motif et confronte chaque metadonnee declaree a la mesure."""
+    where = f"motif {motif.id!r}"
+    if motif.rule != CONWAY_RULE:
+        raise SchemaError(
+            f"{where} : regle {motif.rule!r} inconnue du moteur (seule {CONWAY_RULE} est implementee)"
+        )
+
+    measured = measure_motif(motif.cells)
+
+    canonical = normalize(set(motif.cells))
+    if tuple(motif.cells) != canonical:
+        raise SchemaError(
+            f"{where} : cellules non canoniques (translation canonique triee attendue) -- "
+            f"attendu {canonical}, recu {tuple(motif.cells)}"
+        )
+
+    checks: list[tuple[str, Any, Any]] = [
+        ("periode", motif.period, measured.period),
+        ("translation", tuple(motif.translation_step), measured.translation),
+        ("population", motif.population, measured.population),
+        ("boite", tuple(motif.box), measured.box),
+        ("enveloppe", tuple(motif.envelope), measured.envelope),
+        ("nature", motif.kind, measured.kind),
+    ]
+    for label, declared, actual in checks:
+        if declared != actual:
+            raise SchemaError(f"{where} : {label} declaree {declared!r} != mesuree {actual!r}")
+
+    allowed = admissible_symmetries(measured.translation)
+    for name in motif.symmetries:
+        if name not in SYMMETRY_OPS:
+            raise SchemaError(f"{where} : symetrie inconnue {name!r}")
+        if name not in allowed:
+            raise SchemaError(
+                f"{where} : symetrie {name!r} inadmissible -- elle change la translation "
+                f"{measured.translation} en {_apply_symmetry(name, measured.translation)}"
+            )
+    if "T" not in motif.symmetries:
+        raise SchemaError(f"{where} : la symetrie 'T' (translation) est obligatoire")
+
+    if motif.phases is not None:
+        declared_phases = {k: tuple(v) for k, v in motif.phases.items()}
+        if set(declared_phases) != set(measured.phases):
+            raise SchemaError(
+                f"{where} : phases declarees {sorted(declared_phases)} != mesurees {sorted(measured.phases)}"
+            )
+        for k, cells in declared_phases.items():
+            if tuple(normalize(set(cells))) != measured.phases[k]:
+                raise SchemaError(f"{where} : phase {k} declaree != mesuree {measured.phases[k]}")
+
+    if measured.translation != (0, 0):
+        speed = (measured.translation[0] ** 2 + measured.translation[1] ** 2) ** 0.5 / measured.period
+        if motif.speed is not None and abs(motif.speed - speed) > 1e-9:
+            raise SchemaError(f"{where} : vitesse declaree {motif.speed} != mesuree {speed}")
+        if motif.direction is not None and tuple(motif.direction) != measured.translation:
+            raise SchemaError(
+                f"{where} : direction declaree {tuple(motif.direction)} != mesuree {measured.translation}"
+            )
+    return measured
+
+
+def _place(catalog: Catalog, placement: Placement) -> Grid:
+    motif = catalog.motif(placement.motif_id)
+    phases = motif.phases
+    if phases is None:
+        # Les phases sont derivees a la validation du motif ; on les recalcule ici
+        # pour que la reaction reste verifiable meme si le catalogue ne les porte pas.
+        measured = measure_motif(motif.cells)
+        phases = measured.phases
+    if placement.phase not in phases:
+        raise SchemaError(
+            f"placement de {placement.motif_id!r} : phase {placement.phase} hors de "
+            f"[0, {max(phases)})"
+        )
+    dx, dy = placement.offset
+    return {(x + dx, y + dy) for (x, y) in phases[placement.phase]}
+
+
+def _reactant_survives(cells: Grid, final: Grid) -> bool:
+    """Le reactif apparait-il verbatim (a une translation pres) dans l'etat final ?"""
+    if not final:
+        return False
+    fminx = min(x for x, _ in final); fminy = min(y for _, y in final)
+    shifted = {(x - fminx, y - fminy) for (x, y) in final}
+    nx = min(x for x, _ in cells); ny = min(y for _, y in cells)
+    target = {(x - nx, y - ny) for (x, y) in cells}
+    tw = max(x for x, _ in target); th = max(y for _, y in target)
+    fw = max(x for x, _ in shifted); fh = max(y for _, y in shifted)
+    for ox in range(0, fw - tw + 1):
+        for oy in range(0, fh - th + 1):
+            if {(x + ox, y + oy) for (x, y) in target} <= shifted:
+                return True
+    return False
+
+
+def validate_reaction(reaction: Reaction, catalog: Catalog) -> dict[str, Any]:
+    """Rejoue la reaction jointe et confronte produit, clearance et nature."""
+    where = f"reaction {reaction.id!r}"
+    if reaction.nature not in ("consumable", "reusable", "catalytic"):
+        raise SchemaError(f"{where} : nature {reaction.nature!r} inconnue")
+    if not reaction.reactants:
+        raise SchemaError(f"{where} : aucune espece reactive")
+    if reaction.stabilization_time < 0:
+        raise SchemaError(f"{where} : stabilisation negative")
+
+    placement_grids = [_place(catalog, p) for p in reaction.reactants]
+    initial: Grid = set()
+    for g in placement_grids:
+        initial |= g
+
+    final: Grid = set(initial)
+    ever: Grid = set(initial)
+    for _ in range(reaction.stabilization_time):
+        final = step(final)
+        ever |= final
+
+    # 1. produit declare vs produit mesure
+    has_placements = bool(reaction.products)
+    has_cells = reaction.product_cells is not None
+    if has_placements and has_cells:
+        raise SchemaError(f"{where} : 'products' et 'product_cells' sont exclusifs")
+    if has_placements:
+        expected: Grid = set()
+        for p in reaction.products:
+            expected |= _place(catalog, p)
+    elif has_cells:
+        expected = {tuple(c) for c in reaction.product_cells}
+    else:
+        expected = set()
+    if final != expected:
+        raise SchemaError(
+            f"{where} : produit mesure {sorted(final)} != produit declare {sorted(expected)} "
+            f"a t={reaction.stabilization_time}"
+        )
+    if step(final) != final:
+        raise SchemaError(
+            f"{where} : le produit declare n'est pas stable a t={reaction.stabilization_time} "
+            "(les reactions a produit mobile sont hors domaine de ce validateur)"
+        )
+
+    # 2. zones de clearance : jamais traversees, sur toute la fenetre
+    for rect in reaction.clearance:
+        x0, y0, w, h = rect
+        if w <= 0 or h <= 0:
+            raise SchemaError(f"{where} : clearance {rect} de taille nulle")
+        occupied = {
+            (x, y)
+            for (x, y) in ever
+            if x0 <= x < x0 + w and y0 <= y < y0 + h
+        }
+        if occupied:
+            raise SchemaError(
+                f"{where} : clearance {rect} traversee par {sorted(occupied)[:4]}"
+            )
+
+    # 3. nature : consomme vs catalyse, mesuree
+    survivors = [
+        p.motif_id
+        for p, g in zip(reaction.reactants, placement_grids)
+        if _reactant_survives(g, final)
+    ]
+    if reaction.nature == "consumable" and survivors:
+        raise SchemaError(
+            f"{where} : declaree 'consumable' mais {survivors} survit dans l'etat final"
+        )
+    if reaction.nature in ("reusable", "catalytic") and not survivors:
+        raise SchemaError(
+            f"{where} : declaree {reaction.nature!r} mais aucun reactif ne survit"
+        )
+
+    # 4. region occupee : boite englobante de tout ce qui a vecu
+    if reaction.occupied_region is not None:
+        x0, y0, w, h = reaction.occupied_region
+        measured_region = (
+            min(x for x, _ in ever),
+            min(y for _, y in ever),
+            max(x for x, _ in ever) - min(x for x, _ in ever) + 1,
+            max(y for _, y in ever) - min(y for _, y in ever) + 1,
+        )
+        if tuple(measured_region) != (x0, y0, w, h):
+            raise SchemaError(
+                f"{where} : region occupee declaree {(x0, y0, w, h)} != mesuree {measured_region}"
+            )
+
+    # 5. ports : coherence structurelle (la compatibilite releve de la tranche 3)
+    for port in reaction.ports:
+        if not port.name:
+            raise SchemaError(f"{where} : port sans nom")
+        if abs(port.direction[0]) + abs(port.direction[1]) == 0:
+            raise SchemaError(f"{where} : port {port.name!r} de direction nulle")
+        if reaction.occupied_region is not None:
+            x0, y0, w, h = reaction.occupied_region
+            px, py = port.offset
+            if not (x0 <= px < x0 + w and y0 <= py < y0 + h):
+                raise SchemaError(
+                    f"{where} : port {port.name!r} en {port.offset} hors de la region occupee"
+                )
+
+    return {
+        "id": reaction.id,
+        "nature": reaction.nature,
+        "stabilization_time": reaction.stabilization_time,
+        "population_final": len(final),
+        "survivors": survivors,
+    }
+
+
+def load_catalog(path: str | Path) -> Catalog:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SchemaError("le document doit etre un objet JSON")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise SchemaError(
+            f"schema_version declaree {data.get('schema_version')!r} != {SCHEMA_VERSION!r}"
+        )
+    catalog = Catalog()
+    for raw in data.get("motifs", []):
+        motif = Motif.from_dict(raw)
+        if motif.id in catalog.motifs:
+            raise SchemaError(f"motif duplique : {motif.id!r}")
+        catalog.motifs[motif.id] = motif
+    for raw in data.get("reactions", []):
+        reaction = Reaction.from_dict(raw)
+        if reaction.id in catalog.reactions:
+            raise SchemaError(f"reaction dupliquee : {reaction.id!r}")
+        catalog.reactions[reaction.id] = reaction
+    return catalog
+
+
+def validate_catalog(catalog: Catalog) -> list[dict[str, Any]]:
+    """Valide tout le catalogue : motifs d'abord, puis reactions (qui les citent)."""
+    report: list[dict[str, Any]] = []
+    for motif in catalog.motifs.values():
+        measured = validate_motif(motif)
+        report.append(
+            {
+                "kind": "motif",
+                "id": motif.id,
+                "categorie": measured.kind,
+                "periode": measured.period,
+                "translation": list(measured.translation),
+                "population": measured.population,
+                "enveloppe": list(measured.envelope),
+            }
+        )
+    for reaction in catalog.reactions.values():
+        report.append({"kind": "reaction", **validate_reaction(reaction, catalog)})
+    return report
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Valide un catalogue de motifs et de reactions de Game of Life contre "
+            "le moteur Life du depot (aucune metadonnee acceptee sur confiance)."
+        )
+    )
+    parser.add_argument(
+        "--fixture",
+        default=str(Path(__file__).resolve().parent / "life_components_fixture.json"),
+        help="catalogue JSON a valider",
+    )
+    parser.add_argument("--json", action="store_true", help="sortie JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        catalog = load_catalog(args.fixture)
+        report = validate_catalog(catalog)
+    except (SchemaError, json.JSONDecodeError) as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False, indent=2))
+        else:
+            print(f"ECHEC : {exc}")
+        return 1
+
+    if args.json:
+        print(json.dumps({"ok": True, "schema_version": SCHEMA_VERSION, "items": report},
+                         ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"Schema {SCHEMA_VERSION} -- {args.fixture}")
+    for row in report:
+        if row["kind"] == "motif":
+            print(
+                f"  motif    {row['id']:24s} {row['categorie']:11s} p={row['periode']} "
+                f"t={tuple(row['translation'])} pop={row['population']} env={tuple(row['enveloppe'])}"
+            )
+        else:
+            print(
+                f"  reaction {row['id']:24s} {row['nature']:11s} "
+                f"st={row['stabilization_time']} pop_final={row['population_final']} "
+                f"survivants={row['survivors']}"
+            )
+    print("OK -- toutes les metadonnees declarees correspondent au replay.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lean/life_components_fixture.json
+++ b/scripts/lean/life_components_fixture.json
@@ -1,0 +1,1133 @@
+{
+  "schema_version": "1.0.0",
+  "rule": "B3/S23",
+  "note": "Fixture cure de la tranche 1+2 de #15635. Les champs numeriques (periode, translation, population, boite, enveloppe, stabilisation, region occupee) sont DERIVES du moteur Life du depot puis re-derives et compares a chaque validation ; les champs de provenance sont cures a la main.",
+  "motifs": [
+    {
+      "id": "block",
+      "kind": "still_life",
+      "period": 1,
+      "translation": [
+        0,
+        0
+      ],
+      "population": 4,
+      "box": [
+        2,
+        2
+      ],
+      "envelope": [
+        2,
+        2
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "R90",
+        "R180",
+        "R270",
+        "Mx",
+        "My",
+        "D1",
+        "D2"
+      ],
+      "provenance": {
+        "source": "nomenclature LifeWiki (conwaylife.com/wiki/Block)",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "still life 2x2 ; le plus petit objet stable non vide"
+      },
+      "cells": [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          1
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ]
+        ]
+      },
+      "direction": null,
+      "speed": null
+    },
+    {
+      "id": "blinker",
+      "kind": "oscillator",
+      "period": 2,
+      "translation": [
+        0,
+        0
+      ],
+      "population": 3,
+      "box": [
+        3,
+        1
+      ],
+      "envelope": [
+        3,
+        3
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "R90",
+        "R180",
+        "R270",
+        "Mx",
+        "My",
+        "D1",
+        "D2"
+      ],
+      "provenance": {
+        "source": "nomenclature LifeWiki (conwaylife.com/wiki/Blinker)",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "oscillateur de periode 2 ; la plus petite forme oscillante"
+      },
+      "cells": [
+        [
+          0,
+          0
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          2,
+          0
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            0
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            2,
+            0
+          ]
+        ],
+        "1": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ]
+        ]
+      },
+      "direction": null,
+      "speed": null
+    },
+    {
+      "id": "toad",
+      "kind": "oscillator",
+      "period": 2,
+      "translation": [
+        0,
+        0
+      ],
+      "population": 6,
+      "box": [
+        4,
+        2
+      ],
+      "envelope": [
+        4,
+        4
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "R90",
+        "R180",
+        "R270",
+        "Mx",
+        "My",
+        "D1",
+        "D2"
+      ],
+      "provenance": {
+        "source": "nomenclature LifeWiki (conwaylife.com/wiki/Toad)",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "oscillateur de periode 2 a 6 cellules (controle de periode identique, forme differente)"
+      },
+      "cells": [
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          1
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            1
+          ],
+          [
+            3,
+            0
+          ]
+        ],
+        "1": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            2
+          ]
+        ]
+      },
+      "direction": null,
+      "speed": null
+    },
+    {
+      "id": "glider",
+      "kind": "spaceship",
+      "period": 4,
+      "translation": [
+        1,
+        -1
+      ],
+      "population": 5,
+      "box": [
+        3,
+        3
+      ],
+      "envelope": [
+        3,
+        3
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "D2"
+      ],
+      "provenance": {
+        "source": "redécouvert par scripts/lean/life_synthesize.py (Loi II, EPIC #12205)",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "glider canonique du depot, retrouve par enumeration bornee puis certifie en Lean"
+      },
+      "cells": [
+        [
+          0,
+          0
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            0
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            1
+          ]
+        ],
+        "1": [
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            1
+          ],
+          [
+            2,
+            2
+          ]
+        ],
+        "2": [
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            1
+          ],
+          [
+            2,
+            2
+          ]
+        ],
+        "3": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            1
+          ]
+        ]
+      },
+      "direction": [
+        1,
+        -1
+      ],
+      "speed": 0.3535533905932738
+    },
+    {
+      "id": "glider_mirror",
+      "kind": "spaceship",
+      "period": 4,
+      "translation": [
+        -1,
+        -1
+      ],
+      "population": 5,
+      "box": [
+        3,
+        3
+      ],
+      "envelope": [
+        3,
+        3
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "D1"
+      ],
+      "provenance": {
+        "source": "reflexion en x du glider du depot",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "glider de direction opposee : meme forme a une reflexion pres, translation differente"
+      },
+      "cells": [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          1
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            0
+          ]
+        ],
+        "1": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            2
+          ]
+        ],
+        "2": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            2,
+            1
+          ]
+        ],
+        "3": [
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            2
+          ]
+        ]
+      },
+      "direction": [
+        -1,
+        -1
+      ],
+      "speed": 0.3535533905932738
+    },
+    {
+      "id": "lwss",
+      "kind": "spaceship",
+      "period": 4,
+      "translation": [
+        -2,
+        0
+      ],
+      "population": 9,
+      "box": [
+        5,
+        4
+      ],
+      "envelope": [
+        5,
+        4
+      ],
+      "rule": "B3/S23",
+      "symmetries": [
+        "T",
+        "My"
+      ],
+      "provenance": {
+        "source": "nomenclature LifeWiki (conwaylife.com/wiki/Lightweight_spaceship)",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "vaisseau leger, periode 4, deplacement de 2 cellules par cycle"
+      },
+      "cells": [
+        [
+          0,
+          1
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "rle": null,
+      "phases": {
+        "0": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            3
+          ],
+          [
+            4,
+            0
+          ],
+          [
+            4,
+            2
+          ]
+        ],
+        "1": [
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            2
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            2
+          ],
+          [
+            3,
+            3
+          ],
+          [
+            4,
+            1
+          ],
+          [
+            4,
+            2
+          ]
+        ],
+        "2": [
+          [
+            0,
+            0
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            0
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            3,
+            0
+          ],
+          [
+            4,
+            1
+          ],
+          [
+            4,
+            3
+          ]
+        ],
+        "3": [
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            1
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            0
+          ],
+          [
+            2,
+            1
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            0
+          ],
+          [
+            3,
+            1
+          ],
+          [
+            3,
+            2
+          ],
+          [
+            4,
+            1
+          ],
+          [
+            4,
+            2
+          ]
+        ]
+      },
+      "direction": [
+        -2,
+        0
+      ],
+      "speed": 0.5
+    }
+  ],
+  "reactions": [
+    {
+      "id": "glider_pair_annihilation",
+      "reactants": [
+        {
+          "motif_id": "glider",
+          "offset": [
+            0,
+            0
+          ],
+          "phase": 0
+        },
+        {
+          "motif_id": "glider_mirror",
+          "offset": [
+            6,
+            2
+          ],
+          "phase": 0
+        }
+      ],
+      "products": [],
+      "product_cells": null,
+      "ports": [
+        {
+          "name": "in0",
+          "offset": [
+            0,
+            0
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        },
+        {
+          "name": "in1",
+          "offset": [
+            6,
+            2
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        }
+      ],
+      "temporal_offset": 0,
+      "stabilization_time": 12,
+      "occupied_region": [
+        0,
+        -2,
+        9,
+        7
+      ],
+      "clearance": [
+        [
+          0,
+          -7,
+          2,
+          2
+        ]
+      ],
+      "nature": "consumable",
+      "spatial_transform": null,
+      "preconditions": [
+        "cellules des reactifs placees telles que declarees"
+      ],
+      "effects": [
+        "empty"
+      ],
+      "provenance": {
+        "source": "mesure firsthand par le moteur Life du depot",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "stabilise a t=12 ; region occupee mesuree"
+      }
+    },
+    {
+      "id": "glider_pair_two_blocks",
+      "reactants": [
+        {
+          "motif_id": "glider",
+          "offset": [
+            0,
+            0
+          ],
+          "phase": 0
+        },
+        {
+          "motif_id": "glider_mirror",
+          "offset": [
+            4,
+            0
+          ],
+          "phase": 0
+        }
+      ],
+      "products": [
+        {
+          "motif_id": "block",
+          "offset": [
+            1,
+            -1
+          ],
+          "phase": 0
+        },
+        {
+          "motif_id": "block",
+          "offset": [
+            4,
+            -1
+          ],
+          "phase": 0
+        }
+      ],
+      "product_cells": null,
+      "ports": [
+        {
+          "name": "in0",
+          "offset": [
+            0,
+            0
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        },
+        {
+          "name": "in1",
+          "offset": [
+            4,
+            0
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        }
+      ],
+      "temporal_offset": 0,
+      "stabilization_time": 5,
+      "occupied_region": [
+        0,
+        -1,
+        7,
+        4
+      ],
+      "clearance": [
+        [
+          0,
+          -6,
+          2,
+          2
+        ]
+      ],
+      "nature": "consumable",
+      "spatial_transform": null,
+      "preconditions": [
+        "cellules des reactifs placees telles que declarees"
+      ],
+      "effects": [
+        "two_blocks"
+      ],
+      "provenance": {
+        "source": "mesure firsthand par le moteur Life du depot",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "stabilise a t=5 ; region occupee mesuree"
+      }
+    },
+    {
+      "id": "block_catalyses_glider",
+      "reactants": [
+        {
+          "motif_id": "glider",
+          "offset": [
+            0,
+            0
+          ],
+          "phase": 0
+        },
+        {
+          "motif_id": "block",
+          "offset": [
+            3,
+            0
+          ],
+          "phase": 0
+        }
+      ],
+      "products": [],
+      "product_cells": [
+        [
+          -5,
+          -4
+        ],
+        [
+          -5,
+          -3
+        ],
+        [
+          -4,
+          -5
+        ],
+        [
+          -4,
+          -2
+        ],
+        [
+          -3,
+          -5
+        ],
+        [
+          -3,
+          -2
+        ],
+        [
+          -2,
+          -4
+        ],
+        [
+          -2,
+          -3
+        ],
+        [
+          7,
+          -4
+        ],
+        [
+          7,
+          -3
+        ],
+        [
+          8,
+          -4
+        ],
+        [
+          8,
+          -3
+        ]
+      ],
+      "ports": [
+        {
+          "name": "in0",
+          "offset": [
+            0,
+            0
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        },
+        {
+          "name": "in1",
+          "offset": [
+            3,
+            0
+          ],
+          "direction": [
+            0,
+            1
+          ],
+          "phase": 0
+        }
+      ],
+      "temporal_offset": 0,
+      "stabilization_time": 43,
+      "occupied_region": [
+        -6,
+        -9,
+        15,
+        13
+      ],
+      "clearance": [
+        [
+          -6,
+          -14,
+          2,
+          2
+        ]
+      ],
+      "nature": "catalytic",
+      "spatial_transform": null,
+      "preconditions": [
+        "cellules des reactifs placees telles que declarees"
+      ],
+      "effects": [
+        "catalytic"
+      ],
+      "provenance": {
+        "source": "mesure firsthand par le moteur Life du depot",
+        "license": "domaine public (objet mathematique du jeu de la vie)",
+        "retrieved": "2026-09-11",
+        "note": "stabilise a t=43 ; region occupee mesuree"
+      }
+    }
+  ]
+}

--- a/scripts/lean/tests/test_life_components.py
+++ b/scripts/lean/tests/test_life_components.py
@@ -1,0 +1,341 @@
+"""Tests du schema de motifs/reactions de Game of Life (tranche 1+2 de #15635).
+
+Le contrat teste ici est celui du critere 2 de #15635 : « aucune metadonnee
+declaree n'est acceptee sur confiance ». Chaque test de rejet falsifie UNE
+metadonnee du fixture et exige que la validation la refuse -- c'est la seule
+facon de montrer que le validateur mesure au lieu de recopier.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LEAN_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = LEAN_DIR.parent.parent
+FIXTURE = LEAN_DIR / "life_components_fixture.json"
+
+sys.path.insert(0, str(LEAN_DIR))
+
+from life_components import (  # noqa: E402
+    FULL_DIHEDRAL,
+    SCHEMA_VERSION,
+    SchemaError,
+    admissible_symmetries,
+    canonical_form,
+    load_catalog,
+    same_object,
+    validate_catalog,
+)
+
+
+def fixture_doc() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def motif_entry(doc: dict, motif_id: str) -> dict:
+    for entry in doc["motifs"]:
+        if entry["id"] == motif_id:
+            return entry
+    raise AssertionError(f"motif {motif_id!r} absent du fixture")
+
+
+def reaction_entry(doc: dict, reaction_id: str) -> dict:
+    for entry in doc["reactions"]:
+        if entry["id"] == reaction_id:
+            return entry
+    raise AssertionError(f"reaction {reaction_id!r} absente du fixture")
+
+
+def validate_doc(doc: dict, tmp_path: Path) -> list[dict]:
+    path = tmp_path / "catalogue.json"
+    path.write_text(json.dumps(doc, ensure_ascii=False), encoding="utf-8")
+    return validate_catalog(load_catalog(path))
+
+
+# --------------------------------------------------------------------------
+# Le fixture lui-meme
+# --------------------------------------------------------------------------
+
+
+def test_fixture_valide_sans_erreur(tmp_path: Path) -> None:
+    report = validate_doc(fixture_doc(), tmp_path)
+    assert len(report) == len(fixture_doc()["motifs"]) + len(fixture_doc()["reactions"])
+
+
+def test_rapport_separe_motifs_et_reactions(tmp_path: Path) -> None:
+    report = validate_doc(fixture_doc(), tmp_path)
+    kinds = {row["kind"] for row in report}
+    assert kinds == {"motif", "reaction"}
+
+
+def test_fixture_couvre_les_quatre_categories_de_la_tranche(tmp_path: Path) -> None:
+    """§1 de #15635 : still lifes, oscillateurs, spaceships et reactions."""
+    report = validate_doc(fixture_doc(), tmp_path)
+    cats = {row["categorie"] for row in report if row["kind"] == "motif"}
+    assert {"still_life", "oscillator", "spaceship"} <= cats
+    assert any(row["kind"] == "reaction" for row in report)
+
+
+# --------------------------------------------------------------------------
+# Motifs : chaque metadonnee declaree est comparee a la mesure
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("champ", "valeur", "attendu"),
+    [
+        ("period", 3, "periode"),
+        ("translation", [0, 0], "translation"),
+        ("population", 6, "population"),
+        ("box", [4, 4], "boite"),
+        ("envelope", [5, 5], "enveloppe"),
+        ("kind", "oscillator", "nature"),
+    ],
+)
+def test_metadonnee_fausse_refusee(
+    champ: str, valeur: object, attendu: str, tmp_path: Path
+) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "glider")[champ] = valeur
+    with pytest.raises(SchemaError, match=attendu):
+        validate_doc(doc, tmp_path)
+
+
+def test_cellules_non_canoniques_refusees(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    entry = motif_entry(doc, "block")
+    entry["cells"] = [[x + 3, y + 2] for x, y in entry["cells"]]
+    with pytest.raises(SchemaError, match="non canoniques"):
+        validate_doc(doc, tmp_path)
+
+
+def test_regle_inconnue_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "block")["rule"] = "B36/S23"
+    with pytest.raises(SchemaError, match="regle"):
+        validate_doc(doc, tmp_path)
+
+
+def test_symetrie_inadmissible_refusee(tmp_path: Path) -> None:
+    """Une symetrie qui change la translation echangerait deux objets distincts."""
+    doc = fixture_doc()
+    motif_entry(doc, "glider")["symmetries"] = ["T", "R90"]
+    with pytest.raises(SchemaError, match="inadmissible"):
+        validate_doc(doc, tmp_path)
+
+
+def test_symetrie_translation_obligatoire(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "block")["symmetries"] = ["R90"]
+    with pytest.raises(SchemaError, match="obligatoire"):
+        validate_doc(doc, tmp_path)
+
+
+def test_phases_fausses_refusees(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    entry = motif_entry(doc, "blinker")
+    entry["phases"] = {k: v for k, v in entry["phases"].items() if k != "1"}
+    with pytest.raises(SchemaError, match="phases"):
+        validate_doc(doc, tmp_path)
+
+
+def test_vitesse_fausse_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "glider")["speed"] = 99.0
+    with pytest.raises(SchemaError, match="vitesse"):
+        validate_doc(doc, tmp_path)
+
+
+def test_motif_duplique_refuse(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    doc["motifs"].append(copy.deepcopy(motif_entry(doc, "block")))
+    with pytest.raises(SchemaError, match="duplique"):
+        validate_doc(doc, tmp_path)
+
+
+def test_champ_manquant_refuse(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    del motif_entry(doc, "block")["population"]
+    with pytest.raises(SchemaError, match="manquant"):
+        validate_doc(doc, tmp_path)
+
+
+def test_schema_version_inconnue_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    doc["schema_version"] = "9.9.9"
+    with pytest.raises(SchemaError, match="schema_version"):
+        validate_doc(doc, tmp_path)
+
+
+def test_provenance_incomplete_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "block")["provenance"] = {"source": "moi", "license": "?", "retrieved": ""}
+    with pytest.raises(SchemaError, match="provenance"):
+        validate_doc(doc, tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Reactions : produit, clearance et nature mesures, pas declares
+# --------------------------------------------------------------------------
+
+
+def test_reaction_motif_inconnu_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_annihilation")["reactants"][0]["motif_id"] = "licorne"
+    with pytest.raises(SchemaError, match="inconnu"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_produit_declare_faux_refuse(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_annihilation")["product_cells"] = [[0, 0], [1, 0], [0, 1]]
+    with pytest.raises(SchemaError, match="produit mesure"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_stabilisation_trop_precoce_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_two_blocks")["stabilization_time"] = 2
+    with pytest.raises(SchemaError, match="produit mesure"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_clearance_traversee_refusee(tmp_path: Path) -> None:
+    """Controle negatif : une clearance posee sur la zone occupee doit rougir."""
+    doc = fixture_doc()
+    entry = reaction_entry(doc, "glider_pair_annihilation")
+    x0, y0, w, h = entry["occupied_region"]
+    entry["clearance"] = [[x0, y0, w, h]]
+    with pytest.raises(SchemaError, match="clearance"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_consommable_avec_survivant_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "block_catalyses_glider")["nature"] = "consumable"
+    with pytest.raises(SchemaError, match="consumable"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_catalytique_sans_survivant_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_annihilation")["nature"] = "catalytic"
+    with pytest.raises(SchemaError, match="aucun reactif"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_phase_hors_bornes_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_two_blocks")["reactants"][0]["phase"] = 7
+    with pytest.raises(SchemaError, match="phase"):
+        validate_doc(doc, tmp_path)
+
+
+def test_produits_et_cellules_brutes_exclusifs(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    entry = reaction_entry(doc, "glider_pair_two_blocks")
+    entry["product_cells"] = [[0, 0], [1, 0], [0, 1], [1, 1]]
+    with pytest.raises(SchemaError, match="exclusifs"):
+        validate_doc(doc, tmp_path)
+
+
+def test_reaction_nature_inconnue_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_annihilation")["nature"] = "magique"
+    with pytest.raises(SchemaError, match="nature"):
+        validate_doc(doc, tmp_path)
+
+
+def test_region_occupee_fausse_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    reaction_entry(doc, "glider_pair_annihilation")["occupied_region"] = [0, 0, 1, 1]
+    with pytest.raises(SchemaError, match="region occupee"):
+        validate_doc(doc, tmp_path)
+
+
+def test_port_hors_region_refuse(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    entry = reaction_entry(doc, "glider_pair_two_blocks")
+    entry["ports"] = [{"name": "in0", "offset": [99, 99], "direction": [0, 1], "phase": 0}]
+    with pytest.raises(SchemaError, match="hors de la region"):
+        validate_doc(doc, tmp_path)
+
+
+def test_port_direction_nulle_refusee(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    entry = reaction_entry(doc, "glider_pair_two_blocks")
+    entry["ports"] = [
+        {"name": "in0", "offset": entry["reactants"][0]["offset"], "direction": [0, 0], "phase": 0}
+    ]
+    with pytest.raises(SchemaError, match="direction nulle"):
+        validate_doc(doc, tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Canonicalisation : normaliser sans fusionner des objets non equivalents
+# --------------------------------------------------------------------------
+
+
+def test_canonical_form_merge_les_symetries_dun_still_life() -> None:
+    block = [(0, 0), (1, 0), (0, 1), (1, 1)]
+    rotated = [(y, -x) for (x, y) in block]
+    assert canonical_form(block, FULL_DIHEDRAL) == canonical_form(rotated, FULL_DIHEDRAL)
+
+
+def test_symetries_admissibles_suivent_la_translation() -> None:
+    assert admissible_symmetries((0, 0)) == FULL_DIHEDRAL
+    assert admissible_symmetries((1, -1)) == ("T", "D2")
+    assert admissible_symmetries((-1, -1)) == ("T", "D1")
+    assert admissible_symmetries((-2, 0)) == ("T", "My")
+
+
+def test_same_object_ne_fusionne_pas_deux_gliders_de_directions_opposees(tmp_path: Path) -> None:
+    """Le coeur du critere 2 : deux formes en miroir ne sont pas le meme objet."""
+    catalog = load_catalog(FIXTURE)
+    gauche = catalog.motif("glider")
+    droite = catalog.motif("glider_mirror")
+    assert gauche.translation_step != droite.translation_step
+    assert not same_object(gauche.cells, droite.cells)
+    assert same_object(gauche.cells, gauche.cells)
+
+
+def test_symetrie_inconnue_refusee() -> None:
+    with pytest.raises(SchemaError, match="inconnue"):
+        canonical_form([(0, 0)], ("Z9",))
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_valide_le_fixture() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(LEAN_DIR / "life_components.py"), "--fixture", str(FIXTURE)],
+        capture_output=True, text=True, timeout=600,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "OK" in proc.stdout
+
+
+def test_cli_rougit_sur_fixture_falsifie(tmp_path: Path) -> None:
+    doc = fixture_doc()
+    motif_entry(doc, "glider")["period"] = 3
+    bad = tmp_path / "faux.json"
+    bad.write_text(json.dumps(doc, ensure_ascii=False), encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(LEAN_DIR / "life_components.py"), "--fixture", str(bad)],
+        capture_output=True, text=True, timeout=600,
+    )
+    assert proc.returncode == 1
+    assert "ECHEC" in proc.stdout
+
+
+def test_schema_version_exportee() -> None:
+    assert SCHEMA_VERSION == fixture_doc()["schema_version"]


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2023:CoursIA — prev: MED/docs #15649

## Contexte

Le moteur cellulaire de #15571 (`scripts/lean/life_synthesize.py`) cherche un motif
en énumérant des cellules dans une boîte, puis en encodant son évolution en SAT. Son
espace de recherche croît avec la surface, la période et la cardinalité — et il ignore
tout ce que la communauté Life sait déjà des briques connues : still lifes, catalyseurs,
oscillateurs, collisions de gliders.

#15635 demande d'ajouter la couche **symbolique** qui manque : un format versionné
pour décrire des *motifs/composants* et des *réactions*, avec la propriété qui la rend
utile — **aucune métadonnée déclarée n'est acceptée sur confiance**. Chaque champ
numérique est re-dérivé par replay dans le moteur Life du dépôt et confronté à ce que
le document prétend. Un écart est un refus, pas un avertissement.

Cette PR livre la **tranche 1+2** (§1 schéma minimal versionné, §2 catalogue
reproductible rejoué indépendamment). Les §3 (générateur de contraintes
compositionnelles) et §4 (démonstrateur multi-composants + ablations de pruning)
restent ouverts → `See #15635`, pas `Closes`.

## Livrable

| Chemin | Rôle |
|---|---|
| `scripts/lean/life_components.py` | schéma (dataclasses gelées), canonicalisation, mesure par replay, validateur, CLI `--fixture` / `--json` |
| `scripts/lean/life_components_fixture.json` | catalogue curé : 6 motifs + 3 réactions, tous rejoués à chaque validation |
| `scripts/lean/tests/test_life_components.py` | 38 tests — un test de rejet par métadonnée falsifiée |
| `docs/lean/life-components-schema.md` | périmètre, mesuré vs déclaré, provenance des faits, limites assumées |
| `scripts/lean/README.md` | section de renvoi vers la doc complète |

## Le contrat : mesurer, pas recopier

**Motif** — la période est la **plus petite** `p` telle que `evolve^p T` soit `T` à
translation près : une période déclarée trop grande est refusée, car ce n'est pas la
période du motif mais un de ses multiples. Sont également re-dérivés la translation par
période (donc direction et vitesse), la population, la boîte initiale, l'enveloppe sur
un cycle, la catégorie (`still_life` / `oscillator` / `spaceship`, dérivée de la période
et de la translation), la forme canonique des cellules et les phases déclarées. Le champ
`rule` n'accepte que `B3/S23`, seule règle que le moteur du dépôt implémente : prétendre
en valider une autre serait une preuve non fournie.

**Symétries** — une symétrie n'est admissible que si elle **préserve le vecteur de
translation** du motif. La restriction n'est pas cosmétique : sous le groupe diédral
complet, les quatre orientations d'un glider se confondraient et la direction de vol —
précisément ce qu'une réaction compositionnelle doit contraindre — disparaîtrait.
Conséquence testée : `glider` et `glider_mirror` ont la même forme à une réflexion près
mais des translations opposées, donc `same_object` répond **faux**.

**Réaction** — l'état à `t = stabilization_time` doit égaler exactement le produit
déclaré **et être stable** (`step(état) == état`). Les zones de clearance ne doivent
être traversées par aucune cellule vivante sur toute la fenêtre (contrôle négatif de
l'absence d'interaction parasite). La région occupée est comparée à la boîte englobante
mesurée de tout ce qui a vécu. La nature (`consumable` / `reusable` / `catalytic`) est
**mesurée** par survie d'un réactif dans l'état final, à translation près.

## Preuve — commandes relancées dans ce worktree

```
$ python -m pytest scripts/lean/tests/test_life_components.py -q
38 passed in 0.60s

$ python -m pytest scripts/lean/tests/ -q
304 passed, 1 skipped in 49.50s        # 266 pré-existants verts : aucune régression

$ python -m pyflakes scripts/lean/life_components.py scripts/lean/tests/test_life_components.py
(propre)

$ python scripts/check_docs_links.py
Scanned 701 files, 6814 links — No broken links found.

$ python scripts/lean/life_components.py --fixture scripts/lean/life_components_fixture.json
  motif    block      still_life  p=1 t=(0, 0)   pop=4 env=(2, 2)
  motif    blinker    oscillator  p=2 t=(0, 0)   pop=3 env=(3, 3)
  motif    toad       oscillator  p=2 t=(0, 0)   pop=6 env=(4, 4)
  motif    glider     spaceship   p=4 t=(1, -1)  pop=5 env=(3, 3)
  motif    glider_mirror  spaceship  p=4 t=(-1, -1) pop=5 env=(3, 3)
  motif    lwss       spaceship   p=4 t=(-2, 0)  pop=9 env=(5, 4)
  reaction glider_pair_annihilation consumable st=12 pop_final=0  survivants=[]
  reaction glider_pair_two_blocks   consumable st=5  pop_final=8  survivants=[]
  reaction block_catalyses_glider   catalytic  st=43 pop_final=12 survivants=['block']
OK -- toutes les metadonnees declarees correspondent au replay.
exit=0
```

Le catalogue curé, mesuré :

| Motif | Catégorie | Période | Translation | Population | Enveloppe |
|---|---|---:|---|---:|---|
| `block` | still_life | 1 | `(0, 0)` | 4 | 2×2 |
| `blinker` | oscillator | 2 | `(0, 0)` | 3 | 3×3 |
| `toad` | oscillator | 2 | `(0, 0)` | 6 | 4×4 |
| `glider` | spaceship | 4 | `(1, -1)` | 5 | 3×3 |
| `glider_mirror` | spaceship | 4 | `(-1, -1)` | 5 | 3×3 |
| `lwss` | spaceship | 4 | `(-2, 0)` | 9 | 5×4 |

| Réaction | Nature | Stabilisation | Produit mesuré |
|---|---|---:|---|
| `glider_pair_annihilation` | consumable | 12 | vide (annihilation complète) |
| `glider_pair_two_blocks` | consumable | 5 | deux `block` |
| `block_catalyses_glider` | catalytic | 43 | 12 cellules, le `block` survit parmi les débris |

La troisième réaction est délibérément **non triviale** : le produit n'est pas la forme
du réactif, donc « le bloc survit » est une mesure qui discrimine. Un cas où le produit
serait exactement la forme du catalyseur serait vrai par construction et ne prouverait
rien.

## Provenance — trois natures d'information, distinguées (critère 8)

1. **Faits importés** — la nomenclature et l'existence des objets (`block`, `blinker`,
   `toad`, `lwss`) viennent de sources Life nommées dans le champ `provenance.source`.
   Ce qui est importé est le *nom*, pas une donnée : les objets mathématiques sont du
   domaine public.
2. **Propriétés revalidées** — période, translation, population, enveloppe, produit,
   stabilisation, clearance, survie. Elles ne sont pas importées : elles sont mesurées
   par le moteur du dépôt à chaque exécution. Le `glider` n'est même pas importé du
   tout — c'est celui que `life_synthesize.py` redécouvre par énumération bornée
   (Loi II, EPIC #12205).
3. **Choix de conception propres à CoursIA** — format du schéma, règle d'admissibilité
   des symétries, exigence de stabilité du produit, convention de placement des phases.
   Ce sont des décisions, énoncées comme telles dans la doc.

## Périmètre

Le diff ne contient que les cinq chemins listés plus haut (`git diff --cached --stat` :
5 files changed, 2398 insertions(+), 0 deletions). Aucun workflow, aucun notebook, aucun
catalogue : `COURSE_CATALOG.generated.*` reste byte-identique à `main`. Rien n'est
supprimé — la PR est purement additive.

## Limites assumées

- Une réaction dont le **produit est mobile** est hors du domaine du validateur : c'est
  une limite énoncée dans la doc, pas un silence.
- La **sémantique de compatibilité des ports** (quel port de quel composant rencontre
  quel autre, à quelle phase) appartient à §3 et n'est pas prétendue ici — les ports ne
  sont validés que structurellement (nom, direction non nulle, position dans la région
  occupée).
- Le validateur ne connaît que la règle Conway `B3/S23`, celle du moteur du dépôt.

See #15635 · See #15571 · See #12205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
