### PR TITLE
fix(rag,#15674): exercice 3 MatchAny — part du corpus via décompte filtré, pas par comparaison de top-10

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
@@ -5,10 +5,10 @@
    "id": "5b08c667",
    "metadata": {
     "papermill": {
-     "duration": 0.006932,
-     "end_time": "2026-09-07T21:59:19.663841",
+     "duration": 0.003267,
+     "end_time": "2026-09-12T09:15:44.498388",
      "exception": false,
-     "start_time": "2026-09-07T21:59:19.656909",
+     "start_time": "2026-09-12T09:15:44.495121",
      "status": "completed"
     },
     "tags": []
@@ -50,10 +50,10 @@
    "id": "99f69b09",
    "metadata": {
     "papermill": {
-     "duration": 0.007004,
-     "end_time": "2026-09-07T21:59:19.683952",
+     "duration": 0.002477,
+     "end_time": "2026-09-12T09:15:44.503606",
      "exception": false,
-     "start_time": "2026-09-07T21:59:19.676948",
+     "start_time": "2026-09-12T09:15:44.501129",
      "status": "completed"
     },
     "tags": []
@@ -77,16 +77,16 @@
    "id": "872a4a4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:19.702848Z",
-     "iopub.status.busy": "2026-09-07T21:59:19.702848Z",
-     "iopub.status.idle": "2026-09-07T21:59:20.774101Z",
-     "shell.execute_reply": "2026-09-07T21:59:20.774101Z"
+     "iopub.execute_input": "2026-09-12T09:15:44.510078Z",
+     "iopub.status.busy": "2026-09-12T09:15:44.509791Z",
+     "iopub.status.idle": "2026-09-12T09:15:45.190172Z",
+     "shell.execute_reply": "2026-09-12T09:15:45.189632Z"
     },
     "papermill": {
-     "duration": 1.088141,
-     "end_time": "2026-09-07T21:59:20.776100",
+     "duration": 0.6848,
+     "end_time": "2026-09-12T09:15:45.190981",
      "exception": false,
-     "start_time": "2026-09-07T21:59:19.687959",
+     "start_time": "2026-09-12T09:15:44.506181",
      "status": "completed"
     },
     "tags": []
@@ -96,10 +96,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "N=    1,000 (d=64) | k-NN exact top-10 :     0.6 ms\n",
-      "N=   10,000 (d=64) | k-NN exact top-10 :     2.1 ms\n",
-      "N=  100,000 (d=64) | k-NN exact top-10 :    20.6 ms\n",
-      "N=1,000,000 (d=64) | k-NN exact top-10 :   207.3 ms\n"
+      "N=    1,000 (d=64) | k-NN exact top-10 :     0.2 ms\n",
+      "N=   10,000 (d=64) | k-NN exact top-10 :     1.3 ms\n",
+      "N=  100,000 (d=64) | k-NN exact top-10 :    13.5 ms\n",
+      "N=1,000,000 (d=64) | k-NN exact top-10 :   139.7 ms\n"
      ]
     }
    ],
@@ -139,10 +139,10 @@
    "id": "336b70ac",
    "metadata": {
     "papermill": {
-     "duration": 0.005087,
-     "end_time": "2026-09-07T21:59:20.783795",
+     "duration": 0.00273,
+     "end_time": "2026-09-12T09:15:45.196876",
      "exception": false,
-     "start_time": "2026-09-07T21:59:20.778708",
+     "start_time": "2026-09-12T09:15:45.194146",
      "status": "completed"
     },
     "tags": []
@@ -168,16 +168,16 @@
    "id": "05c79505",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:20.796309Z",
-     "iopub.status.busy": "2026-09-07T21:59:20.795310Z",
-     "iopub.status.idle": "2026-09-07T21:59:21.804441Z",
-     "shell.execute_reply": "2026-09-07T21:59:21.803427Z"
+     "iopub.execute_input": "2026-09-12T09:15:45.203181Z",
+     "iopub.status.busy": "2026-09-12T09:15:45.202954Z",
+     "iopub.status.idle": "2026-09-12T09:15:45.721860Z",
+     "shell.execute_reply": "2026-09-12T09:15:45.721509Z"
     },
     "papermill": {
-     "duration": 1.017133,
-     "end_time": "2026-09-07T21:59:21.805442",
+     "duration": 0.522938,
+     "end_time": "2026-09-12T09:15:45.722453",
      "exception": false,
-     "start_time": "2026-09-07T21:59:20.788309",
+     "start_time": "2026-09-12T09:15:45.199515",
      "status": "completed"
     },
     "tags": []
@@ -194,7 +194,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\2135674488.py:16: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_16184\\2135674488.py:16: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
       "  plt.show()\n"
      ]
     }
@@ -224,10 +224,10 @@
    "id": "98ef526b",
    "metadata": {
     "papermill": {
-     "duration": 0.003515,
-     "end_time": "2026-09-07T21:59:21.812461",
+     "duration": 0.003003,
+     "end_time": "2026-09-12T09:15:45.728504",
      "exception": false,
-     "start_time": "2026-09-07T21:59:21.808946",
+     "start_time": "2026-09-12T09:15:45.725501",
      "status": "completed"
     },
     "tags": []
@@ -251,10 +251,10 @@
    "id": "dcaffeac",
    "metadata": {
     "papermill": {
-     "duration": 0.0036,
-     "end_time": "2026-09-07T21:59:21.820712",
+     "duration": 0.002909,
+     "end_time": "2026-09-12T09:15:45.736268",
      "exception": false,
-     "start_time": "2026-09-07T21:59:21.817112",
+     "start_time": "2026-09-12T09:15:45.733359",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +282,16 @@
    "id": "e6cb79d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:21.832618Z",
-     "iopub.status.busy": "2026-09-07T21:59:21.832028Z",
-     "iopub.status.idle": "2026-09-07T21:59:21.850902Z",
-     "shell.execute_reply": "2026-09-07T21:59:21.850305Z"
+     "iopub.execute_input": "2026-09-12T09:15:45.742981Z",
+     "iopub.status.busy": "2026-09-12T09:15:45.742735Z",
+     "iopub.status.idle": "2026-09-12T09:15:45.749889Z",
+     "shell.execute_reply": "2026-09-12T09:15:45.749512Z"
     },
     "papermill": {
-     "duration": 0.025176,
-     "end_time": "2026-09-07T21:59:21.851907",
+     "duration": 0.011467,
+     "end_time": "2026-09-12T09:15:45.750557",
      "exception": false,
-     "start_time": "2026-09-07T21:59:21.826731",
+     "start_time": "2026-09-12T09:15:45.739090",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +337,10 @@
    "id": "48358bc6",
    "metadata": {
     "papermill": {
-     "duration": 0.003599,
-     "end_time": "2026-09-07T21:59:21.860520",
+     "duration": 0.00307,
+     "end_time": "2026-09-12T09:15:45.756684",
      "exception": false,
-     "start_time": "2026-09-07T21:59:21.856921",
+     "start_time": "2026-09-12T09:15:45.753614",
      "status": "completed"
     },
     "tags": []
@@ -361,16 +361,16 @@
    "id": "a0ee062a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:21.870365Z",
-     "iopub.status.busy": "2026-09-07T21:59:21.869365Z",
-     "iopub.status.idle": "2026-09-07T21:59:40.301167Z",
-     "shell.execute_reply": "2026-09-07T21:59:40.299524Z"
+     "iopub.execute_input": "2026-09-12T09:15:45.764454Z",
+     "iopub.status.busy": "2026-09-12T09:15:45.764075Z",
+     "iopub.status.idle": "2026-09-12T09:15:51.588289Z",
+     "shell.execute_reply": "2026-09-12T09:15:51.587801Z"
     },
     "papermill": {
-     "duration": 18.437757,
-     "end_time": "2026-09-07T21:59:40.302257",
+     "duration": 5.829276,
+     "end_time": "2026-09-12T09:15:51.589086",
      "exception": false,
-     "start_time": "2026-09-07T21:59:21.864500",
+     "start_time": "2026-09-12T09:15:45.759810",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +380,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "collection 'chunks' créée sur disque -> <USER_PATH>\\AppData\\Local\\Temp\\rag05_vymdqugb\n"
+      "collection 'chunks' créée sur disque -> C:\\Users\\jsboi\\AppData\\Local\\Temp\\rag05_24pack7h\n"
      ]
     },
     {
@@ -422,10 +422,10 @@
    "id": "661a9585",
    "metadata": {
     "papermill": {
-     "duration": 0.006973,
-     "end_time": "2026-09-07T21:59:40.318766",
+     "duration": 0.003047,
+     "end_time": "2026-09-12T09:15:51.595264",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.311793",
+     "start_time": "2026-09-12T09:15:51.592217",
      "status": "completed"
     },
     "tags": []
@@ -447,16 +447,16 @@
    "id": "8ef39016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:40.336639Z",
-     "iopub.status.busy": "2026-09-07T21:59:40.336067Z",
-     "iopub.status.idle": "2026-09-07T21:59:40.410437Z",
-     "shell.execute_reply": "2026-09-07T21:59:40.408924Z"
+     "iopub.execute_input": "2026-09-12T09:15:51.602497Z",
+     "iopub.status.busy": "2026-09-12T09:15:51.602020Z",
+     "iopub.status.idle": "2026-09-12T09:15:51.643450Z",
+     "shell.execute_reply": "2026-09-12T09:15:51.642863Z"
     },
     "papermill": {
-     "duration": 0.085034,
-     "end_time": "2026-09-07T21:59:40.411455",
+     "duration": 0.045894,
+     "end_time": "2026-09-12T09:15:51.644232",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.326421",
+     "start_time": "2026-09-12T09:15:51.598338",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +483,10 @@
    "id": "2f0e6cd0",
    "metadata": {
     "papermill": {
-     "duration": 0.007033,
-     "end_time": "2026-09-07T21:59:40.424005",
+     "duration": 0.002951,
+     "end_time": "2026-09-12T09:15:51.650447",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.416972",
+     "start_time": "2026-09-12T09:15:51.647496",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +512,10 @@
    "id": "6c546513",
    "metadata": {
     "papermill": {
-     "duration": 0.006822,
-     "end_time": "2026-09-07T21:59:40.438331",
+     "duration": 0.002579,
+     "end_time": "2026-09-12T09:15:51.655675",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.431509",
+     "start_time": "2026-09-12T09:15:51.653096",
      "status": "completed"
     },
     "tags": []
@@ -543,16 +543,16 @@
    "id": "4d83e15c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:40.450107Z",
-     "iopub.status.busy": "2026-09-07T21:59:40.450107Z",
-     "iopub.status.idle": "2026-09-07T21:59:40.472547Z",
-     "shell.execute_reply": "2026-09-07T21:59:40.470860Z"
+     "iopub.execute_input": "2026-09-12T09:15:51.662444Z",
+     "iopub.status.busy": "2026-09-12T09:15:51.661999Z",
+     "iopub.status.idle": "2026-09-12T09:15:51.670563Z",
+     "shell.execute_reply": "2026-09-12T09:15:51.670093Z"
     },
     "papermill": {
-     "duration": 0.030009,
-     "end_time": "2026-09-07T21:59:40.473535",
+     "duration": 0.012866,
+     "end_time": "2026-09-12T09:15:51.671262",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.443526",
+     "start_time": "2026-09-12T09:15:51.658396",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +628,10 @@
    "id": "bf8383b9",
    "metadata": {
     "papermill": {
-     "duration": 0.004999,
-     "end_time": "2026-09-07T21:59:40.483542",
+     "duration": 0.002994,
+     "end_time": "2026-09-12T09:15:51.677552",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.478543",
+     "start_time": "2026-09-12T09:15:51.674558",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "e711c757",
    "metadata": {
     "papermill": {
-     "duration": 0.00463,
-     "end_time": "2026-09-07T21:59:40.493120",
+     "duration": 0.002895,
+     "end_time": "2026-09-12T09:15:51.683394",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.488490",
+     "start_time": "2026-09-12T09:15:51.680499",
      "status": "completed"
     },
     "tags": []
@@ -689,16 +689,16 @@
    "id": "3b070cc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:40.503974Z",
-     "iopub.status.busy": "2026-09-07T21:59:40.502958Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.324161Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.323518Z"
+     "iopub.execute_input": "2026-09-12T09:15:51.691717Z",
+     "iopub.status.busy": "2026-09-12T09:15:51.691482Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.448867Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.448471Z"
     },
     "papermill": {
-     "duration": 0.827711,
-     "end_time": "2026-09-07T21:59:41.325166",
+     "duration": 0.763163,
+     "end_time": "2026-09-12T09:15:52.449492",
      "exception": false,
-     "start_time": "2026-09-07T21:59:40.497455",
+     "start_time": "2026-09-12T09:15:51.686329",
      "status": "completed"
     },
     "tags": []
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 0.8s\n"
+      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 0.7s\n"
      ]
     }
    ],
@@ -746,10 +746,10 @@
    "id": "15be578f",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-09-07T21:59:41.332182",
+     "duration": 0.002817,
+     "end_time": "2026-09-12T09:15:52.455328",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.329181",
+     "start_time": "2026-09-12T09:15:52.452511",
      "status": "completed"
     },
     "tags": []
@@ -770,16 +770,16 @@
    "id": "1cd46fa2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.341088Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.340463Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.416629Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.415628Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.461901Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.461691Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.520391Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.519863Z"
     },
     "papermill": {
-     "duration": 0.081969,
-     "end_time": "2026-09-07T21:59:41.418150",
+     "duration": 0.063037,
+     "end_time": "2026-09-12T09:15:52.521028",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.336181",
+     "start_time": "2026-09-12T09:15:52.457991",
      "status": "completed"
     },
     "tags": []
@@ -789,7 +789,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "référence exacte : recall@10=1.000, latence=1.7 ms, évaluations=10000 par requête\n"
+      "référence exacte : recall@10=1.000, latence=1.4 ms, évaluations=10000 par requête\n"
      ]
     }
    ],
@@ -815,10 +815,10 @@
    "id": "da8b3e9e",
    "metadata": {
     "papermill": {
-     "duration": 0.005004,
-     "end_time": "2026-09-07T21:59:41.427167",
+     "duration": 0.002945,
+     "end_time": "2026-09-12T09:15:52.527053",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.422163",
+     "start_time": "2026-09-12T09:15:52.524108",
      "status": "completed"
     },
     "tags": []
@@ -837,16 +837,16 @@
    "id": "0a423623",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.437441Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.436900Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.558188Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.557382Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.533811Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.533481Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.589692Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.589175Z"
     },
     "papermill": {
-     "duration": 0.12702,
-     "end_time": "2026-09-07T21:59:41.558188",
+     "duration": 0.060536,
+     "end_time": "2026-09-12T09:15:52.590438",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.431168",
+     "start_time": "2026-09-12T09:15:52.529902",
      "status": "completed"
     },
     "tags": []
@@ -857,19 +857,13 @@
      "output_type": "stream",
      "text": [
       " ef  | recall@10 | latence(ms) | évaluations\n",
-      "   1 | 0.040    |    0.13   | 16\n",
-      "   2 | 0.050    |    0.20   | 30\n",
-      "   4 | 0.070    |    0.43   | 61\n",
-      "   8 | 0.165    |    0.47   | 116\n",
-      "  16 | 0.240    |    1.05   | 179\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  32 | 0.405    |    1.39   | 307\n",
-      "  64 | 0.645    |    1.52   | 521\n"
+      "   1 | 0.040    |    0.06   | 16\n",
+      "   2 | 0.050    |    0.07   | 30\n",
+      "   4 | 0.070    |    0.12   | 61\n",
+      "   8 | 0.165    |    0.23   | 116\n",
+      "  16 | 0.240    |    0.35   | 179\n",
+      "  32 | 0.405    |    0.58   | 307\n",
+      "  64 | 0.645    |    1.05   | 521\n"
      ]
     }
    ],
@@ -922,10 +916,10 @@
    "id": "6f1a05c8",
    "metadata": {
     "papermill": {
-     "duration": 0.005005,
-     "end_time": "2026-09-07T21:59:41.567624",
+     "duration": 0.002746,
+     "end_time": "2026-09-12T09:15:52.596146",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.562619",
+     "start_time": "2026-09-12T09:15:52.593400",
      "status": "completed"
     },
     "tags": []
@@ -953,16 +947,16 @@
    "id": "5d865191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.577002Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.575981Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.683298Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.683298Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.611477Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.611288Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.680724Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.680256Z"
     },
     "papermill": {
-     "duration": 0.11261,
-     "end_time": "2026-09-07T21:59:41.684234",
+     "duration": 0.07382,
+     "end_time": "2026-09-12T09:15:52.681499",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.571624",
+     "start_time": "2026-09-12T09:15:52.607679",
      "status": "completed"
     },
     "tags": []
@@ -979,7 +973,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\3844112144.py:23: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_16184\\3844112144.py:23: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
       "  plt.show()\n"
      ]
     }
@@ -1016,10 +1010,10 @@
    "id": "6a70f864",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-09-07T21:59:41.692235",
+     "duration": 0.003004,
+     "end_time": "2026-09-12T09:15:52.687686",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.688234",
+     "start_time": "2026-09-12T09:15:52.684682",
      "status": "completed"
     },
     "tags": []
@@ -1050,10 +1044,10 @@
    "id": "d6c07d66",
    "metadata": {
     "papermill": {
-     "duration": 0.003504,
-     "end_time": "2026-09-07T21:59:41.699253",
+     "duration": 0.002978,
+     "end_time": "2026-09-12T09:15:52.693738",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.695749",
+     "start_time": "2026-09-12T09:15:52.690760",
      "status": "completed"
     },
     "tags": []
@@ -1076,16 +1070,16 @@
    "id": "99a8b748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.709042Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.709042Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.731725Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.730998Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.700922Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.700707Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.725766Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.725078Z"
     },
     "papermill": {
-     "duration": 0.028623,
-     "end_time": "2026-09-07T21:59:41.732662",
+     "duration": 0.029674,
+     "end_time": "2026-09-12T09:15:52.726651",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.704039",
+     "start_time": "2026-09-12T09:15:52.696977",
      "status": "completed"
     },
     "tags": []
@@ -1123,10 +1117,10 @@
    "id": "c8ce81ab",
    "metadata": {
     "papermill": {
-     "duration": 0.003938,
-     "end_time": "2026-09-07T21:59:41.740323",
+     "duration": 0.002873,
+     "end_time": "2026-09-12T09:15:52.732483",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.736385",
+     "start_time": "2026-09-12T09:15:52.729610",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1148,10 @@
    "id": "d91992e5",
    "metadata": {
     "papermill": {
-     "duration": 0.003508,
-     "end_time": "2026-09-07T21:59:41.748036",
+     "duration": 0.003213,
+     "end_time": "2026-09-12T09:15:52.738508",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.744528",
+     "start_time": "2026-09-12T09:15:52.735295",
      "status": "completed"
     },
     "tags": []
@@ -1190,10 +1184,10 @@
    "id": "89e80388",
    "metadata": {
     "papermill": {
-     "duration": 0.004504,
-     "end_time": "2026-09-07T21:59:41.756541",
+     "duration": 0.003388,
+     "end_time": "2026-09-12T09:15:52.745247",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.752037",
+     "start_time": "2026-09-12T09:15:52.741859",
      "status": "completed"
     },
     "tags": []
@@ -1222,16 +1216,16 @@
    "id": "0e411f47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.765565Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.765565Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.934497Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.934497Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.752954Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.752650Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.883075Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.882652Z"
     },
     "papermill": {
-     "duration": 0.174437,
-     "end_time": "2026-09-07T21:59:41.935497",
+     "duration": 0.135306,
+     "end_time": "2026-09-12T09:15:52.883890",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.761060",
+     "start_time": "2026-09-12T09:15:52.748584",
      "status": "completed"
     },
     "tags": []
@@ -1241,7 +1235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple guide 1 : latence dims=128 : [(10000, 3.4), (100000, 36.9)]\n",
+      "Exemple guide 1 : latence dims=128 : [(10000, 2.8), (100000, 28.0)]\n",
       "Effet attendu de la dimension : à mesurer — la latence doit croître avec d, mais l'ordre de grandeur reste en N.\n"
      ]
     }
@@ -1270,10 +1264,10 @@
    "id": "b1aaa5cb",
    "metadata": {
     "papermill": {
-     "duration": 0.003502,
-     "end_time": "2026-09-07T21:59:41.943001",
+     "duration": 0.003167,
+     "end_time": "2026-09-12T09:15:52.890489",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.939499",
+     "start_time": "2026-09-12T09:15:52.887322",
      "status": "completed"
     },
     "tags": []
@@ -1294,16 +1288,16 @@
    "id": "83a78773",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.952630Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.952630Z",
-     "iopub.status.idle": "2026-09-07T21:59:41.965539Z",
-     "shell.execute_reply": "2026-09-07T21:59:41.965539Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.897494Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.897314Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.900579Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.900079Z"
     },
     "papermill": {
-     "duration": 0.018912,
-     "end_time": "2026-09-07T21:59:41.966541",
+     "duration": 0.007717,
+     "end_time": "2026-09-12T09:15:52.901361",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.947629",
+     "start_time": "2026-09-12T09:15:52.893644",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1327,10 @@
    "id": "9da4b0c1",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-09-07T21:59:41.974539",
+     "duration": 0.003088,
+     "end_time": "2026-09-12T09:15:52.907677",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.970540",
+     "start_time": "2026-09-12T09:15:52.904589",
      "status": "completed"
     },
     "tags": []
@@ -1355,16 +1349,16 @@
    "id": "dad4b659",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:41.982582Z",
-     "iopub.status.busy": "2026-09-07T21:59:41.982582Z",
-     "iopub.status.idle": "2026-09-07T21:59:42.089271Z",
-     "shell.execute_reply": "2026-09-07T21:59:42.089271Z"
+     "iopub.execute_input": "2026-09-12T09:15:52.914926Z",
+     "iopub.status.busy": "2026-09-12T09:15:52.914593Z",
+     "iopub.status.idle": "2026-09-12T09:15:52.992299Z",
+     "shell.execute_reply": "2026-09-12T09:15:52.991583Z"
     },
     "papermill": {
-     "duration": 0.112694,
-     "end_time": "2026-09-07T21:59:42.090273",
+     "duration": 0.082152,
+     "end_time": "2026-09-12T09:15:52.993059",
      "exception": false,
-     "start_time": "2026-09-07T21:59:41.977579",
+     "start_time": "2026-09-12T09:15:52.910907",
      "status": "completed"
     },
     "tags": []
@@ -1402,10 +1396,10 @@
    "id": "68625efd",
    "metadata": {
     "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-09-07T21:59:42.099272",
+     "duration": 0.00334,
+     "end_time": "2026-09-12T09:15:52.999931",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.094271",
+     "start_time": "2026-09-12T09:15:52.996591",
      "status": "completed"
     },
     "tags": []
@@ -1427,16 +1421,16 @@
    "id": "d9fdea59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:42.109195Z",
-     "iopub.status.busy": "2026-09-07T21:59:42.108196Z",
-     "iopub.status.idle": "2026-09-07T21:59:42.120537Z",
-     "shell.execute_reply": "2026-09-07T21:59:42.119985Z"
+     "iopub.execute_input": "2026-09-12T09:15:53.007431Z",
+     "iopub.status.busy": "2026-09-12T09:15:53.007064Z",
+     "iopub.status.idle": "2026-09-12T09:15:53.010380Z",
+     "shell.execute_reply": "2026-09-12T09:15:53.009887Z"
     },
     "papermill": {
-     "duration": 0.018355,
-     "end_time": "2026-09-07T21:59:42.121544",
+     "duration": 0.00827,
+     "end_time": "2026-09-12T09:15:53.011160",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.103189",
+     "start_time": "2026-09-12T09:15:53.002890",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1460,10 @@
    "id": "a5cce54f",
    "metadata": {
     "papermill": {
-     "duration": 0.004514,
-     "end_time": "2026-09-07T21:59:42.132071",
+     "duration": 0.003258,
+     "end_time": "2026-09-12T09:15:53.017667",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.127557",
+     "start_time": "2026-09-12T09:15:53.014409",
      "status": "completed"
     },
     "tags": []
@@ -1488,16 +1482,16 @@
    "id": "fd1ee930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:42.142143Z",
-     "iopub.status.busy": "2026-09-07T21:59:42.142143Z",
-     "iopub.status.idle": "2026-09-07T21:59:42.168241Z",
-     "shell.execute_reply": "2026-09-07T21:59:42.167256Z"
+     "iopub.execute_input": "2026-09-12T09:15:53.025429Z",
+     "iopub.status.busy": "2026-09-12T09:15:53.025194Z",
+     "iopub.status.idle": "2026-09-12T09:15:53.122350Z",
+     "shell.execute_reply": "2026-09-12T09:15:53.121329Z"
     },
     "papermill": {
-     "duration": 0.031169,
-     "end_time": "2026-09-07T21:59:42.168241",
+     "duration": 0.102183,
+     "end_time": "2026-09-12T09:15:53.123371",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.137072",
+     "start_time": "2026-09-12T09:15:53.021188",
      "status": "completed"
     },
     "tags": []
@@ -1535,10 +1529,10 @@
    "id": "07d64ee4",
    "metadata": {
     "papermill": {
-     "duration": 0.007028,
-     "end_time": "2026-09-07T21:59:42.182283",
+     "duration": 0.003594,
+     "end_time": "2026-09-12T09:15:53.130726",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.175255",
+     "start_time": "2026-09-12T09:15:53.127132",
      "status": "completed"
     },
     "tags": []
@@ -1550,10 +1544,17 @@
     "aussi `MatchAny` pour **ou** plusieurs valeurs d'un même champ (par ex. deux thèmes). C'est un\n",
     "opérateur différent : on perd le filtrage fin, on gagne du volume.\n",
     "\n",
-    "Complétez `filtre_match_any` : un `Filter` avec UNE `FieldCondition` sur `theme` utilisant\n",
-    "`m.MatchAny(any=[...])` (deux thèmes), puis interrogez `client2.query_points`. Renvoyez les points,\n",
-    "et comparez le nombre de résultats à celui de `no_filter` (sans filtre) : quelle part du corpus\n",
-    "est retenue ?\n"
+    "Complétez `filtre_match_any` en deux gestes :\n",
+    "\n",
+    "1. **Chercher** : un `Filter` avec UNE `FieldCondition` sur `theme` utilisant `m.MatchAny(any=[...])`\n",
+    "   (deux thèmes), puis interrogez `client2.query_points` — le même geste que l'exemple guidé 3.\n",
+    "2. **Recenser** : « quelle part du corpus est retenue ? » ne se lit **pas** sur cette requête. Un\n",
+    "   k-NN rend au plus `limit` points — comparer les longueurs de deux top-10 (`no_filter` et le\n",
+    "   vôtre) donne 10/10 = 100 % : un artefact de `limit`, pas une propriété du filtre. Le bon outil\n",
+    "   est le décompte filtré, `client2.count(\"chunks\", count_filter=filtre, exact=True)` — déjà\n",
+    "   croisé en section 2 pour prouver la persistance — rapporté au total sans filtre.\n",
+    "\n",
+    "Renvoyez les points de la recherche, et imprimez la part retenue (filtré / total)."
    ]
   },
   {
@@ -1562,16 +1563,16 @@
    "id": "b293a37c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T21:59:42.191776Z",
-     "iopub.status.busy": "2026-09-07T21:59:42.191776Z",
-     "iopub.status.idle": "2026-09-07T21:59:42.198782Z",
-     "shell.execute_reply": "2026-09-07T21:59:42.197803Z"
+     "iopub.execute_input": "2026-09-12T09:15:53.141166Z",
+     "iopub.status.busy": "2026-09-12T09:15:53.140572Z",
+     "iopub.status.idle": "2026-09-12T09:15:53.144743Z",
+     "shell.execute_reply": "2026-09-12T09:15:53.144064Z"
     },
     "papermill": {
-     "duration": 0.012517,
-     "end_time": "2026-09-07T21:59:42.198782",
+     "duration": 0.010691,
+     "end_time": "2026-09-12T09:15:53.145834",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.186265",
+     "start_time": "2026-09-12T09:15:53.135143",
      "status": "completed"
     },
     "tags": []
@@ -1587,13 +1588,15 @@
    ],
    "source": [
     "def filtre_match_any(themes=(\"sécurité\", \"réseau\"), limit=10):\n",
-    "    # TODO étudiant : construire un Filter avec m.MatchAny(any=[...]) sur theme,\n",
-    "    # puis interroger client2.query_points(\"chunks\", ..., query_filter=filtre) et renvoyer les points.\n",
+    "    # TODO étudiant : (1) construire un Filter avec m.MatchAny(any=[...]) sur theme,\n",
+    "    # interroger client2.query_points(\"chunks\", ..., query_filter=filtre) et renvoyer les points.\n",
     "    # Indice : m.FieldCondition(key=\"theme\", match=m.MatchAny(any=list(themes))).\n",
+    "    # (2) Part du corpus retenue : client2.count(\"chunks\", count_filter=filtre, exact=True).count\n",
+    "    # divisé par le total sans filtre — jamais par comparaison de longueurs de top-k.\n",
     "    result = None\n",
     "    return result\n",
     "\n",
-    "print(\"Exercice 3 à compléter : le filtre MatchAny et la part du corpus.\")\n"
+    "print(\"Exercice 3 à compléter : le filtre MatchAny et la part du corpus.\")"
    ]
   },
   {
@@ -1601,10 +1604,10 @@
    "id": "ee96182e",
    "metadata": {
     "papermill": {
-     "duration": 0.00353,
-     "end_time": "2026-09-07T21:59:42.206824",
+     "duration": 0.003412,
+     "end_time": "2026-09-12T09:15:53.153545",
      "exception": false,
-     "start_time": "2026-09-07T21:59:42.203294",
+     "start_time": "2026-09-12T09:15:53.150133",
      "status": "completed"
     },
     "tags": []
@@ -1652,18 +1655,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 24.90412,
-   "end_time": "2026-09-07T21:59:42.558624",
+   "duration": 10.792438,
+   "end_time": "2026-09-12T09:15:53.615152",
    "environment_variables": {},
    "exception": null,
-   "input_path": "05-Stockage-Vectoriel.ipynb",
-   "output_path": "05-Stockage-Vectoriel.ipynb",
+   "input_path": "D:\\Dev\\CoursIA-15674\\MyIA.AI.Notebooks\\GenAI\\RAG-et-Memoire-Semantique\\05-Stockage-Vectoriel.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-15674\\MyIA.AI.Notebooks\\GenAI\\RAG-et-Memoire-Semantique\\05-Stockage-Vectoriel_output.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T21:59:17.654504",
+   "start_time": "2026-09-12T09:15:42.822714",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb
@@ -5,10 +5,10 @@
    "id": "5b08c667",
    "metadata": {
     "papermill": {
-     "duration": 0.003267,
-     "end_time": "2026-09-12T09:15:44.498388",
+     "duration": 0.004062,
+     "end_time": "2026-09-12T21:55:04.070642+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:44.495121",
+     "start_time": "2026-09-12T21:55:04.066580+00:00",
      "status": "completed"
     },
     "tags": []
@@ -50,10 +50,10 @@
    "id": "99f69b09",
    "metadata": {
     "papermill": {
-     "duration": 0.002477,
-     "end_time": "2026-09-12T09:15:44.503606",
+     "duration": 0.003415,
+     "end_time": "2026-09-12T21:55:04.077121+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:44.501129",
+     "start_time": "2026-09-12T21:55:04.073706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -77,16 +77,16 @@
    "id": "872a4a4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:44.510078Z",
-     "iopub.status.busy": "2026-09-12T09:15:44.509791Z",
-     "iopub.status.idle": "2026-09-12T09:15:45.190172Z",
-     "shell.execute_reply": "2026-09-12T09:15:45.189632Z"
+     "iopub.execute_input": "2026-09-12T21:55:04.084377Z",
+     "iopub.status.busy": "2026-09-12T21:55:04.084377Z",
+     "iopub.status.idle": "2026-09-12T21:55:05.165400Z",
+     "shell.execute_reply": "2026-09-12T21:55:05.164389Z"
     },
     "papermill": {
-     "duration": 0.6848,
-     "end_time": "2026-09-12T09:15:45.190981",
+     "duration": 1.086744,
+     "end_time": "2026-09-12T21:55:05.166683+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:44.506181",
+     "start_time": "2026-09-12T21:55:04.079939+00:00",
      "status": "completed"
     },
     "tags": []
@@ -96,10 +96,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "N=    1,000 (d=64) | k-NN exact top-10 :     0.2 ms\n",
-      "N=   10,000 (d=64) | k-NN exact top-10 :     1.3 ms\n",
-      "N=  100,000 (d=64) | k-NN exact top-10 :    13.5 ms\n",
-      "N=1,000,000 (d=64) | k-NN exact top-10 :   139.7 ms\n"
+      "N=    1,000 (d=64) | k-NN exact top-10 :     0.8 ms\n",
+      "N=   10,000 (d=64) | k-NN exact top-10 :     1.4 ms\n",
+      "N=  100,000 (d=64) | k-NN exact top-10 :    14.2 ms\n",
+      "N=1,000,000 (d=64) | k-NN exact top-10 :   207.6 ms\n"
      ]
     }
    ],
@@ -139,10 +139,10 @@
    "id": "336b70ac",
    "metadata": {
     "papermill": {
-     "duration": 0.00273,
-     "end_time": "2026-09-12T09:15:45.196876",
+     "duration": 0.00341,
+     "end_time": "2026-09-12T21:55:05.172734+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.194146",
+     "start_time": "2026-09-12T21:55:05.169324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -168,16 +168,16 @@
    "id": "05c79505",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:45.203181Z",
-     "iopub.status.busy": "2026-09-12T09:15:45.202954Z",
-     "iopub.status.idle": "2026-09-12T09:15:45.721860Z",
-     "shell.execute_reply": "2026-09-12T09:15:45.721509Z"
+     "iopub.execute_input": "2026-09-12T21:55:05.181358Z",
+     "iopub.status.busy": "2026-09-12T21:55:05.181358Z",
+     "iopub.status.idle": "2026-09-12T21:55:06.160068Z",
+     "shell.execute_reply": "2026-09-12T21:55:06.160068Z"
     },
     "papermill": {
-     "duration": 0.522938,
-     "end_time": "2026-09-12T09:15:45.722453",
+     "duration": 0.983149,
+     "end_time": "2026-09-12T21:55:06.160068+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.199515",
+     "start_time": "2026-09-12T21:55:05.176919+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,7 +194,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_16184\\2135674488.py:16: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\2135674488.py:16: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
       "  plt.show()\n"
      ]
     }
@@ -224,10 +224,10 @@
    "id": "98ef526b",
    "metadata": {
     "papermill": {
-     "duration": 0.003003,
-     "end_time": "2026-09-12T09:15:45.728504",
+     "duration": 0.00523,
+     "end_time": "2026-09-12T21:55:06.168860+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.725501",
+     "start_time": "2026-09-12T21:55:06.163630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -251,10 +251,10 @@
    "id": "dcaffeac",
    "metadata": {
     "papermill": {
-     "duration": 0.002909,
-     "end_time": "2026-09-12T09:15:45.736268",
+     "duration": 0.003372,
+     "end_time": "2026-09-12T21:55:06.175704+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.733359",
+     "start_time": "2026-09-12T21:55:06.172332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +282,16 @@
    "id": "e6cb79d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:45.742981Z",
-     "iopub.status.busy": "2026-09-12T09:15:45.742735Z",
-     "iopub.status.idle": "2026-09-12T09:15:45.749889Z",
-     "shell.execute_reply": "2026-09-12T09:15:45.749512Z"
+     "iopub.execute_input": "2026-09-12T21:55:06.182997Z",
+     "iopub.status.busy": "2026-09-12T21:55:06.182997Z",
+     "iopub.status.idle": "2026-09-12T21:55:06.192911Z",
+     "shell.execute_reply": "2026-09-12T21:55:06.192911Z"
     },
     "papermill": {
-     "duration": 0.011467,
-     "end_time": "2026-09-12T09:15:45.750557",
+     "duration": 0.013331,
+     "end_time": "2026-09-12T21:55:06.192911+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.739090",
+     "start_time": "2026-09-12T21:55:06.179580+00:00",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +337,10 @@
    "id": "48358bc6",
    "metadata": {
     "papermill": {
-     "duration": 0.00307,
-     "end_time": "2026-09-12T09:15:45.756684",
+     "duration": 0.004587,
+     "end_time": "2026-09-12T21:55:06.201035+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.753614",
+     "start_time": "2026-09-12T21:55:06.196448+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,16 +361,16 @@
    "id": "a0ee062a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:45.764454Z",
-     "iopub.status.busy": "2026-09-12T09:15:45.764075Z",
-     "iopub.status.idle": "2026-09-12T09:15:51.588289Z",
-     "shell.execute_reply": "2026-09-12T09:15:51.587801Z"
+     "iopub.execute_input": "2026-09-12T21:55:06.208939Z",
+     "iopub.status.busy": "2026-09-12T21:55:06.208939Z",
+     "iopub.status.idle": "2026-09-12T21:55:12.231707Z",
+     "shell.execute_reply": "2026-09-12T21:55:12.231707Z"
     },
     "papermill": {
-     "duration": 5.829276,
-     "end_time": "2026-09-12T09:15:51.589086",
+     "duration": 6.028757,
+     "end_time": "2026-09-12T21:55:12.232776+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:45.759810",
+     "start_time": "2026-09-12T21:55:06.204019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -380,7 +380,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "collection 'chunks' créée sur disque -> C:\\Users\\jsboi\\AppData\\Local\\Temp\\rag05_24pack7h\n"
+      "collection 'chunks' créée sur disque -> rag05_ba5vqogb\n"
      ]
     },
     {
@@ -404,7 +404,7 @@
     "    \"chunks\",\n",
     "    vectors_config=models.VectorParams(size=64, distance=models.Distance.COSINE),\n",
     ")\n",
-    "print(\"collection 'chunks' créée sur disque ->\", STORE_DIR)\n",
+    "print(\"collection 'chunks' créée sur disque ->\", os.path.basename(STORE_DIR))\n",
     "\n",
     "# Upsert par lots (comme en production on ne vide pas 10⁶ points d'un coup).\n",
     "BATCH = 500\n",
@@ -422,10 +422,10 @@
    "id": "661a9585",
    "metadata": {
     "papermill": {
-     "duration": 0.003047,
-     "end_time": "2026-09-12T09:15:51.595264",
+     "duration": 0.003254,
+     "end_time": "2026-09-12T21:55:12.239819+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.592217",
+     "start_time": "2026-09-12T21:55:12.236565+00:00",
      "status": "completed"
     },
     "tags": []
@@ -447,16 +447,16 @@
    "id": "8ef39016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:51.602497Z",
-     "iopub.status.busy": "2026-09-12T09:15:51.602020Z",
-     "iopub.status.idle": "2026-09-12T09:15:51.643450Z",
-     "shell.execute_reply": "2026-09-12T09:15:51.642863Z"
+     "iopub.execute_input": "2026-09-12T21:55:12.248201Z",
+     "iopub.status.busy": "2026-09-12T21:55:12.248201Z",
+     "iopub.status.idle": "2026-09-12T21:55:12.291900Z",
+     "shell.execute_reply": "2026-09-12T21:55:12.291330Z"
     },
     "papermill": {
-     "duration": 0.045894,
-     "end_time": "2026-09-12T09:15:51.644232",
+     "duration": 0.049239,
+     "end_time": "2026-09-12T21:55:12.291900+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.598338",
+     "start_time": "2026-09-12T21:55:12.242661+00:00",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +483,10 @@
    "id": "2f0e6cd0",
    "metadata": {
     "papermill": {
-     "duration": 0.002951,
-     "end_time": "2026-09-12T09:15:51.650447",
+     "duration": 0.003294,
+     "end_time": "2026-09-12T21:55:12.299050+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.647496",
+     "start_time": "2026-09-12T21:55:12.295756+00:00",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +512,10 @@
    "id": "6c546513",
    "metadata": {
     "papermill": {
-     "duration": 0.002579,
-     "end_time": "2026-09-12T09:15:51.655675",
+     "duration": 0.00333,
+     "end_time": "2026-09-12T21:55:12.305851+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.653096",
+     "start_time": "2026-09-12T21:55:12.302521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -543,16 +543,16 @@
    "id": "4d83e15c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:51.662444Z",
-     "iopub.status.busy": "2026-09-12T09:15:51.661999Z",
-     "iopub.status.idle": "2026-09-12T09:15:51.670563Z",
-     "shell.execute_reply": "2026-09-12T09:15:51.670093Z"
+     "iopub.execute_input": "2026-09-12T21:55:12.313223Z",
+     "iopub.status.busy": "2026-09-12T21:55:12.313223Z",
+     "iopub.status.idle": "2026-09-12T21:55:12.323276Z",
+     "shell.execute_reply": "2026-09-12T21:55:12.323276Z"
     },
     "papermill": {
-     "duration": 0.012866,
-     "end_time": "2026-09-12T09:15:51.671262",
+     "duration": 0.015556,
+     "end_time": "2026-09-12T21:55:12.324369+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.658396",
+     "start_time": "2026-09-12T21:55:12.308813+00:00",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +628,10 @@
    "id": "bf8383b9",
    "metadata": {
     "papermill": {
-     "duration": 0.002994,
-     "end_time": "2026-09-12T09:15:51.677552",
+     "duration": 0.003474,
+     "end_time": "2026-09-12T21:55:12.331368+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.674558",
+     "start_time": "2026-09-12T21:55:12.327894+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "e711c757",
    "metadata": {
     "papermill": {
-     "duration": 0.002895,
-     "end_time": "2026-09-12T09:15:51.683394",
+     "duration": 0.003374,
+     "end_time": "2026-09-12T21:55:12.338540+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.680499",
+     "start_time": "2026-09-12T21:55:12.335166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -689,16 +689,16 @@
    "id": "3b070cc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:51.691717Z",
-     "iopub.status.busy": "2026-09-12T09:15:51.691482Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.448867Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.448471Z"
+     "iopub.execute_input": "2026-09-12T21:55:12.347647Z",
+     "iopub.status.busy": "2026-09-12T21:55:12.346573Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.147067Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.147067Z"
     },
     "papermill": {
-     "duration": 0.763163,
-     "end_time": "2026-09-12T09:15:52.449492",
+     "duration": 0.80623,
+     "end_time": "2026-09-12T21:55:13.148226+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:51.686329",
+     "start_time": "2026-09-12T21:55:12.341996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 0.7s\n"
+      "graphe petit-monde bâti : 10000 nœuds, m=8, r=3 — 0.8s\n"
      ]
     }
    ],
@@ -746,10 +746,10 @@
    "id": "15be578f",
    "metadata": {
     "papermill": {
-     "duration": 0.002817,
-     "end_time": "2026-09-12T09:15:52.455328",
+     "duration": 0.002437,
+     "end_time": "2026-09-12T21:55:13.154481+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.452511",
+     "start_time": "2026-09-12T21:55:13.152044+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,16 +770,16 @@
    "id": "1cd46fa2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.461901Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.461691Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.520391Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.519863Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.164339Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.163739Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.227631Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.227631Z"
     },
     "papermill": {
-     "duration": 0.063037,
-     "end_time": "2026-09-12T09:15:52.521028",
+     "duration": 0.068001,
+     "end_time": "2026-09-12T21:55:13.227631+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.457991",
+     "start_time": "2026-09-12T21:55:13.159630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -789,7 +789,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "référence exacte : recall@10=1.000, latence=1.4 ms, évaluations=10000 par requête\n"
+      "référence exacte : recall@10=1.000, latence=1.5 ms, évaluations=10000 par requête\n"
      ]
     }
    ],
@@ -815,10 +815,10 @@
    "id": "da8b3e9e",
    "metadata": {
     "papermill": {
-     "duration": 0.002945,
-     "end_time": "2026-09-12T09:15:52.527053",
+     "duration": 0.003997,
+     "end_time": "2026-09-12T21:55:13.236297+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.524108",
+     "start_time": "2026-09-12T21:55:13.232300+00:00",
      "status": "completed"
     },
     "tags": []
@@ -837,16 +837,16 @@
    "id": "0a423623",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.533811Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.533481Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.589692Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.589175Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.243987Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.243987Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.308300Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.308300Z"
     },
     "papermill": {
-     "duration": 0.060536,
-     "end_time": "2026-09-12T09:15:52.590438",
+     "duration": 0.069699,
+     "end_time": "2026-09-12T21:55:13.309404+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.529902",
+     "start_time": "2026-09-12T21:55:13.239705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -857,13 +857,13 @@
      "output_type": "stream",
      "text": [
       " ef  | recall@10 | latence(ms) | évaluations\n",
-      "   1 | 0.040    |    0.06   | 16\n",
-      "   2 | 0.050    |    0.07   | 30\n",
-      "   4 | 0.070    |    0.12   | 61\n",
-      "   8 | 0.165    |    0.23   | 116\n",
-      "  16 | 0.240    |    0.35   | 179\n",
-      "  32 | 0.405    |    0.58   | 307\n",
-      "  64 | 0.645    |    1.05   | 521\n"
+      "   1 | 0.040    |    0.11   | 16\n",
+      "   2 | 0.050    |    0.08   | 30\n",
+      "   4 | 0.070    |    0.13   | 61\n",
+      "   8 | 0.165    |    0.25   | 116\n",
+      "  16 | 0.240    |    0.38   | 179\n",
+      "  32 | 0.405    |    0.72   | 307\n",
+      "  64 | 0.645    |    1.11   | 521\n"
      ]
     }
    ],
@@ -916,10 +916,10 @@
    "id": "6f1a05c8",
    "metadata": {
     "papermill": {
-     "duration": 0.002746,
-     "end_time": "2026-09-12T09:15:52.596146",
+     "duration": 0.003556,
+     "end_time": "2026-09-12T21:55:13.317135+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.593400",
+     "start_time": "2026-09-12T21:55:13.313579+00:00",
      "status": "completed"
     },
     "tags": []
@@ -947,16 +947,16 @@
    "id": "5d865191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.611477Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.611288Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.680724Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.680256Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.324179Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.324179Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.391291Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.391291Z"
     },
     "papermill": {
-     "duration": 0.07382,
-     "end_time": "2026-09-12T09:15:52.681499",
+     "duration": 0.072204,
+     "end_time": "2026-09-12T21:55:13.392330+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.607679",
+     "start_time": "2026-09-12T21:55:13.320126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -973,7 +973,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_16184\\3844112144.py:23: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\3844112144.py:23: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
       "  plt.show()\n"
      ]
     }
@@ -1010,10 +1010,10 @@
    "id": "6a70f864",
    "metadata": {
     "papermill": {
-     "duration": 0.003004,
-     "end_time": "2026-09-12T09:15:52.687686",
+     "duration": 0.003333,
+     "end_time": "2026-09-12T21:55:13.399582+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.684682",
+     "start_time": "2026-09-12T21:55:13.396249+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1044,10 +1044,10 @@
    "id": "d6c07d66",
    "metadata": {
     "papermill": {
-     "duration": 0.002978,
-     "end_time": "2026-09-12T09:15:52.693738",
+     "duration": 0.002755,
+     "end_time": "2026-09-12T21:55:13.405850+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.690760",
+     "start_time": "2026-09-12T21:55:13.403095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1070,16 +1070,16 @@
    "id": "99a8b748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.700922Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.700707Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.725766Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.725078Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.416343Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.416343Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.439900Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.439900Z"
     },
     "papermill": {
-     "duration": 0.029674,
-     "end_time": "2026-09-12T09:15:52.726651",
+     "duration": 0.029843,
+     "end_time": "2026-09-12T21:55:13.440951+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.696977",
+     "start_time": "2026-09-12T21:55:13.411108+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1117,10 +1117,10 @@
    "id": "c8ce81ab",
    "metadata": {
     "papermill": {
-     "duration": 0.002873,
-     "end_time": "2026-09-12T09:15:52.732483",
+     "duration": 0.002949,
+     "end_time": "2026-09-12T21:55:13.447846+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.729610",
+     "start_time": "2026-09-12T21:55:13.444897+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1148,10 +1148,10 @@
    "id": "d91992e5",
    "metadata": {
     "papermill": {
-     "duration": 0.003213,
-     "end_time": "2026-09-12T09:15:52.738508",
+     "duration": 0.004077,
+     "end_time": "2026-09-12T21:55:13.455494+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.735295",
+     "start_time": "2026-09-12T21:55:13.451417+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1184,10 +1184,10 @@
    "id": "89e80388",
    "metadata": {
     "papermill": {
-     "duration": 0.003388,
-     "end_time": "2026-09-12T09:15:52.745247",
+     "duration": 0.002706,
+     "end_time": "2026-09-12T21:55:13.462228+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.741859",
+     "start_time": "2026-09-12T21:55:13.459522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1216,16 +1216,16 @@
    "id": "0e411f47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.752954Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.752650Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.883075Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.882652Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.472531Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.471919Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.597011Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.596560Z"
     },
     "papermill": {
-     "duration": 0.135306,
-     "end_time": "2026-09-12T09:15:52.883890",
+     "duration": 0.129968,
+     "end_time": "2026-09-12T21:55:13.597011+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.748584",
+     "start_time": "2026-09-12T21:55:13.467043+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1235,7 +1235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exemple guide 1 : latence dims=128 : [(10000, 2.8), (100000, 28.0)]\n",
+      "Exemple guide 1 : latence dims=128 : [(10000, 2.7), (100000, 27.4)]\n",
       "Effet attendu de la dimension : à mesurer — la latence doit croître avec d, mais l'ordre de grandeur reste en N.\n"
      ]
     }
@@ -1264,10 +1264,10 @@
    "id": "b1aaa5cb",
    "metadata": {
     "papermill": {
-     "duration": 0.003167,
-     "end_time": "2026-09-12T09:15:52.890489",
+     "duration": 0.004849,
+     "end_time": "2026-09-12T21:55:13.605594+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.887322",
+     "start_time": "2026-09-12T21:55:13.600745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1288,16 +1288,16 @@
    "id": "83a78773",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.897494Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.897314Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.900579Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.900079Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.613738Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.613738Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.617604Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.617007Z"
     },
     "papermill": {
-     "duration": 0.007717,
-     "end_time": "2026-09-12T09:15:52.901361",
+     "duration": 0.008936,
+     "end_time": "2026-09-12T21:55:13.618186+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.893644",
+     "start_time": "2026-09-12T21:55:13.609250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1327,10 +1327,10 @@
    "id": "9da4b0c1",
    "metadata": {
     "papermill": {
-     "duration": 0.003088,
-     "end_time": "2026-09-12T09:15:52.907677",
+     "duration": 0.00431,
+     "end_time": "2026-09-12T21:55:13.626185+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.904589",
+     "start_time": "2026-09-12T21:55:13.621875+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1349,16 +1349,16 @@
    "id": "dad4b659",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:52.914926Z",
-     "iopub.status.busy": "2026-09-12T09:15:52.914593Z",
-     "iopub.status.idle": "2026-09-12T09:15:52.992299Z",
-     "shell.execute_reply": "2026-09-12T09:15:52.991583Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.634423Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.634423Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.712516Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.712516Z"
     },
     "papermill": {
-     "duration": 0.082152,
-     "end_time": "2026-09-12T09:15:52.993059",
+     "duration": 0.083049,
+     "end_time": "2026-09-12T21:55:13.713077+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.910907",
+     "start_time": "2026-09-12T21:55:13.630028+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1396,10 +1396,10 @@
    "id": "68625efd",
    "metadata": {
     "papermill": {
-     "duration": 0.00334,
-     "end_time": "2026-09-12T09:15:52.999931",
+     "duration": 0.002562,
+     "end_time": "2026-09-12T21:55:13.719578+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:52.996591",
+     "start_time": "2026-09-12T21:55:13.717016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1421,16 +1421,16 @@
    "id": "d9fdea59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:53.007431Z",
-     "iopub.status.busy": "2026-09-12T09:15:53.007064Z",
-     "iopub.status.idle": "2026-09-12T09:15:53.010380Z",
-     "shell.execute_reply": "2026-09-12T09:15:53.009887Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.730165Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.729545Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.733746Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.733141Z"
     },
     "papermill": {
-     "duration": 0.00827,
-     "end_time": "2026-09-12T09:15:53.011160",
+     "duration": 0.009758,
+     "end_time": "2026-09-12T21:55:13.734352+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.002890",
+     "start_time": "2026-09-12T21:55:13.724594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1460,10 +1460,10 @@
    "id": "a5cce54f",
    "metadata": {
     "papermill": {
-     "duration": 0.003258,
-     "end_time": "2026-09-12T09:15:53.017667",
+     "duration": 0.004571,
+     "end_time": "2026-09-12T21:55:13.742015+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.014409",
+     "start_time": "2026-09-12T21:55:13.737444+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1482,16 +1482,16 @@
    "id": "fd1ee930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:53.025429Z",
-     "iopub.status.busy": "2026-09-12T09:15:53.025194Z",
-     "iopub.status.idle": "2026-09-12T09:15:53.122350Z",
-     "shell.execute_reply": "2026-09-12T09:15:53.121329Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.749954Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.749954Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.771691Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.771092Z"
     },
     "papermill": {
-     "duration": 0.102183,
-     "end_time": "2026-09-12T09:15:53.123371",
+     "duration": 0.026822,
+     "end_time": "2026-09-12T21:55:13.772336+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.021188",
+     "start_time": "2026-09-12T21:55:13.745514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1529,10 +1529,10 @@
    "id": "07d64ee4",
    "metadata": {
     "papermill": {
-     "duration": 0.003594,
-     "end_time": "2026-09-12T09:15:53.130726",
+     "duration": 0.003392,
+     "end_time": "2026-09-12T21:55:13.779823+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.127132",
+     "start_time": "2026-09-12T21:55:13.776431+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1563,16 +1563,16 @@
    "id": "b293a37c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-12T09:15:53.141166Z",
-     "iopub.status.busy": "2026-09-12T09:15:53.140572Z",
-     "iopub.status.idle": "2026-09-12T09:15:53.144743Z",
-     "shell.execute_reply": "2026-09-12T09:15:53.144064Z"
+     "iopub.execute_input": "2026-09-12T21:55:13.789339Z",
+     "iopub.status.busy": "2026-09-12T21:55:13.787618Z",
+     "iopub.status.idle": "2026-09-12T21:55:13.792464Z",
+     "shell.execute_reply": "2026-09-12T21:55:13.792464Z"
     },
     "papermill": {
-     "duration": 0.010691,
-     "end_time": "2026-09-12T09:15:53.145834",
+     "duration": 0.009068,
+     "end_time": "2026-09-12T21:55:13.793508+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.135143",
+     "start_time": "2026-09-12T21:55:13.784440+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1604,10 +1604,10 @@
    "id": "ee96182e",
    "metadata": {
     "papermill": {
-     "duration": 0.003412,
-     "end_time": "2026-09-12T09:15:53.153545",
+     "duration": 0.003418,
+     "end_time": "2026-09-12T21:55:13.799964+00:00",
      "exception": false,
-     "start_time": "2026-09-12T09:15:53.150133",
+     "start_time": "2026-09-12T21:55:13.796546+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1655,18 +1655,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.16"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.792438,
-   "end_time": "2026-09-12T09:15:53.615152",
+   "duration": 12.013736,
+   "end_time": "2026-09-12T21:55:14.137902+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-15674\\MyIA.AI.Notebooks\\GenAI\\RAG-et-Memoire-Semantique\\05-Stockage-Vectoriel.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-15674\\MyIA.AI.Notebooks\\GenAI\\RAG-et-Memoire-Semantique\\05-Stockage-Vectoriel_output.ipynb",
+   "input_path": "05-Stockage-Vectoriel.ipynb",
+   "output_path": "05-Stockage-Vectoriel.ipynb",
    "parameters": {},
-   "start_time": "2026-09-12T09:15:42.822714",
+   "start_time": "2026-09-12T21:55:02.124166+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15731

## Summary

L'exercice 3 (`MatchAny`) du notebook 05 demandait : « comparez le nombre de résultats à celui de `no_filter` (sans filtre) : **quelle part du corpus est retenue ?** » — or les deux requêtes comparées sont des **top-10** (`no_filter` : `limit=10` cellule 26 ; stub : `limit=10` par défaut). Deux requêtes k-NN rendent chacune au plus `limit` points : la « part du corpus » lue sur leurs longueurs vaut 10/10 = 100 % quel que soit le filtre — un artefact de `limit`, pas une propriété du filtre. La question posée n'était pas répondable par l'outillage fourni (finding H05 re-vérifié firsthand par l'opener, CONFIRMED pedagogy).

## Le correctif (2 cellules : 1 markdown + 1 stub)

L'énoncé réécrit décompose l'exercice en deux gestes, et le piège devient l'enseignement :

1. **Chercher** (geste inchangé) : `Filter` avec `FieldCondition` sur `theme` en `m.MatchAny(any=[...])`, requête `client2.query_points` — le même geste que l'exemple guidé 3.
2. **Recenser** (le correctif) : la question « quelle part du corpus est retenue ? » ne se lit pas sur une requête k-NN. L'énoncé nomme l'artefact (comparer deux top-10 donne 10/10 = 100 %) et oriente vers le bon outil : `client2.count("chunks", count_filter=filtre, exact=True)` rapporté au total sans filtre.

L'API `count` est **déjà dans le vocabulaire du notebook** : la cellule 11 (section 2, preuve de persistance) l'utilise sans filtre — l'exercice l'étend avec `count_filter`, en miroir de `query_points(query_filter=...)`. Support mesuré avant d'écrire : `count_filter` + `MatchAny` fonctionne en mode local Qdrant (sonde :memory:, 5/10 points sur un payload binaire — exactement le comportement attendu).

Le stub (cellule 40) garde `result = None  # TODO étudiant` (C.1) ; seuls les commentaires TODO décrivent les deux gestes.

## Vérification

```
$ python scripts/notebook_tools/notebook_tools.py execute <05> --timeout 600
[+] SUCCESS — 12.2s (kernel coursia-ml-training)
$ python scripts/notebook_tools/validate_pr_notebooks.py <05>
PASS (17 cells)
```

- Ré-exécution complète (C.2 : cellule code source modifiée), séquence 1..17, 0 erreur.
- C.1 : stub intact (`result = None` + print, aucun `raise NotImplementedError`).
- Sorties re-productives : les 3 chemins temp présents dans les sorties (warning ipykernel matplotlib ×2, print `STORE_DIR` du notebook) sont **pré-existants sur main dans les mêmes cellules** (4, 9, 23) — même classe, non introduits ici.
- Catalogue byte-identique à main (aucun fichier catalogue touché).

Closes #15674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-13T05:04:28Z -->

## Rouge `Always-on guards` : collision de lane fantome (corrige, non un defaut du diff)

L'organe `lane_claim` bloquait sur une collision **inexistante**. Verdict du helper du depot, rejoue localement :

```
{"guard_pass": false, "pr_lane": "myia-po-2023:CoursIA",
 "blocking_lane": "myia-po-2023:CoursIA. Énoncé", "blocking_issue": 15674, ...}
```

`myia-po-2023:CoursIA. Énoncé` n'est pas une lane : c'est mon propre commentaire `[DELIVERED]` sur #15674 qui ecrivait `lane myia-po-2023:CoursIA.` suivi d'un mot accentue. L'extracteur avale le point final et la capitale accentuee et fabrique une lane fantome — meme classe que #15864. Le gate voyait donc ma lane fermer une issue « detenue » par une autre lane, qui etait la mienne deformee.

Corrige a la source : le commentaire de #15674 passe au tiret cadratin (`lane myia-po-2023:CoursIA —`), la forme que son `[CLAIMED]` voisin utilise deja et qui parse correctement. Verifie avec le helper du depot :

```
{"guard_pass": true, "blocking_lane": null, "blocking_claim_at": null, ...}   EXIT=0
```

Aucun fichier du diff n'est en cause : le rouge venait du texte d'un commentaire d'issue, pas du notebook.
