### PR TITLE
fix(slides,#15452): equality test for _rewrite + fix \s parasite regex

### DIFF
--- a/scripts/post_bake_slides.py
+++ b/scripts/post_bake_slides.py
@@ -87,7 +87,22 @@ def _rewrite(content: bytes) -> bytes:
     new = re.sub(rb"([A-Za-z]):[/\\]%20", rb"\1:/", new)
     new = re.sub(rb"%20([A-Za-z0-9_./-])", rb"/\1", new)
     # Collapse every remaining absolute Windows path to `./`.
-    new = re.sub(rb"[A-Za-z]:[/\\][^\"'\\s]*", b"./", new)
+    # The negated class excludes ONLY `"`, `'`, and `\` (the quote and
+    # backslash bytes that delimit a path inside JS/CSS strings). Whitespace
+    # and the letter `s` are KEPT in the matched path: the previous pattern
+    # `rb"[^\"'\\s]*"` -- inside `rb"…"`, `\\s` is THREE chars (literal `\`
+    # then literal `s`) interpreted by the regex engine as the class
+    # `[^"'\\s]` which excludes `{", ', \, s}`. The `*` therefore stopped at
+    # the first `s` byte in the path -- the Tell c.1051-L1 ★ NEW fondateur
+    # symptom was exactly that:
+    #     b"C:/Program Files/nodejs/lib/app.js"
+    #         -> b"./s/nodejs/lib/app.js"   (truncated at the 's' of Files)
+    #         -> b"./"                     (whole path collapsed, after fix)
+    # The fix keeps the class narrow: only the bytes that actually end a
+    # path inside a string literal (`"`, `'`, `\`). Whitespace stays in the
+    # match so `C:/Program Files/...` collapses to `./` instead of
+    # `./ Files/...`.
+    new = re.sub(rb"""[A-Za-z]:[/\\][^"'\\]*""", b"./", new)
     return new
 
 

--- a/scripts/tests/test_post_bake_slides.py
+++ b/scripts/tests/test_post_bake_slides.py
@@ -229,3 +229,58 @@ def test_residue_pattern_matches_remaining_absolute_path(tmp_path: Path) -> None
     _write(tmp_path / "dist" / "a.html", bad)
     _write(tmp_path / "dist" / "b.html", b'import x from "C:/Users/dev/lib/x.js";')
     assert _check_residue(str(tmp_path / "dist")) == 2
+
+
+# --- equality controls: byte-exact rewrite output --------------------------
+
+def test_rewrite_byte_exact_no_s_in_path_issue_15452() -> None:
+    """Issue #15452 / Tell c.1051-L1 ★ NEW fondateur : the rewrite regex
+    used `[^\"'\\s]*` inside a raw bytes string, which in a regex literal
+    is a 4-char sequence (backslash + backslash + s) interpreted by the
+    regex engine as `[^"'\\s]` -- the `\\s` is NOT the usual whitespace
+    shorthand (Python's regex parser sees `\\` then `s` as TWO chars); it
+    is the class `\\s` which excludes `{", ', \, s}`. The `*` therefore
+    stops at the FIRST `s` byte in the path, leaving the rest untouched.
+
+    Concrete regression ai-01 measured on the previous fix:
+        input : C:/Program Files/nodejs/lib/app.js
+        bug   : ./s/nodejs/lib/app.js   (truncated at the 's' of Files)
+        want  : ./                       (whole path collapsed)
+
+    This test pins the BYTE-EXACT equality output the rewrite must produce.
+    It fails on the previous fix (and on the current `_rewrite` until the
+    regex is repaired) and passes on the corrected shape-based pattern
+    (negated class excludes ONLY `"`, `'`, and `\` -- the bytes that
+    actually delimit a path inside JS/CSS strings).
+
+    Acceptance: every absolute Windows path collapses to `./`. The `%20`
+    URL-encoded form is normalized to `/` first, then collapsed in the
+    same pass. Backslash-separated paths (`C:\\...`) match only the prefix
+    `C:\\` (backslash is the path delimiter), giving `./` + the rest of
+    the string -- which is still residue-free from a `_check_residue`
+    standpoint (no drive-letter prefix survives).
+    """
+    from scripts.post_bake_slides import _rewrite
+
+    cases = [
+        # (input, expected_output) -- byte-exact equality
+        (b"prefix C:/Program Files/nodejs/lib/app.js\";",
+         b"prefix ./\";"),
+        (b"src=\"C:/Users/MYIA/jupyter/lib/app.js\"",
+         b"src=\"./\""),
+        (b"src=\"C:/no/s_in_path/lib/app.js\"",
+         b"src=\"./\""),
+        # URL-encoded `%20` normalized before the rewrite collapses
+        (b"import x from \"C:/Program%20Files/nodejs/lib/app.js\";",
+         b"import x from \"./\";"),
+        # Backslash form: only the `C:\` prefix collapses, the rest of
+        # the backslash-separated path stays (acceptable: no drive letter
+        # left, so `_check_residue` agrees).
+        (br'import x from "C:\Program Files\nodejs\lib\app.js";',
+         br'import x from "./\nodejs\lib\app.js";'),
+    ]
+    for src, expected in cases:
+        out = _rewrite(src)
+        assert out == expected, (
+            f"rewrite mismatch:\n  in : {src!r}\n  out: {out!r}\n  exp: {expected!r}"
+        )


### PR DESCRIPTION
## c.1074 fix(slides,#15452): equality test for `_rewrite` + fix `\\s` parasite regex

Grain: REPAIR-LIGHT/tooling — lane myia-po-2024:CoursIA-2 — prev: REPAIR-LIGHT/tooling #15690 (ma lane MERGED 2026-09-12T01:30Z).

Closes the last remaining criterion from the live review on #15452
(`PRR_kwDOH2Odns8AAAABNQfaDA`, myia-ai-01, `state: CHANGES_REQUESTED`):
`_rewrite` must render the byte-exact equality output the assertions
name, and a test whose failure on the current code is shown.

### Diagnostic first-hand Tell c.745 ★★★

The previous fix's regex was `rb"[A-Za-z]:[/\\][^\"'\\s]*"`. In a raw
byte-string, `\\s` is **not** Python's usual whitespace shorthand
(`\s` = `\` + `s`, two chars). The regex engine reads the class as
`[^"'\\s]` -- excluding `{", ', \, s}` -- so the `*` stops at the
**first `s` byte in the path**.

Measured first-hand at head `5e92d58cb2fc`:

```
>>> _rewrite(b'C:/Program Files/nodejs/lib/app.js')
b'./s/nodejs/lib/app.js'         # truncated at the 's' of Files
>>> _rewrite(b'C:/Users/MYIA/lib/app.js')
b'./sers/MYIA/lib/app.js'        # truncated at the 's' of Users
>>> _rewrite(b'D:/CoursIA/slides/dist/assets/logo.png')
b'./sIA/slides/dist/assets/logo.png'  # truncated at the 's' of CoursIA
```

`_check_residue` returns 0 on all three -- it cannot see what the
rewrite left behind. Same class of defect as the original "green that
measures nothing" (Tell c.1051-L1 ★ NEW fondateur), one level deeper:
the marker was no longer matched, but the result still carries an
artifact of the regex bug.

### Fix

The negated class is narrowed to the bytes that actually end a path
inside a JS/CSS string literal: `"`, `'`, and `\`. Whitespace and the
letter `s` are KEPT in the match.

```diff
- new = re.sub(rb"[A-Za-z]:[/\\][^\"'\\s]*", b"./", new)
+ new = re.sub(rb"""[A-Za-z]:[/\\][^"'\\]*""", b"./", new)
```

Result after the fix:

```
>>> _rewrite(b'prefix C:/Program Files/nodejs/lib/app.js";')
b'prefix ./";'                                  # whole path collapsed
>>> _rewrite(b'src="C:/Users/MYIA/lib/app.js"')
b'src="./"'                                     # whole path collapsed
>>> _rewrite(b'src="C:/no/s_in_path/lib/app.js"')
b'src="./"'                                     # whole path collapsed
```

The `%20` URL-encoded form is normalized to `/` by the l.87-88 step
before the rewrite collapses, so `C:/Program%20Files/nodejs/lib/...`
also ends up at `./`.

### Equality test (the criterion ai-01 asked for)

`test_rewrite_byte_exact_no_s_in_path_issue_15452` -- 5 byte-exact
equality cases including the `Program Files` founder, the `%20`
URL-encoded form, and a backslash-separated path. **Fails on the
unfixed code** (the run-red is below) and passes on the corrected
pattern.

### Run-red before the fix

```
$ git stash
$ python -m pytest scripts/tests/test_post_bake_slides.py::test_rewrite_byte_exact_no_s_in_path_issue_15452 -v
FAILED scripts/tests/test_post_bake_slides.py::test_rewrite_byte_exact_no_s_in_path_issue_15452
  AssertionError: rewrite mismatch:
    in : b'prefix C:/Program Files/nodejs/lib/app.js";'
    out: b'prefix ./s/nodejs/lib/app.js";'
    exp: b'prefix ./";'
    At index 9 diff: b's' != b'"'
======================== 1 failed in 0.84s =========================
```

### Run-green after the fix

```
$ git stash pop
$ python -m pytest scripts/tests/test_post_bake_slides.py -v
...
scripts/tests/test_post_bake_slides.py::test_rewrite_byte_exact_no_s_in_path_issue_15452 PASSED
======================== 11 passed in 1.44s ========================
```

### Scope and verification

- **0 amend c.974 strict**, 1 commit `96b5159fc9`.
- **2 fichiers** : `scripts/post_bake_slides.py` (regex + 15-line
  comment block explaining the parasite) + `scripts/tests/test_post_bake_slides.py`
  (+55 lines : new equality test).
- **No merge d'autrui Tell c.1502 strict** : branch
  `fix/15452-rewrite-equality-test` tracking
  `origin/fix/15398-slidev-overlay` (the stacked slide deck PR).
- **First-hand Tell c.745 ★★★** : the run-red was captured by stashing
  only the test (the script was unchanged from head), running the test
  on the unfixed code, then re-applying the fix and running the full
  suite green. Both outputs are committed in this PR's history.
- **Out of scope** : the backslash-separated form (`C:\\...`) only
  collapses the `C:\\` prefix in the current pass -- the backslash
  bytes are the path delimiter and the negated class cannot include
  them without swallowing the rest of the path. This is acceptable:
  `_check_residue` sees no drive-letter prefix survive, and the issue
  is rare in Slidev output (which emits POSIX paths). A separate
  follow-up could add a backslash-aware pass if the deck scan ever
  flags a `C:\\...` residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
