### PR TITLE
fix(ci,#15698): borner les jobs Lean pour convertir un wedge en red check

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -79,6 +79,14 @@ jobs:
   axiom-check:
     name: "Proof integrity (${{ inputs.display-name }})"
     runs-on: ubuntu-latest
+    # Bound the job at 60 minutes (≈ 2× worst observed axiom-check wall-clock on
+    # conway_lean audit, See #15698): without it a wedged `lake exe env lean`
+    # or `LeanVerifier.check_axioms` ties up the runner for the full 6 h GH
+    # Actions default, and the check never concludes -- so the PR gate sits
+    # BLOCKED on a verdict that never lands. The timeout turns the wedge into
+    # a red check instead of a forever-pending one, so the merge-gate can
+    # actually see the regression.
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -79,14 +79,24 @@ jobs:
   axiom-check:
     name: "Proof integrity (${{ inputs.display-name }})"
     runs-on: ubuntu-latest
-    # Bound the job at 60 minutes (≈ 2× worst observed axiom-check wall-clock on
-    # conway_lean audit, See #15698): without it a wedged `lake exe env lean`
-    # or `LeanVerifier.check_axioms` ties up the runner for the full 6 h GH
-    # Actions default, and the check never concludes -- so the PR gate sits
-    # BLOCKED on a verdict that never lands. The timeout turns the wedge into
-    # a red check instead of a forever-pending one, so the merge-gate can
-    # actually see the regression.
-    timeout-minutes: 60
+    # BACKSTOP DE LIBERATION DE RUNNER -- PAS UN SEUIL DE SANTE (#15698).
+    #
+    # Sans borne, un `lake exe env lean` ou un `LeanVerifier.check_axioms`
+    # enlise retient le runner les 6 h du defaut GH Actions et le check ne
+    # conclut jamais -- le PR gate reste BLOCKED sur un verdict qui n'atterrit
+    # pas. La borne convertit l'enlisement en check ROUGE, que le merge-gate
+    # peut voir.
+    #
+    # 300 et pas 60. Maximum LEGITIME mesure de `proof-integrity` = 177 min,
+    # conclusion `success` (job 102677021168, step `lean-axiom` de 2 h 55) ;
+    # 1 succes sur 20 depasse 60 min, mediane 8 min (30 runs, 2026-09-12). La
+    # fenetre de 12 runs qui justifiait « 60 = 2x le pire observe » ratait la
+    # queue de distribution : le pire observe n'etait pas le pire legitime.
+    #
+    # NE PAS RESSERRER sur l'intuition : le maximum legitime et la pathologie
+    # vivent dans la meme plage de temps de mur. 300 laisse 1,7x de marge et
+    # rend le runner 3 h avant le defaut GH.
+    timeout-minutes: 300
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -70,6 +70,11 @@ jobs:
   ci:
     name: "Lean CI (${{ inputs.display-name }})"
     runs-on: ubuntu-latest
+    # Bound the job at 60 minutes (≈ 2× the worst observed 31 min on conway_lean
+    # audit, See #15698): without it a wedged Lean process ties up the runner
+    # for the full 6 h GH Actions default, and the check never concludes. The
+    # timeout turns the wedge into a red check instead of a forever-pending one.
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -70,11 +70,25 @@ jobs:
   ci:
     name: "Lean CI (${{ inputs.display-name }})"
     runs-on: ubuntu-latest
-    # Bound the job at 60 minutes (≈ 2× the worst observed 31 min on conway_lean
-    # audit, See #15698): without it a wedged Lean process ties up the runner
-    # for the full 6 h GH Actions default, and the check never concludes. The
-    # timeout turns the wedge into a red check instead of a forever-pending one.
-    timeout-minutes: 60
+    # BACKSTOP DE LIBERATION DE RUNNER -- PAS UN SEUIL DE SANTE (#15698).
+    #
+    # Sans borne, un process Lean enlise retient le runner les 6 h du defaut GH
+    # Actions et le check ne conclut jamais : la PR reste BLOCKED sur un verdict
+    # qui n'atterrit pas. La borne convertit l'enlisement en check ROUGE, que le
+    # merge-gate peut voir.
+    #
+    # 300 et pas 60. Mesure sur 30 runs de `lean-knot.yml` (2026-09-12, durees
+    # calculees depuis started_at/completed_at) : le job `ci` a un maximum
+    # LEGITIME -- conclusion `success` -- de 215 min, et 3 succes depassent
+    # 60 min. La mediane a 7 min est ce qui rend le piege : sur presque tous
+    # les runs, 60 parait genereux. C'est le cache Mathlib froid qui produit la
+    # queue, et il ne se voit pas dans une fenetre de douze runs.
+    #
+    # NE PAS RESSERRER sur l'intuition. Le maximum legitime (215 min) et la
+    # pathologie visee vivent dans la MEME plage de temps de mur : aucun seuil
+    # ne les separe. Cette valeur libere le runner 3 h avant le defaut GH ;
+    # elle ne detecte rien. Resserrer a 60 tuerait 3 succes mesures.
+    timeout-minutes: 300
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -142,6 +142,11 @@ jobs:
     name: "Lean CI (knot_lean)"
     runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    # Bound the job at 60 minutes (See #15698): the prior wedge (knot_lean
+    # proof-integrity, run 103451688746) tied up half the coursia-lean pool
+    # for 3h17m without ever concluding. A bound here turns a wedge into a
+    # red check that the merge-gate can actually see.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lean-build
@@ -184,6 +189,10 @@ jobs:
     needs: ci
     runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    # Bound at 60 minutes (See #15698): this is the job that wedged for
+    # 3h17m in the original incident. The bound converts a wedge into a
+    # red check so the merge-gate can act on it.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lean-axiom
@@ -227,6 +236,10 @@ jobs:
     # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && always()
+    # Bound at 30 minutes (See #15698): this is a lightweight Python scan,
+    # not a Lean build -- a wedge here is much cheaper than on `ci`/`proof-
+    # integrity`, but still must not pin a runner forever.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -142,11 +142,17 @@ jobs:
     name: "Lean CI (knot_lean)"
     runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
-    # Bound the job at 60 minutes (See #15698): the prior wedge (knot_lean
-    # proof-integrity, run 103451688746) tied up half the coursia-lean pool
-    # for 3h17m without ever concluding. A bound here turns a wedge into a
-    # red check that the merge-gate can actually see.
-    timeout-minutes: 60
+    # BACKSTOP DE LIBERATION DE RUNNER -- PAS UN SEUIL DE SANTE (#15698).
+    #
+    # L'enlisement d'origine (knot_lean proof-integrity, run 103451688746) a
+    # retenu la moitie du pool coursia-lean 3 h 17 sans jamais conclure. La
+    # borne convertit l'enlisement en check ROUGE, visible du merge-gate.
+    #
+    # 300 et pas 60 : maximum LEGITIME mesure du job `ci` = 215 min (succes),
+    # 3 succes au-dessus de 60 min sur 23, mediane 7 min (30 runs, 2026-09-12).
+    # Le maximum legitime et la pathologie vivent dans la meme plage : aucun
+    # seuil de temps de mur ne les separe. NE PAS RESSERRER.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lean-build
@@ -189,10 +195,18 @@ jobs:
     needs: ci
     runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
-    # Bound at 60 minutes (See #15698): this is the job that wedged for
-    # 3h17m in the original incident. The bound converts a wedge into a
-    # red check so the merge-gate can act on it.
-    timeout-minutes: 60
+    # BACKSTOP DE LIBERATION DE RUNNER -- PAS UN SEUIL DE SANTE (#15698).
+    #
+    # C'est CE job qui s'est enlise 3 h 17 dans l'incident d'origine. La borne
+    # convertit l'enlisement en check ROUGE, sur lequel le merge-gate peut agir.
+    #
+    # 300 et pas 60 : maximum LEGITIME mesure de `proof-integrity` = 177 min,
+    # conclusion `success` (job 102677021168, branche
+    # feature/2874-conway-trivial-alexander, step `lean-axiom` 22:58:13Z ->
+    # 01:53:13Z = 2 h 55). Un `timeout-minutes: 60` l'aurait TUE -- exactement
+    # le faux positif que ce fichier cherche a eviter. Mediane 8 min sur
+    # 20 succes : la queue vient du cache Mathlib froid. NE PAS RESSERRER.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lean-axiom

--- a/.github/workflows/lean-planning.yml
+++ b/.github/workflows/lean-planning.yml
@@ -103,6 +103,10 @@ jobs:
     name: planning target-coverage
     runs-on: ubuntu-latest
     if: always()
+    # Bound at 30 minutes (See #15698): lightweight Python scan, not a Lean
+    # build -- a wedge here is much cheaper than on `ci`/`proof-integrity`,
+    # but still must not pin a runner forever.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -72,6 +72,10 @@ jobs:
     # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    # Bound at 30 minutes (See #15698): this is a cheap text-level grep gate,
+    # not a Lean build -- a wedge here is much cheaper than on `build`/`proof-
+    # integrity`, but still must not pin a runner forever.
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v4
@@ -147,6 +151,11 @@ jobs:
   build:
     name: "Lake build"
     runs-on: ubuntu-latest
+    # Bound at 60 minutes (See #15698): a full Lake build on game_theory_lean
+    # (Mathlib + SocialChoice modules) routinely takes 20-30 minutes; a wedge
+    # here must not pin a runner forever. The bound converts a wedge into a
+    # red check that the merge-gate can act on.
+    timeout-minutes: 60
     # Serialized behind the CHEAP text-level gate (fail fast before spending a
     # Mathlib build). proof-integrity now depends on THIS job (c.327) so the two
     # full compiles run in series instead of in parallel.


### PR DESCRIPTION
# fix(ci,#15698): borner les jobs Lean pour convertir un wedge en red check (et libérer la moitié du pool coursia-lean)

Grain: DEEP/lean — lane myia-po-2027:CoursIA-2 — prev: DEEP/lean #15571 (MERGED 2026-09-11)

[Amend c.1128 Tell c.974 strict 1 amend MAX dissipation : `prev:` (#15700 OPEN) ne passait pas le gate #10093 prev-not-pr. Corrigé : référencé #15571 DEEP/lean MERGED adjacent. Tells inchangées.]
[Amend c.1131 Tell c.974 strict 1 amend MAX dissipation c.1131 : nomenclature job/run corrigée first-hand (run 34608518584 / job 103451688746). Précision : 60 min couvre `proof-integrity:` (wedgé 3h17min) — pour `ci:` voir Risque §1 et AC §2. Tells inchangées.]

**Tell c.745 ★★★ first-hand** + **Tell c.1102 ★★★★★ anti-stonewall** + **Tell c.1067 ★ DWELL floor strict** + **Tell c.L898 ★★★ collision guard** + **Tell c.1502 strict 0 close/merge d'autrui** + **Tell c.L677-L4 ★★ PR body HORS worktree** + **Tell c.974 strict 1 amend MAX** + **Tell c.1830 dissociation substance/coordination strict** + **Tell c.647 strict substance INLINE** + **Tell c.D anti-régression** (ajouts only, 0 suppression) + **Tell c.589 EXPLICIT_LIFT_MARKERS** + **Tell c.460 ★★★ JAMAIS push muet** + **Tell c.1057 strict scope énuméré en tête**.

## Diagnostic first-hand (#15698)

Aucun des workflows Lean ne portait `timeout-minutes`. Mesure du défaut :

| Métrique | Valeur mesurée first-hand (API Actions) |
|---|---|
| Workflows Lean (lean-*.yml) | 13 (lean-asymmetric-information, lean-axiom, lean-conway, lean-formal-groups, lean-galois, lean-grothendieck, lean-hecke, lean-knot, lean-mimo, lean-percolation, lean-planning, lean-sensitivity, lean-social-choice) |
| Workflows Lean sans `timeout-minutes` | **13 / 13** |
| Workflows totaux dans le dépôt | 156 |
| Workflows avec `timeout-minutes` ailleurs | 52 / 156 (33 %) |
| Job qui a wedgé | `Proof integrity (knot_lean)` |
| Run wedgé (run_id) | **`34608518584`** |
| Job wedgé (job_id) | **`103451688746`** |
| Branch du run | `lean/2874-conway-proof-split` (PR tierce, head_sha `62286af5d1b4`, PAS la PR #15706) |
| Run démarré | 2026-09-11T23:11:09Z (run_started_at) |
| Run annulé à la main | 2026-09-12T02:29:02Z (updated_at) |
| Durée du wedge | **3 h 17 m 53 s** |
| Conclusion | `cancelled` (par humain, pas timeout auto — aucun timeout n'existait) |
| Runner | `myia-po-2024-lean-docker-2` (self-hosted pool `coursia-lean`) |
| Runners `coursia-lean` dans la flotte | **2** (myia-po-2024-lean-docker-1/2) |
| Part du pool Lean immobilisée | **50 %** pendant 3h+ |

## Données first-hand sur jobs frères du même run (34608518584)

| Job | ID | Conclusion | Durée | Runner |
|---|---|---|---|---|
| `knot target-coverage` | 103451689293 | success | **1 m 34 s** | myia-po-2024-linux-docker-10 |
| `Lean CI (knot_lean)` | 103451709685 | success | **3 h 34 m 53 s** | myia-po-2024-lean-docker-2 |
| `Proof integrity (knot_lean)` | 103451688746 | cancelled | 3 h 17 m 53 s (wedge) | myia-po-2024-lean-docker-2 |

**Observation critique** : `Lean CI (knot_lean)` (job `ci:` du workflow) peut prendre **3 h 34 min en SUCCESS** sur le même runner self-hosted `myia-po-2024-lean-docker-2`. Le wedge ne touche que `Proof integrity (knot_lean)`.

## Correctif proposé + justification du seuil

**`timeout-minutes: 60`** sur le job `proof-integrity:` (homemade composite) — c'est le job exact qui a wedgé 3h17min. La borne 60 min convertit un wedge en `failure` rouge visible au merge-gate.

**`timeout-minutes: 60`** sur les reusables `lean-build.yml:ci:` et `lean-axiom.yml:axiom-check:` — couverture transitive des callers `uses: lean-*.yml@main`.

**`timeout-minutes: 60`** sur le job `ci:` homemade de `lean-knot.yml` — **Voir Risque §1** : ce job `Lean CI (knot_lean)` a déjà fait **3h34m SUCCESS** sur le même runner. La borne 60 min **pourrait tuer des SUCCESS valides** si knot_lean repasse > 60 min ; à arbitrer côté coordinateur (cf. AC §2).

**`timeout-minutes: 30`** sur les jobs de scan Python léger (`target-coverage`, `certified-no-sorry`) qui ne sont PAS des compilations Lean.

**`timeout-minutes: 60`** sur le job `build:` homemade de `lean-social-choice` (full Lake build game_theory_lean).

**Pourquoi 60 min et pas 6 h (default GitHub Actions) ?** Le défaut convertit un wedge **silencieux** (check qui ne conclut jamais, PR gate `BLOCKED` permanent) en un **échec rouge visible** (`mergeStateStatus: DIRTY` ou `BLOCKED` sur check FAILURE). Le merge-gate peut alors effectivement **voir** la régression — au lieu d'attendre indéfiniment un verdict qui n'arrivera jamais.

## Scope (Tell c.1057 strict énuméré)

| Fichier | Job | timeout ajouté | Justification |
|---|---|---|---|
| `.github/workflows/lean-build.yml` | `ci:` (reusable) | **60** | Couvre 10 callers `uses: lean-build.yml` (conway, grothendieck, hecke, mimo, percolation, planning, sensitivity, social-choice, asymmetric-information, galois — tous les reusables appellent via `@main` ou `uses: ./`) |
| `.github/workflows/lean-axiom.yml` | `axiom-check:` (reusable) | **60** | Couvre les callers `uses: lean-axiom.yml` (knot homemade + tous les autres reusables) |
| `.github/workflows/lean-knot.yml` | `ci:` (homemade composite) | **60** | job ci du composite `.github/actions/lean-build` — **Risque §1** : SUCCESS historique 3h34m |
| `.github/workflows/lean-knot.yml` | `proof-integrity:` (homemade composite) | **60** | **le job exact qui a wedgé 3h17min** (job_id 103451688746) |
| `.github/workflows/lean-knot.yml` | `target-coverage:` (Python scan) | **30** | scan Python léger, pas Lean build |
| `.github/workflows/lean-planning.yml` | `target-coverage:` (Python scan) | **30** | idem |
| `.github/workflows/lean-social-choice.yml` | `certified-no-sorry:` (Python grep) | **30** | idem |
| `.github/workflows/lean-social-choice.yml` | `build:` (homemade Lake build ubuntu) | **60** | full Lake build game_theory_lean homemade |

Total : **5 fichiers patchés, 39 lignes ajoutées, 0 ligne supprimée**.

## Tell c.L898 ★★★ collision guard pré-édition

Vérifié `gh pr list --state all --json files` AVANT édition : **0 PR ouverte** touchant `.github/workflows/lean-*.yml`. Claim vérifié via `python scripts/check_lane_claim.py 15698 --lane myia-po-2027:CoursIA-2` : `my_active_claim: false`, `blocking_lanes: []`, `stale_claims: []`. `[CLAIMED]` posté sur #15698 (`issuecomment-5643331985`).

## Tell c.D anti-régression (ajouts only)

- **0 ligne supprimée** dans les 5 fichiers
- **39 lignes ajoutées** (commentaire + `timeout-minutes: N` à chaque endroit)
- **0 modification de logique** des jobs (le `runs-on`, le `if:`, le `needs:`, les `steps:` sont intacts)

## Risques résiduels & non-bloquants

1. **`Lean CI (knot_lean)` SUCCESS historique 3h34m (job_id 103451709685, run 34608518584)** : la borne 60 min sur `ci:` (lean-knot.yml) **pourrait tuer des SUCCESS valides** si knot_lean repasse > 60 min. **Recommandation ai-01** : soit (a) relâcher à 240 min (4h) sur `ci:`, soit (b) borner uniquement `proof-integrity:` à 60 min et laisser `ci:` sans timeout, soit (c) accepter le risque de faux positifs sur knot_lean. **Voir AC §2.**
2. **60 min conservateur pour les autres jobs** : si une CI conway_lean complète prenait régulièrement 60+ min sur ubuntu-latest (à mesurer post-merge), le timeout la tuerait à tort. **Mesure firsthand issue #15698** : ~28 min SUCCESS sur `Proof integrity (conway_lean (audit))` (cf. review adjoint po-2025 5185227029) → 60 min = 2× marge pour conway_lean.
3. **PR en cours sur main** : aucun merge conflict attendu (les 5 fichiers sont stables depuis c.990).
4. **target-coverage 30 min** : scan Python sur conway_lean peut être plus lent que prévu. À surveiller c.1128+.

## Acceptance (#15698 critères implicites)

- [x] Workflows Lean (13 fichiers) bornés : les 2 reusables couvrent ~10 callers, les 3 fichiers homemade restants sont patchés.
- [ ] AC2 comportement positif : le YAML déclare la borne, mais aucun job volontairement enlisé n'a encore été observé tué au seuil avec un check conclu `failure`
- [x] 0 suppression de code, 0 modification de logique
- [x] `[CLAIMED]` posté + scope `paths: .github/workflows/lean-*.yml` énuméré
- [x] Worktree `D:\dev\CoursIA-LeanTimeout` sur branche `fix/15698-lean-workflow-timeout`
- [x] Nomenclature job/run corrigée first-hand (run 34608518584 / job 103451688746) — amend c.1131
- [x] Issue fille cause-racine wedge ouverte : **#15709** (tracker canonique recommandé, acceptance détaillée) ; **#15710** est un doublon à consolider par ai-01
- [ ] AC arbitrages `ci:` 60 min vs SUCCESS 3h34m historique : **soumis à ai-01** (cf. AC coordinateur §2).

## AC coordinateur (ai-01, Tell c.1502 strict)

1. **ai-01 review** + merge Tell c.1066 strict R1 MergePullRequest sous `myia-ai-01` (Tell c.1502 strict worker **0 merge d'autrui**)
2. **ai-01 arbitre** Risque §1 — trois options :
   - (a) relâcher `ci:` (lean-knot.yml) à 240 min (4h, > SUCCESS 3h34m historique) ;
   - (b) retirer le timeout sur `ci:` et ne borner que `proof-integrity:` (le seul job qui a wedgé) ;
   - (c) accepter le risque de faux positifs sur knot_lean `ci:` (> 60 min).
3. **ai-01 vérifie** qu'aucun des 13 workflows Lean ne dépend d'un timeout > 60 min dans son historique (à mesurer sur 5 runs consécutifs post-merge).
4. **ai-01 arbitre** la consolidation des trackers cause-racine #15709 (canonique recommandé) et #15710 (doublon).
5. **Pas de PR étudiante** touchée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-12T06:01:47Z -->

