### PR TITLE
fix(symboliclearning,#15658): SL-12b' cellule verdict — cas introuvable sans crash + comptes dérivés

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction-output.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction-output.ipynb
@@ -6,10 +6,10 @@
    "id": "35408f79",
    "metadata": {
     "papermill": {
-     "duration": 0.00333,
-     "end_time": "2026-09-11T10:58:52.724489",
+     "duration": 0.007596,
+     "end_time": "2026-09-12T00:08:31.176734",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.721159",
+     "start_time": "2026-09-12T00:08:31.169138",
      "status": "completed"
     },
     "tags": []
@@ -43,16 +43,16 @@
    "id": "0b7a93b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:58:52.732078Z",
-     "iopub.status.busy": "2026-09-11T10:58:52.731472Z",
-     "iopub.status.idle": "2026-09-11T10:58:52.819396Z",
-     "shell.execute_reply": "2026-09-11T10:58:52.818973Z"
+     "iopub.execute_input": "2026-09-12T00:08:31.192884Z",
+     "iopub.status.busy": "2026-09-12T00:08:31.191887Z",
+     "iopub.status.idle": "2026-09-12T00:08:31.303146Z",
+     "shell.execute_reply": "2026-09-12T00:08:31.302135Z"
     },
     "papermill": {
-     "duration": 0.0931,
-     "end_time": "2026-09-11T10:58:52.820633",
+     "duration": 0.120842,
+     "end_time": "2026-09-12T00:08:31.304147",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.727533",
+     "start_time": "2026-09-12T00:08:31.183305",
      "status": "completed"
     },
     "tags": []
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy 2.4.3\n",
+      "numpy 2.2.6\n",
       "Convention booléenne ±1, table de vérité (n=2) :\n",
       "[[0 0]\n",
       " [0 1]\n",
@@ -144,10 +144,10 @@
    "id": "e647cbf4",
    "metadata": {
     "papermill": {
-     "duration": 0.003564,
-     "end_time": "2026-09-11T10:58:52.827417",
+     "duration": 0.006675,
+     "end_time": "2026-09-12T00:08:31.317990",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.823853",
+     "start_time": "2026-09-12T00:08:31.311315",
      "status": "completed"
     },
     "tags": []
@@ -171,16 +171,16 @@
    "id": "048ed488",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:58:52.833768Z",
-     "iopub.status.busy": "2026-09-11T10:58:52.833507Z",
-     "iopub.status.idle": "2026-09-11T10:58:52.839577Z",
-     "shell.execute_reply": "2026-09-11T10:58:52.839021Z"
+     "iopub.execute_input": "2026-09-12T00:08:31.333078Z",
+     "iopub.status.busy": "2026-09-12T00:08:31.332079Z",
+     "iopub.status.idle": "2026-09-12T00:08:31.340832Z",
+     "shell.execute_reply": "2026-09-12T00:08:31.339859Z"
     },
     "papermill": {
-     "duration": 0.01014,
-     "end_time": "2026-09-11T10:58:52.840384",
+     "duration": 0.017852,
+     "end_time": "2026-09-12T00:08:31.341843",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.830244",
+     "start_time": "2026-09-12T00:08:31.323991",
      "status": "completed"
     },
     "tags": []
@@ -246,10 +246,10 @@
    "id": "4dbc1176",
    "metadata": {
     "papermill": {
-     "duration": 0.002825,
-     "end_time": "2026-09-11T10:58:52.845893",
+     "duration": 0.004533,
+     "end_time": "2026-09-12T00:08:31.349944",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.843068",
+     "start_time": "2026-09-12T00:08:31.345411",
      "status": "completed"
     },
     "tags": []
@@ -273,16 +273,16 @@
    "id": "e798c705",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:58:52.852663Z",
-     "iopub.status.busy": "2026-09-11T10:58:52.852366Z",
-     "iopub.status.idle": "2026-09-11T10:58:52.867795Z",
-     "shell.execute_reply": "2026-09-11T10:58:52.867380Z"
+     "iopub.execute_input": "2026-09-12T00:08:31.361692Z",
+     "iopub.status.busy": "2026-09-12T00:08:31.360697Z",
+     "iopub.status.idle": "2026-09-12T00:08:31.383937Z",
+     "shell.execute_reply": "2026-09-12T00:08:31.382870Z"
     },
     "papermill": {
-     "duration": 0.02005,
-     "end_time": "2026-09-11T10:58:52.868568",
+     "duration": 0.030314,
+     "end_time": "2026-09-12T00:08:31.384994",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.848518",
+     "start_time": "2026-09-12T00:08:31.354680",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "dd5a8e78",
    "metadata": {
     "papermill": {
-     "duration": 0.002596,
-     "end_time": "2026-09-11T10:58:52.873981",
+     "duration": 0.005524,
+     "end_time": "2026-09-12T00:08:31.397714",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.871385",
+     "start_time": "2026-09-12T00:08:31.392190",
      "status": "completed"
     },
     "tags": []
@@ -389,16 +389,16 @@
    "id": "bd2ba7e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:58:52.880810Z",
-     "iopub.status.busy": "2026-09-11T10:58:52.880602Z",
-     "iopub.status.idle": "2026-09-11T10:58:53.041580Z",
-     "shell.execute_reply": "2026-09-11T10:58:53.041041Z"
+     "iopub.execute_input": "2026-09-12T00:08:31.412755Z",
+     "iopub.status.busy": "2026-09-12T00:08:31.412755Z",
+     "iopub.status.idle": "2026-09-12T00:08:31.657759Z",
+     "shell.execute_reply": "2026-09-12T00:08:31.657759Z"
     },
     "papermill": {
-     "duration": 0.165408,
-     "end_time": "2026-09-11T10:58:53.042405",
+     "duration": 0.254016,
+     "end_time": "2026-09-12T00:08:31.659296",
      "exception": false,
-     "start_time": "2026-09-11T10:58:52.876997",
+     "start_time": "2026-09-12T00:08:31.405280",
      "status": "completed"
     },
     "tags": []
@@ -479,10 +479,10 @@
    "id": "b1057ae6",
    "metadata": {
     "papermill": {
-     "duration": 0.002839,
-     "end_time": "2026-09-11T10:58:53.048177",
+     "duration": 0.006806,
+     "end_time": "2026-09-12T00:08:31.673842",
      "exception": false,
-     "start_time": "2026-09-11T10:58:53.045338",
+     "start_time": "2026-09-12T00:08:31.667036",
      "status": "completed"
     },
     "tags": []
@@ -506,16 +506,16 @@
    "id": "9705f16d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:58:53.055799Z",
-     "iopub.status.busy": "2026-09-11T10:58:53.055462Z",
-     "iopub.status.idle": "2026-09-11T10:59:07.332343Z",
-     "shell.execute_reply": "2026-09-11T10:59:07.331629Z"
+     "iopub.execute_input": "2026-09-12T00:08:31.689078Z",
+     "iopub.status.busy": "2026-09-12T00:08:31.689078Z",
+     "iopub.status.idle": "2026-09-12T00:09:19.029025Z",
+     "shell.execute_reply": "2026-09-12T00:09:19.028013Z"
     },
     "papermill": {
-     "duration": 14.282319,
-     "end_time": "2026-09-11T10:59:07.333471",
+     "duration": 47.355342,
+     "end_time": "2026-09-12T00:09:19.036183",
      "exception": false,
-     "start_time": "2026-09-11T10:58:53.051152",
+     "start_time": "2026-09-12T00:08:31.680841",
      "status": "completed"
     },
     "tags": []
@@ -525,7 +525,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Phase 1 Pavlov : 16 opérations × 4 seeds, durée = 14.3s\n",
+      "Phase 1 Pavlov : 16 opérations × 4 seeds, durée = 47.3s\n",
       "                    Op | acc_lin (mean±std) | acc_sk (mean±std)  | Δ(sk - lin)\n",
       "--------------------------------------------------------------------------------\n",
       "                 FALSE | 100.0 ±  0.0      |   0.0 ±  0.0      | -100.0\n",
@@ -604,10 +604,10 @@
    "id": "4f9c8a3d",
    "metadata": {
     "papermill": {
-     "duration": 0.002872,
-     "end_time": "2026-09-11T10:59:07.339389",
+     "duration": 0.009152,
+     "end_time": "2026-09-12T00:09:19.053798",
      "exception": false,
-     "start_time": "2026-09-11T10:59:07.336517",
+     "start_time": "2026-09-12T00:09:19.044646",
      "status": "completed"
     },
     "tags": []
@@ -631,16 +631,16 @@
    "id": "a59b8576",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:59:07.348605Z",
-     "iopub.status.busy": "2026-09-11T10:59:07.348229Z",
-     "iopub.status.idle": "2026-09-11T10:59:07.354481Z",
-     "shell.execute_reply": "2026-09-11T10:59:07.353869Z"
+     "iopub.execute_input": "2026-09-12T00:09:19.075927Z",
+     "iopub.status.busy": "2026-09-12T00:09:19.074417Z",
+     "iopub.status.idle": "2026-09-12T00:09:19.087637Z",
+     "shell.execute_reply": "2026-09-12T00:09:19.086624Z"
     },
     "papermill": {
-     "duration": 0.011185,
-     "end_time": "2026-09-11T10:59:07.355629",
+     "duration": 0.025667,
+     "end_time": "2026-09-12T00:09:19.088996",
      "exception": false,
-     "start_time": "2026-09-11T10:59:07.344444",
+     "start_time": "2026-09-12T00:09:19.063329",
      "status": "completed"
     },
     "tags": []
@@ -701,10 +701,10 @@
    "id": "48dda853",
    "metadata": {
     "papermill": {
-     "duration": 0.004074,
-     "end_time": "2026-09-11T10:59:07.362723",
+     "duration": 0.0076,
+     "end_time": "2026-09-12T00:09:19.104481",
      "exception": false,
-     "start_time": "2026-09-11T10:59:07.358649",
+     "start_time": "2026-09-12T00:09:19.096881",
      "status": "completed"
     },
     "tags": []
@@ -729,16 +729,16 @@
    "id": "9c2f3788",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:59:07.369562Z",
-     "iopub.status.busy": "2026-09-11T10:59:07.369201Z",
-     "iopub.status.idle": "2026-09-11T10:59:14.660061Z",
-     "shell.execute_reply": "2026-09-11T10:59:14.659483Z"
+     "iopub.execute_input": "2026-09-12T00:09:19.123599Z",
+     "iopub.status.busy": "2026-09-12T00:09:19.123045Z",
+     "iopub.status.idle": "2026-09-12T00:09:46.385706Z",
+     "shell.execute_reply": "2026-09-12T00:09:46.384693Z"
     },
     "papermill": {
-     "duration": 7.295334,
-     "end_time": "2026-09-11T10:59:14.660914",
+     "duration": 27.275028,
+     "end_time": "2026-09-12T00:09:46.387707",
      "exception": false,
-     "start_time": "2026-09-11T10:59:07.365580",
+     "start_time": "2026-09-12T00:09:19.112679",
      "status": "completed"
     },
     "tags": []
@@ -748,7 +748,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Phase 2 Pavlov : 11 opérations × 3 seeds × n=4, durée = 7.3s\n",
+      "Phase 2 Pavlov : 11 opérations × 3 seeds × n=4, durée = 27.2s\n",
       "                  Op | n_coeffs | acc_lin | acc_sk  | Δ(sk-lin)\n",
       "----------------------------------------------------------------------\n",
       "             delay_0 |   1      |  100.0  |    6.2  | -93.8\n",
@@ -810,10 +810,10 @@
    "id": "36d9f9f0",
    "metadata": {
     "papermill": {
-     "duration": 0.002889,
-     "end_time": "2026-09-11T10:59:14.666982",
+     "duration": 0.008308,
+     "end_time": "2026-09-12T00:09:46.403522",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.664093",
+     "start_time": "2026-09-12T00:09:46.395214",
      "status": "completed"
     },
     "tags": []
@@ -840,16 +840,16 @@
    "id": "1e8276cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:59:14.674322Z",
-     "iopub.status.busy": "2026-09-11T10:59:14.673988Z",
-     "iopub.status.idle": "2026-09-11T10:59:14.679457Z",
-     "shell.execute_reply": "2026-09-11T10:59:14.678878Z"
+     "iopub.execute_input": "2026-09-12T00:09:46.424005Z",
+     "iopub.status.busy": "2026-09-12T00:09:46.424005Z",
+     "iopub.status.idle": "2026-09-12T00:09:46.436290Z",
+     "shell.execute_reply": "2026-09-12T00:09:46.435278Z"
     },
     "papermill": {
-     "duration": 0.009829,
-     "end_time": "2026-09-11T10:59:14.680245",
+     "duration": 0.025921,
+     "end_time": "2026-09-12T00:09:46.438391",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.670416",
+     "start_time": "2026-09-12T00:09:46.412470",
      "status": "completed"
     },
     "tags": []
@@ -944,10 +944,10 @@
    "id": "39feeafb",
    "metadata": {
     "papermill": {
-     "duration": 0.002953,
-     "end_time": "2026-09-11T10:59:14.686031",
+     "duration": 0.008141,
+     "end_time": "2026-09-12T00:09:46.455044",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.683078",
+     "start_time": "2026-09-12T00:09:46.446903",
      "status": "completed"
     },
     "tags": []
@@ -973,16 +973,16 @@
    "id": "46387edd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T10:59:14.693621Z",
-     "iopub.status.busy": "2026-09-11T10:59:14.693251Z",
-     "iopub.status.idle": "2026-09-11T10:59:14.767972Z",
-     "shell.execute_reply": "2026-09-11T10:59:14.767537Z"
+     "iopub.execute_input": "2026-09-12T00:09:46.478183Z",
+     "iopub.status.busy": "2026-09-12T00:09:46.477183Z",
+     "iopub.status.idle": "2026-09-12T00:09:46.497712Z",
+     "shell.execute_reply": "2026-09-12T00:09:46.496697Z"
     },
     "papermill": {
-     "duration": 0.080135,
-     "end_time": "2026-09-11T10:59:14.768867",
+     "duration": 0.034907,
+     "end_time": "2026-09-12T00:09:46.499759",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.688732",
+     "start_time": "2026-09-12T00:09:46.464852",
      "status": "completed"
     },
     "tags": []
@@ -992,7 +992,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SHA-256 du notebook : f959dc7d7bdd91ba…\n",
+      "SHA-256 du notebook : b7f1b5814f07eb5e…\n",
       "Commandes reproductibles : ce notebook est un script Python linéaire (9 cellules code + 15 cellules markdown = 24 cellules au total)\n",
       "\n",
       "================================================================================\n",
@@ -1042,14 +1042,25 @@
     "    if not os.path.isabs(nb_path):\n",
     "        nb_path = os.path.join(os.getcwd(), nb_path)\n",
     "except (NameError, KeyError, TypeError):\n",
+    "    nb_path = None\n",
+    "if not nb_path or not os.path.exists(nb_path):\n",
+    "    # Fallback glob par nom de fichier (worktree sparse-checkout inclus, Tell c.435 L4)\n",
     "    import glob\n",
     "    candidates = [p for p in glob.glob(\"**/SL-12b-PavlovDLS-Reproduction.ipynb\", recursive=True)\n",
     "                   if \"output\" not in p and \"_archive\" not in p]\n",
-    "    nb_path = candidates[0] if candidates else __file__\n",
-    "with open(nb_path, \"rb\") as fh:\n",
-    "    h = hashlib.sha256(fh.read()).hexdigest()\n",
-    "print(f\"SHA-256 du notebook : {h[:16]}…\")\n",
-    "print(f\"Commandes reproductibles : ce notebook est un script Python linéaire (9 cellules code + 15 cellules markdown = 24 cellules au total)\")\n",
+    "    nb_path = candidates[0] if candidates else None\n",
+    "if nb_path and os.path.exists(nb_path):\n",
+    "    with open(nb_path, \"rb\") as fh:\n",
+    "        h = hashlib.sha256(fh.read()).hexdigest()\n",
+    "    import json as _json\n",
+    "    with open(nb_path, encoding=\"utf-8\") as fh:\n",
+    "        _cells = _json.load(fh)[\"cells\"]\n",
+    "    n_code = sum(1 for c in _cells if c[\"cell_type\"] == \"code\")\n",
+    "    n_md = sum(1 for c in _cells if c[\"cell_type\"] == \"markdown\")\n",
+    "    print(f\"SHA-256 du notebook : {h[:16]}…\")\n",
+    "    print(f\"Commandes reproductibles : ce notebook est un script Python linéaire ({n_code} cellules code + {n_md} cellules markdown = {len(_cells)} cellules au total)\")\n",
+    "else:\n",
+    "    print(f\"Notebook introuvable ({nb_path or 'aucun candidat trouvé'}) : SHA-256 et compte de cellules non calculés\")\n",
     "\n",
     "claims = [\n",
     "    (\"La transformée de Walsh est exacte pour toute opération booléenne n=2 et n=4\",\n",
@@ -1087,10 +1098,10 @@
    "id": "c4286d56",
    "metadata": {
     "papermill": {
-     "duration": 0.003104,
-     "end_time": "2026-09-11T10:59:14.775127",
+     "duration": 0.008421,
+     "end_time": "2026-09-12T00:09:46.515944",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.772023",
+     "start_time": "2026-09-12T00:09:46.507523",
      "status": "completed"
     },
     "tags": []
@@ -1119,10 +1130,10 @@
    "id": "95c48a8c",
    "metadata": {
     "papermill": {
-     "duration": 0.002916,
-     "end_time": "2026-09-11T10:59:14.781021",
+     "duration": 0.010885,
+     "end_time": "2026-09-12T00:09:46.535482",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.778105",
+     "start_time": "2026-09-12T00:09:46.524597",
      "status": "completed"
     },
     "tags": []
@@ -1163,10 +1174,10 @@
    "id": "23b1840e",
    "metadata": {
     "papermill": {
-     "duration": 0.002953,
-     "end_time": "2026-09-11T10:59:14.786947",
+     "duration": 0.00887,
+     "end_time": "2026-09-12T00:09:46.553780",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.783994",
+     "start_time": "2026-09-12T00:09:46.544910",
      "status": "completed"
     },
     "tags": []
@@ -1186,10 +1197,10 @@
    "id": "8e7e3a64",
    "metadata": {
     "papermill": {
-     "duration": 0.002923,
-     "end_time": "2026-09-11T10:59:14.792943",
+     "duration": 0.010834,
+     "end_time": "2026-09-12T00:09:46.572098",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.790020",
+     "start_time": "2026-09-12T00:09:46.561264",
      "status": "completed"
     },
     "tags": []
@@ -1209,10 +1220,10 @@
    "id": "52f2694b",
    "metadata": {
     "papermill": {
-     "duration": 0.002844,
-     "end_time": "2026-09-11T10:59:14.798839",
+     "duration": 0.013339,
+     "end_time": "2026-09-12T00:09:46.594171",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.795995",
+     "start_time": "2026-09-12T00:09:46.580832",
      "status": "completed"
     },
     "tags": []
@@ -1232,10 +1243,10 @@
    "id": "c12fb380",
    "metadata": {
     "papermill": {
-     "duration": 0.002737,
-     "end_time": "2026-09-11T10:59:14.804308",
+     "duration": 0.009826,
+     "end_time": "2026-09-12T00:09:46.615574",
      "exception": false,
-     "start_time": "2026-09-11T10:59:14.801571",
+     "start_time": "2026-09-12T00:09:46.605748",
      "status": "completed"
     },
     "tags": []
@@ -1273,18 +1284,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 24.206912,
-   "end_time": "2026-09-11T10:59:15.045144",
+   "duration": 77.407285,
+   "end_time": "2026-09-12T00:09:46.974183",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction-output.ipynb",
+   "input_path": "SL-12b-PavlovDLS-Reproduction.ipynb",
+   "output_path": "SL-12b-PavlovDLS-Reproduction-output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T10:58:50.838232",
+   "start_time": "2026-09-12T00:08:29.566898",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction.ipynb
@@ -6,10 +6,10 @@
    "id": "35408f79",
    "metadata": {
     "papermill": {
-     "duration": 0.003208,
-     "end_time": "2026-09-11T11:00:05.009940",
+     "duration": 0.005479,
+     "end_time": "2026-09-12T00:07:32.890023",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.006732",
+     "start_time": "2026-09-12T00:07:32.884544",
      "status": "completed"
     },
     "tags": []
@@ -43,16 +43,16 @@
    "id": "0b7a93b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:05.016147Z",
-     "iopub.status.busy": "2026-09-11T11:00:05.015939Z",
-     "iopub.status.idle": "2026-09-11T11:00:05.094414Z",
-     "shell.execute_reply": "2026-09-11T11:00:05.093860Z"
+     "iopub.execute_input": "2026-09-12T00:07:32.907261Z",
+     "iopub.status.busy": "2026-09-12T00:07:32.907261Z",
+     "iopub.status.idle": "2026-09-12T00:07:33.013289Z",
+     "shell.execute_reply": "2026-09-12T00:07:33.012782Z"
     },
     "papermill": {
-     "duration": 0.082511,
-     "end_time": "2026-09-11T11:00:05.095180",
+     "duration": 0.118583,
+     "end_time": "2026-09-12T00:07:33.014704",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.012669",
+     "start_time": "2026-09-12T00:07:32.896121",
      "status": "completed"
     },
     "tags": []
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numpy 2.4.3\n",
+      "numpy 2.2.6\n",
       "Convention booléenne ±1, table de vérité (n=2) :\n",
       "[[0 0]\n",
       " [0 1]\n",
@@ -144,10 +144,10 @@
    "id": "e647cbf4",
    "metadata": {
     "papermill": {
-     "duration": 0.002464,
-     "end_time": "2026-09-11T11:00:05.100286",
+     "duration": 0.005563,
+     "end_time": "2026-09-12T00:07:33.025544",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.097822",
+     "start_time": "2026-09-12T00:07:33.019981",
      "status": "completed"
     },
     "tags": []
@@ -171,16 +171,16 @@
    "id": "048ed488",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:05.106419Z",
-     "iopub.status.busy": "2026-09-11T11:00:05.106186Z",
-     "iopub.status.idle": "2026-09-11T11:00:05.113650Z",
-     "shell.execute_reply": "2026-09-11T11:00:05.113246Z"
+     "iopub.execute_input": "2026-09-12T00:07:33.038200Z",
+     "iopub.status.busy": "2026-09-12T00:07:33.037667Z",
+     "iopub.status.idle": "2026-09-12T00:07:33.046304Z",
+     "shell.execute_reply": "2026-09-12T00:07:33.045766Z"
     },
     "papermill": {
-     "duration": 0.01174,
-     "end_time": "2026-09-11T11:00:05.114383",
+     "duration": 0.016168,
+     "end_time": "2026-09-12T00:07:33.047372",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.102643",
+     "start_time": "2026-09-12T00:07:33.031204",
      "status": "completed"
     },
     "tags": []
@@ -246,10 +246,10 @@
    "id": "4dbc1176",
    "metadata": {
     "papermill": {
-     "duration": 0.00259,
-     "end_time": "2026-09-11T11:00:05.119754",
+     "duration": 0.006619,
+     "end_time": "2026-09-12T00:07:33.059001",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.117164",
+     "start_time": "2026-09-12T00:07:33.052382",
      "status": "completed"
     },
     "tags": []
@@ -273,16 +273,16 @@
    "id": "e798c705",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:05.125220Z",
-     "iopub.status.busy": "2026-09-11T11:00:05.125030Z",
-     "iopub.status.idle": "2026-09-11T11:00:05.140638Z",
-     "shell.execute_reply": "2026-09-11T11:00:05.140171Z"
+     "iopub.execute_input": "2026-09-12T00:07:33.071809Z",
+     "iopub.status.busy": "2026-09-12T00:07:33.071809Z",
+     "iopub.status.idle": "2026-09-12T00:07:33.089932Z",
+     "shell.execute_reply": "2026-09-12T00:07:33.089932Z"
     },
     "papermill": {
-     "duration": 0.019312,
-     "end_time": "2026-09-11T11:00:05.141377",
+     "duration": 0.02639,
+     "end_time": "2026-09-12T00:07:33.090943",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.122065",
+     "start_time": "2026-09-12T00:07:33.064553",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "dd5a8e78",
    "metadata": {
     "papermill": {
-     "duration": 0.002901,
-     "end_time": "2026-09-11T11:00:05.147008",
+     "duration": 0.006531,
+     "end_time": "2026-09-12T00:07:33.103825",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.144107",
+     "start_time": "2026-09-12T00:07:33.097294",
      "status": "completed"
     },
     "tags": []
@@ -389,16 +389,16 @@
    "id": "bd2ba7e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:05.153016Z",
-     "iopub.status.busy": "2026-09-11T11:00:05.152812Z",
-     "iopub.status.idle": "2026-09-11T11:00:05.289229Z",
-     "shell.execute_reply": "2026-09-11T11:00:05.288768Z"
+     "iopub.execute_input": "2026-09-12T00:07:33.116311Z",
+     "iopub.status.busy": "2026-09-12T00:07:33.115766Z",
+     "iopub.status.idle": "2026-09-12T00:07:33.305115Z",
+     "shell.execute_reply": "2026-09-12T00:07:33.304103Z"
     },
     "papermill": {
-     "duration": 0.140469,
-     "end_time": "2026-09-11T11:00:05.290013",
+     "duration": 0.196375,
+     "end_time": "2026-09-12T00:07:33.305115",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.149544",
+     "start_time": "2026-09-12T00:07:33.108740",
      "status": "completed"
     },
     "tags": []
@@ -408,7 +408,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AND (Sinkhorn) : acc ternaire = 25%\n",
+      "AND (Sinkhorn) : acc ternaire = 25%"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "  c quantifié = [1. 1. 1. 1.]\n"
      ]
     }
@@ -479,10 +486,10 @@
    "id": "b1057ae6",
    "metadata": {
     "papermill": {
-     "duration": 0.002775,
-     "end_time": "2026-09-11T11:00:05.295627",
+     "duration": 0.00401,
+     "end_time": "2026-09-12T00:07:33.314323",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.292852",
+     "start_time": "2026-09-12T00:07:33.310313",
      "status": "completed"
     },
     "tags": []
@@ -506,16 +513,16 @@
    "id": "9705f16d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:05.302366Z",
-     "iopub.status.busy": "2026-09-11T11:00:05.302123Z",
-     "iopub.status.idle": "2026-09-11T11:00:17.546709Z",
-     "shell.execute_reply": "2026-09-11T11:00:17.546166Z"
+     "iopub.execute_input": "2026-09-12T00:07:33.323419Z",
+     "iopub.status.busy": "2026-09-12T00:07:33.321911Z",
+     "iopub.status.idle": "2026-09-12T00:08:05.108311Z",
+     "shell.execute_reply": "2026-09-12T00:08:05.107302Z"
     },
     "papermill": {
-     "duration": 12.249118,
-     "end_time": "2026-09-11T11:00:17.547473",
+     "duration": 31.792407,
+     "end_time": "2026-09-12T00:08:05.110318",
      "exception": false,
-     "start_time": "2026-09-11T11:00:05.298355",
+     "start_time": "2026-09-12T00:07:33.317911",
      "status": "completed"
     },
     "tags": []
@@ -525,7 +532,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Phase 1 Pavlov : 16 opérations × 4 seeds, durée = 12.2s\n",
+      "Phase 1 Pavlov : 16 opérations × 4 seeds, durée = 31.8s\n",
       "                    Op | acc_lin (mean±std) | acc_sk (mean±std)  | Δ(sk - lin)\n",
       "--------------------------------------------------------------------------------\n",
       "                 FALSE | 100.0 ±  0.0      |   0.0 ±  0.0      | -100.0\n",
@@ -604,10 +611,10 @@
    "id": "4f9c8a3d",
    "metadata": {
     "papermill": {
-     "duration": 0.002587,
-     "end_time": "2026-09-11T11:00:17.552822",
+     "duration": 0.004,
+     "end_time": "2026-09-12T00:08:05.118319",
      "exception": false,
-     "start_time": "2026-09-11T11:00:17.550235",
+     "start_time": "2026-09-12T00:08:05.114319",
      "status": "completed"
     },
     "tags": []
@@ -631,16 +638,16 @@
    "id": "a59b8576",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:17.560661Z",
-     "iopub.status.busy": "2026-09-11T11:00:17.560471Z",
-     "iopub.status.idle": "2026-09-11T11:00:17.566249Z",
-     "shell.execute_reply": "2026-09-11T11:00:17.565744Z"
+     "iopub.execute_input": "2026-09-12T00:08:05.126946Z",
+     "iopub.status.busy": "2026-09-12T00:08:05.126439Z",
+     "iopub.status.idle": "2026-09-12T00:08:05.133939Z",
+     "shell.execute_reply": "2026-09-12T00:08:05.132998Z"
     },
     "papermill": {
-     "duration": 0.009702,
-     "end_time": "2026-09-11T11:00:17.567020",
+     "duration": 0.013127,
+     "end_time": "2026-09-12T00:08:05.134446",
      "exception": false,
-     "start_time": "2026-09-11T11:00:17.557318",
+     "start_time": "2026-09-12T00:08:05.121319",
      "status": "completed"
     },
     "tags": []
@@ -701,10 +708,10 @@
    "id": "48dda853",
    "metadata": {
     "papermill": {
-     "duration": 0.002817,
-     "end_time": "2026-09-11T11:00:17.572598",
+     "duration": 0.004001,
+     "end_time": "2026-09-12T00:08:05.142550",
      "exception": false,
-     "start_time": "2026-09-11T11:00:17.569781",
+     "start_time": "2026-09-12T00:08:05.138549",
      "status": "completed"
     },
     "tags": []
@@ -729,16 +736,16 @@
    "id": "9c2f3788",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:17.579155Z",
-     "iopub.status.busy": "2026-09-11T11:00:17.578923Z",
-     "iopub.status.idle": "2026-09-11T11:00:23.810981Z",
-     "shell.execute_reply": "2026-09-11T11:00:23.810572Z"
+     "iopub.execute_input": "2026-09-12T00:08:05.151257Z",
+     "iopub.status.busy": "2026-09-12T00:08:05.149985Z",
+     "iopub.status.idle": "2026-09-12T00:08:22.590332Z",
+     "shell.execute_reply": "2026-09-12T00:08:22.589823Z"
     },
     "papermill": {
-     "duration": 6.23632,
-     "end_time": "2026-09-11T11:00:23.811734",
+     "duration": 17.44576,
+     "end_time": "2026-09-12T00:08:22.591341",
      "exception": false,
-     "start_time": "2026-09-11T11:00:17.575414",
+     "start_time": "2026-09-12T00:08:05.145581",
      "status": "completed"
     },
     "tags": []
@@ -748,7 +755,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Phase 2 Pavlov : 11 opérations × 3 seeds × n=4, durée = 6.2s\n",
+      "Phase 2 Pavlov : 11 opérations × 3 seeds × n=4, durée = 17.4s\n",
       "                  Op | n_coeffs | acc_lin | acc_sk  | Δ(sk-lin)\n",
       "----------------------------------------------------------------------\n",
       "             delay_0 |   1      |  100.0  |    6.2  | -93.8\n",
@@ -810,10 +817,10 @@
    "id": "36d9f9f0",
    "metadata": {
     "papermill": {
-     "duration": 0.002602,
-     "end_time": "2026-09-11T11:00:23.817152",
+     "duration": 0.007263,
+     "end_time": "2026-09-12T00:08:22.606136",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.814550",
+     "start_time": "2026-09-12T00:08:22.598873",
      "status": "completed"
     },
     "tags": []
@@ -840,16 +847,16 @@
    "id": "1e8276cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:23.823010Z",
-     "iopub.status.busy": "2026-09-11T11:00:23.822809Z",
-     "iopub.status.idle": "2026-09-11T11:00:23.827966Z",
-     "shell.execute_reply": "2026-09-11T11:00:23.827585Z"
+     "iopub.execute_input": "2026-09-12T00:08:22.623379Z",
+     "iopub.status.busy": "2026-09-12T00:08:22.621601Z",
+     "iopub.status.idle": "2026-09-12T00:08:22.634574Z",
+     "shell.execute_reply": "2026-09-12T00:08:22.633055Z"
     },
     "papermill": {
-     "duration": 0.00903,
-     "end_time": "2026-09-11T11:00:23.828666",
+     "duration": 0.021728,
+     "end_time": "2026-09-12T00:08:22.635590",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.819636",
+     "start_time": "2026-09-12T00:08:22.613862",
      "status": "completed"
     },
     "tags": []
@@ -944,10 +951,10 @@
    "id": "39feeafb",
    "metadata": {
     "papermill": {
-     "duration": 0.002543,
-     "end_time": "2026-09-11T11:00:23.833937",
+     "duration": 0.007553,
+     "end_time": "2026-09-12T00:08:22.650453",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.831394",
+     "start_time": "2026-09-12T00:08:22.642900",
      "status": "completed"
     },
     "tags": []
@@ -973,16 +980,16 @@
    "id": "46387edd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:00:23.839942Z",
-     "iopub.status.busy": "2026-09-11T11:00:23.839720Z",
-     "iopub.status.idle": "2026-09-11T11:00:23.948571Z",
-     "shell.execute_reply": "2026-09-11T11:00:23.948094Z"
+     "iopub.execute_input": "2026-09-12T00:08:22.668263Z",
+     "iopub.status.busy": "2026-09-12T00:08:22.667733Z",
+     "iopub.status.idle": "2026-09-12T00:08:22.709346Z",
+     "shell.execute_reply": "2026-09-12T00:08:22.708302Z"
     },
     "papermill": {
-     "duration": 0.112871,
-     "end_time": "2026-09-11T11:00:23.949330",
+     "duration": 0.052561,
+     "end_time": "2026-09-12T00:08:22.711069",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.836459",
+     "start_time": "2026-09-12T00:08:22.658508",
      "status": "completed"
     },
     "tags": []
@@ -992,7 +999,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SHA-256 du notebook : dcf16a9f5399761f…\n",
+      "SHA-256 du notebook : bec6c4501d30e473…\n",
       "Commandes reproductibles : ce notebook est un script Python linéaire (9 cellules code + 15 cellules markdown = 24 cellules au total)\n",
       "\n",
       "================================================================================\n",
@@ -1042,14 +1049,25 @@
     "    if not os.path.isabs(nb_path):\n",
     "        nb_path = os.path.join(os.getcwd(), nb_path)\n",
     "except (NameError, KeyError, TypeError):\n",
+    "    nb_path = None\n",
+    "if not nb_path or not os.path.exists(nb_path):\n",
+    "    # Fallback glob par nom de fichier (worktree sparse-checkout inclus, Tell c.435 L4)\n",
     "    import glob\n",
     "    candidates = [p for p in glob.glob(\"**/SL-12b-PavlovDLS-Reproduction.ipynb\", recursive=True)\n",
     "                   if \"output\" not in p and \"_archive\" not in p]\n",
-    "    nb_path = candidates[0] if candidates else __file__\n",
-    "with open(nb_path, \"rb\") as fh:\n",
-    "    h = hashlib.sha256(fh.read()).hexdigest()\n",
-    "print(f\"SHA-256 du notebook : {h[:16]}…\")\n",
-    "print(f\"Commandes reproductibles : ce notebook est un script Python linéaire (9 cellules code + 15 cellules markdown = 24 cellules au total)\")\n",
+    "    nb_path = candidates[0] if candidates else None\n",
+    "if nb_path and os.path.exists(nb_path):\n",
+    "    with open(nb_path, \"rb\") as fh:\n",
+    "        h = hashlib.sha256(fh.read()).hexdigest()\n",
+    "    import json as _json\n",
+    "    with open(nb_path, encoding=\"utf-8\") as fh:\n",
+    "        _cells = _json.load(fh)[\"cells\"]\n",
+    "    n_code = sum(1 for c in _cells if c[\"cell_type\"] == \"code\")\n",
+    "    n_md = sum(1 for c in _cells if c[\"cell_type\"] == \"markdown\")\n",
+    "    print(f\"SHA-256 du notebook : {h[:16]}…\")\n",
+    "    print(f\"Commandes reproductibles : ce notebook est un script Python linéaire ({n_code} cellules code + {n_md} cellules markdown = {len(_cells)} cellules au total)\")\n",
+    "else:\n",
+    "    print(f\"Notebook introuvable ({nb_path or 'aucun candidat trouvé'}) : SHA-256 et compte de cellules non calculés\")\n",
     "\n",
     "claims = [\n",
     "    (\"La transformée de Walsh est exacte pour toute opération booléenne n=2 et n=4\",\n",
@@ -1087,10 +1105,10 @@
    "id": "c4286d56",
    "metadata": {
     "papermill": {
-     "duration": 0.002736,
-     "end_time": "2026-09-11T11:00:23.955088",
+     "duration": 0.008277,
+     "end_time": "2026-09-12T00:08:22.728540",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.952352",
+     "start_time": "2026-09-12T00:08:22.720263",
      "status": "completed"
     },
     "tags": []
@@ -1119,10 +1137,10 @@
    "id": "95c48a8c",
    "metadata": {
     "papermill": {
-     "duration": 0.002943,
-     "end_time": "2026-09-11T11:00:23.961187",
+     "duration": 0.00874,
+     "end_time": "2026-09-12T00:08:22.745018",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.958244",
+     "start_time": "2026-09-12T00:08:22.736278",
      "status": "completed"
     },
     "tags": []
@@ -1163,10 +1181,10 @@
    "id": "23b1840e",
    "metadata": {
     "papermill": {
-     "duration": 0.002907,
-     "end_time": "2026-09-11T11:00:23.967014",
+     "duration": 0.009001,
+     "end_time": "2026-09-12T00:08:22.762647",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.964107",
+     "start_time": "2026-09-12T00:08:22.753646",
      "status": "completed"
     },
     "tags": []
@@ -1186,10 +1204,10 @@
    "id": "8e7e3a64",
    "metadata": {
     "papermill": {
-     "duration": 0.003031,
-     "end_time": "2026-09-11T11:00:23.972992",
+     "duration": 0.008719,
+     "end_time": "2026-09-12T00:08:22.781296",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.969961",
+     "start_time": "2026-09-12T00:08:22.772577",
      "status": "completed"
     },
     "tags": []
@@ -1209,10 +1227,10 @@
    "id": "52f2694b",
    "metadata": {
     "papermill": {
-     "duration": 0.002927,
-     "end_time": "2026-09-11T11:00:23.978882",
+     "duration": 0.008009,
+     "end_time": "2026-09-12T00:08:22.797141",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.975955",
+     "start_time": "2026-09-12T00:08:22.789132",
      "status": "completed"
     },
     "tags": []
@@ -1232,10 +1250,10 @@
    "id": "c12fb380",
    "metadata": {
     "papermill": {
-     "duration": 0.003371,
-     "end_time": "2026-09-11T11:00:23.985003",
+     "duration": 0.007687,
+     "end_time": "2026-09-12T00:08:22.814881",
      "exception": false,
-     "start_time": "2026-09-11T11:00:23.981632",
+     "start_time": "2026-09-12T00:08:22.807194",
      "status": "completed"
     },
     "tags": []
@@ -1273,18 +1291,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 21.10813,
-   "end_time": "2026-09-11T11:00:24.229678",
+   "duration": 51.564474,
+   "end_time": "2026-09-12T00:08:23.051034",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12b-PavlovDLS-Reproduction.ipynb",
+   "input_path": "SL-12b-PavlovDLS-Reproduction.ipynb",
+   "output_path": "SL-12b-PavlovDLS-Reproduction.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T11:00:03.121548",
+   "start_time": "2026-09-12T00:07:31.486560",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2026:CoursIA — prev: MED/docs #15577

## Sujet — #15658 : ce qui restait réellement à livrer

Vérification G.1 préalable contre le main mergé (un seul commit a jamais touché le notebook : `b3643e4ea` = le squash-merge de #15540 ; l'issue décrivait le head de review `f4ec73cd6c`, antérieur au rework « Tell c.402/c.435 » de la résolution de chemin entré dans le merge) :

| Acceptance | État sur main avant cette PR | Cette PR |
|---|---|---|
| #1 SHA-256 dans les sorties committées | ✅ déjà livrée (`dcf16a9f5399761f…` en sortie) | re-prouvée par re-exécution (`bec6c4501d30e473…`) |
| #2 cas « introuvable » → ligne explicite | ❌ ouverte, **aggravée** : fallback `__file__` = NameError en kernel Jupyter (crash) | **livrée** |
| #3 `torch>=2.0` unique | ✅ déjà livrée (une seule décl., l. 31 ; le second hit d'un grep naïf est `LTNtorch>=1.0`, paquet distinct) | non touchée |
| #4 comptes dérivés, pas codés en dur | ❌ ouverte (`9/15/24` littéraux dans la f-string) | **livrée** |

## Fix (cellule verdict, cell 17)

- fallback `candidates[0] if candidates else __file__` → `else None` + garde `os.path.exists` : le cas introuvable imprime `Notebook introuvable (…)` au lieu de lever `NameError` ;
- comptes dérivés de la **même source de vérité** (`nb_path` lu en json) : `{n_code} cellules code + {n_md} cellules markdown = {len(_cells)}` interpolés, plus aucun littéral.

## Exécutions réelles (C.2)

Sémantique de paire préservée (deux exécutions indépendantes, comme sur main) :

```
$ python -m papermill SL-12b-PavlovDLS-Reproduction.ipynb SL-12b-PavlovDLS-Reproduction.ipynb        # run 1, in-place
$ python -m papermill SL-12b-PavlovDLS-Reproduction.ipynb SL-12b-PavlovDLS-Reproduction-output.ipynb  # run 2 → jumeau
```

- **run 1** (source) : 24 cellules, 9/9 `execution_count` 1..9, 0 erreur, `papermill.exception=None`, 0 bannière — sortie cell 17 : `SHA-256 du notebook : bec6c4501d30e473…` + `…(9 cellules code + 15 cellules markdown = 24 cellules au total)` **dérivés** ;
- **run 2** (jumeau `-output`) : même propreté, SHA `b7f1b5814f07eb5e…` (chaque artefact hashe ce qu'il a réellement lu — comportement identique à la paire sur main : `dcf16a9f` vs `f959dc7d`) ;
- **run de contrôle (acceptance #2)** : copie exécutée depuis un cwd sans candidat (`--cwd` scratchpad) → `Notebook introuvable (aucun candidat trouvé) : SHA-256 et compte de cellules non calculés`, **0 erreur, notebook exécuté de bout en bout** (rc=0, 0 bannière papermill) — l'ancien code y crashe en NameError.

## Notes 02:27Z de la review Hermes — différées, justification

`temporal_ops` (docstring 16 ops pour 11 produites) et `parity_k ≡ xor_first_{k-1}` (3 doublons fonctionnels, « 27 opérations » = 24 distinctes) touchent le **générateur d'expériences** : les corriger change la population mesurée (27→24), donc exige re-mesure Phase 1+2 + mise à cohérence README/body — un sujet distinct (Hermes lui-même les scope « pour une tranche ultérieure / nettoyé en G2 »). Une PR = un sujet : à instruire dans un ticket frère, pas ici.

Closes #15658 (les 4 acceptances : #1/#3 déjà vraies sur main et inchangées, #2/#4 livrées ci-dessus, #1 re-prouvée par re-exécution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
