### PR TITLE
fix(lean,#15629): subprocess encoding="utf-8" sur l'appel lake env lean du notebook Lean-22

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-22-MIMO-Detection-Flips.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-22-MIMO-Detection-Flips.ipynb
@@ -5,10 +5,10 @@
    "id": "70952654",
    "metadata": {
     "papermill": {
-     "duration": 0.003927,
-     "end_time": "2026-08-21T15:32:03.745056+00:00",
+     "duration": 0.009319,
+     "end_time": "2026-09-11T23:34:19.907695",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.741129+00:00",
+     "start_time": "2026-09-11T23:34:19.898376",
      "status": "completed"
     },
     "tags": []
@@ -51,10 +51,10 @@
    "id": "c5f10467",
    "metadata": {
     "papermill": {
-     "duration": 0.002979,
-     "end_time": "2026-08-21T15:32:03.751318+00:00",
+     "duration": 0.006611,
+     "end_time": "2026-09-11T23:34:19.920254",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.748339+00:00",
+     "start_time": "2026-09-11T23:34:19.913643",
      "status": "completed"
     },
     "tags": []
@@ -81,10 +81,10 @@
    "id": "d23c3fa4",
    "metadata": {
     "papermill": {
-     "duration": 0.003191,
-     "end_time": "2026-08-21T15:32:03.757627+00:00",
+     "duration": 0.009681,
+     "end_time": "2026-09-11T23:34:19.937880",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.754436+00:00",
+     "start_time": "2026-09-11T23:34:19.928199",
      "status": "completed"
     },
     "tags": []
@@ -116,16 +116,16 @@
    "id": "5fe45a9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:32:03.765260Z",
-     "iopub.status.busy": "2026-08-21T15:32:03.765070Z",
-     "iopub.status.idle": "2026-08-21T15:32:03.863701Z",
-     "shell.execute_reply": "2026-08-21T15:32:03.863095Z"
+     "iopub.execute_input": "2026-09-11T23:34:19.956168Z",
+     "iopub.status.busy": "2026-09-11T23:34:19.956168Z",
+     "iopub.status.idle": "2026-09-11T23:34:20.098796Z",
+     "shell.execute_reply": "2026-09-11T23:34:20.097746Z"
     },
     "papermill": {
-     "duration": 0.103786,
-     "end_time": "2026-08-21T15:32:03.864572+00:00",
+     "duration": 0.153799,
+     "end_time": "2026-09-11T23:34:20.100240",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.760786+00:00",
+     "start_time": "2026-09-11T23:34:19.946441",
      "status": "completed"
     },
     "tags": []
@@ -200,10 +200,10 @@
    "id": "7265b4ad",
    "metadata": {
     "papermill": {
-     "duration": 0.003381,
-     "end_time": "2026-08-21T15:32:03.871570+00:00",
+     "duration": 0.008725,
+     "end_time": "2026-09-11T23:34:20.117724",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.868189+00:00",
+     "start_time": "2026-09-11T23:34:20.108999",
      "status": "completed"
     },
     "tags": []
@@ -224,16 +224,16 @@
    "id": "1992087b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:32:03.879039Z",
-     "iopub.status.busy": "2026-08-21T15:32:03.878837Z",
-     "iopub.status.idle": "2026-08-21T15:32:03.926471Z",
-     "shell.execute_reply": "2026-08-21T15:32:03.925770Z"
+     "iopub.execute_input": "2026-09-11T23:34:20.137408Z",
+     "iopub.status.busy": "2026-09-11T23:34:20.136397Z",
+     "iopub.status.idle": "2026-09-11T23:34:20.205507Z",
+     "shell.execute_reply": "2026-09-11T23:34:20.203902Z"
     },
     "papermill": {
-     "duration": 0.052322,
-     "end_time": "2026-08-21T15:32:03.927058+00:00",
+     "duration": 0.080697,
+     "end_time": "2026-09-11T23:34:20.206576",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.874736+00:00",
+     "start_time": "2026-09-11T23:34:20.125879",
      "status": "completed"
     },
     "tags": []
@@ -301,10 +301,10 @@
    "id": "12d3c789",
    "metadata": {
     "papermill": {
-     "duration": 0.003618,
-     "end_time": "2026-08-21T15:32:03.934915+00:00",
+     "duration": 0.007937,
+     "end_time": "2026-09-11T23:34:20.223742",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.931297+00:00",
+     "start_time": "2026-09-11T23:34:20.215805",
      "status": "completed"
     },
     "tags": []
@@ -323,10 +323,10 @@
    "id": "b9d3df9c",
    "metadata": {
     "papermill": {
-     "duration": 0.003516,
-     "end_time": "2026-08-21T15:32:03.942226+00:00",
+     "duration": 0.009986,
+     "end_time": "2026-09-11T23:34:20.243695",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.938710+00:00",
+     "start_time": "2026-09-11T23:34:20.233709",
      "status": "completed"
     },
     "tags": []
@@ -352,10 +352,10 @@
    "id": "1e6685ce",
    "metadata": {
     "papermill": {
-     "duration": 0.003726,
-     "end_time": "2026-08-21T15:32:03.950552+00:00",
+     "duration": 0.009042,
+     "end_time": "2026-09-11T23:34:20.262657",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.946826+00:00",
+     "start_time": "2026-09-11T23:34:20.253615",
      "status": "completed"
     },
     "tags": []
@@ -376,16 +376,16 @@
    "id": "c4310610",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:32:03.958528Z",
-     "iopub.status.busy": "2026-08-21T15:32:03.958337Z",
-     "iopub.status.idle": "2026-08-21T15:46:31.208937Z",
-     "shell.execute_reply": "2026-08-21T15:46:31.206792Z"
+     "iopub.execute_input": "2026-09-11T23:34:20.284633Z",
+     "iopub.status.busy": "2026-09-11T23:34:20.284633Z",
+     "iopub.status.idle": "2026-09-11T23:35:06.334872Z",
+     "shell.execute_reply": "2026-09-11T23:35:06.333860Z"
     },
     "papermill": {
-     "duration": 867.25636,
-     "end_time": "2026-08-21T15:46:31.210374+00:00",
+     "duration": 46.070454,
+     "end_time": "2026-09-11T23:35:06.344033",
      "exception": false,
-     "start_time": "2026-08-21T15:32:03.954014+00:00",
+     "start_time": "2026-09-11T23:34:20.273579",
      "status": "completed"
     },
     "tags": []
@@ -395,13 +395,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[setup] oleans absents : preparation du cache Mathlib puis build (long)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "[setup] lac mimo_lean trouve, oleans presents : mimo_lean\n",
       "--- lake env lean : les quatre theoremes phases (chargement de l'environnement) ---\n"
      ]
     },
@@ -467,7 +461,8 @@
     "    tmp = Path(tempfile.gettempdir()) / f\"lean22_{tag}.lean\"\n",
     "    tmp.write_text(snippet, encoding=\"utf-8\")\n",
     "    res = subprocess.run([\"lake\", \"env\", \"lean\", str(tmp)],\n",
-    "                         cwd=str(LAKE_DIR), capture_output=True, text=True, timeout=600)\n",
+    "                         cwd=str(LAKE_DIR), capture_output=True, text=True,\n",
+    "                         encoding=\"utf-8\", timeout=600)\n",
     "    print(res.stdout)\n",
     "    print(res.stderr)\n",
     "    tmp.unlink(missing_ok=True)\n",
@@ -501,10 +496,10 @@
    "id": "28f1611c",
    "metadata": {
     "papermill": {
-     "duration": 0.00393,
-     "end_time": "2026-08-21T15:46:31.218923+00:00",
+     "duration": 0.009581,
+     "end_time": "2026-09-11T23:35:06.363588",
      "exception": false,
-     "start_time": "2026-08-21T15:46:31.214993+00:00",
+     "start_time": "2026-09-11T23:35:06.354007",
      "status": "completed"
     },
     "tags": []
@@ -533,16 +528,16 @@
    "id": "f6286096",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:46:31.229667Z",
-     "iopub.status.busy": "2026-08-21T15:46:31.229371Z",
-     "iopub.status.idle": "2026-08-21T15:46:56.775479Z",
-     "shell.execute_reply": "2026-08-21T15:46:56.774659Z"
+     "iopub.execute_input": "2026-09-11T23:35:06.388963Z",
+     "iopub.status.busy": "2026-09-11T23:35:06.387450Z",
+     "iopub.status.idle": "2026-09-11T23:35:53.391081Z",
+     "shell.execute_reply": "2026-09-11T23:35:53.390069Z"
     },
     "papermill": {
-     "duration": 25.55342,
-     "end_time": "2026-08-21T15:46:56.776106+00:00",
+     "duration": 47.024461,
+     "end_time": "2026-09-11T23:35:53.399628",
      "exception": false,
-     "start_time": "2026-08-21T15:46:31.222686+00:00",
+     "start_time": "2026-09-11T23:35:06.375167",
      "status": "completed"
     },
     "tags": []
@@ -635,10 +630,10 @@
    "id": "4b799252",
    "metadata": {
     "papermill": {
-     "duration": 0.003504,
-     "end_time": "2026-08-21T15:46:56.783520+00:00",
+     "duration": 0.012391,
+     "end_time": "2026-09-11T23:35:53.421615",
      "exception": false,
-     "start_time": "2026-08-21T15:46:56.780016+00:00",
+     "start_time": "2026-09-11T23:35:53.409224",
      "status": "completed"
     },
     "tags": []
@@ -659,10 +654,10 @@
    "id": "a9c66539",
    "metadata": {
     "papermill": {
-     "duration": 0.003516,
-     "end_time": "2026-08-21T15:46:56.790355+00:00",
+     "duration": 0.010727,
+     "end_time": "2026-09-11T23:35:53.443883",
      "exception": false,
-     "start_time": "2026-08-21T15:46:56.786839+00:00",
+     "start_time": "2026-09-11T23:35:53.433156",
      "status": "completed"
     },
     "tags": []
@@ -699,16 +694,16 @@
    "id": "66bb5c2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:46:56.809938Z",
-     "iopub.status.busy": "2026-08-21T15:46:56.809743Z",
-     "iopub.status.idle": "2026-08-21T15:47:22.227130Z",
-     "shell.execute_reply": "2026-08-21T15:47:22.226434Z"
+     "iopub.execute_input": "2026-09-11T23:35:53.466629Z",
+     "iopub.status.busy": "2026-09-11T23:35:53.465554Z",
+     "iopub.status.idle": "2026-09-11T23:36:42.730943Z",
+     "shell.execute_reply": "2026-09-11T23:36:42.729929Z"
     },
     "papermill": {
-     "duration": 25.423373,
-     "end_time": "2026-08-21T15:47:22.227804+00:00",
+     "duration": 49.285362,
+     "end_time": "2026-09-11T23:36:42.740634",
      "exception": false,
-     "start_time": "2026-08-21T15:46:56.804431+00:00",
+     "start_time": "2026-09-11T23:35:53.455272",
      "status": "completed"
     },
     "tags": []
@@ -784,10 +779,10 @@
    "id": "18f7ee57",
    "metadata": {
     "papermill": {
-     "duration": 0.003539,
-     "end_time": "2026-08-21T15:47:22.235193+00:00",
+     "duration": 0.009949,
+     "end_time": "2026-09-11T23:36:42.760991",
      "exception": false,
-     "start_time": "2026-08-21T15:47:22.231654+00:00",
+     "start_time": "2026-09-11T23:36:42.751042",
      "status": "completed"
     },
     "tags": []
@@ -829,16 +824,16 @@
    "id": "00f09991",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:47:22.242971Z",
-     "iopub.status.busy": "2026-08-21T15:47:22.242813Z",
-     "iopub.status.idle": "2026-08-21T15:47:47.655603Z",
-     "shell.execute_reply": "2026-08-21T15:47:47.654803Z"
+     "iopub.execute_input": "2026-09-11T23:36:42.787411Z",
+     "iopub.status.busy": "2026-09-11T23:36:42.786394Z",
+     "iopub.status.idle": "2026-09-11T23:37:33.005259Z",
+     "shell.execute_reply": "2026-09-11T23:37:33.003736Z"
     },
     "papermill": {
-     "duration": 25.417584,
-     "end_time": "2026-08-21T15:47:47.656256+00:00",
+     "duration": 50.241723,
+     "end_time": "2026-09-11T23:37:33.014435",
      "exception": false,
-     "start_time": "2026-08-21T15:47:22.238672+00:00",
+     "start_time": "2026-09-11T23:36:42.772712",
      "status": "completed"
     },
     "tags": []
@@ -919,16 +914,16 @@
    "id": "fix-11790-code25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:47:47.666151Z",
-     "iopub.status.busy": "2026-08-21T15:47:47.665934Z",
-     "iopub.status.idle": "2026-08-21T15:48:13.240307Z",
-     "shell.execute_reply": "2026-08-21T15:48:13.239570Z"
+     "iopub.execute_input": "2026-09-11T23:37:33.037922Z",
+     "iopub.status.busy": "2026-09-11T23:37:33.037922Z",
+     "iopub.status.idle": "2026-09-11T23:38:20.130443Z",
+     "shell.execute_reply": "2026-09-11T23:38:20.128920Z"
     },
     "papermill": {
-     "duration": 25.580268,
-     "end_time": "2026-08-21T15:48:13.240982+00:00",
+     "duration": 47.114398,
+     "end_time": "2026-09-11T23:38:20.139284",
      "exception": false,
-     "start_time": "2026-08-21T15:47:47.660714+00:00",
+     "start_time": "2026-09-11T23:37:33.024886",
      "status": "completed"
     },
     "tags": []
@@ -1011,10 +1006,10 @@
    "id": "534105cf",
    "metadata": {
     "papermill": {
-     "duration": 0.004254,
-     "end_time": "2026-08-21T15:48:13.249384+00:00",
+     "duration": 0.01088,
+     "end_time": "2026-09-11T23:38:20.160116",
      "exception": false,
-     "start_time": "2026-08-21T15:48:13.245130+00:00",
+     "start_time": "2026-09-11T23:38:20.149236",
      "status": "completed"
     },
     "tags": []
@@ -1049,10 +1044,10 @@
    "id": "a3c04a64",
    "metadata": {
     "papermill": {
-     "duration": 0.003888,
-     "end_time": "2026-08-21T15:48:13.257134+00:00",
+     "duration": 0.011733,
+     "end_time": "2026-09-11T23:38:20.185431",
      "exception": false,
-     "start_time": "2026-08-21T15:48:13.253246+00:00",
+     "start_time": "2026-09-11T23:38:20.173698",
      "status": "completed"
     },
     "tags": []
@@ -1080,10 +1075,10 @@
    "id": "1ccdcf28",
    "metadata": {
     "papermill": {
-     "duration": 0.004673,
-     "end_time": "2026-08-21T15:48:13.265928+00:00",
+     "duration": 0.01043,
+     "end_time": "2026-09-11T23:38:20.207326",
      "exception": false,
-     "start_time": "2026-08-21T15:48:13.261255+00:00",
+     "start_time": "2026-09-11T23:38:20.196896",
      "status": "completed"
     },
     "tags": []
@@ -1112,16 +1107,16 @@
    "id": "fff8c4d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:13.276414Z",
-     "iopub.status.busy": "2026-08-21T15:48:13.276176Z",
-     "iopub.status.idle": "2026-08-21T15:48:15.525522Z",
-     "shell.execute_reply": "2026-08-21T15:48:15.524811Z"
+     "iopub.execute_input": "2026-09-11T23:38:20.232000Z",
+     "iopub.status.busy": "2026-09-11T23:38:20.232000Z",
+     "iopub.status.idle": "2026-09-11T23:38:22.300198Z",
+     "shell.execute_reply": "2026-09-11T23:38:22.299189Z"
     },
     "papermill": {
-     "duration": 2.255587,
-     "end_time": "2026-08-21T15:48:15.525996+00:00",
+     "duration": 2.082389,
+     "end_time": "2026-09-11T23:38:22.301205",
      "exception": false,
-     "start_time": "2026-08-21T15:48:13.270409+00:00",
+     "start_time": "2026-09-11T23:38:20.218816",
      "status": "completed"
     },
     "tags": []
@@ -1189,10 +1184,10 @@
    "id": "e24177d3",
    "metadata": {
     "papermill": {
-     "duration": 0.00397,
-     "end_time": "2026-08-21T15:48:15.534491+00:00",
+     "duration": 0.009987,
+     "end_time": "2026-09-11T23:38:22.323999",
      "exception": false,
-     "start_time": "2026-08-21T15:48:15.530521+00:00",
+     "start_time": "2026-09-11T23:38:22.314012",
      "status": "completed"
     },
     "tags": []
@@ -1232,10 +1227,10 @@
    "id": "795fd561",
    "metadata": {
     "papermill": {
-     "duration": 0.003872,
-     "end_time": "2026-08-21T15:48:15.542325+00:00",
+     "duration": 0.012662,
+     "end_time": "2026-09-11T23:38:22.348315",
      "exception": false,
-     "start_time": "2026-08-21T15:48:15.538453+00:00",
+     "start_time": "2026-09-11T23:38:22.335653",
      "status": "completed"
     },
     "tags": []
@@ -1283,16 +1278,16 @@
    "id": "fix-11790-mc-normtails",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:15.551533Z",
-     "iopub.status.busy": "2026-08-21T15:48:15.551281Z",
-     "iopub.status.idle": "2026-08-21T15:48:17.007585Z",
-     "shell.execute_reply": "2026-08-21T15:48:17.006548Z"
+     "iopub.execute_input": "2026-09-11T23:38:22.375343Z",
+     "iopub.status.busy": "2026-09-11T23:38:22.375343Z",
+     "iopub.status.idle": "2026-09-11T23:38:24.907271Z",
+     "shell.execute_reply": "2026-09-11T23:38:24.905641Z"
     },
     "papermill": {
-     "duration": 1.462105,
-     "end_time": "2026-08-21T15:48:17.008372+00:00",
+     "duration": 2.54855,
+     "end_time": "2026-09-11T23:38:24.908924",
      "exception": false,
-     "start_time": "2026-08-21T15:48:15.546267+00:00",
+     "start_time": "2026-09-11T23:38:22.360374",
      "status": "completed"
     },
     "tags": []
@@ -1306,7 +1301,13 @@
       "borne 2e^(-t^2/2) = [1.765  1.2131 0.6493 0.2707 0.0879 0.0222]\n",
       "     M | P(||w||-E>||w||>t) t=0.5 | P(||w||-E>||w||>t) t=1.0 | P(||w||-E>||w||>t) t=1.5 | P(||w||-E>||w||>t) t=2.0 | P(||w||-E>||w||>t) t=2.5 | P(||w||-E>||w||>t) t=3.0\n",
       "--------------------------------------------------------------------------------\n",
-      "    50 | 0.4781                 | 0.1544                 | 0.0324                 | 0.0045                 | 0.0004                 | 0.0001                \n",
+      "    50 | 0.4781                 | 0.1544                 | 0.0324                 | 0.0045                 | 0.0004                 | 0.0001                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "   200 | 0.4814                 | 0.1580                 | 0.0334                 | 0.0041                 | 0.0003                 | 0.0000                \n"
      ]
     },
@@ -1317,7 +1318,13 @@
       "  1000 | 0.4759                 | 0.1529                 | 0.0333                 | 0.0042                 | 0.0004                 | 0.0000                \n",
       "\n",
       "--- Diagnostic : ratio empirique / borne (doit rester <= 1.0) ---\n",
-      "M=  50 : max ratio = 0.274  (devrait etre <= 1.0)\n",
+      "M=  50 : max ratio = 0.274  (devrait etre <= 1.0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "M= 200 : max ratio = 0.271  (devrait etre <= 1.0)\n"
      ]
     },
@@ -1382,10 +1389,10 @@
    "id": "c673a71d",
    "metadata": {
     "papermill": {
-     "duration": 0.004054,
-     "end_time": "2026-08-21T15:48:17.016971+00:00",
+     "duration": 0.011564,
+     "end_time": "2026-09-11T23:38:24.932639",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.012917+00:00",
+     "start_time": "2026-09-11T23:38:24.921075",
      "status": "completed"
     },
     "tags": []
@@ -1425,10 +1432,10 @@
    "id": "708586fc",
    "metadata": {
     "papermill": {
-     "duration": 0.004054,
-     "end_time": "2026-08-21T15:48:17.025146+00:00",
+     "duration": 0.011049,
+     "end_time": "2026-09-11T23:38:24.955554",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.021092+00:00",
+     "start_time": "2026-09-11T23:38:24.944505",
      "status": "completed"
     },
     "tags": []
@@ -1472,10 +1479,10 @@
    "id": "f320f15e",
    "metadata": {
     "papermill": {
-     "duration": 0.004206,
-     "end_time": "2026-08-21T15:48:17.033723+00:00",
+     "duration": 0.011848,
+     "end_time": "2026-09-11T23:38:24.978297",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.029517+00:00",
+     "start_time": "2026-09-11T23:38:24.966449",
      "status": "completed"
     },
     "tags": []
@@ -1501,10 +1508,10 @@
    "id": "46c68ecf",
    "metadata": {
     "papermill": {
-     "duration": 0.004297,
-     "end_time": "2026-08-21T15:48:17.042395+00:00",
+     "duration": 0.011541,
+     "end_time": "2026-09-11T23:38:24.999763",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.038098+00:00",
+     "start_time": "2026-09-11T23:38:24.988222",
      "status": "completed"
     },
     "tags": []
@@ -1561,10 +1568,10 @@
    "id": "2f75ee39",
    "metadata": {
     "papermill": {
-     "duration": 0.004379,
-     "end_time": "2026-08-21T15:48:17.052209+00:00",
+     "duration": 0.012561,
+     "end_time": "2026-09-11T23:38:25.024908",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.047830+00:00",
+     "start_time": "2026-09-11T23:38:25.012347",
      "status": "completed"
     },
     "tags": []
@@ -1583,10 +1590,10 @@
    "id": "82fcc55e",
    "metadata": {
     "papermill": {
-     "duration": 0.004007,
-     "end_time": "2026-08-21T15:48:17.060270+00:00",
+     "duration": 0.011521,
+     "end_time": "2026-09-11T23:38:25.048817",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.056263+00:00",
+     "start_time": "2026-09-11T23:38:25.037296",
      "status": "completed"
     },
     "tags": []
@@ -1611,16 +1618,16 @@
    "id": "653ff8c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:17.070069Z",
-     "iopub.status.busy": "2026-08-21T15:48:17.069888Z",
-     "iopub.status.idle": "2026-08-21T15:48:17.073129Z",
-     "shell.execute_reply": "2026-08-21T15:48:17.072490Z"
+     "iopub.execute_input": "2026-09-11T23:38:25.075374Z",
+     "iopub.status.busy": "2026-09-11T23:38:25.073645Z",
+     "iopub.status.idle": "2026-09-11T23:38:25.080908Z",
+     "shell.execute_reply": "2026-09-11T23:38:25.079896Z"
     },
     "papermill": {
-     "duration": 0.009066,
-     "end_time": "2026-08-21T15:48:17.073627+00:00",
+     "duration": 0.022448,
+     "end_time": "2026-09-11T23:38:25.083002",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.064561+00:00",
+     "start_time": "2026-09-11T23:38:25.060554",
      "status": "completed"
     },
     "tags": []
@@ -1653,10 +1660,10 @@
    "id": "5e0bf875",
    "metadata": {
     "papermill": {
-     "duration": 0.004586,
-     "end_time": "2026-08-21T15:48:17.082348+00:00",
+     "duration": 0.011254,
+     "end_time": "2026-09-11T23:38:25.105275",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.077762+00:00",
+     "start_time": "2026-09-11T23:38:25.094021",
      "status": "completed"
     },
     "tags": []
@@ -1681,16 +1688,16 @@
    "id": "c5cf7bf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:17.092844Z",
-     "iopub.status.busy": "2026-08-21T15:48:17.092515Z",
-     "iopub.status.idle": "2026-08-21T15:48:17.096572Z",
-     "shell.execute_reply": "2026-08-21T15:48:17.095900Z"
+     "iopub.execute_input": "2026-09-11T23:38:25.131464Z",
+     "iopub.status.busy": "2026-09-11T23:38:25.131464Z",
+     "iopub.status.idle": "2026-09-11T23:38:25.138231Z",
+     "shell.execute_reply": "2026-09-11T23:38:25.137707Z"
     },
     "papermill": {
-     "duration": 0.010253,
-     "end_time": "2026-08-21T15:48:17.097166+00:00",
+     "duration": 0.023627,
+     "end_time": "2026-09-11T23:38:25.140399",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.086913+00:00",
+     "start_time": "2026-09-11T23:38:25.116772",
      "status": "completed"
     },
     "tags": []
@@ -1723,10 +1730,10 @@
    "id": "c905a0bc",
    "metadata": {
     "papermill": {
-     "duration": 0.004327,
-     "end_time": "2026-08-21T15:48:17.106114+00:00",
+     "duration": 0.011747,
+     "end_time": "2026-09-11T23:38:25.163917",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.101787+00:00",
+     "start_time": "2026-09-11T23:38:25.152170",
      "status": "completed"
     },
     "tags": []
@@ -1751,16 +1758,16 @@
    "id": "d06ba7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:17.117059Z",
-     "iopub.status.busy": "2026-08-21T15:48:17.116690Z",
-     "iopub.status.idle": "2026-08-21T15:48:17.120397Z",
-     "shell.execute_reply": "2026-08-21T15:48:17.119774Z"
+     "iopub.execute_input": "2026-09-11T23:38:25.189246Z",
+     "iopub.status.busy": "2026-09-11T23:38:25.189246Z",
+     "iopub.status.idle": "2026-09-11T23:38:25.196240Z",
+     "shell.execute_reply": "2026-09-11T23:38:25.194753Z"
     },
     "papermill": {
-     "duration": 0.01041,
-     "end_time": "2026-08-21T15:48:17.120944+00:00",
+     "duration": 0.021681,
+     "end_time": "2026-09-11T23:38:25.197241",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.110534+00:00",
+     "start_time": "2026-09-11T23:38:25.175560",
      "status": "completed"
     },
     "tags": []
@@ -1792,10 +1799,10 @@
    "id": "ba28ed73",
    "metadata": {
     "papermill": {
-     "duration": 0.004849,
-     "end_time": "2026-08-21T15:48:17.130430+00:00",
+     "duration": 0.010113,
+     "end_time": "2026-09-11T23:38:25.215710",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.125581+00:00",
+     "start_time": "2026-09-11T23:38:25.205597",
      "status": "completed"
     },
     "tags": []
@@ -1826,16 +1833,16 @@
    "id": "9ec4b0cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-21T15:48:17.141570Z",
-     "iopub.status.busy": "2026-08-21T15:48:17.141212Z",
-     "iopub.status.idle": "2026-08-21T15:48:17.144850Z",
-     "shell.execute_reply": "2026-08-21T15:48:17.144222Z"
+     "iopub.execute_input": "2026-09-11T23:38:25.242537Z",
+     "iopub.status.busy": "2026-09-11T23:38:25.241980Z",
+     "iopub.status.idle": "2026-09-11T23:38:25.248754Z",
+     "shell.execute_reply": "2026-09-11T23:38:25.247743Z"
     },
     "papermill": {
-     "duration": 0.010209,
-     "end_time": "2026-08-21T15:48:17.145384+00:00",
+     "duration": 0.024586,
+     "end_time": "2026-09-11T23:38:25.250755",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.135175+00:00",
+     "start_time": "2026-09-11T23:38:25.226169",
      "status": "completed"
     },
     "tags": []
@@ -1871,10 +1878,10 @@
    "id": "d7a4dd6d",
    "metadata": {
     "papermill": {
-     "duration": 0.004735,
-     "end_time": "2026-08-21T15:48:17.154967+00:00",
+     "duration": 0.012572,
+     "end_time": "2026-09-11T23:38:25.276609",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.150232+00:00",
+     "start_time": "2026-09-11T23:38:25.264037",
      "status": "completed"
     },
     "tags": []
@@ -1896,10 +1903,10 @@
    "id": "674c5a05",
    "metadata": {
     "papermill": {
-     "duration": 0.004709,
-     "end_time": "2026-08-21T15:48:17.164364+00:00",
+     "duration": 0.014842,
+     "end_time": "2026-09-11T23:38:25.303681",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.159655+00:00",
+     "start_time": "2026-09-11T23:38:25.288839",
      "status": "completed"
     },
     "tags": []
@@ -1935,10 +1942,10 @@
    "id": "58f270da",
    "metadata": {
     "papermill": {
-     "duration": 0.006051,
-     "end_time": "2026-08-21T15:48:17.175770+00:00",
+     "duration": 0.012555,
+     "end_time": "2026-09-11T23:38:25.331205",
      "exception": false,
-     "start_time": "2026-08-21T15:48:17.169719+00:00",
+     "start_time": "2026-09-11T23:38:25.318650",
      "status": "completed"
     },
     "tags": []
@@ -1980,7 +1987,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 247.900008,
+   "end_time": "2026-09-11T23:38:25.796724",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-22-MIMO-Detection-Flips.ipynb",
+   "output_path": "Lean-22-MIMO-Detection-Flips.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T23:34:17.896716",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2026:CoursIA — prev: MED/docs #15577

## Sujet (tranche Lean-22 de #15629)

Le notebook `Lean-22-MIMO-Detection-Flips.ipynb` (cellule 9) appelle `lake env lean` via `subprocess.run(..., text=True)` **sans `encoding=`** : sur une machine ACP-1252, le thread lecteur du pipe décode en page de code ANSI et crashe sur les glyphes non-cp1252 des sorties Lean (ℝ, ℕ, →), laissant `res.stdout = None` — **sans erreur remontée à Papermill** (l'exécution paraît verte, la sortie est muette).

## Fix (+2/−1, cellule 9)

```python
subprocess.run(["lake", "env", "lean", str(tmp)],
               cwd=str(LAKE_DIR), capture_output=True, text=True,
               encoding="utf-8", timeout=600)
```

Recensement par parsing à parenthèses équilibrées des appels : exactement **un** appel `text=True` sans `encoding` dans ce notebook — les `encoding="utf-8"` détectés à proximité par un scan fenêtré sont ceux de `tmp.write_text(...)`, pas du subprocess (faux positifs du scan naïf).

## Contrôle positif du mécanisme (machine myia-po-2026, GetACP=65001)

Cette machine a l'option système UTF-8 active — le contexte cp1252 de l'incident ne peut pas y vivre naturellement. Le contrôle positif force l'encoding du pipe pour simuler une machine ACP-1252 sans le fix :

```python
EMITTER = [sys.executable, "-c", "print('theorem flip_descend : Real ℝ (glyphs) ℕ → ✔')"]
subprocess.run(EMITTER, capture_output=True, text=True, encoding="cp1252")  # simulé sans fix
subprocess.run(EMITTER, capture_output=True, text=True, encoding="utf-8")   # le fix
```

Appel cp1252 — **signature exacte de l'incident** :

    Exception in thread Thread-1 (_readerthread):
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 30: character maps to <undefined>
    res.stdout = None
    res.stderr = ''

Appel utf-8 (le fix) :

    res2.stdout = 'theorem flip_descend : Real ℝ (glyphs) ℕ → ✔\n'

## Exécution réelle (C.2) — build + runs A/B

- `mimo_lean` reconstruit : `lake build` **8702 jobs BUILD_OK**, `Converse.olean` présent (Mathlib via cache).
- **Run A** (sans `PYTHONUTF8`, env naturel du lanceur) : Papermill natif Windows, kernel `python3`, 41 cellules en 4:07 — 13 cellules code `execution_count` contigus 1..13, **0 erreur, 0 sortie dégradée "None"**, 5 cellules portent des glyphes non-cp1252 dans leurs sorties réelles.
- **Run B** (avec `PYTHONUTF8=1`, mêmes `MIMO_LEAN_PATH`/`--cwd`) : 41 cellules en 3:36.
- **Outputs A/B identiques 13/13** (comparaison JSON cell-by-cell) — la dépendance à l'env du lanceur disparaît.

Le notebook committé est le run A exécuté (chemins `metadata.papermill` normalisés au basename, seule normalisation tolérée ; le hook de scrub des chemins absolus passe Passed).

See #15629 (tranche Lean-22 — l'issue reste ouverte pour les occurrences legacy restantes du pattern repo-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
