### PR TITLE
feat(ict,#15480): banc synthetique factorise Mess3/RRXOR — generateurs, beliefs exacts, vary-one (tranche 1/n)

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -12,10 +12,10 @@ name: ICT-Series Tests
 #       sensitivity consolides depuis ict/tests/, #9478).
 #       ict/tests/ = 42 strates package.
 #   - test-floor compte la COLLECTION parametree (items developpes par
-#     @pytest.mark.parametrize) : tests/ = 1046 items, ict/tests/ = 686 items.
-#     55 != 1046 PAR CONSTRUCTION (une strate se developpe en N items parametres) :
+#     @pytest.mark.parametrize) : tests/ = 1107 items, ict/tests/ = 724 items.
+#     55 != 1107 PAR CONSTRUCTION (une strate se developpe en N items parametres) :
 #     NE PAS "harmoniser" le floor sur le compte de strates, ni inversement. Le
-#     floor garde la collection (1046/686), le label garde les strates (55/42).
+#     floor garde la collection (1107/724), le label garde les strates (55/42).
 #
 # Provenance : a l'intro du workflow (59ac5fc10) le header reclamait 34/119
 # tests, mais la CI a TOUJOURS collecte davantage (run d'origine 30896333149) :
@@ -30,6 +30,19 @@ name: ICT-Series Tests
 # collecte DEPASSE le floor (drift ascendant = floor a remonter dans la PR qui
 # l'introduit). Quand la collection change, ajuster matrix.test-floor dans la
 # meme PR.
+# Mesure firsthand po-2027 (2026-09-13, worktree detache REBASE sur origin/main,
+# python 3.9.25 + numpy 1.26.4 + scipy + matplotlib SANS torch -- la forme de
+# l'env CI, verifiee fidele : le job 103632939140 (main@5772d72dc7) porte
+# "Collected: 692 tests (floor: 692)", identique a la mesure locale) :
+# tests/ = 1107 SUR ORIGIN/MAIN (la prose du header de main annoncait encore
+# 1046/670 alors que son floor etait deja 1071 -- incoherence heritee, corrigee ici)
+# et ict/tests/ = 708 sur origin/main -> 724 sur cette branche (+16 items
+# bench_factorise #15657). La mesure anterieure du 2026-09-12 annoncait 692 -> 708 :
+# elle portait sur un main LOCAL PERIME, anterieur a l'arrivee de
+# ict/tests/test_attention_schema.py (#15547) sur origin/main ; le chiffre de la
+# branche etait donc faux de 16, et le floor avec lui.
+# Le venv local AVEC torch collecte 1111 en tests/ : les 4 items d'ecart sont
+# tests/test_sae_traces_layout.py, `importorskip("torch")` module-level.
 # Imposer un troisieme rootdir depuis la racine reproduirait le ModuleNotFoundError
 # documente dans #9387 (acceptance : une panne d'infra doit se distinguer d'un finding).
 #
@@ -123,10 +136,13 @@ jobs:
           # (#15479 tranche 2, tests/test_causal_hooks.py -- importorskip
           # FONCTION-niveau : comptes a la collecte meme sans torch, skips a
           # l'execution seulement, convention test_jlens_traces.py).
+          # Floor 1071 -> 1107 (cette PR) : +36 de DRIFT MAIN, aucun apport de
+          # la branche -- origin/main@4793dc31cd1f collecte 1107 sous py3.9.25
+          # sans torch, la branche collecte 1107 (mesure firsthand po-2027).
           - suite-name: "tests/ (56)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series
             test-args: tests
-            test-floor: 1071
+            test-floor: 1107
           # ict/tests/ : 42 strates package (85 - 43 consolides dans tests/,
           # #9478) -> 686 items collectes = 670 (mesure 2x sur
           # origin/main@5302d974aa, CI-confirme run 34307798875) + 16 tests
@@ -139,13 +155,28 @@ jobs:
           # (sys.path.insert module-level ignore sous importlib).
           # Floor 670 -> 692 : +22 items coeur numpy du moteur causal
           # (#15479 tranche 1, ict/tests/test_causal_engine.py).
-          # Floor 708 -> 728 : +20 items case 4 self-model minimal
-          # #8182 (PR case 4, ict/tests/test_self_model_minimal.py --
-          # 43e strate package, collection locale mesuree 728).
+          # Floor 692 -> 708 : +16 items case 5 attention-schema #8182
+          # (PR #15547, ict/tests/test_attention_schema.py) -- porte par MAIN.
+          # (La prose de main ci-dessus annonce encore 686 : elle est en retard
+          # d'un cran sur son propre floor, 708.)
+          # Floor 708 -> 728 : +20 items case 4 self-model minimal #8182
+          # (PR case 4, ict/tests/test_self_model_minimal.py -- 43e strate
+          # package, collection locale mesuree 728) -- porte par MAIN
+          # egalement, posterieurement.
+          # Floor 728 -> 744 (cette PR) : +16 items bench_factorise #15657,
+          # mesures sur l'arbre REBASE (44 fichiers test_*.py cote origin/main,
+          # 45 cote branche). La mesure anterieure de cette branche
+          # (708 -> 724) est SUPERSEDEE, pas corrigee de quelques items : elle
+          # portait sur un origin/main PERIME, anterieur a l'arrivee du 44e
+          # module -- un floor mesure contre un origin/main perime est faux
+          # quelle que soit la qualite de la mesure locale. 728 + 16 = 744
+          # ferme l'arithmetique, et 744 EST la collection mesuree sur l'arbre
+          # rebase (py3.9.25 + numpy 1.26.4 + scipy 1.13.1 + matplotlib 3.9.4,
+          # SANS torch -- la forme de l'env CI).
           - suite-name: "ict/tests/ (43 package)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests
             test-args: .
-            test-floor: 728
+            test-floor: 744
 
     steps:
       - uses: actions/checkout@v4

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bench_factorise.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/bench_factorise.py
@@ -1,0 +1,260 @@
+"""Banc synthetique factorise pour la triangulation causale (issue #15480).
+
+Le banc produit des sequences dont la factorisation latente est CONNUE :
+deux processus generatifs independants, un par facteur. Les etats de belief
+exacts se calculent par filtration forward sur chaque facteur separement
+(independance des generateurs), sans approximation.
+
+Deux generateurs sont fournis :
+
+- :class:`Mess3` : POMDP a 3 etats caches en cycle (avec probabilite de
+  glissement), emissions gaussiennes 1D. La geometrie de belief vit dans le
+  2-simplexe.
+- :class:`RRXOR` : processus XOR recursif. Bits d'entree iid uniformes
+  ``b_t`` ; etat cache ``(b_{t-1}, b_t)`` ; observation ``y_t = b_{t-1} XOR
+  b_t``. Le belief exact vit sur les 4 sommets du 3-simplexe.
+
+La classe :class:`FactoredBench` combine deux generateurs quelconques en un
+banc a deux facteurs (l'issue nomme ``Mess3 x RRXOR`` ou deux Mess3
+independants ; les deux sont couverts par la meme architecture), construit
+les jeux vary-one (un facteur gele, l'autre qui varie par seed) et fournit
+les beliefs joints exacts comme produit des marginales.
+
+L'engine d'intervention qui consommera ce banc est la couche transversale
+#15479 (``ict/causal_engine.py`` + hooks), pas ce module : le banc ne fait
+que generer et filtrer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Sequence, Tuple
+
+import numpy as np
+
+Array = np.ndarray
+
+
+class ProcessError(ValueError):
+    """Erreur de parametrage ou d'usage d'un generateur du banc."""
+
+
+@dataclass(frozen=True)
+class Mess3:
+    """Mess3 : 3 etats caches en cycle, emissions gaussiennes 1D.
+
+    Parametres par defaut : modes bien separees (ecart des moyennes >= 4
+    ecarts-types) pour que la v1 ait une verite terrain lisible. Les
+    etudes de superposition resserreront l'ecart ensuite.
+    """
+
+    stay: float = 0.95
+    means: Tuple[float, float, float] = (-0.15, 0.0, 0.15)
+    std: float = 0.05
+    n_states: int = 3
+    name: str = "mess3"
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.stay < 1.0:
+            raise ProcessError(f"stay doit etre dans (0,1), recu {self.stay}")
+        if self.std <= 0:
+            raise ProcessError(f"std doit etre > 0, recu {self.std}")
+        if len(self.means) != self.n_states:
+            raise ProcessError("une moyenne par etat requise")
+
+    # --- structure connue -------------------------------------------------
+    def transition_matrix(self) -> Array:
+        """Matrice T[i, j] = P(s_{t+1} = j | s_t = i) : rester, sinon avancer au suivant du cycle."""
+        slip = 1.0 - self.stay
+        t = np.zeros((self.n_states, self.n_states))
+        for i in range(self.n_states):
+            t[i, i] = self.stay
+            t[i, (i + 1) % self.n_states] = slip
+        return t
+
+    def stationary(self) -> Array:
+        """Loi stationnaire : uniforme par symetrie du cycle."""
+        return np.full(self.n_states, 1.0 / self.n_states)
+
+    def emission_loglik(self, obs: Array) -> Array:
+        """Log-vraisemblance log P(obs | s) pour chaque etat, forme (T, n_states)."""
+        means = np.asarray(self.means)[None, :]
+        return -0.5 * ((obs[:, None] - means) / self.std) ** 2 - np.log(
+            self.std * np.sqrt(2.0 * np.pi)
+        )
+
+    # --- generation --------------------------------------------------------
+    def sample(self, n: int, seed: int) -> Tuple[Array, Array]:
+        """Echantillonne n pas ; retourne (etats, observations), etat initial tiré selon la stationnaire."""
+        rng = np.random.default_rng(seed)
+        t = self.transition_matrix()
+        states = np.empty(n, dtype=np.int64)
+        obs = np.empty(n)
+        s = rng.choice(self.n_states, p=self.stationary())
+        for k in range(n):
+            states[k] = s
+            obs[k] = rng.normal(self.means[s], self.std)
+            s = rng.choice(self.n_states, p=t[s])
+        return states, obs
+
+    # --- belief exact ------------------------------------------------------
+    def beliefs(self, obs: Array) -> Array:
+        """Filtration forward exacte : belief[k] = P(s_k | obs_{0..k}), forme (T, n_states)."""
+        if obs.ndim != 1:
+            raise ProcessError("Mess3.beliefs attend une serie 1D")
+        t = self.transition_matrix()
+        prior = self.stationary()
+        ll = self.emission_loglik(obs)
+        out = np.empty((len(obs), self.n_states))
+        b = prior
+        for k in range(len(obs)):
+            pred = b @ t if k > 0 else b
+            w = pred * np.exp(ll[k] - ll[k].max())
+            z = w.sum()
+            if z <= 0.0:
+                raise ProcessError(f"log-vraisemblance degeneratee au pas {k}")
+            b = w / z
+            out[k] = b
+        return out
+
+
+@dataclass(frozen=True)
+class RRXOR:
+    """XOR recursif : bits iid ``b_t``, observation ``y_t = b_{t-1} XOR b_t``.
+
+    Etat cache au pas t : la paire ``(b_{t-1}, b_t)``, 4 etats ordonnes
+    ``00, 01, 10, 11``. L'observation etant deterministe dans l'etat, le
+    belief exact apres observation vit sur les 2 etats coherents avec
+    ``y_t``, uniformes (les entrees sont iid uniformes).
+    """
+
+    n_states: int = 4
+    name: str = "rrxor"
+
+    def transition_matrix(self) -> Array:
+        """T[(a,b) -> (b,c)] = 1/2 pour c dans {0,1} : le bit frais est iid uniforme."""
+        t = np.zeros((4, 4))
+        for a in (0, 1):
+            for b in (0, 1):
+                for c in (0, 1):
+                    t[2 * a + b, 2 * b + c] = 0.5
+        return t
+
+    def stationary(self) -> Array:
+        return np.full(4, 0.25)
+
+    def emission_matrix(self) -> Array:
+        """E[i, y] = P(y_t = y | etat i) : deterministe, y = a XOR b."""
+        e = np.zeros((4, 2))
+        for a in (0, 1):
+            for b in (0, 1):
+                e[2 * a + b, a ^ b] = 1.0
+        return e
+
+    def sample(self, n: int, seed: int) -> Tuple[Array, Array]:
+        """Echantillonne n bits iid + l'observation XOR ; retourne (etats (b_{t-1}, b_t), y)."""
+        rng = np.random.default_rng(seed)
+        bits = rng.integers(0, 2, size=n + 1)
+        states = 2 * bits[:-1] + bits[1:]
+        obs = bits[:-1] ^ bits[1:]
+        return states, obs
+
+    def beliefs(self, obs: Array) -> Array:
+        """Filtration forward exacte sur les 4 etats ; observation binaire deterministe.
+
+        Le premier pas n'a pas d'observation antecedente : prior stationnaire
+        (l'etat (b_{-1}, b_0) n'est jamais observable via y_0 seul).
+        """
+        if obs.ndim != 1 or not np.all(np.isin(obs, (0, 1))):
+            raise ProcessError("RRXOR.beliefs attend une serie binaire 1D")
+        t = self.transition_matrix()
+        e = self.emission_matrix()
+        prior = self.stationary()
+        out = np.empty((len(obs), 4))
+        b = prior
+        for k in range(len(obs)):
+            pred = b @ t if k > 0 else b
+            w = pred * e[:, int(obs[k])]
+            b = w / w.sum()
+            out[k] = b
+        return out
+
+
+@dataclass
+class FactoredBench:
+    """Banc a deux facteurs independants, factorisation latente connue.
+
+    Chaque pas produit l'observation jointe ``(obs_A[t], obs_B[t])``. Les
+    beliefs joints exacts sont le produit des beliefs marginaux (independance
+    des generateurs) : ``P(s_A, s_B | o_{0..t}) = P(s_A|o_A) P(s_B|o_B)``.
+    """
+
+    factor_a: object
+    factor_b: object
+    name: str = "bench"
+
+    def __post_init__(self) -> None:
+        requis = ("sample", "beliefs", "n_states", "name")
+        for p in (self.factor_a, self.factor_b):
+            for attr in requis:
+                if not hasattr(p, attr):
+                    raise ProcessError(
+                        f"{type(p).__name__} n'expose pas '{attr}' : generateur incompatible"
+                    )
+
+    # --- generation jointe --------------------------------------------------
+    def sample(self, n: int, seed_a: int, seed_b: int) -> Dict[str, Array]:
+        """Echantillonne les deux facteurs independamment ; trajectoires et observations jointes."""
+        sa, oa = self.factor_a.sample(n, seed_a)
+        sb, ob = self.factor_b.sample(n, seed_b)
+        return {
+            "states_a": sa,
+            "states_b": sb,
+            "obs_a": oa,
+            "obs_b": ob,
+            "obs_joint": np.stack([oa, ob], axis=1),
+        }
+
+    def beliefs(self, obs_a: Array, obs_b: Array) -> Dict[str, Array]:
+        """Beliefs marginaux exacts par facteur, et belief joint = produit (independance)."""
+        ba = self.factor_a.beliefs(obs_a)
+        bb = self.factor_b.beliefs(obs_b)
+        joint = (ba[:, :, None] * bb[:, None, :]).reshape(len(ba), -1)
+        return {"belief_a": ba, "belief_b": bb, "belief_joint": joint}
+
+    # --- protocole vary-one ---------------------------------------------------
+    def vary_one(
+        self,
+        n: int,
+        frozen: str,
+        seed_frozen: int,
+        seeds_varying: Sequence[int],
+    ) -> Dict[str, object]:
+        """Jeu vary-one : la trajectoire du facteur gele est identique sur toutes
+        les repliques, celle du facteur libre varie par seed.
+
+        ``frozen`` vaut ``"a"`` ou ``"b"`` ; retourne la trajectoire gelee et la
+        liste des trajectoires libres.
+        """
+        if frozen not in ("a", "b"):
+            raise ProcessError(f"frozen doit valoir 'a' ou 'b', recu {frozen!r}")
+        frozen_proc = self.factor_a if frozen == "a" else self.factor_b
+        varying_proc = self.factor_b if frozen == "a" else self.factor_a
+        fixed_states, fixed_obs = frozen_proc.sample(n, seed_frozen)
+        reps = [varying_proc.sample(n, s) for s in seeds_varying]
+        return {
+            "frozen": frozen,
+            "fixed_states": fixed_states,
+            "fixed_obs": fixed_obs,
+            "varying_states": [r[0] for r in reps],
+            "varying_obs": [r[1] for r in reps],
+            "seeds_varying": list(seeds_varying),
+        }
+
+
+def belief_simplex_coords(beliefs: Array) -> Array:
+    """Coordonnees barycentriques 2D des beliefs d'un processus a 3 etats (triangle de Simon)."""
+    if beliefs.shape[1] != 3:
+        raise ProcessError("coordonnees simplexe definies pour 3 etats seulement")
+    v = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, np.sqrt(3.0) / 2.0]])
+    return beliefs @ v

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
@@ -1,0 +1,225 @@
+"""Tests CPU deterministes du banc factorise (issue #15480, tranche 1).
+
+Contre-verification majeure : les beliefs exacts sont confrontes a une
+enumeration brute de toutes les sequences d'etats sur n court — le forward
+ne se valide pas par lui-meme.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+import pytest
+
+from ict.bench_factorise import (
+    FactoredBench,
+    Mess3,
+    ProcessError,
+    RRXOR,
+    belief_simplex_coords,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mess3 : structure, generation, beliefs
+# ---------------------------------------------------------------------------
+
+
+def test_mess3_transition_lignes_stochastiques_cycle():
+    m = Mess3()
+    t = m.transition_matrix()
+    assert np.allclose(t.sum(axis=1), 1.0)
+    # cycle : depuis chaque etat, soit rester, soit avancer au suivant
+    for i in range(3):
+        j = (i + 1) % 3
+        assert t[i, i] == pytest.approx(0.95)
+        assert t[i, j] == pytest.approx(0.05)
+        assert t[i, 3 - i - j] == 0.0
+
+
+def test_mess3_stationnaire_uniforme():
+    m = Mess3()
+    assert np.allclose(m.stationary(), [1 / 3] * 3)
+
+
+def test_mess3_sample_reproductible_et_formes():
+    m = Mess3()
+    s1, o1 = m.sample(50, seed=7)
+    s2, o2 = m.sample(50, seed=7)
+    assert np.array_equal(s1, s2) and np.array_equal(o1, o2)
+    assert s1.shape == (50,) and o1.shape == (50,)
+    assert set(np.unique(s1)) <= {0, 1, 2}
+
+
+def test_mess3_parametrage_invalide_rejete():
+    with pytest.raises(ProcessError):
+        Mess3(stay=1.5)
+    with pytest.raises(ProcessError):
+        Mess3(std=0.0)
+    with pytest.raises(ProcessError):
+        Mess3(means=(0.0, 1.0))
+
+
+def _mess3_bruteforce_beliefs(m: Mess3, obs: np.ndarray) -> np.ndarray:
+    """Enumeration de toutes les sequences d'etats : P(s_k | o_{0..k}) exact par sommation."""
+    n = len(obs)
+    means = np.asarray(m.means)
+    out = np.zeros((n, m.n_states))
+    total_prec = np.zeros(m.n_states)  # somme des poids des prefixes, par etat final
+    # weight prefix jusqu'a k-1, par etat s_{k-1} : recursion sur prefixes
+    w_prev = np.zeros(m.n_states)  # poids non normalises des sequences s_{0..k-1}
+    log_norm = 0.0
+    # initialisation : k = 0
+    prior = m.stationary()
+    for k in range(n):
+        w_new = np.zeros(m.n_states)
+        for s in range(m.n_states):
+            lik = math.exp(-0.5 * ((obs[k] - means[s]) / m.std) ** 2)
+            if k == 0:
+                w_new[s] = prior[s] * lik
+            else:
+                for sprev in range(m.n_states):
+                    trans = m.transition_matrix()[sprev, s]
+                    if trans > 0 and w_prev[sprev] > 0:
+                        w_new[s] += w_prev[sprev] * trans * lik
+        z = w_new.sum()
+        w_prev = w_new / z
+        log_norm += math.log(z)
+        out[k] = w_prev
+    return out
+
+
+def test_mess3_beliefs_vs_enumeration_brute():
+    m = Mess3(means=(-0.15, 0.0, 0.15), std=0.05, stay=0.9)
+    _, obs = m.sample(12, seed=42)
+    fast = m.beliefs(obs)
+    brute = _mess3_bruteforce_beliefs(m, obs)
+    assert fast.shape == (12, 3)
+    assert np.allclose(fast, brute, atol=1e-12)
+
+
+def test_mess3_beliefs_somment_a_un_et_modes_lisibles():
+    m = Mess3()
+    states, obs = m.sample(500, seed=3)
+    b = m.beliefs(obs)
+    assert np.allclose(b.sum(axis=1), 1.0, atol=1e-12)
+    # modes bien separees : argmax du belief = etat emis la plupart du temps
+    acc = (b.argmax(axis=1) == states).mean()
+    assert acc > 0.95, f"modes mal separees, accuracy={acc}"
+
+
+def test_mess3_beliefs_rejette_2d():
+    with pytest.raises(ProcessError):
+        Mess3().beliefs(np.zeros((3, 2)))
+
+
+# ---------------------------------------------------------------------------
+# RRXOR : invariants, beliefs
+# ---------------------------------------------------------------------------
+
+
+def test_rrxor_invariant_xor_et_etats():
+    r = RRXOR()
+    states, obs = r.sample(200, seed=11)
+    # y_t = a XOR b avec etat = 2a + b
+    a, b = states // 2, states % 2
+    assert np.array_equal(a ^ b, obs)
+    assert set(np.unique(states)) <= {0, 1, 2, 3}
+
+
+def test_rrxor_transition_stationnaire():
+    r = RRXOR()
+    t = r.transition_matrix()
+    assert np.allclose(t.sum(axis=1), 1.0)
+    assert np.allclose(t @ r.stationary(), r.stationary())
+    # chaque etat a exactement 2 successeurs equiprobables
+    assert np.all((t > 0).sum(axis=1) == 2)
+    assert np.allclose(t[t > 0], 0.5)
+
+
+def test_rrxor_beliefs_sur_2_etats_coherents():
+    r = RRXOR()
+    states, obs = r.sample(100, seed=5)
+    b = r.beliefs(obs)
+    assert np.allclose(b.sum(axis=1), 1.0, atol=1e-12)
+    e = r.emission_matrix()
+    for k in range(len(obs)):
+        coherent = e[:, int(obs[k])] > 0
+        assert coherent.sum() == 2
+        assert b[k, coherent] == pytest.approx(0.5)
+        assert b[k, ~coherent] == pytest.approx(0.0, abs=1e-15)
+
+
+def test_rrxor_beliefs_rejette_non_binaire():
+    with pytest.raises(ProcessError):
+        RRXOR().beliefs(np.array([0, 2, 1]))
+
+
+# ---------------------------------------------------------------------------
+# Banc factorise : produit, independance, vary-one
+# ---------------------------------------------------------------------------
+
+
+def test_bench_observation_jointe_et_beliefs_produit():
+    bench = FactoredBench(Mess3(), RRXOR())
+    run = bench.sample(30, seed_a=1, seed_b=2)
+    assert run["obs_joint"].shape == (30, 2)
+    assert np.array_equal(run["obs_joint"][:, 0], run["obs_a"])
+    bel = bench.beliefs(run["obs_a"], run["obs_b"])
+    na, nb = 3, 4
+    assert bel["belief_joint"].shape == (30, na * nb)
+    recompose = bel["belief_joint"].reshape(30, na, nb)
+    assert np.allclose(recompose, bel["belief_a"][:, :, None] * bel["belief_b"][:, None, :])
+    assert np.allclose(bel["belief_joint"].sum(axis=1), 1.0, atol=1e-12)
+
+
+def test_bench_deux_mess3_independants():
+    """L'option « deux Mess3 independants » de l'issue : meme architecture, facteurs homogenes."""
+    bench = FactoredBench(Mess3(means=(-0.15, 0.0, 0.15)), Mess3(means=(1.0, 1.2, 1.4), name="mess3_b"))
+    run = bench.sample(20, seed_a=0, seed_b=9)
+    bel = bench.beliefs(run["obs_a"], run["obs_b"])
+    assert bel["belief_joint"].shape == (20, 9)
+    # independance : la trajectory de B ne change pas le belief de A
+    run2 = bench.sample(20, seed_a=0, seed_b=10)
+    bel2 = bench.beliefs(run2["obs_a"], run2["obs_b"])
+    assert np.allclose(bel["belief_a"], bel2["belief_a"])
+
+
+def test_bench_vary_one_facteur_gele_identique_libre_different():
+    bench = FactoredBench(Mess3(), RRXOR())
+    vy = bench.vary_one(40, frozen="a", seed_frozen=77, seeds_varying=[1, 2, 3])
+    reps = np.stack(vy["varying_obs"])
+    assert np.array_equal(reps[0], reps[0])
+    assert not np.array_equal(reps[0], reps[1])
+    assert not np.array_equal(reps[1], reps[2])
+    # gele : meme trajectoire reconstruite par le meme seed
+    s_again, o_again = bench.factor_a.sample(40, 77)
+    assert np.array_equal(vy["fixed_obs"], o_again)
+    with pytest.raises(ProcessError):
+        bench.vary_one(5, frozen="z", seed_frozen=0, seeds_varying=[1])
+
+
+def test_bench_generateurs_incompatibles_rejetes():
+    class PasUnGenerateur:
+        pass
+
+    with pytest.raises(ProcessError):
+        FactoredBench(Mess3(), PasUnGenerateur())
+
+
+def test_belief_simplex_coords_dans_le_triangle():
+    m = Mess3()
+    _, obs = m.sample(100, seed=13)
+    xy = belief_simplex_coords(m.beliefs(obs))
+    assert xy.shape == (100, 2)
+    # tout point barycentrique du triangle est dans l'enveloppe convexe des sommets
+    assert xy[:, 0].min() >= -1e-12 and xy[:, 0].max() <= 1.0 + 1e-12
+    assert xy[:, 1].min() >= -1e-12 and xy[:, 1].max() <= np.sqrt(3) / 2 + 1e-12
+    with pytest.raises(ProcessError):
+        belief_simplex_coords(np.ones((2, 4)) / 4)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
@@ -193,7 +193,12 @@ def test_bench_vary_one_facteur_gele_identique_libre_different():
     bench = FactoredBench(Mess3(), RRXOR())
     vy = bench.vary_one(40, frozen="a", seed_frozen=77, seeds_varying=[1, 2, 3])
     reps = np.stack(vy["varying_obs"])
-    assert np.array_equal(reps[0], reps[0])
+    # le facteur gele ne depend PAS des seeds libres : meme trajectoire gelee
+    # quand on change la liste des seeds qui varient. Sans cette mesure, la
+    # propriete ne reposait que sur la construction du code (un seul appel a
+    # sample(n, seed_frozen)), ce qu'aucune assertion ne verifiait.
+    vy_autres_seeds = bench.vary_one(40, frozen="a", seed_frozen=77, seeds_varying=[4, 5])
+    assert np.array_equal(vy["fixed_obs"], vy_autres_seeds["fixed_obs"])
     assert not np.array_equal(reps[0], reps[1])
     assert not np.array_equal(reps[1], reps[2])
     # gele : meme trajectoire reconstruite par le meme seed

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_bench_factorise.py
@@ -67,41 +67,39 @@ def test_mess3_parametrage_invalide_rejete():
 
 
 def _mess3_bruteforce_beliefs(m: Mess3, obs: np.ndarray) -> np.ndarray:
-    """Enumeration de toutes les sequences d'etats : P(s_k | o_{0..k}) exact par sommation."""
+    """Enumeration exacte (independante du forward) : pour chaque sequence
+    complete d'etats, poids joint = prior * prod(transitions) * prod(likelihoods),
+    puis marginalisation en P(s_k | o_{0..n-1}) — beliefs lisses, a comparer
+    au forward apres troncature des observations au meme prefixe."""
     n = len(obs)
     means = np.asarray(m.means)
-    out = np.zeros((n, m.n_states))
-    total_prec = np.zeros(m.n_states)  # somme des poids des prefixes, par etat final
-    # weight prefix jusqu'a k-1, par etat s_{k-1} : recursion sur prefixes
-    w_prev = np.zeros(m.n_states)  # poids non normalises des sequences s_{0..k-1}
-    log_norm = 0.0
-    # initialisation : k = 0
     prior = m.stationary()
-    for k in range(n):
-        w_new = np.zeros(m.n_states)
-        for s in range(m.n_states):
-            lik = math.exp(-0.5 * ((obs[k] - means[s]) / m.std) ** 2)
-            if k == 0:
-                w_new[s] = prior[s] * lik
-            else:
-                for sprev in range(m.n_states):
-                    trans = m.transition_matrix()[sprev, s]
-                    if trans > 0 and w_prev[sprev] > 0:
-                        w_new[s] += w_prev[sprev] * trans * lik
-        z = w_new.sum()
-        w_prev = w_new / z
-        log_norm += math.log(z)
-        out[k] = w_prev
-    return out
+    t = m.transition_matrix()
+
+    def lik(o: float, s: int) -> float:
+        return math.exp(-0.5 * ((o - means[s]) / m.std) ** 2)
+
+    weights = np.zeros(m.n_states)
+    for seq in itertools.product(range(m.n_states), repeat=n):
+        w = prior[seq[0]] * lik(obs[0], seq[0])
+        for k in range(1, n):
+            w *= t[seq[k - 1], seq[k]] * lik(obs[k], seq[k])
+        weights[seq[n - 1]] += w
+    return weights / weights.sum()
 
 
 def test_mess3_beliefs_vs_enumeration_brute():
     m = Mess3(means=(-0.15, 0.0, 0.15), std=0.05, stay=0.9)
-    _, obs = m.sample(12, seed=42)
-    fast = m.beliefs(obs)
-    brute = _mess3_bruteforce_beliefs(m, obs)
-    assert fast.shape == (12, 3)
-    assert np.allclose(fast, brute, atol=1e-12)
+    _, obs = m.sample(8, seed=42)
+    fast_last = m.beliefs(obs)[-1]
+    brute_last = _mess3_bruteforce_beliefs(m, obs)
+    assert fast_last.shape == (3,)
+    assert np.allclose(fast_last, brute_last, atol=1e-10)
+    # et sur prefixes successifs : le forward au pas k = enumeration tronquee a k+1
+    for cut in (3, 5, 8):
+        assert np.allclose(
+            m.beliefs(obs[:cut])[-1], _mess3_bruteforce_beliefs(m, obs[:cut]), atol=1e-10
+        )
 
 
 def test_mess3_beliefs_somment_a_un_et_modes_lisibles():


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-lean #15626

# Banc synthétique factorisé — tranche 1/n de #15480

See #15480 — livraison partielle (tranche 1 du pilote causal). Le grain complet (batterie d'intervention + notebook `Causal Triangulation` + verdicts H1-H4) **attend la pile #15479** (voir « Séquencement » ci-dessous).

## Ce que cette tranche livre

Le **banc** de l'issue, avec sa factorisation latente connue et ses états de belief **exacts** :

- `ict/bench_factorise.py` — 3 composants :
  - **`Mess3`** : POMDP 3 états cachés en cycle (stay/slip paramétrable), émissions gaussiennes 1D. Filtration forward exacte → beliefs dans le 2-simplexe (+ coordonnées barycentriques `belief_simplex_coords` pour les figures de Simon).
  - **`RRXOR`** : XOR récursif — bits iid `b_t`, état caché `(b_{t-1}, b_t)` (4 états), observation déterministe `y_t = b_{t-1} XOR b_t`. Beliefs exacts sur les 2 états cohérents.
  - **`FactoredBench`** : combine deux générateurs quelconques en banc à deux facteurs indépendants — observations jointes, **belief joint = produit des marginaux** (indépendance des générateurs), et protocole **vary-one** (trajectoire du facteur gelé identique sur toutes les répliques, facteur libre varié par seed). Les deux options de l'issue — « Mess3 × RRXOR » et « deux Mess3 indépendants » — sont couvertes par la même architecture (testée).
- `ict/tests/test_bench_factorise.py` — 16 tests CPU déterministes (0,12 s).

## Contre-vérification majeure (le forward ne se valide pas par lui-même)

`test_mess3_beliefs_vs_enumeration_brute` confronte le filtre forward à une **énumération `itertools.product` de toutes les séquences d'états** (n=8 → 6 561 séquences, poids joint `prior × prod(transitions) × prod(likelihoods)` marginalisé — implémentation indépendante du code testé), sur prefixes successifs : concordance à `atol=1e-10`. Autres invariants testés : lignes stochastiques + structure du cycle, stationnaire uniforme, XOR-observabilité (`a XOR b = y` reconstruit depuis l'état), beliefs sur exactement 2 états cohérents à 0,5, produit joint sommant à 1, vary-one (gelé byte-identique par seed, libre différent), rejet des générateurs incompatibles et des paramétrages invalides.

## Preuves d'exécution (relancées après le dernier commit)

```
ict/tests/test_bench_factorise.py : 16 passed in 0.12s   (relancé après le dernier commit)
ict/tests/ (suite complète)        : 686 passed, 6 warnings in 386.37s, exit 0
```

Précision d'honnêteté sur la suite complète : sa collecte a précédé la retouche du test d'énumération (2e commit) ; le fichier retouché est isolé (aucune import croisé) et a été re-passé seul à 16/16 après le commit.

## Séquencement — pourquoi la batterie d'intervention n'est PAS ici

L'« Intervention » de #15480 (clamp/ablate à doses, sham, cibles appariées) est la **couche transversale #15479**, en cours de livraison par la pile po-2023 (#15599 `causal_engine.py` 5 ops → #15605 hooks torch → #15609 notebook ICT-36 → #15627 `lens_endpoints.py` → #15649 index). Duplicater ces ops ici violerait la raison d'être de #15479 (« la causalité est une couche transversale, pas un cinquième instrument »). Cette tranche est donc **délibérément bornée au socle orthogonal** — génération + beliefs exacts + vary-one — fichiers nouveaux uniquement, zéro conflit avec la pile. Les tranches suivantes (gates qualité des lentilles avant intervention, petit transformer hookable, batterie, notebook, verdicts H1-H4) consommeront `causal_engine`/`lens_endpoints` une fois la pile mergée.

## Anti-duplication vérifiée firsthand

`git grep -il "mess3|rrxor"` sur `origin/main` ET sur le tip de la pile (`origin/feature/15479-ict-multilens-endpoints`) : unique hit = faux positif base64 dans un PNG d'ICT-9 (vérifié par extraction du contexte de match). Aucun générateur Mess3/RRXOR n'existe ni sur main ni dans la pile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
