### PR TITLE
Fix: deck 05-theorie-des-jeux — 16 -> 0 slide hors canvas (#14888)

### DIFF
--- a/slides/05-theorie-des-jeux/slides.md
+++ b/slides/05-theorie-des-jeux/slides.md
@@ -253,6 +253,14 @@ layout: dense
   - Autres: jouer equilibres de Nash = 1 equilibre de sous-jeu
   - Mais autres equilibres de sous-jeu possibles (cooperation)
 
+*Notebook : [GameTheory-10-ForwardInduction-SPE](../../MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb) (equilibres de sous-jeu, induction sur plusieurs manches).*
+
+---
+layout: dense
+---
+
+# Menaces credibles -- punition et engagement
+
 ## Stratégies de punition
 
 - Ex: Prisonnier puis Argent gratuit -> equilibre faible (0,0) = menace de punition
@@ -265,6 +273,14 @@ layout: dense
 - Ex: bruler le pont derriere soi -> Rend la menace credible
 
 <img src="./images/img_017.png" alt="Se lier les mains : bruler le pont rend la menace credible" style="display:block; margin:6px auto 2px; max-height:90px; width:auto; max-width:100%; object-fit:contain;">
+
+*Notebooks : [GameTheory-09b-Commitment-Stackelberg](../../MyIA.AI.Notebooks/GameTheory/GameTheory-09b-Commitment-Stackelberg.ipynb) (se lier les mains, menace credible) · [GameTheory-06c-RepeatedGames-FolkTheorem](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb) (strategies de punition).*
+
+---
+layout: dense
+---
+
+# Jeux a étapes -- induction arriere et repetition
 
 ## Problemes de l'induction arriere
 
@@ -286,7 +302,7 @@ layout: dense
 <img src="./images/img_021.png" alt="Jeux repetes : punition perpetuelle et evolution de la confiance" style="width:100%; height:90px; object-fit:contain;">
 </div>
 
-*Notebooks : [GameTheory-06c-RepeatedGames-FolkTheorem](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb) (folk theorem, punition) · [GameTheory-06-EvolutionTrust](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb) (evolution de la confiance) · [GameTheory-09b-Commitment-Stackelberg](../../MyIA.AI.Notebooks/GameTheory/GameTheory-09b-Commitment-Stackelberg.ipynb) (se lier les mains).*
+*Notebooks : [GameTheory-06c-RepeatedGames-FolkTheorem](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb) (folk theorem) · [GameTheory-06-EvolutionTrust](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb) (evolution de la confiance).*
 
 ---
 layout: dense
@@ -330,6 +346,14 @@ layout: dense
 
 <img src="./images/img_025.png" alt="Equilibre de lame de couteau : instabilite autour de x=0" style="display:block; margin:4px auto; width:100%; max-height:36px; object-fit:contain;">
 
+*Notebook : [GameTheory-03-Topology2x2](../../MyIA.AI.Notebooks/GameTheory/GameTheory-03-Topology2x2.ipynb) — topologie complete des jeux 2x2, cf slide suivante.*
+
+---
+layout: dense
+---
+
+# Formes stratégiques avancees -- causalite et cycles
+
 ## Modèles causaux
 
 - Proprietes causales des inputs -> Statiques comparees
@@ -351,7 +375,7 @@ layout: dense
 <img src="./images/img_028.png" alt="Resolution de pierre-papier-ciseaux : support des strategies mixtes" style="width:100%; height:100px; object-fit:contain;">
 </div>
 
-*Notebooks : [GameTheory-03-Topology2x2](../../MyIA.AI.Notebooks/GameTheory/GameTheory-03-Topology2x2.ipynb) (topologie complete, cf slide suivante) · [GameTheory-03d-Plan-de-deformation](../../MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb) (deformation, RPS) · [GameTheory-05-ZeroSum-Minimax](../../MyIA.AI.Notebooks/GameTheory/GameTheory-05-ZeroSum-Minimax.ipynb).*
+*Notebooks : [GameTheory-03d-Plan-de-deformation](../../MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb) (deformation, pierre-papier-ciseaux) · [GameTheory-05-ZeroSum-Minimax](../../MyIA.AI.Notebooks/GameTheory/GameTheory-05-ZeroSum-Minimax.ipynb) (somme nulle, EU = 0).*
 
 ---
 layout: dense
@@ -396,7 +420,14 @@ layout: default
 
 <img src="./images/img_030.png" alt="Duel : equilibre a meme distance" style="display:block; margin:4px auto; width:100%; max-height:28px; object-fit:contain;">
 
-## Loi de Hotelling et l'electeur median
+*Notebook : [GameTheory-04c-NashExistence-Python](../../MyIA.AI.Notebooks/GameTheory/GameTheory-04c-NashExistence-Python.ipynb) (existence d'un equilibre hors matrice finie).*
+
+---
+layout: default
+---
+
+# Loi de Hotelling et l'electeur median
+
 
 - 2 vendeurs de glace sur la plage, choix de l'emplacement
   - Equilibre = les deux au milieu
@@ -435,6 +466,14 @@ layout: dense
 
 <img src="./images/img_032.png" alt="Formalisation Bayesienne : joueurs, etats, types et croyances" style="display:block; margin:4px auto; max-height:30px; width:auto; max-width:100%; object-fit:contain;">
 
+*Notebook : [GameTheory-11-BayesianGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb) (types, croyances, formalisation).*
+
+---
+layout: dense
+---
+
+# Jeux Bayesiens -- equilibres et dilemme du Sheriff
+
 ## Equilibres de Nash Bayesien
 
 - Objectif = maximisation de la recompense esperee
@@ -472,7 +511,15 @@ layout: dense
 
 - Profile stratégique et système de croyance consistant tels que les stratégies sont sequentiellement rationnelles
 
-## Jeux de signalisation
+*Notebook : [GameTheory-17b-Asymmetric-Information](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17b-Asymmetric-Information.ipynb) — croyances consistantes et rationalite sequentielle.*
+
+---
+layout: dense
+---
+
+# Jeux de signalisation -- pooling, separating, semi-separation
+
+## Trois categories de PBE
 
 - Emetteur S (connait son type) -> message m, Recepteur R -> action a
 - 3 catégories de PBE:
@@ -490,7 +537,7 @@ layout: dense
 
 <img src="./images/img_037.png" alt="Exemples de PBE : pooling, separating et semi-separation" style="display:block; margin:4px auto; max-height:90px; width:auto; max-width:100%; object-fit:contain;">
 
-*Notebooks : [GameTheory-12-ReputationGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb) (pooling/separating) · [GameTheory-17b-Asymmetric-Information](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17b-Asymmetric-Information.ipynb) · [GameTheory-17d-Lean-Screening-Signaling](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17d-Lean-Screening-Signaling.ipynb).*
+*Notebooks : [GameTheory-12-ReputationGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb) (pooling/separating) · [GameTheory-17d-Lean-Screening-Signaling](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17d-Lean-Screening-Signaling.ipynb) (screening formalise).*
 
 ---
 layout: section
@@ -646,7 +693,14 @@ layout: dense
 
 <img src="./images/img_040.png" alt="Theoremes de l'electeur median : resultats de vote" style="display:block; margin:4px auto; max-height:80px; width:auto; max-width:100%; object-fit:contain;">
 
-## Si pas de vainqueur de Condorcet
+*Notebook : [SocialChoice/03-Voting-Methods](../../MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb) (Condorcet, electeur median).*
+
+---
+layout: dense
+---
+
+# En l'absence de vainqueur de Condorcet
+
 
 - Méthode **Minimax**: celui qui fait le mieux au pire
   - Mais très stratégique (ex: anarchistes)
@@ -683,7 +737,14 @@ layout: dense
 <img src="./images/img_044.png" alt="Scrutin au jugement majoritaire : mediane des scores" style="width:100%; height:90px; object-fit:contain;">
 </div>
 
-## Scrutins stochastiques
+*Notebook : [SocialChoice/03-Voting-Methods](../../MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb) (Borda, assentiment, jugement majoritaire).*
+
+---
+layout: dense
+---
+
+# Scrutins stochastiques
+
 
 - **Scrutin Stochocratique**: option preferee puis tirage au sort
   - Theoreme d'Hylland: seule méthode avec unanimite non stratégique
@@ -716,6 +777,14 @@ layout: default
 
 <img src="./images/img_048.png" alt="Negociation a offres alternees : fenetre d'accord et partage a l'equilibre" style="display:block; margin:10px auto; max-height:200px; width:auto; max-width:100%; object-fit:contain;">
 
+*Notebooks : [GameTheory-04d-Marchandage-Asymetrique](../../MyIA.AI.Notebooks/GameTheory/GameTheory-04d-Marchandage-Asymetrique.ipynb) (offres alternees, discompte) · [GameTheory-07-ExtensiveForm](../../MyIA.AI.Notebooks/GameTheory/GameTheory-07-ExtensiveForm.ipynb) (ultimatum).*
+
+---
+layout: dense
+---
+
+# Negociation -- protocoles et concession
+
 ## Domaines orientes tâches
 
 - Offres (T1, T2) de repartitions de tâches parmi T
@@ -726,7 +795,7 @@ layout: default
 - Mesure de l'aversion au risque de conflit
 - Le risque plus faible concede, sinon tirage au sort
 
-*Notebooks : [GameTheory-04d-Marchandage-Asymetrique](../../MyIA.AI.Notebooks/GameTheory/GameTheory-04d-Marchandage-Asymetrique.ipynb) (offres alternees) · [GameTheory-07-ExtensiveForm](../../MyIA.AI.Notebooks/GameTheory/GameTheory-07-ExtensiveForm.ipynb) (ultimatum). Zeuthen : pas de notebook dedie.*
+*Zeuthen et la concession monotone : pas de notebook dedie dans la serie — la mesure d'aversion au risque reste traitee en cours.*
 
 ---
 layout: default
@@ -808,6 +877,14 @@ layout: dense
 
 - Possibilite de dialogue -> maximisation commune
 - Division en partie cooperative et partie competitive (valeur co-co)
+
+*Notebook : [GameTheory-14-DifferentialGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb) (point de selle, Stackelberg differentiel).*
+
+---
+layout: dense
+---
+
+# Equilibres differentiels -- boucle ouverte et Markoviens
 
 ## Equilibres en boucle ouverte
 

--- a/slides/05-theorie-des-jeux/style.css
+++ b/slides/05-theorie-des-jeux/style.css
@@ -1,0 +1,79 @@
+/* 05-theorie-des-jeux — tenir dans le cadre 980x552.
+ *
+ * Mesure au rendu headless (scan_slidev_composition, deck servi par
+ * `slidev dev`, parcouru via window.__slidev__.nav) : 16 slides sur 39
+ * portaient des elements hors canvas au moment du claim de #14888 —
+ * pas 9 sur 36 comme le dit le body de l'issue, redige avant que
+ * #15115 n'ajoute 21 ancres in-slide et 3 slides.
+ *
+ * Deux populations distinctes, deux correctifs distincts :
+ *
+ *  - STRUCTUREL (+91 a +436 px) : saturation d'origine du layout
+ *    `dense`, cinq slides marp compactees par slide Slidev. Traite
+ *    dans slides.md par decoupe (4 splits), pas ici — aucune
+ *    compression typographique ne recupere 436 px.
+ *
+ *  - MARGINAL (+2 a +39 px) : la ligne d'ancre `*Notebook : [...]*`
+ *    posee par #15115 EST elle-meme le debordement. Au corps du layout
+ *    `dense` (15 px, line-height 1.5) elle coute 22 px sur une ligne,
+ *    45 sur deux, et fait sortir du cadre des slides qui y tenaient
+ *    avant elle — slide 4 mesuree a y=532->554 sur un canvas de 552.
+ *
+ * La regle ci-dessous traite le second cas. Elle vit ici et non dans
+ * `theme-ia101/layouts/dense.vue` parce que le layout est partage par
+ * d'autres decks qui ne portent pas d'ancres : le blast radius d'une
+ * retouche du theme depasse le defaut mesure. Elle vit ici et non
+ * dans un bloc `<style>` du markdown parce qu'un `<style>` de deck
+ * Slidev est scope A SA SLIDE — verifie firsthand par sonde DOM : le
+ * selecteur matchait (`element.matches(...)` vrai) et la font-size
+ * calculee restait a 15 px. Slidev auto-charge en revanche le
+ * `style.css` de la racine du deck (precedents : decks 02, 06, 08,
+ * S3, S8).
+ *
+ * Le selecteur ne vise que le dernier paragraphe fait d'une seule
+ * emphase — c'est-a-dire exactement la forme `*Notebook(s) : ...*`,
+ * et rien d'autre du corps.
+ *
+ * Il n'est PAS restreint au layout `dense` : la slide « Allocation par
+ * la negociation » est en `layout: default` et portait la meme ancre a
+ * 54 px sur deux lignes (bbox 516->570 pour un canvas de 552). Un pied
+ * de page reste un pied de page quel que soit le layout ; le fichier
+ * etant deja local au deck, elargir ici ne deborde sur aucun autre.
+ */
+
+.slidev-layout > p:last-child:has(> em:only-child) {
+  font-size: 0.72em;
+  line-height: 1.15;
+  margin-top: 3px;
+  margin-bottom: 0;
+  opacity: 0.82;
+}
+
+/* ------------------------------------------------------------------ *
+ * Compression typographique verticale — pattern des decks 02 et 06.
+ *
+ * Les slides `dense` de ce deck empilent 4 a 6 sections H2 heritees de
+ * la compaction marp d'origine. Resserrer les marges de titres et
+ * l'interligne des listes ne retire aucun contenu et ne retouche
+ * aucune image : c'est de l'espace vertical mort recupere.
+ * ------------------------------------------------------------------ */
+
+/* 1. Titres : recuperer l'espace des marges. */
+.slidev-layout h1 {
+  margin-bottom: 0.35em;
+}
+.slidev-layout h2 {
+  margin-top: 0.45em;
+  margin-bottom: 0.2em;
+}
+
+/* 2. Listes : interligne resserre. */
+.slidev-layout li {
+  line-height: 1.3;
+  margin: 0.1em 0;
+}
+
+/* 3. Paragraphes des slides a sections empilees. */
+.slidev-layout p {
+  margin: 0.35em 0;
+}


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/guard #15648

## Ce que livre cette PR

Le deck `slides/05-theorie-des-jeux` ne porte plus **aucun contenu hors du canvas** 980x552.

| Mesure (`scan_slidev_composition`, Playwright headless, deck servi en dev) | slides | pire depassement |
|---|---:|---:|
| Base `162779ec06` (avant grain) | **16 / 39** | +436 px |
| + 4 decoupes | 16 / 43 | +190 px |
| + `style.css` (ancre au pied de page) | 10 / 43 | +180 px |
| + compression typographique | 7 / 43 | +136 px |
| + 6 decoupes | **0 / 49** | — |

Aucun contenu retire, aucune image retouchee.

## Le body de l'issue etait perime — la dette avait EMPIRE

#14888 annonce « 9 slides sur 36 ». La re-mesure firsthand a la tete
`162779ec06` en trouve **16 sur 39** : entre-temps #15115 a ajoute
« 21 ancres in-slide + 3 slides neuves ». Le body est date de sa
redaction, pas de sa lecture.

## Deux populations, deux instruments

**STRUCTUREL (+91 a +436 px)** — la saturation d'origine du layout `dense` :
jusqu'a 5 slides marp compactees en une slide Slidev. Aucune compression
typographique ne recupere 436 px : **decoupe** (option 1 de l'issue).
10 splits, chacun coupe avant une section `##` et donne a la premiere
moitie une ligne d'ancre propre, relevance-matchee, pointant un notebook
**dont l'existence a ete verifiee** dans `MyIA.AI.Notebooks/GameTheory/`.

**MARGINAL (+2 a +39 px)** — la ligne `*Notebook : [...]*` posee par #15115
**est elle-meme** le debordement. Slide 4 mesuree a y=532->554 sur un
canvas de 552 ; au corps du layout `dense` (15 px, line-height 1.5) cette
ligne coute 22 px sur une ligne et 45 sur deux. C'est un **pied de page**
rendu comme un paragraphe de corps : **`style.css`** (option 2).

## Deux decisions de placement, chacune payee d'une mesure

**Pourquoi pas `theme-ia101/layouts/dense.vue`** — le layout est partage
par d'autres decks qui ne portent pas d'ancres. Le blast radius d'une
retouche du theme depasse le defaut mesure.

**Pourquoi pas un bloc `<style>` dans le markdown** — parce que ca ne
marche pas, et c'est mesure et non suppose : premiere tentative, le bloc
`<style>` etait **inerte**, slide 4 identique au pixel pres. Sonde DOM
(`element.matches(...)` -> `true`, `getComputedStyle().fontSize` -> `15px`
inchange) : le selecteur etait bon, la regle n'atteignait jamais la page.
**Un `<style>` de deck Slidev est scope a SA slide.** Slidev auto-charge
en revanche le `style.css` de la racine du deck — precedents maison :
decks `02`, `06`, `08`, `S3`, `S8`.

La regle d'ancre n'est **pas** restreinte a `.dense` : « Allocation par la
negociation » est en `layout: default` et portait la meme ancre a 54 px
sur deux lignes (bbox 516->570). Un pied de page reste un pied de page ;
le fichier etant local au deck, elargir n'y deborde sur aucun autre.

## Verification

- **Contrôle positif arme et vert** en cours de campagne
  (`--baseline-slide 19`, `controle_positif_ok: true`) : le chemin de
  flagging est prouve vivant, donc « rien a signaler » veut dire quelque
  chose. Le contrôle est passe au rouge **une fois la slide 19 reparee** —
  c'est le comportement attendu, pas une panne (il affirme qu'une slide
  nommee EST signalee).
- **44 ancres du deck verifiees vivantes (0 morte)** apres la renumerotation
  de #15586 ; les 11 ancres neuves de cette PR pointent des notebooks dont
  l'existence est verifiee sur disque.

## Ce qui reste — et qui n'est pas tenu pour acquis

`scan_slidev_composition` porte lui-meme sa borne : *« ADVISORY only — ne
remplace pas le QA visuel humain pour la composition »*. **Un QA visuel par
une lane qui VOIT est mandate en parallele** ; cette PR ne se merge pas sur
le seul vert de l'organe.

Deux residus honnêtes, tous deux nommes plutot que tus :

1. **3 chevauchements `LI`x`LI` de 1 px vertical** (slides 15, 27, 29),
   apparus avec la compression `li { margin: 0.1em 0 }` — boites de listes
   adjacentes qui se touchent. Overlap `[170, 1]`, `[348, 1]`, `[189, 1]` :
   1 px sur l'axe Y. A confirmer ou infirmer par le QA visuel.
2. **Angle mort de l'organe** : `A` et `EM` ne sont pas dans `CONTENT_TAGS`
   — un lien ou une emphase coupes au bord du canvas ne sont **pas**
   comptes. C'est exactement la forme de nos lignes d'ancre. Signale
   comme sujet separe, pas corrige ici (principe 3 du CLAUDE.md).

See #14888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
