### PR TITLE
docs(genai,#15673): README racine GenAI aligne sur COMFYUI_API_TOKEN — 6 occurrences + promesses de fallback reecrites sur le comportement mesure

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -78,9 +78,9 @@ Avant de commencer, vérifiez votre configuration :
 - `OPENAI_API_KEY` — gpt-image-1, GPT-5, Whisper, TTS (Image, Audio, Texte)
 - `ANTHROPIC_API_KEY` — Claude Vision (Video)
 - `HUGGINGFACE_TOKEN` — modèles HF open-source (Image, Video)
-- `COMFYUI_BEARER_TOKEN` — services locaux ComfyUI (Image local, Video) ; fourni par l'enseignant
+- `COMFYUI_API_TOKEN` (alias accepté : `COMFYUI_AUTH_TOKEN`) — services locaux ComfyUI (Image local, Video) ; fourni par l'enseignant
 
-Sans `COMFYUI_BEARER_TOKEN`, les notebooks basculent automatiquement en mode cloud (DALL-E/OpenAI) si `OPENAI_API_KEY` est présent — c'est la **graceful degradation** systématique de la série.
+Sans `COMFYUI_API_TOKEN`, les notebooks locaux se connectent **sans authentification** (`comfyui_client.py` l'affiche) et reçoivent 401 si le service en exige une. La génération cloud (`OPENAI_API_KEY`) est portée par des notebooks distincts de la série — il n'y a pas de bascule automatique local→cloud dans un même notebook.
 
 ## Limitations connues
 
@@ -98,7 +98,7 @@ Chaque sous-domaine (Image, Audio, Video, Texte, SemanticKernel) est indépendan
 
 ### Erreurs fréquentes
 
-- **ComfyUI 401 Unauthorized** : vérifier `COMFYUI_BEARER_TOKEN` dans `.env`. Sans token, fallback cloud (DALL-E/OpenAI) si `OPENAI_API_KEY` présent.
+- **ComfyUI 401 Unauthorized** : vérifier `COMFYUI_API_TOKEN` dans `.env` (token fourni par l'enseignant). Sans token, le notebook se connecte sans authentification et le service refuse — ce n'est pas un secret mal configuré.
 - **Docker services ne démarrent pas** : `python scripts/genai-stack/genai.py docker status` puis `genai.py docker start`. Détails : [docs/genai/genai-services.md](../../docs/genai/genai-services.md).
 
 ## Concepts clés
@@ -297,7 +297,7 @@ Oui. Chaque sous-domaine (Image, Audio, Video, Texte, SemanticKernel) est indép
 
 ### Erreur ComfyUI 401 Unauthorized
 
-Vérifiez que `COMFYUI_BEARER_TOKEN` est configuré dans `.env`. Le token est disponible auprès de l'enseignant. Sans token, les notebooks basculent en mode cloud (DALL-E/OpenAI) si `OPENAI_API_KEY` est présent.
+Vérifiez que `COMFYUI_API_TOKEN` est configuré dans `.env`. Le token est disponible auprès de l'enseignant. Sans token, les notebooks locaux se connectent sans authentification (401 si le service en exige une) ; la génération cloud se fait dans les notebooks dédiés, avec `OPENAI_API_KEY`.
 
 ### Docker services ne démarrent pas
 
@@ -353,10 +353,10 @@ Lancez Jupyter Lab et commencez par `00-GenAI-Environment/00-1-Environment-Setup
 Les services GenAI locaux (Qwen Image Edit, Z-Image, Whisper, etc.) sont protégés par authentification Bearer Token.
 
 1. **Obtenir le token** : contactez votre enseignant
-2. **Configuration** : ajoutez `COMFYUI_BEARER_TOKEN` dans `.env`
+2. **Configuration** : ajoutez `COMFYUI_API_TOKEN` dans `.env`
 3. **Utilisation** : les notebooks chargent automatiquement les credentials via `comfyui_client.py`
 
-Tous les notebooks supportent la graceful degradation : sans token, ils utilisent les APIs cloud en fallback.
+Sans token, `comfyui_client.py` se connecte sans authentification (401 si le service en exige une) — il n'y a pas de bascule cloud automatique ; les notebooks cloud sont des notebooks distincts.
 
 ### Variables d'environnement
 
@@ -367,7 +367,7 @@ Les clés essentielles dans `.env` :
 | `OPENAI_API_KEY` | gpt-image-1, GPT-5, Whisper, TTS | Image, Audio, Texte |
 | `ANTHROPIC_API_KEY` | Claude Vision | Video |
 | `HUGGINGFACE_TOKEN` | Modèles HF open-source | Image, Video |
-| `COMFYUI_BEARER_TOKEN` | Services locaux ComfyUI | Image (local), Video |
+| `COMFYUI_API_TOKEN` | Services locaux ComfyUI (alias `COMFYUI_AUTH_TOKEN`) | Image (local), Video |
 
 Template complet : [`.env.example`](.env.example)
 


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2023:CoursIA — prev: MED/docs #15679

## Summary

Le README racine de GenAI prescrivait encore `COMFYUI_BEARER_TOKEN` (6 occurrences) — un nom que zéro ligne de code ne lit. Canon mesuré sur ce commit de base : `COMFYUI_API_TOKEN`, lu par `comfyui_client.py:990`, prescrit par `.env.example:67` avec l'alias `COMFYUI_AUTH_TOKEN` (les deux portent la même valeur). Résiduel du correctif #15307, restreint au README Image.

Les 6 occurrences (L81, L83, L101, L300, L356, L370 — numéros d'alors, #15587 a décalé la fin) sont alignées sur le canon, alias documenté aux deux endroits qui présentent la variable (credentials + tableau).

## La promesse de fallback cloud, réécrite sur le comportement mesuré

L'issue demandait de « vérifier que la promesse de bascule automatique décrit le comportement réel des notebooks concernés ». Mesuré sur ce commit de base — le comportement réel n'est pas une bascule :

- **Census** : zéro cellule code des notebooks GenAI ne lit `OPENAI_API_KEY` et `COMFYUI_API_TOKEN` ensemble — il n'existe aucun switch cloud dans un notebook local.
- **Comportement réel sans token** (mesuré, `comfyui_client.py:1018` et notebook 01-5 cellule 3) : connexion **sans authentification**, warning affiché, 401 si le service en exige une.
- La seule implémentation « fallback » de la série est l'**exercice étudiant** de 03-1 (TODO étudiant, forge↔comfyui) — pas un fallback cloud.
- La génération cloud (gpt-image-1) vit dans des **notebooks distincts** (01-1, 01-2), pas derrière une bascule.

Les 4 phrases portant la promesse (L83, L101, L300, L359 — cette dernière sans le nom mort mais même promesse, couverte par l'acceptance « ET les phrases de fallback cloud ») sont réécrites sur ce comportement. La 401 est désormais décrite comme ce qu'elle est : un notebook non authentifié contre un service qui exige l'auth — pas un secret mal configuré.

**Promesse de bascule restée vraie, laissée telle quelle** : L225 « basculent automatiquement si `.env` configuré » décrit la priorité d'endpoint `COMFYUI_API_URL > QWEN_IMAGE_EDIT_URL` (mesurée, 01-5 cellule 3) — bascule locale↔distant, pas cloud.

## Audit même-classe, fichier entier

Toutes les variables d'environnement citées dans le README, confrontées aux 78 clés déclarées de `.env.example` : `COMFYUI_BEARER_TOKEN` était la **seule** morte. Après ce commit : 0.

## Residuals signalés (hors scope de cette PR)

- Quatre fichiers du harnais prescrivent aussi `COMFYUI_BEARER_TOKEN` : `.claude/rules/genai-config.md`, `.claude/agents/genai-iterator.md`, `.claude/commands/validate-genai.md`, `.claude/skills/genai-iterate/SKILL.md` — autre périmètre que ce grain.
- `Image/README.md:271` : « sans token, ils basculent vers les API cloud quand c'est possible » — même promesse non mesurée, côté #15290 (encore ouverte) pour ne pas diverger une seconde fois.

## Vérification

```
$ grep -c COMFYUI_BEARER_TOKEN MyIA.AI.Notebooks/GenAI/README.md
6 -> 0
$ git diff --stat
 MyIA.AI.Notebooks/GenAI/README.md | 14 +++++++-------
```

1 fichier, +7/−7. Marqueurs `CATALOG-STATUS` intacts, catalogue byte-identique à main.

Closes #15673. See #15290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-12T11:31:45Z -->



---
Note de drainage (2026-09-14) : le libellé residuel nommant le correctif #15307 a ete adjuste par le coordinateur ; ce re-edit du body re-declenche l event edited pour que le garde close-keyword relise le body courant (le rerun rejouerait le payload original, cf #15849). Aucun changement de fond.


- Correction (2026-09-14, drainage) : prev: repointe de #15728 (PR fermee non mergee -> violation prev-abandoned du garde #13475) vers #15679 (MED/docs, MERGEE, predecesseur reel de la lane). Genre inchange (LIGHT/readme), aucun retagage.
