### PR TITLE
fix(ci,#15693): publier le motif du verdict PR gate (output.summary + trois etats)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -65,7 +65,16 @@ on:
 
 permissions:
   contents: read
-  checks: read
+  # `write`, not `read`, for #15693: the verdict is PATCHed onto this job's
+  # OWN check-run `output` so the required check carries its motive. The step
+  # summary does not reach that surface (measured: it renders on the run page
+  # while `output.summary` stays null -- see `write_step_summary` in
+  # scripts/pr_gate.py), and POSTing a twin check-run bearing this required
+  # name is inert (GitHub ANDs same-named legs in different suites, #11519).
+  # The PATCH requires a GitHub App token; the job's own GITHUB_TOKEN is one.
+  # Fork PRs get a read-only token: there the PATCH degrades to a warning and
+  # the verdict is unaffected.
+  checks: write
   statuses: read
   # #13510: on starvation (deadline, nothing red, constituents still
   # pending) the script cancels ITS OWN run so the leg concludes CANCELLED

--- a/scripts/ci/merge_dwell.py
+++ b/scripts/ci/merge_dwell.py
@@ -74,7 +74,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 #: Plancher par defaut, en minutes. 120 = le mandat user du 2026-09-07.
 DEFAULT_DWELL_MIN = 120.0
@@ -139,12 +139,20 @@ def evaluate(
             "dwell ecoule: tete du {}, {:.0f} min "
             "(plancher {:.0f} min)".format(stamp, age_min, dwell_min)
         )
+    # #15693 : l'heure de LEVEE absolue, pas seulement les minutes restantes.
+    # « 101 min » oblige la lane a refaire le calcul et l'incite a agir ; un
+    # re-push reactionnaire remet le plancher a zero depuis la nouvelle tete
+    # (le defaut multiplie le temps d'attente au lieu de le mesurer).
+    lift = (committed_at + timedelta(minutes=dwell_min)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
     return False, remaining, (
-        "tete du {}, {:.0f} min -- plancher {:.0f} min, reste {:.0f} min. "
+        "tete du {}, {:.0f} min -- plancher {:.0f} min, reste {:.0f} min, "
+        "leve au premier balayage suivant {}. "
         "Le balayage horaire (pr-gate-stale-sweep.yml, cron '7 * * * *') "
         "re-agrege cette jambe des que le plancher est ecoule ; aucun geste "
         "manuel n'est requis. Urgence (main rouge) : poser le label `{}` sur "
-        "la PR.".format(stamp, age_min, dwell_min, remaining, WAIVER_LABEL)
+        "la PR.".format(stamp, age_min, dwell_min, remaining, lift, WAIVER_LABEL)
     )
 
 

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -55,20 +55,40 @@ now and later, with no per-workflow wiring to maintain.
 ## Publication (#15693)
 
 A verdict this script computes is worthless if only the job log carries it:
-the surface a lane reads on a red PR is the check-run's `output.summary`,
-which for the AUTO check-run of the `pull_request` leg is fed from
-`$GITHUB_STEP_SUMMARY`. Measured 2026-09-12 on 5/5 red PRs: `FAILURE` with
-a null summary while the cause (`pr_gate.py`'s own verdict string) lived
-only in the log. The verdict is therefore published to the step summary
-(`write_step_summary`), and the FAIL message separates three states with
-opposite repairs: real reds ("failing checks"), checks that never concluded
-(cancelled/timed_out/stale/startup_failure -- nothing was measured about
-the code, rerun), and the DWELL floor (head timestamp + earliest lift time,
-no action). Advisory non-green checks are listed as not blocking. The
-fail-closed RULES are untouched: an unconcluded check still fails the gate
-(rule 1/3), only the message stops misattributing the repair. The
-`workflow_run` sweep path keeps POSTing its own check-run with its output
-fields (`--post-check-run`), exactly as before.
+the surface a lane reads on a red PR is the required check's
+`output.summary`, which measured `null` while the cause (`pr_gate.py`'s own
+verdict string) lived only in the log -- 5/5 red PRs in the issue, plus a
+re-measurement of #15724, #15720, #15718.
+
+**The obvious mechanism does not work, and that is measured, not assumed.**
+Writing `$GITHUB_STEP_SUMMARY` renders a summary on the run page but does
+NOT populate the auto check-run's `output.summary`: on this file's own red
+gate (run 34681884304) the step summary renders while
+`gh api .../check-runs/<id> --jq .output.summary` returns `null`; the
+SUCCESSFUL sweep job (103506691766) writes the same organ and is null too;
+and a scan of 1098 `github-actions` check-runs over 40 main commits finds
+ZERO with a non-null summary. Every check-run that does carry one was
+created by the Checks API (POST) -- e.g. the shadow aggregator's
+`fast-lane (ombre): *`. POSTing a twin bearing THIS required name is not an
+option either: it lands in a foreign suite and GitHub ANDs the two, which is
+why the stale-sweep re-runs the original run instead of posting beside it
+(78 PRs blocked, #11519).
+
+So the verdict is published on two surfaces: the step summary
+(`write_step_summary`, the run page) and, for the check-run itself,
+:func:`publish_check_run_output`, which PATCHes our own check-run's
+`output` in place -- the only write that reaches the required leg, and one
+that needs a GitHub App token (a PAT is refused), hence the job's own.
+
+The FAIL message separates three states with opposite repairs: real reds
+("failing checks"), checks that never concluded (cancelled/timed_out/stale/
+startup_failure -- nothing was measured about the code, so rerun), and the
+DWELL floor (head timestamp + earliest lift time, no action). Advisory
+non-green checks are listed as not blocking. The fail-closed RULES are
+untouched: an unconcluded check still fails the gate (rule 1/3), only the
+message stops misattributing the repair. The `workflow_run` sweep path keeps
+POSTing its own check-run with its output fields (`--post-check-run`),
+exactly as before.
 
 ## Design rules that matter
 
@@ -729,6 +749,136 @@ def _gh_api_post(path: str, fields: dict[str, str]) -> dict:
         raise GateError(f"gh api -X POST {path} returned non-JSON: {exc}") from exc
 
 
+def _gh_api_patch(path: str, fields: dict[str, str]) -> dict:
+    """Call `gh api -X PATCH <path>` with one `-f key=value` per field.
+
+    Same contract as :func:`_gh_api_post`: raises `GateError` on any failure,
+    so the caller decides whether that is fatal (rule 1) or a degradation.
+    """
+    cmd = ["gh", "api", "-X", "PATCH", path]
+    for key, value in fields.items():
+        cmd += ["-f", f"{key}={value}"]
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment problem
+        raise GateError(f"gh CLI not available: {exc}") from exc
+
+    if completed.returncode != 0:
+        raise GateError(
+            f"gh api -X PATCH {path} failed (exit {completed.returncode}): "
+            f"{completed.stderr.strip()[:400]}"
+        )
+    body = completed.stdout.strip()
+    if not body:
+        return {}
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise GateError(f"gh api -X PATCH {path} returned non-JSON: {exc}") from exc
+
+
+def own_job_id(
+    repo: str,
+    run_id: str,
+    job_name: str,
+    run_attempt: "str | None" = None,
+    *,
+    fetch=None,
+) -> "int | None":
+    """The check-run id of OUR OWN job, or None when it cannot be resolved.
+
+    A job IS a check-run: `GET /actions/runs/<id>/jobs` reports `id`, and the
+    Checks API serves that same number (`/check-runs/<id>`) -- measured on
+    job 103506691766, whose `check_run_url` ends in its own job id.
+
+    `run_attempt` filters out the superseded attempts a re-run leaves in the
+    same listing; without it the first name match could be a previous
+    attempt's check-run, whose output nothing will ever read again.
+    """
+    api = fetch if fetch is not None else _gh_api
+    payload = api(f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+    if not isinstance(payload, dict):
+        raise GateError(f"unexpected jobs payload for run {run_id}")
+    for job in payload.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        if run_attempt is not None and str(job.get("run_attempt")) != str(run_attempt):
+            continue
+        if job.get("name") == job_name:
+            return job.get("id")
+    return None
+
+
+def publish_check_run_output(
+    repo: str,
+    run_id: str,
+    job_name: str,
+    code: int,
+    message: str,
+    advisory: Sequence[str] = (),
+    run_attempt: "str | None" = None,
+    *,
+    fetch=None,
+    patch=None,
+) -> bool:
+    """PATCH the verdict onto the AUTO check-run's `output` (acceptance 1).
+
+    Why PATCH and not POST. A second check-run bearing the required name
+    lands in a FOREIGN check suite and GitHub ANDs the two, so a posted
+    verdict never replaces a stale one -- the measurement that removed
+    POSTing from pr-gate-stale-sweep.yml (78 PRs blocked, #11519) and the
+    reason `pr-gate-rerun.yml` re-runs the original run instead of posting
+    beside it. PATCH edits the check-run IN PLACE, in its own suite, which is
+    what `gh run rerun` does for the conclusion -- and what the conclusion's
+    MOTIVE needs just as much.
+
+    The PATCH must be authenticated by a GitHub App: a PAT is refused with
+    "You must authenticate via a GitHub App" (measured 2026-09-12). The job's
+    own `GITHUB_TOKEN` is an installation token of the app that owns this
+    check-run, which is why the call is made from inside the job and with
+    that token.
+
+    Returns True when the output was written. Every other outcome -- no job
+    id resolvable, token refused, fork PR (read-only token), network -- is
+    False plus a warning to the log. Publication must never flip a verdict:
+    the exit code and the log line stay the source of truth.
+    """
+    try:
+        job_id = own_job_id(
+            repo, run_id, job_name, run_attempt, fetch=fetch
+        )
+    except GateError as exc:
+        print(f"[pr-gate] WARN -- check-run id unresolved: {exc}", flush=True)
+        return False
+    if not job_id:
+        print(
+            f"[pr-gate] WARN -- no job named {job_name!r} in run {run_id}; "
+            "check-run output not published",
+            flush=True,
+        )
+        return False
+
+    title = message.splitlines()[0] if message else job_name
+    writer = patch if patch is not None else _gh_api_patch
+    try:
+        writer(
+            f"repos/{repo}/check-runs/{job_id}",
+            {
+                "output[title]": f"{job_name}: {title}"[:255],
+                "output[summary]": verdict_body(message, advisory),
+            },
+        )
+    except GateError as exc:
+        print(f"[pr-gate] WARN -- check-run output not published: {exc}", flush=True)
+        return False
+    return True
+
+
 # Seconds to hold the step open after a successful self-cancel POST, so the
 # cancellation signal reaches the runner BEFORE this process exits. Exiting
 # first would complete the run as FAILURE and make the cancel a no-op -- the
@@ -1004,21 +1154,58 @@ def _workflow_command_escape(text: str) -> str:
     return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
 
+def verdict_body(message: str, advisory: Sequence[str] = ()) -> str:
+    """The published text of a verdict -- ONE builder, two surfaces (#15693).
+
+    Both the step summary and the check-run `output.summary` are rendered
+    from this string, so the two can never drift: acceptance 1 asks the
+    summary to name the cause "the same as the log", and the only way to
+    keep that true over time is to have a single source.
+
+    The DWELL floor gets its do-not-repush guidance (a reaction push resets
+    the 120-min floor from the new head); advisory checks are listed as
+    non-blocking (#15548: a cancelled advisory read as the blocker while the
+    real one was already repaired 18 min earlier).
+    """
+    lines = [message]
+    if message.startswith("DWELL"):
+        lines += [
+            "",
+            "Plancher mecanique -- rien a reparer dans la PR. Ne pas "
+            "re-pusher (un re-push remet le plancher a zero depuis la "
+            "nouvelle tete) ; le balayage horaire leve seul.",
+        ]
+    if advisory:
+        lines += ["", "Advisory (not blocking):"]
+        lines += [f"- {entry}" for entry in advisory]
+    return "\n".join(lines)
+
+
 def write_step_summary(
     code: int, message: str, advisory: Sequence[str] = ()
 ) -> None:
-    """Publish the verdict to the job's step summary (#15693).
+    """Publish the verdict to the job's STEP SUMMARY (#15693).
 
-    GitHub feeds the AUTO check-run's `output.summary` -- the surface a lane
-    reads on a red PR -- from `$GITHUB_STEP_SUMMARY` (the same organ
-    pr-gate-stale-sweep.yml already writes). Before #15693 the required
-    check reported `FAILURE` with a null summary on 5/5 measured PRs while
-    the cause lived only in the job log, so every red gate was an
-    investigation. The message is the exact verdict string (log == summary,
-    acceptance 1), the DWELL floor gets its do-not-repush guidance (a
-    reaction push resets the 120-min floor from the new head), and advisory
-    checks are listed as non-blocking (#15548: a cancelled advisory read as
-    the blocker while the real one was already repaired).
+    This is the surface GitHub renders at the top of the run page -- the page
+    a human opens from the red check. It is NOT the check-run's
+    `output.summary`, and the difference is measured, not assumed:
+
+        run 34681884304 (this file's own red gate, 2026-09-12): the step
+        summary IS rendered on the run page -- `curl .../actions/runs/
+        34681884304 | grep 'failing checks'` returns the verdict -- while
+        `gh api .../check-runs/103521890556 --jq .output.summary` returns
+        null. Same for the SUCCESSFUL sweep job 103506691766 (its log writes
+        `$GITHUB_STEP_SUMMARY`; its check-run summary is null), and a scan of
+        1098 `github-actions` check-runs over 40 main commits finds ZERO with
+        a non-null summary. Every check-run that does carry one is created by
+        the Checks API (POST), e.g. the shadow aggregator's
+        `fast-lane (ombre): *`.
+
+    So the issue's premise -- "$GITHUB_STEP_SUMMARY feeds the auto
+    check-run's output.summary" -- is false on this repository, and this
+    function alone would not satisfy acceptance 1. It is kept because the
+    run-page rendering is real and useful; the check-run surface is served
+    separately by :func:`publish_check_run_output`.
 
     No-op when `GITHUB_STEP_SUMMARY` is unset (local runs). A write failure
     degrades to a warning: publication must never flip a verdict -- the
@@ -1031,19 +1218,9 @@ def write_step_summary(
         f"## PR gate: {'PASS' if code == 0 else 'FAIL'}",
         "",
         "```",
-        message,
+        verdict_body(message, advisory),
         "```",
     ]
-    if message.startswith("DWELL"):
-        lines += [
-            "",
-            "Plancher mecanique -- rien a reparer dans la PR. Ne pas "
-            "re-pusher (un re-push remet le plancher a zero depuis la "
-            "nouvelle tete) ; le balayage horaire leve seul.",
-        ]
-    if advisory:
-        lines += ["", "Advisory (not blocking):"]
-        lines += [f"- {entry}" for entry in advisory]
     try:
         with open(path, "a", encoding="utf-8") as handle:
             handle.write("\n".join(lines) + "\n")
@@ -1111,8 +1288,18 @@ def main(argv: Iterable[str] | None = None) -> int:
         "--run-id",
         default=None,
         help=(
-            "Workflow run id used to self-cancel on starvation (#13510); "
-            "defaults to $GITHUB_RUN_ID when the script runs inside Actions."
+            "Workflow run id used to self-cancel on starvation (#13510) and "
+            "to locate our own check-run for publication (#15693); defaults "
+            "to $GITHUB_RUN_ID when the script runs inside Actions."
+        ),
+    )
+    parser.add_argument(
+        "--no-check-run-output",
+        action="store_true",
+        help=(
+            "Ne pas publier le verdict dans l'`output` de notre propre "
+            "check-run (#15693). Le resume du run (step summary) reste "
+            "ecrit. Utile si un leg doit rester muet sur cette surface."
         ),
     )
     parser.add_argument(
@@ -1258,7 +1445,25 @@ def main(argv: Iterable[str] | None = None) -> int:
     # emission tail, and a STARVED leg still owes the lane its named
     # constituents. The fork short-circuit publishes at its own early
     # return; local runs (no GITHUB_STEP_SUMMARY) no-op inside.
-    write_step_summary(code, message, detail.get("advisory", ()))
+    advisory = detail.get("advisory", ())
+    write_step_summary(code, message, advisory)
+    # The check-run surface, which the step summary does NOT reach (measured;
+    # see `write_step_summary`). This is the one acceptance 1 names: the
+    # required check itself must carry its motive. Skipped on the operator
+    # harness (`--post-check-run`), whose contract is to POST its verdict on
+    # the PR head -- its own auto check-run sits on the default branch and is
+    # not the PR's gate leg.
+    run_id = args.run_id or os.environ.get("GITHUB_RUN_ID")
+    if run_id and not args.no_check_run_output and not args.post_check_run:
+        publish_check_run_output(
+            args.repo,
+            run_id,
+            args.self_name,
+            code,
+            message,
+            advisory,
+            os.environ.get("GITHUB_RUN_ATTEMPT"),
+        )
 
     # #13510: render a starvation as CANCELLED, not FAILURE. The PR stays
     # BLOCKED (a cancelled required check is not success), but the leg no

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -52,6 +52,24 @@ Waits for every other check on the head SHA to settle, then fails if any of
 them failed. One name to require; it covers whatever CI happens to exist,
 now and later, with no per-workflow wiring to maintain.
 
+## Publication (#15693)
+
+A verdict this script computes is worthless if only the job log carries it:
+the surface a lane reads on a red PR is the check-run's `output.summary`,
+which for the AUTO check-run of the `pull_request` leg is fed from
+`$GITHUB_STEP_SUMMARY`. Measured 2026-09-12 on 5/5 red PRs: `FAILURE` with
+a null summary while the cause (`pr_gate.py`'s own verdict string) lived
+only in the log. The verdict is therefore published to the step summary
+(`write_step_summary`), and the FAIL message separates three states with
+opposite repairs: real reds ("failing checks"), checks that never concluded
+(cancelled/timed_out/stale/startup_failure -- nothing was measured about
+the code, rerun), and the DWELL floor (head timestamp + earliest lift time,
+no action). Advisory non-green checks are listed as not blocking. The
+fail-closed RULES are untouched: an unconcluded check still fails the gate
+(rule 1/3), only the message stops misattributing the repair. The
+`workflow_run` sweep path keeps POSTing its own check-run with its output
+fields (`--post-check-run`), exactly as before.
+
 ## Design rules that matter
 
 1. **Bias to fail.** Timeout, API error, or a check with no verdict => exit 1.
@@ -119,6 +137,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -138,6 +157,19 @@ CONCLUSION_OK = frozenset({"success", "neutral", "skipped"})
 # de-duplication it can no longer mean "superseded", only "no verdict".
 CONCLUSION_BAD = frozenset(
     {"failure", "timed_out", "cancelled", "action_required", "stale", "startup_failure"}
+)
+
+# Four of the six CONCLUSION_BAD members mean the check MEASURED NOTHING about
+# the code (cancelled by runner famine, timed out, stale, never started). The
+# other two (failure, action_required) are real reds. #15693: the published
+# verdict separates the two -- "failing checks: X" on a cancelled X asserts
+# something false about the code and invites fixing what is not broken
+# (measured on #15548: the lane investigated an infra famine while its real
+# blocker, already repaired 18 min earlier, went unread). The fail-closed RULE
+# is untouched: an unconcluded check still fails the gate (rule 1/3); only the
+# MESSAGE stops lying about which gesture repairs it (rerun, not a code fix).
+CONCLUSION_UNCONCLUDED = frozenset(
+    {"cancelled", "timed_out", "stale", "startup_failure"}
 )
 
 DEFAULT_SELF_NAME = "PR gate"
@@ -452,6 +484,10 @@ def classify(
     kept separate rather than merged into `ok` so a caller can print "advisory
     X failed" instead of silently rewriting a failure into a pass.
 
+    `bad` entries carry their conclusion as a suffix ("name (conclusion)",
+    #15693) so `verdict` can separate real reds from checks that never
+    concluded without re-reading the check set.
+
     `advisory_jobs` is the roster of job names whose parent workflow carries
     the advisory marker but the job itself does not (e.g.
     ``machine-dep-timing`` -> ``machine-dep-timing-advisory``); the gate would
@@ -523,7 +559,11 @@ def classify(
         elif conclusion in CONCLUSION_OK:
             ok.append(name)
         elif conclusion in CONCLUSION_BAD:
-            bad.append(name)
+            # #15693: carry the conclusion so `verdict` can separate real
+            # reds from checks that never concluded (same annotation style
+            # as the advisory list below -- the bare name loses exactly the
+            # information the published message needs).
+            bad.append(f"{name} ({conclusion})")
         else:
             # Unknown conclusion: bias to fail (rule 1). A conclusion GitHub
             # adds later must not silently become a pass.
@@ -541,6 +581,33 @@ def _report_advisory(advisory: Sequence[str]) -> None:
     """
     for entry in advisory:
         print(f"[pr-gate] advisory (not blocking): {entry}", flush=True)
+
+
+# Suffix added by `classify` to every CONCLUSION_BAD entry ("name
+# (conclusion)"). Used by `_split_bad` to route each entry to its clause
+# without re-reading the check set; anchored at end-of-string because the
+# annotation is always the LAST parenthesised group of the entry.
+_UNCONCLUDED_SUFFIX_RE = re.compile(
+    r" \((?:cancelled|timed_out|stale|startup_failure)\)$"
+)
+
+
+def _split_bad(bad: Sequence[str]) -> tuple[list[str], list[str]]:
+    """Split annotated `bad` entries into (real reds, never-concluded).
+
+    Real reds are `failure`/`action_required` (and unknown conclusions, which
+    rule 1 refuses) -- the lane has code work. Never-concluded are the four
+    CONCLUSION_UNCONCLUDED members -- nothing was measured about the code and
+    the repair is a rerun (#15693 three-state refinement).
+    """
+    failed: list[str] = []
+    unconcluded: list[str] = []
+    for entry in bad:
+        if _UNCONCLUDED_SUFFIX_RE.search(entry):
+            unconcluded.append(entry)
+        else:
+            failed.append(entry)
+    return failed, unconcluded
 
 
 def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[int, str]:
@@ -570,7 +637,22 @@ def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[
     not look like a benign display issue.
     """
     if bad:
-        return 1, "FAIL -- failing checks: " + ", ".join(bad)
+        # #15693: one FAIL prefix, two clauses with OPPOSITE repairs. A real
+        # red names the check under "failing checks" (the historical phrase --
+        # greppable, and what the log annotation has carried since #15472).
+        # A check that never concluded is named separately with its repair
+        # gesture: "failing checks: X" on a cancelled X told #15548's lane
+        # its code was broken when the runner famine had eaten the verdict.
+        failed, unconcluded = _split_bad(bad)
+        parts = []
+        if failed:
+            parts.append("failing checks: " + ", ".join(failed))
+        if unconcluded:
+            parts.append(
+                "checks that never concluded (rerun the run -- this is not "
+                "a code failure): " + ", ".join(unconcluded)
+            )
+        return 1, "FAIL -- " + "; ".join(parts)
     if not settled:
         if pending:
             return 1, (
@@ -786,6 +868,7 @@ def wait_and_decide(
     sleep=time.sleep,
     fetch=fetch_checks,
     now=time.monotonic,
+    detail: "dict | None" = None,
 ) -> tuple[int, str]:
     """Poll until the check set is stable, then decide.
 
@@ -802,6 +885,12 @@ def wait_and_decide(
     whose own name does not carry the marker. Empty frozenset (default) disables
     the workflow-name side of `is_advisory` -- the historical behaviour, kept
     for tests that do not care.
+
+    `detail`, when a dict is given, is filled with the advisory list of the
+    LAST classification before the verdict (`detail["advisory"]`) so `main`
+    can publish it in the step summary (#15693) without changing this
+    function's 2-tuple return. The last classify is authoritative: the
+    deadline path re-classifies into `final_*` and overwrites the entry.
     """
     deadline = now() + timeout_min * 60.0
     quiet_streak = 0
@@ -812,6 +901,8 @@ def wait_and_decide(
     while True:
         checks = fetch(repo, sha)
         pending, bad, ok, advisory = classify(checks, self_name, adv_jobs)
+        if detail is not None:
+            detail["advisory"] = list(advisory)
 
         if bad:
             # Fail fast: a failure cannot be undone by waiting longer.
@@ -849,6 +940,8 @@ def wait_and_decide(
             final_pending, final_bad, final_ok, final_advisory = classify(
                 final_checks, self_name, adv_jobs
             )
+            if detail is not None:
+                detail["advisory"] = list(final_advisory)
             if not final_pending and not final_bad:
                 # Everything settled in the gap: treat as a clean settle.
                 # Still consult the delivery canary (rule 8) so an empty
@@ -909,6 +1002,53 @@ def _workflow_command_escape(text: str) -> str:
     first would re-escape the `%` those substitutions introduce (%250D).
     """
     return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def write_step_summary(
+    code: int, message: str, advisory: Sequence[str] = ()
+) -> None:
+    """Publish the verdict to the job's step summary (#15693).
+
+    GitHub feeds the AUTO check-run's `output.summary` -- the surface a lane
+    reads on a red PR -- from `$GITHUB_STEP_SUMMARY` (the same organ
+    pr-gate-stale-sweep.yml already writes). Before #15693 the required
+    check reported `FAILURE` with a null summary on 5/5 measured PRs while
+    the cause lived only in the job log, so every red gate was an
+    investigation. The message is the exact verdict string (log == summary,
+    acceptance 1), the DWELL floor gets its do-not-repush guidance (a
+    reaction push resets the 120-min floor from the new head), and advisory
+    checks are listed as non-blocking (#15548: a cancelled advisory read as
+    the blocker while the real one was already repaired).
+
+    No-op when `GITHUB_STEP_SUMMARY` is unset (local runs). A write failure
+    degrades to a warning: publication must never flip a verdict -- the
+    exit code and the log line remain the source of truth.
+    """
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = [
+        f"## PR gate: {'PASS' if code == 0 else 'FAIL'}",
+        "",
+        "```",
+        message,
+        "```",
+    ]
+    if message.startswith("DWELL"):
+        lines += [
+            "",
+            "Plancher mecanique -- rien a reparer dans la PR. Ne pas "
+            "re-pusher (un re-push remet le plancher a zero depuis la "
+            "nouvelle tete) ; le balayage horaire leve seul.",
+        ]
+    if advisory:
+        lines += ["", "Advisory (not blocking):"]
+        lines += [f"- {entry}" for entry in advisory]
+    try:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    except OSError as exc:
+        print(f"[pr-gate] WARN -- step summary not written: {exc}", flush=True)
 
 
 def _optional_int(raw: str) -> "int | None":
@@ -1018,6 +1158,9 @@ def main(argv: Iterable[str] | None = None) -> int:
             "reporting PASS without polling.",
             flush=True,
         )
+        # #15693: even the fork short-circuit publishes -- a student PR's
+        # check-run should not be the only one whose summary stays null.
+        write_step_summary(0, "PASS -- fork PR short-circuit (issue #10072)")
         # The workflow_run re-aggregation path runs on the default branch, so it
         # cannot read the fork flag from the pull_request payload. It still POSTs
         # here: a fork PR must surface `success` on its head SHA to match the
@@ -1046,6 +1189,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     # blocked 44h/9h before the fix landed.
     advisory_jobs = derive_advisory_jobs(args.workflows_dir)
 
+    detail: dict = {}
     try:
         code, message = wait_and_decide(
             args.repo,
@@ -1056,6 +1200,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             args.settle_polls,
             always_on_jobs,
             advisory_jobs,
+            detail=detail,
         )
     except GateError as exc:
         # Rule 1: an unreadable state is a failure, never a pass. Fall
@@ -1064,41 +1209,6 @@ def main(argv: Iterable[str] | None = None) -> int:
         # most opaque failure mode (API unreadable at all) mute in the UI
         # (#15472). Verdict semantics unchanged: code 1, same message.
         code, message = 1, f"FAIL -- cannot establish check state: {exc}"
-
-    # #13510: render a starvation as CANCELLED, not FAILURE. The PR stays
-    # BLOCKED (a cancelled required check is not success), but the leg no
-    # longer claims a failure that never happened, and pr-gate-stale-sweep
-    # already treats a cancelled gate leg as a re-run candidate (#11862) --
-    # the same recovery channel as a supersession-cancel. Workflow-run mode
-    # only: --post-check-run runs on the default branch as an operator
-    # harness whose own run is NOT the PR's gate leg, so it keeps POSTing
-    # the verdict instead of cancelling itself.
-    if (
-        code == 1
-        and message.startswith("STARVED")
-        and not args.no_self_cancel
-        and not args.post_check_run
-    ):
-        run_id = args.run_id or os.environ.get("GITHUB_RUN_ID")
-        if run_id:
-            print(
-                f"[pr-gate] STARVED -- constituents still pending, nothing "
-                f"red; cancelling own run {run_id} so the leg concludes "
-                "CANCELLED, not FAILURE (#13510). The PR stays blocked; "
-                "pr-gate-stale-sweep will re-aggregate.",
-                flush=True,
-            )
-            if cancel_own_run(args.repo, run_id):
-                # Hold the step open so the cancel signal lands before we
-                # exit (see CANCEL_GRACE_SEC). Exit code stays 1: if the
-                # cancel lost the race, rule 1 still holds.
-                time.sleep(CANCEL_GRACE_SEC)
-        else:
-            print(
-                "[pr-gate] STARVED but no run id resolvable (local run) -- "
-                "FAIL per rule 1",
-                flush=True,
-            )
 
     # --- plancher de merge (mandat user 2026-09-07) ---------------------
     #
@@ -1137,6 +1247,53 @@ def main(argv: Iterable[str] | None = None) -> int:
                     print("[pr-gate] {}".format(dwell_msg), flush=True)
                 else:
                     code, message = 1, "DWELL -- {}".format(dwell_msg)
+
+    # --- #15693: publish the verdict BEFORE the #13510 self-cancel --------
+    #
+    # The dwell block above has already applied the final message rewrite
+    # (dwell only fires on code==0; the self-cancel below only on code==1 +
+    # STARVED -- the two rewrites are mutually exclusive, so the summary
+    # written here is final). Writing BEFORE the self-cancel matters: a
+    # cancelled job can be torn down before this process reaches its
+    # emission tail, and a STARVED leg still owes the lane its named
+    # constituents. The fork short-circuit publishes at its own early
+    # return; local runs (no GITHUB_STEP_SUMMARY) no-op inside.
+    write_step_summary(code, message, detail.get("advisory", ()))
+
+    # #13510: render a starvation as CANCELLED, not FAILURE. The PR stays
+    # BLOCKED (a cancelled required check is not success), but the leg no
+    # longer claims a failure that never happened, and pr-gate-stale-sweep
+    # already treats a cancelled gate leg as a re-run candidate (#11862) --
+    # the same recovery channel as a supersession-cancel. Workflow-run mode
+    # only: --post-check-run runs on the default branch as an operator
+    # harness whose own run is NOT the PR's gate leg, so it keeps POSTing
+    # the verdict instead of cancelling itself.
+    if (
+        code == 1
+        and message.startswith("STARVED")
+        and not args.no_self_cancel
+        and not args.post_check_run
+    ):
+        run_id = args.run_id or os.environ.get("GITHUB_RUN_ID")
+        if run_id:
+            print(
+                f"[pr-gate] STARVED -- constituents still pending, nothing "
+                f"red; cancelling own run {run_id} so the leg concludes "
+                "CANCELLED, not FAILURE (#13510). The PR stays blocked; "
+                "pr-gate-stale-sweep will re-aggregate.",
+                flush=True,
+            )
+            if cancel_own_run(args.repo, run_id):
+                # Hold the step open so the cancel signal lands before we
+                # exit (see CANCEL_GRACE_SEC). Exit code stays 1: if the
+                # cancel lost the race, rule 1 still holds.
+                time.sleep(CANCEL_GRACE_SEC)
+        else:
+            print(
+                "[pr-gate] STARVED but no run id resolvable (local run) -- "
+                "FAIL per rule 1",
+                flush=True,
+            )
 
     print(f"[pr-gate] {message}", flush=True)
     _maybe_post_check_run(args, code, message)

--- a/scripts/tests/test_merge_dwell.py
+++ b/scripts/tests/test_merge_dwell.py
@@ -60,6 +60,19 @@ def test_message_de_refus_nomme_le_geste_de_levee():
     assert merge_dwell.WAIVER_LABEL in msg
 
 
+def test_message_de_refus_porte_lheure_de_levee_absolue():
+    """#15693 : l'heure de tete ET l'heure de LEVEE. « 101 min » oblige la
+    lane a refaire le calcul et l'incite a agir ; un re-push reactionnaire
+    remet le plancher a zero depuis la nouvelle tete. Tete 11:55 + plancher
+    120 min -> leve au premier balayage suivant 13:55."""
+    ok, _, msg = merge_dwell.evaluate(
+        NOW.replace(hour=11, minute=55), NOW, 120.0
+    )
+    assert ok is False
+    assert "tete du 2026-09-07T11:55:00Z" in msg
+    assert "2026-09-07T13:55:00Z" in msg, "l'heure de levee, pas seulement les minutes"
+
+
 # --- 2. le futur n'est pas « tres vieux » -----------------------------------
 
 def test_tete_dans_le_futur_refusee():

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -29,13 +29,19 @@ import pr_gate  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def _no_step_summary_env(monkeypatch):
-    """Keep unit-test runs of main() from writing into the real step summary
-    of the pytest job itself (Actions sets GITHUB_STEP_SUMMARY for every
-    step, so without this the #15693 publication would append "PR gate:
-    FAIL" sections to the test workflow's own summary page). Tests that
-    exercise the summary set the variable explicitly."""
+def _no_publication_env(monkeypatch):
+    """Keep unit-test runs of main() from publishing into the pytest job's own
+    surfaces.
+
+    Actions sets GITHUB_STEP_SUMMARY and GITHUB_RUN_ID for EVERY step, so
+    without this the #15693 publication would append "PR gate: FAIL" sections
+    to the test workflow's own summary page -- and, worse, the check-run
+    PATCH would call the real Jobs API on the pytest job's own run. Tests
+    that exercise either surface set the variables explicitly.
+    """
     monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ATTEMPT", raising=False)
 
 
 # --- helpers -----------------------------------------------------------------
@@ -1464,11 +1470,19 @@ def test_dwell_disabled_by_default(monkeypatch):
 # Measured 2026-09-12 on 5/5 red PRs: the required check reported FAILURE
 # with `output.summary: null` while the cause lived only in the job log --
 # every red gate became an investigation (#15548 burned cycles on an infra
-# famine while the real blocker was already repaired 18 min earlier). The
-# fix publishes the exact verdict string to $GITHUB_STEP_SUMMARY (which
-# GitHub feeds into the AUTO check-run's output.summary) and splits the
-# FAIL message into states with OPPOSITE repairs: real reds vs checks that
-# never concluded. The fail-closed rules stay untouched.
+# famine while the real blocker was already repaired 18 min earlier).
+#
+# The issue's stated remedy -- "$GITHUB_STEP_SUMMARY feeds the AUTO
+# check-run's output.summary" -- is FALSE, and the tests below pin what was
+# measured instead: the step summary renders on the run page but the
+# check-run summary stays null (1098 `github-actions` check-runs over 40
+# main commits, all null; this file's own red gate renders the summary while
+# its `output.summary` returns null). The check-run surface is therefore
+# PATCHed in place -- the only write that reaches a required leg, since a
+# POSTed twin lands in a foreign suite and GitHub ANDs the two (#11519).
+#
+# The FAIL message splits into states with OPPOSITE repairs: real reds vs
+# checks that never concluded. The fail-closed rules stay untouched.
 
 
 def test_bad_entries_carry_their_conclusion():
@@ -1662,3 +1676,209 @@ def test_step_summary_and_posted_check_run_coexist(tmp_path, monkeypatch):
     assert "FAIL -- failing checks: Lean CI (failure)" in summary.read_text(
         encoding="utf-8"
     )
+
+
+# --- #15693 -- the check-run surface: PATCH our own check-run ----------------
+#
+# Why these tests exist at all: the step summary above does NOT reach the
+# check-run, so without the PATCH the required leg still reports "Process
+# completed with exit code 1" with a null summary. The PATCH is the only
+# write that reaches it, and it is a fragile call (App-only auth, a job-id
+# lookup, a fork token that cannot write) -- so each failure mode is pinned
+# as a degradation that leaves the verdict alone.
+
+
+def _jobs_two_attempts(name=None):
+    name = name or pr_gate.DEFAULT_SELF_NAME
+    return {"jobs": [
+        {"id": 1111, "name": name, "run_attempt": "1"},
+        {"id": 4242, "name": name, "run_attempt": "2"},
+    ]}
+
+
+def test_own_job_id_picks_the_current_attempt():
+    """A re-run leaves the superseded attempt in the same listing. Matching
+    it would publish the verdict into a check-run nothing reads again."""
+    got = pr_gate.own_job_id("o/r", "99", pr_gate.DEFAULT_SELF_NAME, "2",
+                             fetch=lambda _p: _jobs_two_attempts())
+    assert got == 4242
+
+
+def test_own_job_id_is_none_when_the_name_is_absent():
+    assert pr_gate.own_job_id(
+        "o/r", "99", pr_gate.DEFAULT_SELF_NAME, "2",
+        fetch=lambda _p: _jobs_two_attempts(name="un autre job"),
+    ) is None
+
+
+def test_check_run_output_is_patched_with_the_verdict(monkeypatch):
+    """Acceptance 1 on the surface it names: the REQUIRED check carries the
+    motive, as the exact verdict string (log == summary). PATCH, not POST --
+    a POSTed twin bearing this required name lands in a foreign suite and is
+    ANDed with the original by GitHub (#11519)."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "424242")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+    seen = {}
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda path, fields: seen.update({"path": path, "fields": fields}) or {},
+    )
+    ok = pr_gate.publish_check_run_output(
+        "o/r", "424242", pr_gate.DEFAULT_SELF_NAME, 1,
+        "FAIL -- failing checks: Lean CI (failure)",
+        ["ICT tests/ (55) (cancelled)"],
+        "2",
+    )
+    assert ok is True
+    assert seen["path"] == "repos/o/r/check-runs/4242", "in place, own suite"
+    assert seen["fields"]["output[summary]"] == (
+        "FAIL -- failing checks: Lean CI (failure)\n"
+        "\n"
+        "Advisory (not blocking):\n"
+        "- ICT tests/ (55) (cancelled)"
+    )
+    assert seen["fields"]["output[title]"].startswith(
+        "PR gate: FAIL -- failing checks"
+    )
+
+
+def test_check_run_output_is_reached_from_the_emission_tail(monkeypatch):
+    """The wiring: main() publishes on the check-run surface when Actions
+    gives it a run id -- not only when a test calls the helper."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "424242")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+    seen = {}
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda path, fields: seen.update({"path": path}) or {},
+    )
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"])
+    assert code == 1
+    assert seen["path"] == "repos/o/r/check-runs/4242"
+
+
+def test_check_run_output_is_a_noop_without_a_run_id(monkeypatch):
+    """Local runs (no GITHUB_RUN_ID) must not touch the network -- the same
+    no-op contract the step summary has without GITHUB_STEP_SUMMARY."""
+    def boom(_path):
+        raise AssertionError("aucun appel reseau attendu hors Actions")
+
+    monkeypatch.setattr(pr_gate, "_gh_api", boom)
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("pas de PATCH")),
+    )
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    assert pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+
+
+def test_check_run_output_patch_failure_never_flips_the_verdict(capsys, monkeypatch):
+    """A refused PATCH (fork token is read-only, API hiccup, App auth) is a
+    degraded rendering: the verdict stays FAIL and the run keeps its exit
+    code. Publication must never be load-bearing on the verdict."""
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+
+    def refuse(_path, _fields):
+        raise pr_gate.GateError("You must authenticate via a GitHub App.")
+
+    monkeypatch.setattr(pr_gate, "_gh_api_patch", refuse)
+    ok = pr_gate.publish_check_run_output(
+        "o/r", "424242", pr_gate.DEFAULT_SELF_NAME, 0, "PASS", (), "2"
+    )
+    assert ok is False
+    assert "WARN -- check-run output not published" in capsys.readouterr().out
+
+
+def test_check_run_output_unresolved_job_id_is_a_warning(capsys, monkeypatch):
+    """A run whose job list is unreadable (or names a different job) must
+    not raise: the caller has already computed the verdict."""
+    monkeypatch.setattr(
+        pr_gate, "_gh_api", lambda _p: _jobs_two_attempts(name="un autre job")
+    )
+    ok = pr_gate.publish_check_run_output(
+        "o/r", "424242", pr_gate.DEFAULT_SELF_NAME, 1, "FAIL", (), "2"
+    )
+    assert ok is False
+    assert "no job named" in capsys.readouterr().out
+
+
+def test_no_check_run_output_flag_disables_the_patch(monkeypatch):
+    """Escape hatch: a leg can keep the run-page summary and stay silent on
+    the check-run surface."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "424242")
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("pas de PATCH")),
+    )
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--no-check-run-output"]
+    )
+    assert code == 1
+
+
+def test_post_check_run_mode_keeps_its_own_contract(monkeypatch):
+    """The operator harness (`--post-check-run`) POSTs onto the PR head; its
+    own auto check-run sits on the default branch and is not the PR's gate
+    leg, so it must not be PATCHed."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "424242")
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("pas de PATCH")),
+    )
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    monkeypatch.setattr(pr_gate, "_gh_api_post", lambda *_a, **_k: {})
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"]
+    )
+    assert code == 1
+
+
+def test_the_two_surfaces_render_the_same_text(tmp_path, monkeypatch):
+    """One builder, two surfaces: acceptance 1 asks the summary to name the
+    cause "the same as the log", and the only durable way to keep that true
+    is a shared body -- so a DWELL verdict's guidance lands on both."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setenv("GITHUB_RUN_ID", "424242")
+    monkeypatch.setattr(pr_gate, "_gh_api", lambda _p: _jobs_two_attempts())
+    seen = {}
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_patch",
+        lambda path, fields: seen.update(fields) or {},
+    )
+    dwell_msg = (
+        "tete du 2026-09-07T11:55:00Z, 5 min -- plancher 120 min, reste "
+        "115 min, leve au premier balayage suivant 2026-09-07T13:55:00Z."
+    )
+    monkeypatch.setattr(
+        pr_gate, "_merge_dwell", _FakeDwell(verdict=(False, dwell_msg)),
+        raising=False,
+    )
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_k: (0, "PASS"))
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
+    )
+    assert code == 1
+    body = pr_gate.verdict_body("DWELL -- " + dwell_msg)
+    assert seen["output[summary]"] == body, "check-run: le corps partage"
+    assert "2026-09-07T13:55:00Z" in seen["output[summary]"]
+    assert "Ne pas re-pusher" in seen["output[summary]"]
+    assert body in summary.read_text(encoding="utf-8"), "step summary: le meme corps"

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -21,9 +21,21 @@ import itertools
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pr_gate  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_step_summary_env(monkeypatch):
+    """Keep unit-test runs of main() from writing into the real step summary
+    of the pytest job itself (Actions sets GITHUB_STEP_SUMMARY for every
+    step, so without this the #15693 publication would append "PR gate:
+    FAIL" sections to the test workflow's own summary page). Tests that
+    exercise the summary set the variable explicitly."""
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
 
 
 # --- helpers -----------------------------------------------------------------
@@ -174,10 +186,12 @@ def test_frozen_check_with_terminal_conclusion_settles_14976():
 
 def test_frozen_check_with_failure_conclusion_is_bad_14976():
     """The frozen shape with a red conclusion must fail fast, not STARVE: a
-    wedged record carrying `failure` is a real red the operator must see."""
+    wedged record carrying `failure` is a real red the operator must see.
+    #15693: the bad entry carries its conclusion so the verdict can tell a
+    real red from a check that never concluded."""
     checks = [run("Detect notebook changes", "failure", status="in_progress")]
     pending, bad, _ok, _adv = pr_gate.classify(checks, "PR gate")
-    assert bad == ["Detect notebook changes"] and pending == []
+    assert bad == ["Detect notebook changes (failure)"] and pending == []
 
 
 def test_pending_labels_carry_the_observed_couple_14976():
@@ -258,7 +272,7 @@ def test_self_exclusion_is_not_a_loose_prefix():
     """"PR gateway" is a different check and must still be judged."""
     checks = [run("PR gateway", "failure")]
     _pending, bad, _ok, _adv = pr_gate.classify(checks, "PR gate")
-    assert bad == ["PR gateway"]
+    assert bad == ["PR gateway (failure)"]
 
 
 # --- decision table ----------------------------------------------------------
@@ -893,7 +907,7 @@ def test_non_advisory_failure_still_blocks():
         run("Exercises >= 3 advisory (label, non-blocking)", "failure"),
     ]
     _pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate")
-    assert bad == ["Lean CI (grothendieck_lean)"]
+    assert bad == ["Lean CI (grothendieck_lean) (failure)"]
     assert len(advisory) == 1
     assert pr_gate.verdict([], bad, settled=True)[0] == 1
 
@@ -1443,3 +1457,208 @@ def test_dwell_disabled_by_default(monkeypatch):
     code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--pr", "7"])
     assert code == 0
     assert fake.calls == []
+
+
+# --- #15693 -- publish the verdict motif (three states + step summary) --------
+#
+# Measured 2026-09-12 on 5/5 red PRs: the required check reported FAILURE
+# with `output.summary: null` while the cause lived only in the job log --
+# every red gate became an investigation (#15548 burned cycles on an infra
+# famine while the real blocker was already repaired 18 min earlier). The
+# fix publishes the exact verdict string to $GITHUB_STEP_SUMMARY (which
+# GitHub feeds into the AUTO check-run's output.summary) and splits the
+# FAIL message into states with OPPOSITE repairs: real reds vs checks that
+# never concluded. The fail-closed rules stay untouched.
+
+
+def test_bad_entries_carry_their_conclusion():
+    """The conclusion travels with the name -- `verdict` must be able to
+    tell a cancelled check (nothing measured, rerun) from a failed one
+    (code work) without re-reading the check set."""
+    checks = [run("ICT tests/ (55)", "cancelled", rid=1),
+              run("Lean CI", "failure", rid=2)]
+    _pending, bad, _ok, _adv = pr_gate.classify(checks, "PR gate")
+    assert bad == ["ICT tests/ (55) (cancelled)", "Lean CI (failure)"]
+
+
+def test_unconcluded_check_is_not_called_failing():
+    """#15693 refinement state 2: `failing checks: X` on a cancelled X
+    asserts something false about the code (#15548 -- the runner famine ate
+    the verdict, the lane investigated its own code). The gate still FAILS
+    (rule 1/3, fail-closed untouched); only the repair gesture changes."""
+    code, msg = decide([run("ICT tests/ (55)", "cancelled")])
+    assert code == 1, "rule 1: unconcluded still blocks"
+    assert "failing checks" not in msg, msg
+    assert "never concluded" in msg
+    assert "rerun" in msg
+    assert "ICT tests/ (55) (cancelled)" in msg
+
+
+def test_real_failure_keeps_the_historical_failing_checks_phrase():
+    """State 3: a genuine red keeps the exact `failing checks: ` phrase the
+    log annotation has carried since #15472 (greppable surface)."""
+    code, msg = decide([run("Lean CI", "failure")])
+    assert code == 1
+    assert msg == "FAIL -- failing checks: Lean CI (failure)"
+
+
+def test_mixed_bad_renders_both_clauses():
+    """A red and a cancelled check in one verdict: each lands under its own
+    clause with its own repair."""
+    checks = [run("Lean CI", "failure", rid=1),
+              run("ICT tests/ (55)", "cancelled", rid=2)]
+    code, msg = decide(checks)
+    assert code == 1
+    assert "failing checks: Lean CI (failure)" in msg
+    assert "checks that never concluded" in msg
+    assert "ICT tests/ (55) (cancelled)" in msg
+    # order: the real red comes first (it is the one with code work).
+    assert msg.index("failing checks") < msg.index("never concluded")
+
+
+def test_step_summary_written_from_the_emission_tail(tmp_path, monkeypatch):
+    """Acceptance 1: the summary carries the exact verdict string -- the
+    same text as the log, not a paraphrase."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"])
+    assert code == 1
+    text = summary.read_text(encoding="utf-8")
+    assert "## PR gate: FAIL" in text
+    assert "FAIL -- failing checks: Lean CI (failure)" in text
+
+
+def test_step_summary_is_a_noop_without_the_env(tmp_path, monkeypatch):
+    """Local runs have no GITHUB_STEP_SUMMARY: publication degrades to a
+    no-op, never a crash, and the verdict stays in the exit code."""
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"])
+    assert code == 1
+    assert not (tmp_path / "summary.md").exists()
+
+
+def test_step_summary_carries_the_advisory_section(tmp_path, monkeypatch):
+    """Acceptance 3: advisory checks are listed as NOT blocking. #15548's
+    cost: a cancelled advisory (ICT) read as the blocker while the real
+    red went unread. The advisory list must reach the summary through the
+    real wait_and_decide, not a paraphrase."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    checks = [
+        run("Always-on guards", "failure", rid=1),
+        run("CJK residue advisory (label, non-blocking)", "cancelled", rid=2),
+    ]
+
+    # `fetch` is a default argument of wait_and_decide (bound at def time),
+    # so a module-attribute monkeypatch would not reach it -- wrap and inject.
+    real_wait = pr_gate.wait_and_decide
+
+    def wait_with_fixed_fetch(*a, **kw):
+        kw["fetch"] = lambda *_f: checks
+        return real_wait(*a, **kw)
+
+    monkeypatch.setattr(pr_gate, "wait_and_decide", wait_with_fixed_fetch)
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef"])
+    assert code == 1
+    text = summary.read_text(encoding="utf-8")
+    assert "FAIL -- failing checks: Always-on guards (failure)" in text
+    assert "Advisory (not blocking):" in text
+    assert "CJK residue advisory (label, non-blocking) (cancelled)" in text
+
+
+def test_wait_and_decide_fills_detail_with_the_last_advisory():
+    """The detail dict carries the LAST classification's advisory list (the
+    deadline re-read overwrites an earlier poll's), keeping the 2-tuple
+    return intact for every existing caller."""
+    checks = [
+        run("Always-on guards", "failure", rid=1),
+        run("CJK residue advisory (label, non-blocking)", "failure", rid=2),
+    ]
+    detail: dict = {}
+    code, _msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=1, poll_sec=0, settle_polls=2,
+        sleep=lambda _s: None, fetch=lambda _r, _s: checks, now=lambda: 0.0,
+        detail=detail,
+    )
+    assert code == 1
+    assert detail["advisory"] == [
+        "CJK residue advisory (label, non-blocking) (failure)"
+    ]
+
+
+def test_step_summary_dwell_guides_against_repush(tmp_path, monkeypatch):
+    """Acceptance 2: a DWELL red is a mechanical floor. The summary carries
+    the head timestamp AND the lift time, plus the do-not-repush guidance --
+    a reaction push resets the 120-min floor from the new head (the defect
+    multiplied the wait instead of measuring it)."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    dwell_msg = (
+        "tete du 2026-09-07T11:55:00Z, 5 min -- plancher 120 min, reste "
+        "115 min, leve au premier balayage suivant 2026-09-07T13:55:00Z. "
+        "Le balayage horaire re-agrege cette jambe."
+    )
+    fake = _FakeDwell(verdict=(False, dwell_msg))
+    monkeypatch.setattr(pr_gate, "_merge_dwell", fake, raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", lambda *_a, **_k: (0, "PASS"))
+
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--pr", "7", "--dwell-min", "120"]
+    )
+    assert code == 1
+    text = summary.read_text(encoding="utf-8")
+    assert "DWELL -- tete du 2026-09-07T11:55:00Z" in text
+    assert "2026-09-07T13:55:00Z" in text, "the LIFT time, not just minutes"
+    assert "Ne pas re-pusher" in text
+
+
+def test_step_summary_fork_short_circuit(tmp_path, monkeypatch):
+    """The fork PASS publishes too (#10072) -- a student PR's check-run
+    should not be the only one whose summary stays null."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("fork must not poll")),
+    )
+    code = pr_gate.main(["--repo", "o/r", "--sha", "deadbeef", "--is-fork"])
+    assert code == 0
+    text = summary.read_text(encoding="utf-8")
+    assert "## PR gate: PASS" in text
+    assert "fork PR short-circuit" in text
+
+
+def test_step_summary_and_posted_check_run_coexist(tmp_path, monkeypatch):
+    """Acceptance 5: on the sweep path (--post-check-run) the explicit
+    Checks-API POST keeps its own output fields verbatim AND the step
+    summary is written -- the two publication surfaces do not replace each
+    other."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(
+        pr_gate, "wait_and_decide",
+        lambda *_a, **_k: (1, "FAIL -- failing checks: Lean CI (failure)"),
+    )
+    posted = {}
+    monkeypatch.setattr(
+        pr_gate, "_gh_api_post",
+        lambda path, fields: posted.update({"fields": fields}) or {},
+    )
+    code = pr_gate.main(
+        ["--repo", "o/r", "--sha", "deadbeef", "--post-check-run"]
+    )
+    assert code == 1
+    assert posted["fields"]["output[summary]"] == (
+        "FAIL -- failing checks: Lean CI (failure)"
+    )
+    assert "FAIL -- failing checks: Lean CI (failure)" in summary.read_text(
+        encoding="utf-8"
+    )

--- a/scripts/tests/test_remeasure_bad_pending.py
+++ b/scripts/tests/test_remeasure_bad_pending.py
@@ -113,7 +113,7 @@ def test_pr_avec_bad_comptee_correctement():
     latest = pr_gate.dedupe_latest(runs)
     pending, bad, ok, advisory = pr_gate.classify(latest, self_name="PR gate")
     assert len(bad) == 1
-    assert "Always-on guards" in bad
+    assert "Always-on guards" in bad[0]
 
 
 def test_advisory_exclu_du_bad():


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-po-2023:CoursIA — prev: DEEP/tooling #15711

## Summary

Le seul check requis de `main` rougissait **muet** : `conclusion: failure`, `output.summary: null`. La cause était pourtant calculée (`pr_gate.py` la construit), mais ne sortait que dans le log du job — chaque rouge requis devenait une enquête.

**La prémisse de l'issue est fausse, et c'est la mesure qui l'a montrée.** L'issue affirmait que `$GITHUB_STEP_SUMMARY` alimente l'`output.summary` du check-run auto. Mesure du 2026-09-12 : non.

| Sonde | Résultat |
|---|---|
| Ce fichier, sur cette PR, tête précédente `6513eafe9e` (rouge) — résumé de run écrit et **rendu sur la page du run** (`curl .../runs/34681884304 \| grep 'failing checks'` le retourne) | `output.summary: null` |
| Job de balayage `103506691766` (**succès**), dont le log écrit le même organe | `output.summary: null` |
| 1098 check-runs `github-actions` sur 40 commits de `main` | **0** avec un résumé |
| Contrôle positif : `fast-lane (ombre): perimeter-review-guard`, `CodeQL` | résumé **non nul** — mais tous deux créés par l'API Checks (POST), pas par un step summary |

Deux conséquences, chacune mesurée :

- **POSTer un jumeau** portant le nom requis ne marche pas : il atterrit dans une **suite étrangère** et GitHub **ANDe** les deux, donc un verdict posté ne remplace jamais un verdict périmé — la mesure qui a retiré le POST du balayage (#11519, 78 PRs bloquées).
- **PATCHer notre propre check-run** est la seule écriture qui atteint la jambe requise. L'API l'exige d'un **GitHub App** (un PAT est refusé : « You must authenticate via a GitHub App », mesuré) ; le `GITHUB_TOKEN` du job en est un, c'est donc lui qui écrit, depuis le job, sur son propre check-run.

Correctif : `publish_check_run_output` PATCH `output[title]`/`output[summary]` sur l'id de notre propre job (à une place, dans sa propre suite — aucun jumeau, aucun AND). Plus `write_step_summary`, qui garde le rendu de la page de run, utile en soi. **Aucun changement de logique de classification**, aucun nouveau check-run, rien de nouveau qui soit requis.

## Mesure avant/après sur une PR ROUGE réelle (acceptance 4)

Même PR, même rouge (`Always-on guards` porte un organe bloquant) ; seule la tête change, à cause de ce commit :

```
# AVANT -- tête 6513eafe9e (code d'avant ce commit)
$ gh api .../commits/6513eafe9e/check-runs --jq '[.check_runs[]|select(.name=="PR gate")]|sort_by(.started_at)|.[-1]'
{"conclusion":"failure","title":null,"summary":null}

# APRES -- tête feed8e51c32e (ce commit)
$ gh api .../commits/feed8e51c32e/check-runs --jq '[.check_runs[]|select(.name=="PR gate")]|sort_by(.started_at)|.[-1]'
{"conclusion":"failure",
 "title":"PR gate: FAIL -- failing checks: Always-on guards -- 12 organes, 1 checkout (failure)",
 "summary":"FAIL -- failing checks: Always-on guards -- 12 organes, 1 checkout (failure)"}

# Nombre de check-runs nommés "PR gate" sur la tête d'après : 1
# (le PATCH édite à sa place -- pas de jumeau, donc pas de piège d'AND)
```

Le verdict ne bouge pas (`failure` avant, `failure` après) : la publication n'est jamais porteuse du verdict. Le résumé reprend **le message du log mot pour mot**, et il **survit à la fin du job**.

## Les trois états publiés (affinement d'ai-01 sur l'issue)

Le corps de l'issue demandait de distinguer le `DWELL` d'un échec ; la mesure montre qu'il faut **trois** états, parce que les gestes sont opposés :

| État | Ce que le résumé publie | Geste |
|---|---|---|
| Plancher DWELL | `DWELL -- tete du …, reste N min, leve au premier balayage suivant <heure absolue>` + « ne pas re-pusher » | **rien** (un re-push remet le plancher de 120 min à zéro depuis la nouvelle tête) |
| Check non conclu (`cancelled`, `timed_out`, `stale`, `startup_failure`) | `checks that never concluded (rerun the run -- this is not a code failure): <noms>` | **relancer** — rien n'a été mesuré sur le code |
| Check réellement rouge (`failure`, `action_required`) | `failing checks: <noms>` (phrase historique conservée) | corriger le code |

Plus, en section dédiée : les checks **advisory** non verts, listés `Advisory (not blocking)` (#15548 : ICT annulé se lisait comme le bloqueur alors que le vrai rouge était ailleurs, et déjà réparé 18 min plus tôt).

## Contre quoi le correctif est mesuré

- **Acceptance 1** — `output.summary` non vide portant la cause : mesuré ci-dessus sur le check-run requis lui-même, texte identique au log.
- **Acceptance 2** — DWELL distingué, avec heure de tête **et heure de levée absolue** (`merge_dwell.evaluate` porte désormais `leve au premier balayage suivant <stamp>` — « 101 min » obligeait la lane à refaire le calcul et l'incitait à agir).
- **Acceptance 3** — requis vs advisory : les clauses `failing checks`/`never concluded` ne contiennent que des checks bloquants par construction ; les advisory vont dans leur section étiquetée.
- **Acceptance 4** — contrôle positif avant/après sur une **vraie PR rouge** : section ci-dessus (tête d'avant → `null`, tête d'après → texte).
- **Acceptance 5** — non-régression du sweep : `post_check_run`/`_maybe_post_check_run` sont **intacts**, et le mode `--post-check-run` ne PATCHe pas sa propre jambe (elle est sur la branche par défaut, ce n'est pas la jambe de la PR). Test dédié : les deux surfaces coexistent, `output[summary]` du POST restant verbatim.

Règles fail-closed **intactes** : un check non conclu fait **toujours** échouer le gate (règles 1/3) ; c'est le message qui cesse d'imputer le défaut au code. Le `fail-closed` sur `cancelled` (qui décide `is_advisory`) n'est pas touché.

## Vérification

```
$ python -m pytest scripts/tests/test_pr_gate.py scripts/tests/test_merge_dwell.py \
                   scripts/tests/test_remeasure_bad_pending.py -q
125 passed
```

Contrôle positif de la bascule (anti faux-vert) : les mêmes tests joués contre les **sources d'origine** (`git stash` de `pr_gate.py` + `merge_dwell.py`) donnent **10 échecs / 125** — les 10 épinglent exactement ce que ce commit ajoute (lookup du job par tentative, PATCH du bon id, les trois modes de dégradation en WARN, le corps partagé entre les deux surfaces), les 115 autres passent des deux côtés.

## Portée

Un seul sujet : la publication du verdict — et la correction du mécanisme que l'issue supposait. Ni élargissement de ce qui est requis, ni modification de la classification advisory/bloquant, ni du plancher DWELL.

Note pour la suite : `pr-gate.yml` passe `checks: read` → `checks: write` (nécessaire au PATCH ; un jeton de PR de fork est en lecture seule, la dégradation y est un WARN et le verdict est inchangé).

Closes #15693. See #15472 (annotation `::error::`), See #13510 (auto-cancel STARVED), See #14976 (couple status/conclusion), See #15548 (advisory lu comme bloqueur), See #11519 (POST jumeau inerte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
