### PR TITLE
fix(ci,#15058): plancher de collection ADK contracts 16->18 (perime depuis #15200)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -71,7 +71,7 @@ on:
       # check-runs. Keep one ordinary CI surface that executes the scanner for
       # every workflow change, including workflow-only PRs from forks.
       - '.github/workflows/**'
-      # #15058 ADK contracts: the 16 runtime-contract tests that #13572 makes
+      # #15058 ADK contracts: the 18 runtime-contract tests that #13572 makes
       # its measuring organ (Track2-GoogleADK/utils/test_adk_runtime_contracts.py,
       # C1-C7 on the REAL ADK runtime, scripted LLM, offline) never ran in any
       # CI job -- the reading #13572 prescribes was unavailable. The
@@ -347,7 +347,7 @@ jobs:
           echo "OK: $N tests collected (floor=$GRADEBOOK_TESTS_FLOOR)."
 
   adk-contracts:
-    name: ADK runtime contracts (16)
+    name: ADK runtime contracts (18)
     # #15058: #13572 makes Track2-GoogleADK/utils/test_adk_runtime_contracts.py
     # (C1-C7, REAL ADK 2.8 runtime with a scripted LLM -- offline, no key, no
     # network) its measuring organ, but no CI job ran it: portage was
@@ -382,7 +382,7 @@ jobs:
         run: |
           pytest "MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py" --tb=short -q
 
-      - name: Contracts collection floor (16)
+      - name: Contracts collection floor (18)
         # Same two-signal semantics as the audit (455) / secrets (148) /
         # GradeBook (15) floors above: 0 collected = collection crash (import
         # error -- the exact failure mode a naive wiring of these tests into
@@ -390,7 +390,7 @@ jobs:
         # was deleted, which is a coverage regression, never housekeeping.
         if: always()
         env:
-          ADK_CONTRACTS_FLOOR: 16
+          ADK_CONTRACTS_FLOOR: 18
         run: |
           N=$(python -m pytest "MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/test_adk_runtime_contracts.py" --collect-only -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ tests collected' | grep -oE '^[0-9]+')
           if [ -z "$N" ] || [ "$N" -eq 0 ]; then echo "::error::--collect-only returned no tests — the collection crashed (distinct from a coverage drop)."; exit 1; fi


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2027:CoursIA — prev: MED/notebook-lean #15626

## Ce que fait cette PR

Elle rafraîchit les quatre mentions périmées du job `adk-contracts` : `main` collecte **18** contrats runtime depuis #15200 (qui a ajouté `test_c1b_x_c5_handoff_persists_across_conversation_turns` et `test_c1b_x_c5_session_accumulates_handoffs_after_composition`), alors que le job porte encore nom, commentaire d'invitation, nom d'étape et plancher à **16**.

## Pourquoi c'est un vrai relâchement, pas du cosmétique

La sémantique du plancher est directionnelle : l'ascension est permise, seule la descente échoue. Le filet à 16 ne rouspétait donc pas — il était simplement **plus lâche que le réel** : la suppression future de 2 contrats (16 → retour au plancher nominal) serait passée inaperçue. Le plancher à 18 détecte toute perte.

## Mesure de grounding

```
$ python -m pytest .../test_adk_runtime_contracts.py --collect-only -q   # env miroir exact
18 tests collected
```

Env miroir du job (python 3.11, `litellm==1.93.2 openai==2.24.0 google-adk==2.8.0 pydantic==2.12.5 pydantic-settings python-dotenv`), sur `origin/main` frais — le compte cité est le compte mesuré, pas un décompte de `grep`.

Le commentaire historique « 16/16 green in ~10 s » (mesure #13948 au câblage) est laissé tel quel : il documente la vérification d'alors, pas l'état courant.

Repéré en travaillant #15060 (note incidente dans [le commentaire d'arbitrage](https://github.com/jsboige/CoursIA/issues/15060#issuecomment-5643269060)). See #15058 — le câblage reste sain, seul le compteur datait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
