### PR TITLE
fix(picker,#15682): la secheresse ne donne plus une probabilite nulle a 34 Epics sur 64

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -266,6 +266,66 @@ def infer_genre(title: str, labels: list[str]) -> str:
     return "docs"
 
 
+def genre_signal_present(title: str, labels: list[str]) -> bool:
+    """Le titre porte-t-il un signal de genre, ou `infer_genre` s'est-il
+    replie sur son defaut ?
+
+    `infer_genre` rend `docs` -- un genre **META** -- quand AUCUNE regle ne
+    matche. Ce repli est une **absence de signal**, pas un verdict META, et
+    il est indiscernable d'un `docs` reellement annonce par le titre. La
+    restriction de secheresse lisait les deux de la meme facon et les
+    retirait tous deux du tirage, ce qui donnait une probabilite
+    **exactement nulle** a des Epics de contenu.
+
+    Mesure du 2026-09-12, 322 issues ouvertes : 72 des 115 umbrellas
+    classees META le sont par ce repli -- dont #15475 (ICT Toolkit),
+    #15481 (S-Lens), #15397 (Thom), #13992 (Matrix Profile), #13924-26
+    (ADK / BigQuery), #14467 (reward hacking), #4588 (IIT -> ICT). Aucune
+    n'est de la documentation.
+    """
+    hay = (title + " " + " ".join(labels)).lower()
+    return any(re.search(pattern, hay) for pattern, _ in GENRE_RULES)
+
+
+def drought_admits(item: dict) -> bool:
+    """La restriction de secheresse admet-elle cet item ?
+
+    Trois cas d'admission, dont **un seul** etait implemente :
+
+    1. le genre est de la classe CONTENU -- le cas d'origine ;
+    2. l'item est une **umbrella** : tirer une Epic veut dire *creer un
+       sous-grain dedans* (R5 de proactive-coordination : « piocher ou creer
+       un sous-grain dedans, jamais claimer l'EPIC entier »). Le genre de
+       l'Epic ne decrit donc **jamais** le livrable ; filtrer les umbrellas
+       dessus filtre sur une grandeur qui ne predit pas ce qui sera livre.
+       L'obligation de contenu reste entiere, elle porte sur le sous-grain
+       -- et la banniere la nomme ;
+    3. le genre vient du **repli** de `infer_genre` (aucune regle matchee) :
+       une absence de signal ne vaut pas un verdict META.
+
+    Direction d'echec : admettre a tort coute **un** grain META, et la
+    secheresse persiste alors d'elle-meme au merge suivant (le compte
+    s'incremente) -- c'est auto-correcteur. Exclure a tort coute une
+    invisibilite **permanente**. D'ou l'admission en cas de doute, a
+    l'inverse du fail-CLOSED qui gouverne le COMPTAGE de la secheresse
+    (`substance_drought`), ou le doute doit au contraire compter
+    NON-CONTENU : les deux directions sont coherentes, car compter large et
+    tirer large vont dans le meme sens -- plus de contenu exige, plus de
+    candidats pour le fournir.
+
+    Les genres META reellement annonces (`guard`, `tooling`, `docs`,
+    `readme`, `test`, `ledger`, `refactor`) matchent tous une regle de
+    `GENRE_RULES` : la sequence guard -> tooling -> docs -> test que ce
+    garde existe pour briser reste donc exclue. Les dents sont conservees
+    la ou elles mordent, retirees la ou elles se trompaient.
+    """
+    if item["genre"] in CONTENU:
+        return True
+    if item.get("klass") == "umbrella":
+        return True
+    return not item.get("genre_confident", True)
+
+
 def authoritative_genre(body: str) -> str | None:
     """#13972 : extraire le genre que l'auteur de l'issue a DEClare dans le body.
 
@@ -399,6 +459,10 @@ def fetch_pool(
             "idle": age_days(it["updatedAt"]),
             "updated_at": it["updatedAt"],
             "genre": declared_genre if declared_genre else infer_genre(title, labels),
+            # Le genre est-il **soutenu** (declare par l'auteur, ou une regle
+            # de titre a matche), ou est-ce le repli `docs` de `infer_genre` ?
+            # Cf `genre_signal_present` : le repli ne vaut pas un verdict META.
+            "genre_confident": bool(declared_genre) or genre_signal_present(title, labels),
             "body": body,
             "parent": parent_issue(body),
             "polarity": polarity(title, body),
@@ -2348,11 +2412,20 @@ def print_drought_banner(d: dict, restricted: int, fell_back: bool) -> None:
         print("coordinateur (variation-protocol section 4), ne pas la traverser")
         print("en silence.")
     else:
-        print(f"Le tirage ci-dessous est RESTREINT aux genres CONTENU "
-              f"({restricted} candidats). Ce n'est pas un refus : la lane")
-        print("recoit un grain, et ce grain tient le plancher. Prendre un META")
-        print("de plus avant d'avoir casse la sequence, c'est la monoculture")
-        print("que le mandat interdit.")
+        print(f"Le tirage ci-dessous est RESTREINT ({restricted} candidats) : "
+              f"les genres CONTENU, plus")
+        print("les umbrellas et les items dont le genre n'est qu'un repli de")
+        print("l'inference de titre. Ce n'est pas un refus : la lane recoit un")
+        print("grain, et ce grain tient le plancher. Prendre un META de plus")
+        print("avant d'avoir casse la sequence, c'est la monoculture que le")
+        print("mandat interdit.")
+        print()
+        print("Si le candidat retenu est une UMBRELLA ou porte un genre replie,")
+        print("l'obligation de contenu n'est pas levee -- elle se deplace sur le")
+        print("SOUS-GRAIN : le grain cree dedans doit etre DEEP/MED et porter un")
+        print("genre CONTENU. Une Epic dont le titre ressemble a de la doc peut")
+        print("parfaitement abriter une preuve Lean ; c'est le livrable qui tient")
+        print("le plancher, jamais le titre de l'Epic.")
     print()
     print("Echappatoire : si la secheresse n'est pas reparable par cette lane")
     print("(aucun grain de contenu dans sa capability -- GPU-only, vision-only),")
@@ -2807,7 +2880,7 @@ def main(argv: list[str] | None = None) -> int:
         drought = substance_drought(args.lane, grains_hist, args.drought_run,
                                     grains_err)
         if drought["triggered"] and not args.ignore_drought:
-            restricted = {k: [it for it in v if it["genre"] in CONTENU]
+            restricted = {k: [it for it in v if drought_admits(it)]
                           for k, v in by_class.items()}
             # Degradation gracieuse : si la restriction vide les urnes, on rend
             # le tirage NON restreint plutot que rien. Ne rien rendre

--- a/scripts/tests/test_pick_drought_admission.py
+++ b/scripts/tests/test_pick_drought_admission.py
@@ -1,0 +1,153 @@
+"""Tests de l'admission sous restriction de secheresse (G-VAR-1).
+
+La restriction de secheresse (#13086) donnait une probabilite **exactement
+nulle** aux items dont le genre n'est pas CONTENU. Deux de ses exclusions
+portaient sur un verdict de genre que l'organe ne pouvait pas soutenir :
+
+1. les **umbrellas** -- tirer une Epic veut dire creer un sous-grain dedans
+   (R5 de proactive-coordination), donc le genre de l'Epic ne decrit jamais
+   le livrable ;
+2. les items dont le genre vient du **repli** de `infer_genre` (aucune regle
+   de titre matchee, defaut `docs`) -- une absence de signal n'est pas un
+   verdict META.
+
+Mesure du 2026-09-12, 322 issues ouvertes : 72 des 115 umbrellas classees
+META l'etaient par ce repli, et la restriction retirait **34 Epics sur 64**
+du tirage des lanes en secheresse -- dont #15475 (ICT Toolkit), #15397
+(Thom), #13992 (Matrix Profile), #13924-26 (ADK / BigQuery), #14467 (reward
+hacking), #4588 (IIT -> ICT). Aucune n'est de la documentation.
+
+Un detecteur se valide par ses faux negatifs : le controle positif ci-dessous
+(les genres META reellement annonces restent exclus) est AUSSI obligatoire
+que le reste. Sans lui, ce fichier serait vert alors meme que la correction
+aurait desarme G-VAR-1 -- ce qui rendrait au picker la monoculture que le
+garde existe pour briser.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pick_idle_grain import (  # noqa: E402
+    CONTENU,
+    META,
+    drought_admits,
+    genre_signal_present,
+    infer_genre,
+)
+
+
+def item(genre, klass="grain", confident=True):
+    return {"genre": genre, "klass": klass, "genre_confident": confident}
+
+
+# --------------------------------------------------------------------------
+# Controle POSITIF -- les dents du garde sont conservees
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("genre", sorted(META))
+def test_positive_control_declared_meta_grain_stays_excluded(genre):
+    """Un grain META dont le genre est SOUTENU reste exclu. C'est la
+    raison d'etre du garde : sans cette ligne, la correction le desarme."""
+    assert drought_admits(item(genre, confident=True)) is False
+
+
+@pytest.mark.parametrize("title", [
+    "ci(infra): variance 3-4x du pool self-hosted coursia-ephemeral",
+    "tooling(#5081): inventaire canonique des noms, kernels, cibles",
+    "docs(symboliclearning): reconcilier catalogue, compteurs et structure",
+    "guard(#5081): securiser les renames -- collisions, suffixes",
+    "fix(ci): le sentinel d'arret gracieux survit au reboot",
+])
+def test_positive_control_real_meta_titles_carry_a_signal(title):
+    """Mesure du 2026-09-12 : le travail META reel ANNONCE son genre.
+
+    La sequence guard -> tooling -> docs -> test que ce garde existe pour
+    briser reste donc exclue : ces titres matchent une regle, leur genre
+    est soutenu, et le test precedent les exclut."""
+    assert genre_signal_present(title, []) is True
+    assert infer_genre(title, []) in META
+    assert drought_admits(item(infer_genre(title, []), confident=True)) is False
+
+
+# --------------------------------------------------------------------------
+# Les trois cas d'admission
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("genre", sorted(CONTENU))
+def test_content_genre_is_admitted(genre):
+    """Cas d'origine, inchange."""
+    assert drought_admits(item(genre)) is True
+
+
+@pytest.mark.parametrize("genre", sorted(META))
+def test_umbrella_is_admitted_whatever_its_own_genre(genre):
+    """Une Epic est admise quel que soit SON genre : le livrable est le
+    sous-grain cree dedans, pas l'Epic. L'obligation de contenu n'est pas
+    levee, elle se deplace -- et la banniere le dit."""
+    assert drought_admits(item(genre, klass="umbrella")) is True
+
+
+@pytest.mark.parametrize("genre", sorted(META))
+def test_fallback_genre_is_admitted(genre):
+    """Genre non soutenu (repli de l'inference) : admis. Une absence de
+    signal ne vaut pas un verdict META."""
+    assert drought_admits(item(genre, klass="grain", confident=False)) is True
+
+
+@pytest.mark.parametrize("title", [
+    "[EPIC][ICT] Toolkit multi-instrument de mesure et d'interventions causales",
+    "[EPIC] Thom -- langage, agents transparents et singularites",
+    "ML-11 (Python) : Matrix Profile multidimensionnel -- detection",
+    "feat(adk): migrer Track2 vers le vrai runtime Google ADK",
+    "Reward hacking : mesurer la forme forte de Goodhart sans nouveau run",
+])
+def test_buried_content_titles_fall_through_and_are_admitted(title):
+    """Les titres mesures que la restriction enterrait. `infer_genre` les
+    rend `docs` **par defaut**, sans qu'aucune regle ne matche."""
+    assert genre_signal_present(title, []) is False
+    assert infer_genre(title, []) == "docs"
+    it = item(infer_genre(title, []), klass="grain", confident=False)
+    assert drought_admits(it) is True
+
+
+# --------------------------------------------------------------------------
+# Le defaut de repli lui-meme
+# --------------------------------------------------------------------------
+
+def test_fallback_default_is_a_meta_genre():
+    """La cause racine : le defaut de `infer_genre` est `docs`, un genre
+    META. Si ce defaut changeait de classe, ce fichier devrait etre relu."""
+    assert infer_genre("zzzz aucun mot-cle de genre zzzz", []) == "docs"
+    assert "docs" in META
+
+
+def test_genre_confident_absent_defaults_to_soutenu():
+    """Fail vers l'exclusion quand la cle manque : un appelant qui ne pose
+    pas `genre_confident` ne doit pas elargir le tirage par inadvertance."""
+    assert drought_admits({"genre": "docs", "klass": "grain"}) is False
+
+
+def test_positive_control_the_old_predicate_buried_these_epics():
+    """Controle positif du DEFAUT lui-meme.
+
+    L'ancien predicat etait `it["genre"] in CONTENU` seul. Sans cette
+    ligne, rien dans ce fichier ne prouve que la correction corrige
+    quelque chose : les tests ci-dessus passeraient a l'identique sur un
+    organe qui n'aurait jamais eu le defaut.
+    """
+    def ancien_predicat(it):
+        return it["genre"] in CONTENU
+
+    enterrees = [
+        "[EPIC][ICT] Toolkit multi-instrument de mesure et d'interventions causales",
+        "[EPIC] Thom -- langage, agents transparents et singularites",
+        "ML-11 (Python) : Matrix Profile multidimensionnel -- detection",
+    ]
+    for title in enterrees:
+        it = item(infer_genre(title, []), klass="umbrella", confident=False)
+        assert ancien_predicat(it) is False, f"le defaut ne se reproduit pas : {title}"
+        assert drought_admits(it) is True, f"la correction ne mord pas : {title}"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: LIGHT/docs #15454

Closes #15682

## Le défaut

La restriction de sécheresse de substance (G-VAR-1, #13086) filtrait les trois urnes sur `it["genre"] in CONTENU`. Deux de ses exclusions portent sur un verdict de genre que l'organe **ne peut pas soutenir** :

1. **Les umbrellas.** Tirer une Epic veut dire *créer un sous-grain dedans* (R5 : « piocher ou créer un sous-grain dedans, jamais claimer l'EPIC entier »). Le genre de l'Epic ne décrit donc jamais le livrable.
2. **Le repli de `infer_genre`**, qui rend `docs` — un genre META — quand aucune règle de titre ne matche. C'est une **absence de signal**, indiscernable d'un `docs` annoncé.

Conséquence mesurée : probabilité **exactement nulle** — pas « faible » — pour **34 Epics sur 64** dès qu'une lane est en sécheresse. Au 2026-09-12, deux lanes le sont (`myia-ai-01:CoursIA` et `myia-po-2026:CoursIA`, run = 8 pour un seuil de 3), dont la lane la plus productive de la flotte.

## Mesure

322 issues ouvertes, commandes et script dans #15682.

| | avant | après |
|---|---:|---:|
| umbrellas tirables en sécheresse | **30 / 64** | **64 / 64** |
| grains tirables | 75 / 258 | 179 / 258 |
| éligibles, total | **105** | **243** |

Relevé indépendamment par deux méthodes distinctes (simulation de 300 tirages sur 4 lanes ; recomptage direct du pool) qui rendent le **même** 34.

Les Epics restaurées, aucune n'étant de la documentation : `#15475` ICT Toolkit, `#15481` S-Lens, `#15479` interventions causales, `#15397` Thom, `#13992` ML-11 Matrix Profile, `#13924`-`#13926` ADK/BigQuery, `#14467` Goodhart, `#14463` Pearl↔Hoel, `#14620` Factory, `#14525` Vibe-Coding, `#14407` Bibliographie, `#10355` fallacy FT+PT, `#4588` IIT→ICT.

## Les dents sont conservées

C'est le point qui décide si ce correctif est sain ou s'il désarme G-VAR-1. Les **sept** genres META réellement annoncés matchent tous une règle de `GENRE_RULES` — mesuré sur les titres réels du corpus :

```
SIG   guard      ci(infra): variance 3-4x du pool self-hosted coursia-ephemeral
SIG   tooling    tooling(#5081): inventaire canonique des noms, kernels, cibles
SIG   docs       docs(symboliclearning): reconcilier catalogue, compteurs
SIG   guard      guard(#5081): securiser les renames -- collisions, suffixes
repli docs       [EPIC][ICT] Toolkit multi-instrument de mesure et d'interventions
repli docs       ML-11 (Python) : Matrix Profile multidimensionnel -- detection
repli docs       feat(adk): migrer Track2 vers le vrai runtime Google ADK
```

La séquence `guard → tooling → docs → test` que ce garde existe pour briser **reste exclue**. Les dents sont retirées là où elles se trompaient, pas là où elles mordent.

## Direction d'échec — inversée, et délibérément

Admettre à tort coûte **un** grain META, et la sécheresse persiste alors d'elle-même au merge suivant : c'est auto-correcteur. Exclure à tort coûte une invisibilité **permanente**. D'où l'admission en cas de doute.

Le **comptage** de la sécheresse (`substance_drought`) garde son `fail-CLOSED`, où le doute compte NON-CONTENU. Les deux directions sont cohérentes : compter large et tirer large vont dans le même sens — plus de contenu exigé, plus de candidats pour le fournir.

## L'obligation n'est pas levée, elle se déplace

La bannière le dit désormais explicitement : si le candidat retenu est une umbrella ou porte un genre replié, le **sous-grain** créé dedans doit être DEEP/MED et porter un genre CONTENU. Une Epic dont le titre ressemble à de la doc peut parfaitement abriter une preuve Lean ; c'est le livrable qui tient le plancher, jamais le titre de l'Epic.

## Validation

```
234 passed in 0.52s
```

191 tests existants du picker, inchangés, + **43 neufs** (`scripts/tests/test_pick_drought_admission.py`), dont **deux contrôles positifs** :

- `test_positive_control_real_meta_titles_carry_a_signal` — les genres META annoncés restent exclus. Sans lui, ce fichier serait vert alors même que la correction aurait désarmé G-VAR-1.
- `test_positive_control_the_old_predicate_buried_these_epics` — l'ancien prédicat reproduit l'exclusion. Sans lui, rien ne prouve que la correction corrige quelque chose.

Le picker a aussi été exécuté **pour de vrai** sur une lane en sécheresse (`--lane myia-ai-01:CoursIA`) : bannière rendue, `173 candidats` sous restriction, tirage servi.

Erreurs de collection `ModuleNotFoundError: No module named 'torch'` sur `tests/test_sudoku_*` : préexistantes, sur des fichiers que cette PR ne touche pas.

## Rapport avec #15491

`#15491` veut pondérer les Epics par âge de dernière livraison réelle, boost proposé à `0.5`. Un boost de `0.5` sur une probabilité de `0` rend `0` : ce correctif est en **amont**, et sans lui la pondération de #15491 ne serait mesurable que sur les 30 Epics déjà visibles.

## Ce que cette PR ne fait pas

Elle ne touche **pas** `.claude/rules/**`. La contradiction qui court-circuite le tirage à chaque cycle — R5 « le tirage est le premier geste » contre `variation-protocol.md` §4.1 « ≥1 grain par lane **chaque cycle** » — demande un sign-off user (§A) et vit dans son issue propre.

G-VAR-1 : `tooling` est un genre **META**. Cette PR ne tient donc pas le plancher de contenu de ma lane, et ne le prétend pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
