### PR TITLE
fix(ci,#15332): donner au sweep le heartbeat push que l'observateur a recu

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -99,6 +99,39 @@ on:
     # post-routing (expected: queue collapses from ~6000-8000 s to near zero;
     # cancellations from 19/30 to ~0).
     - cron: '7 * * * *'
+  # Heartbeat independent of the `schedule` event class -- the SAME remedy
+  # #15332 gave the observer (pr-gate-sweep-health-advisory.yml), which this
+  # file never received. The asymmetry was backwards: the heartbeat went to the
+  # organ that only SPEAKS, not to the organ that REPAIRS.
+  #
+  # Measured 2026-09-12T08:19Z by scripts/ci/check_scheduler_liveness.py, the
+  # organ #15332 built for exactly this question -- served cadence vs declared:
+  #
+  #   LATE  pr-gate-stale-sweep.yml            declare   60 min | servi  280 min (4.7x)
+  #   DEAD  pr-gate-sweep-health-advisory.yml  declare   30 min | servi  217 min (7.2x)
+  #   LATE  linux-runner-starvation-advisory.yml declare 30 min | servi  168 min (5.6x)
+  #   OK    stale-guard-red-sweep.yml          declare 1440 min | servi 1440 min
+  #   OK    epic-neglect-sweep.yml             declare 1440 min | servi 1440 min
+  #   OK    grain-orphans-sweep.yml            declare 1440 min | servi 1440 min
+  #
+  # Every sub-hourly cron on this repository is served 4.7-7.2x late; every
+  # daily cron is served exactly. Declaring a sub-hourly cadence here therefore
+  # buys nothing -- GitHub does not deliver it. Against a 120 min DWELL floor,
+  # a 280 min re-aggregation means a PR whose ONLY red is the floor waits the
+  # floor plus up to another ~4.7 h, with no signal that anything is wrong.
+  # That latency is a structural contributor to the merge queue, not an
+  # incident: 71 of 76 open PRs measured the same morning waited on no lane
+  # gesture at all.
+  #
+  # Safe to add now, and it would NOT have been in #12728: that incident was
+  # self-cancellation under a ~2 h runner queue at a 20 min cadence. The queue
+  # collapsed once the job was routed to the dedicated coursia-linux pool --
+  # measured on the last five runs: queue 0 s, 2 s, 3 s, 267 s, 620 s for
+  # 230-293 s of execution. `concurrency.cancel-in-progress: false` below
+  # coalesces a burst of merges into one pending sweep; it never kills a
+  # running one.
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
`Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: MED/docs #15727`

## Substance

Ajoute `push: branches: [main]` aux déclencheurs de `pr-gate-stale-sweep.yml` — **le même remède que #15332 a posé sur l'observateur, et jamais sur l'organe observé.**

`pr-gate-sweep-health-advisory.yml` a reçu son heartbeat hors classe `schedule` dans la PR #15451. Le sweep qu'il surveille ne l'a pas reçu. L'asymétrie est à l'envers : le heartbeat est allé à l'organe qui **parle**, pas à celui qui **répare**.

**1 fichier, 33 insertions, 0 suppression**, toutes dans `.github/workflows/pr-gate-stale-sweep.yml` (2 lignes de déclencheur, 31 de commentaire qui porte la mesure). Aucun autre fichier.

## La mesure qui motive, et son organe

Elle n'est pas de moi : c'est `scripts/ci/check_scheduler_liveness.py`, l'organe que #15332 a fait construire **pour cette question exacte** (cadence servie vs déclarée). Sortie du run `34682956532`, 2026-09-12T08:19:20Z :

```
LATE  pr-gate-stale-sweep.yml               declare   60 min | servi  280 min | dernier run 156 min | 20 runs
DEAD  pr-gate-sweep-health-advisory.yml     declare   30 min | servi  217 min | dernier run 200 min | 20 runs
LATE  linux-runner-starvation-advisory.yml  declare   30 min | servi  168 min | dernier run 107 min | 20 runs
OK    stale-guard-red-sweep.yml             declare 1440 min | servi 1440 min | dernier run 1388 min | 14 runs
OK    epic-neglect-sweep.yml                declare 1440 min | servi 1440 min | dernier run 1160 min | 12 runs
OK    grain-orphans-sweep.yml               declare 1440 min | servi 1440 min | dernier run 1205 min | 14 runs
```

La coupure est nette et elle ne porte pas sur l'organe, elle porte sur **la fréquence déclarée** : **tout cron infra-horaire de ce dépôt est servi 4,7 à 7,2 fois en retard ; tout cron quotidien est servi exactement.** Déclarer `'7 * * * *'` n'achète donc rien — GitHub ne le livre pas.

**Conséquence, contre le plancher DWELL de 120 min** : une PR dont le **seul** rouge est le plancher attend le plancher, **puis** jusqu'à ~4,7 h de plus la ré-agrégation — et rien ne le dit. Le message du gate promet pourtant l'inverse : « *le balayage horaire re-agrège cette jambe dès que le plancher est écoulé ; aucun geste manuel n'est requis* ». Cette phrase est fausse depuis que la cadence servie a décroché.

Contrôle vécu ce matin sur **#15605** : 23 checks verts, `DWELL` écoulé à 08:00:37Z, gate toujours rouge à 08:48Z — 48 min après le plancher, sans aucun défaut de contenu.

## Pourquoi c'est sûr maintenant, et ne l'aurait pas été à #12728

Le commentaire en place documente une auto-destruction : à 20 min de cadence sous ~2 h d'attente runner, 19 runs sur 30 annulés, durée de vie médiane 1228 s ≈ exactement un intervalle de cron. **Cette prémisse n'existe plus** : le routage vers le pool `coursia-linux` dédié a effondré la file, comme #12728 l'attendait. Mesure des cinq derniers runs (`created → started` vs `started → completed`) :

| run | attente | exécution | conclusion |
|---|---:|---:|---|
| `34676314263` | **2 s** | 230 s | success |
| `34667089433` | **3 s** | 269 s | success |
| `34666908817` | 620 s | 265 s | success |
| `34666252052` | 267 s | 293 s | success |
| `34684260882` (dispatch manuel de ce matin) | **0 s** | — | en cours |

Et `concurrency: { group: pr-gate-stale-sweep, cancel-in-progress: false }` reste inchangé : une rafale de merges **coalesce** en un seul sweep en attente, elle n'en tue jamais un en cours. C'est précisément la propriété qui manquait en 2026-08.

`github.event.inputs.dry_run` est vide sur un `push` exactement comme sur un `schedule` — le sweep tourne déjà quotidiennement sous cette forme, en mode non-dry. Aucun autre `github.event.*` n'est lu par ce workflow.

## Ce que ça change concrètement

Un merge sur `main` déclenche la ré-agrégation. Pendant une passe de merge — le moment où la file se forme — la latence passe de « jusqu'à ~4,7 h » à « le merge suivant ».

Le `schedule` reste en place : il couvre les périodes sans merge, où la latence n'a aucune conséquence.

## Ce que ça ne fait pas

- Ça ne répare pas la cadence servie des **deux autres** organes décrochés (`pr-gate-sweep-health-advisory.yml`, déjà doté d'un `push` mais toujours `DEAD` sur sa jambe `schedule` ; `linux-runner-starvation-advisory.yml`, sans heartbeat). Ce sont deux grains distincts, et je ne les emballe pas ici.
- Ça ne tranche pas le geste 3 de #15332 (« documenter le dispatch manuel comme geste `/coordinate` »), signalé comme décision coordinateur par `po-2023` le 2026-09-10 et laissé en attente **par moi** depuis. Je le tranche dans un commentaire sur #15332, pas dans ce diff.

## Acceptance

1. `push: branches: [main]` présent dans les déclencheurs, `schedule` et `workflow_dispatch` conservés.
2. Le YAML parse et rend trois classes de déclencheurs (`schedule`, `push`, `workflow_dispatch`) — vérifié localement.
3. Après merge : un run `event=push` de `pr-gate-stale-sweep.yml` apparaît sur le merge de cette PR elle-même — c'est son propre contrôle positif.
4. Aucun fichier hors `.github/workflows/pr-gate-stale-sweep.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
