### PR TITLE
feat(ci,#15739): le rouge d'adjacence nomme son référentiel + commande de recalcul autonome

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -951,13 +951,29 @@ jobs:
           # et un blocage calcule sur 'merged-sequence' n'ont pas la meme
           # valeur probante, et rien ne les distinguait dans la sortie.
           PREV_SRC=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('prev_source','?'))" 2>/dev/null || echo "?")
-          echo "::error::G-VAR-3 LIGHT-genre adjacency [predecesseur lu sur: $PREV_SRC]: $REASON"
+          # #15739 : le REFERENTIEL complet du verdict -- contre quoi il a
+          # conclu. Un rouge d'adjacence est une fonction de la sequence de
+          # merges AU MOMENT du check ; des qu'une autre PR de la lane merge,
+          # le rouge affiche devient perime sans que rien ne le re-tourne. Le
+          # referential rend la peremption VISIBLE (prev #N + genre + source +
+          # horodatage de la sequence) et la commande de recalcul est DANS le
+          # message, pas dans une doc a retrouver.
+          PREV_PR=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('prev_pr','?'))" 2>/dev/null || echo "?")
+          PREV_GENRE=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('prev_genre','?'))" 2>/dev/null || echo "?")
+          SEQ_AS_OF=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('sequence_as_of') or 'n/a')" 2>/dev/null || echo "n/a")
+          echo "::error::G-VAR-3 LIGHT-genre adjacency [prev: #${PREV_PR} ${PREV_GENRE} via ${PREV_SRC} ; sequence de merges au ${SEQ_AS_OF}]: $REASON"
 
           gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
           <!-- vtr-adjacency-block -->
           **G-VAR-3 : deux grains LIGHT du meme genre consecutifs -- bloquant (#11170).**
 
           ${REASON}
+
+          **Referentiel du verdict (#15739)** -- ce verdict a ete calcule contre : predecesseur \#${PREV_PR} (\`${PREV_GENRE}\`, source \`${PREV_SRC}\`), sequence de merges arretee au \`${SEQ_AS_OF}\`. Un merge posterieur de la meme lane peut l'avoir invalide -- recalculer avec :
+
+          \`\`\`bash
+          python scripts/ci/variation_adjacency_guard.py --pr-number ${PR_NUMBER}
+          \`\`\`
 
           variation-protocol.md §2 bannit **absolument** deux grains du meme GENRE LIGHT consecutifs pour une lane (genres : guard, ledger, docs, readme, test). Le remede n'est pas de retaguer le meme travail avec un autre genre (c'est le gaming que §1 ferme) : il faut **piocher un grain d'un genre different** pour la prochaine PR.
 

--- a/scripts/ci/refresh_stale_adjacency.py
+++ b/scripts/ci/refresh_stale_adjacency.py
@@ -78,6 +78,7 @@ from variation_adjacency_guard import (  # noqa: E402
     check,
     parse_override,
     resolve_merged_prev_genre,
+    sequence_as_of,
 )
 
 MARKER_RE = re.compile(r"<!--\s*refresh-adj:\s*[^>]+\s*-->")
@@ -188,7 +189,14 @@ def simulate_adjacency(pr_number: int, body: str, merged_window: list[dict]) -> 
 
     override = parse_override(get_pr_comments(pr_number))
     merged_prev = resolve_merged_prev_genre(merged_window, g["lane"])
-    return check(body, override=override, merged_prev=merged_prev)
+    verdict = check(body, override=override, merged_prev=merged_prev)
+    # #15739 : le verdict simule porte son referentiel comme celui de la CI --
+    # contre quelle sequence il a conclu (prev_pr/genre/source + horodatage),
+    # pour qu'un lecteur distingue un recalcul frais d'un rouge perime.
+    verdict = dict(verdict)
+    verdict["prev_source"] = "merged-sequence"
+    verdict["sequence_as_of"] = sequence_as_of(merged_window)
+    return verdict
 
 
 def refresh_one(pr_number: int, dry_run: bool, merged_window: list[dict]) -> dict:

--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -105,6 +105,52 @@ from variation_light_cap import (  # noqa: E402
     genre_resolves,
 )
 
+# Same directory as this guard: the date-sliced merged-window fetcher. The
+# self-sufficient recompute mode (#15739) reuses it rather than re-deriving
+# the slicing -- the `--page` incident (fetch_merged_prs_since.py header)
+# came from exactly such a re-derivation.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from fetch_merged_prs_since import fetch as fetch_merged_window  # noqa: E402
+from fetch_merged_prs_since import since_date  # noqa: E402
+
+
+def sequence_as_of(merged_prs: list[dict] | None) -> str | None:
+    """Freshest merge the verdict could see -- the staleness boundary (#15739).
+
+    A same-lane merge with ``mergedAt`` AFTER this timestamp post-dates the
+    verdict's referential and may have moved the predecessor: the red stays
+    displayed while nothing re-runs it. Surfacing the boundary lets a worker
+    distinguish a live red from a stale one. ``mergedAt`` is ISO-8601, so the
+    lexicographic max is the chronologic one. None when the window was absent
+    (the verdict then rests on the ``declared`` axis -- `prev_source` says so).
+    """
+    if not merged_prs:
+        return None
+    return max((pr.get("mergedAt") or "") for pr in merged_prs) or None
+
+
+def _gh_pr_body_comments(pr_number: int) -> dict | None:
+    """``{body, comments}`` of a PR via gh; None when the fetch fails.
+
+    Self-sufficient recompute mode only -- CI passes files, humans paste
+    ``--pr-number N`` (#15739). Failure yields None and the caller degrades
+    loudly (exit 2), never silently to declared data.
+    """
+    try:
+        res = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "body,comments",
+             "--jq", "{body: .body, comments: "
+                     "[.comments[] | {author: .author.login, body: .body}]}"],
+            capture_output=True, text=True, timeout=20,
+            encoding="utf-8", errors="replace",
+        )
+        if res.returncode != 0:
+            return None
+        return json.loads(res.stdout)
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError, TypeError):
+        return None
+
+
 
 # --- G-VAR-3 override (#11708) --------------------------------------------
 #
@@ -557,8 +603,10 @@ def check(body: str | None, override: dict | None = None,
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
-    p.add_argument("--body-file", metavar="FILE", required=True,
-                   help="path to the PR body")
+    p.add_argument("--body-file", metavar="FILE", default=None,
+                   help="path to the PR body. Absent avec --pr-number : mode "
+                        "recalcul autonome (#15739) -- le garde fetch son "
+                        "propre body, ses commentaires et la fenetre de merges.")
     p.add_argument("--comments-file", metavar="FILE", default=None,
                    help="JSON list of {author, body} PR comments, scanned for "
                         "a coordinator [G-VAR-3 OVERRIDE] marker (#11708)")
@@ -571,56 +619,106 @@ def main(argv: list[str] | None = None) -> int:
                    help="PR number, to fetch the CURRENT PR's diff files for "
                         "the #14357 disjoint-files exemption. Without it the "
                         "exemption cannot be evaluated and the gate is "
-                        "fail-closed (no exemption).")
+                        "fail-closed (no exemption). Alone (no --body-file) : "
+                        "self-sufficient recompute -- the exact command the "
+                        "stale-red message tells a worker to paste (#15739).")
     args = p.parse_args(argv)
 
-    try:
-        with open(args.body_file, encoding="utf-8") as f:
-            body = f.read()
-    except OSError as e:
-        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}"}),
-              file=sys.stderr)
-        return 2
+    if not args.body_file and not args.pr_number:
+        p.error("--body-file ou --pr-number requis (mode CI : fichiers ; "
+                "mode recalcul : --pr-number seul, #15739)")
 
+    self_fetch = args.body_file is None
     override = None
-    if args.comments_file:
-        try:
-            with open(args.comments_file, encoding="utf-8") as f:
-                override = parse_override(json.load(f))
-        except (OSError, ValueError) as e:
-            print(json.dumps({"warning": f"comments unreadable: {e}"}),
-                  file=sys.stderr)
-
+    seq_as_of = None
     merged_prev = None
     merged_fallback_note = None
-    if args.merged_prs_file:
+    merged_prs = None
+
+    if self_fetch:
+        # #15739 : la commande `--pr-number N` seule doit marcher telle
+        # qu'elle est copier-collee depuis le message d'un rouge perime. Un
+        # fetch qui echoue est un echec BRUYANT (exit 2) -- jamais un repli
+        # silencieux sur le prev: declare, qui ferait recalculer le worker
+        # contre le mauvais axe en croyant tenir le frais.
+        payload = _gh_pr_body_comments(args.pr_number)
+        if payload is None:
+            print(json.dumps({
+                "guard_pass": False, "blocking": False,
+                "reason": (f"#15739 recalcul autonome : fetch gh pr view "
+                           f"#{args.pr_number} illisible (gh absent, reseau, "
+                           f"ou PR inexistante) -- aucun verdict rendu."),
+            }), file=sys.stderr)
+            return 2
+        body = payload.get("body") or ""
+        override = parse_override(payload.get("comments") or [])
         try:
-            with open(args.merged_prs_file, encoding="utf-8") as f:
-                merged_prs = json.load(f)
-            g = gt.parse_grain_tag(body)
-            merged_prev = resolve_merged_prev_genre(merged_prs, g["lane"] if g else None)
-            if merged_prev[0] is None and merged_prs:
-                # #12636: the merged window was fetched and is non-empty, but the
-                # lane has no grain in it. The guard falls back to the declared
-                # `prev:` -- that fallback must be VISIBLE, never silent (the
-                # pre-#12095 silent fallback is exactly the defect fixed here,
-                # and a window that misses the lane deserves a note, not a mute).
-                merged_fallback_note = (
-                    f"lane {g['lane'] if g else None} absente du window merge "
-                    f"({len(merged_prs)} PRs) -- predecesseur resolu depuis le "
-                    f"prev: declare (#12636)"
-                )
-        except (OSError, ValueError) as e:
-            # #15184: the unreadable path must be LOUD in the JSON verdict, not
-            # only on stderr -- the pre-#12636 silent fallback is the defect
-            # this closes, and a window that was fetched but could not be read
-            # deserves the same note as a window that missed the lane.
+            merged_prs = fetch_merged_window(since_date(21))
+        except (RuntimeError, OSError) as e:
+            print(json.dumps({
+                "guard_pass": False, "blocking": False,
+                "reason": f"#15739 recalcul autonome : fenetre de merges illisible ({e}).",
+            }), file=sys.stderr)
+            return 2
+        g_probe = gt.parse_grain_tag(body)
+        merged_prev = resolve_merged_prev_genre(
+            merged_prs, g_probe["lane"] if g_probe else None)
+        if merged_prev[0] is None and merged_prs:
             merged_fallback_note = (
-                f"window merge illisible ({e}) -- predecesseur resolu depuis le "
-                f"prev: declare (#15184)"
+                f"lane {g_probe['lane'] if g_probe else None} absente du window "
+                f"merge ({len(merged_prs)} PRs) -- predecesseur resolu depuis "
+                f"le prev: declare (#12636)"
             )
-            print(json.dumps({"warning": f"merged-prs unreadable: {e}"}),
+    else:
+        try:
+            with open(args.body_file, encoding="utf-8") as f:
+                body = f.read()
+        except OSError as e:
+            print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}"}),
                   file=sys.stderr)
+            return 2
+
+        if args.comments_file:
+            try:
+                with open(args.comments_file, encoding="utf-8") as f:
+                    override = parse_override(json.load(f))
+            except (OSError, ValueError) as e:
+                print(json.dumps({"warning": f"comments unreadable: {e}"}),
+                      file=sys.stderr)
+
+        if args.merged_prs_file:
+            try:
+                with open(args.merged_prs_file, encoding="utf-8") as f:
+                    merged_prs = json.load(f)
+                g = gt.parse_grain_tag(body)
+                merged_prev = resolve_merged_prev_genre(merged_prs, g["lane"] if g else None)
+                if merged_prev[0] is None and merged_prs:
+                    # #12636: the merged window was fetched and is non-empty, but the
+                    # lane has no grain in it. The guard falls back to the declared
+                    # `prev:` -- that fallback must be VISIBLE, never silent (the
+                    # pre-#12095 silent fallback is exactly the defect fixed here,
+                    # and a window that misses the lane deserves a note, not a mute).
+                    merged_fallback_note = (
+                        f"lane {g['lane'] if g else None} absente du window merge "
+                        f"({len(merged_prs)} PRs) -- predecesseur resolu depuis le "
+                        f"prev: declare (#12636)"
+                    )
+            except (OSError, ValueError) as e:
+                # #15184: the unreadable path must be LOUD in the JSON verdict, not
+                # only on stderr -- the pre-#12636 silent fallback is the defect
+                # this closes, and a window that was fetched but could not be read
+                # deserves the same note as a window that missed the lane.
+                merged_fallback_note = (
+                    f"window merge illisible ({e}) -- predecesseur resolu depuis le "
+                    f"prev: declare (#15184)"
+                )
+                print(json.dumps({"warning": f"merged-prs unreadable: {e}"}),
+                      file=sys.stderr)
+
+    # #15739 : le referentiel du verdict. Sans fenetre de merges, le verdict
+    # repose sur l'axe declared (prev_source le dit) et il n'y a pas de
+    # sequence a dater.
+    seq_as_of = sequence_as_of(merged_prs)
 
     # #14357: the disjoint-files exemption needs the current PR's diff AND a
     # MEASURED predecessor. When the predecessor resolved to the merged
@@ -637,8 +735,9 @@ def main(argv: list[str] | None = None) -> int:
 
     verdict = check(body, override=override, merged_prev=merged_prev,
                     prev_files=prev_files, current_files=current_files)
+    verdict = dict(verdict)
+    verdict["sequence_as_of"] = seq_as_of
     if merged_fallback_note:
-        verdict = dict(verdict)
         verdict["prev_source"] = "declared"
         verdict["prev_fallback"] = merged_fallback_note
         verdict["reason"] = f"{verdict.get('reason', '')} {merged_fallback_note}".strip()

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -877,3 +877,87 @@ def test_unreadable_merged_window_is_loud_in_verdict(tmp_path, capsys):
     assert "prev_fallback" in verdict
     assert "window merge illisible" in verdict["prev_fallback"]
     assert "window merge illisible" in verdict["reason"]
+
+
+# --- #15739 : le referentiel du verdict (peremption visible) ----------------
+
+# Le cas fondateur, mesure le 2026-09-12 : dix PRs LIGHT/docs de
+# myia-po-2025:CoursIA rouges pendant que le predecesseur etait docs (#15723),
+# puis #15687 (MED/notebook-python, merge 08:15:17Z) a deplace le predecesseur
+# -- les dix verdicts affiches restaient rouges sans que rien ne les re-tourne.
+_FOUNDER_BODY = (
+    "Grain: LIGHT/docs — lane myia-po-2025:CoursIA — prev: LIGHT/docs #15723"
+)
+_SEQ_A = [  # sequence AVANT le merge basculeur : le predecesseur est docs
+    {"number": 15723, "body": "Grain: LIGHT/docs — lane myia-po-2025:CoursIA",
+     "mergedAt": "2026-09-12T07:00:00Z"},
+]
+_SEQ_B = _SEQ_A + [  # #15687 merge : le predecesseur devient notebook-python
+    {"number": 15687, "body": "Grain: MED/notebook-python — lane myia-po-2025:CoursIA",
+     "mergedAt": "2026-09-12T08:15:17Z"},
+]
+
+
+def test_sequence_as_of_helper():
+    assert vag.sequence_as_of(None) is None
+    assert vag.sequence_as_of([]) is None
+    got = vag.sequence_as_of(_SEQ_B)
+    assert got == "2026-09-12T08:15:17Z"
+
+
+def test_15739_deux_etats_du_cas_fondateur(tmp_path, capsys):
+    """Controle positif exigé par l'acceptance : un rouge d'adjacence, puis un
+    merge de la même lane changeant le genre du prédécesseur -- la sortie du
+    check nomme les DEUX états (rouge avec son référentiel, recalcul vert)."""
+    body_file = tmp_path / "body.txt"
+    body_file.write_text(_FOUNDER_BODY, encoding="utf-8")
+
+    seq_a = tmp_path / "seq_a.json"
+    seq_a.write_text(json.dumps(_SEQ_A), encoding="utf-8")
+    rc_a = vag.main(["--body-file", str(body_file), "--merged-prs-file", str(seq_a)])
+    red = json.loads(capsys.readouterr().out)
+
+    # Etat 1 (le rouge perissable) : bloquant, ET son referentiel est nomme.
+    assert rc_a == 1
+    assert red["guard_pass"] is False and red["blocking"] is True
+    assert red["prev_pr"] == 15723
+    assert red["prev_genre"] == "docs"
+    assert red["prev_source"] == "merged-sequence"
+    assert red["sequence_as_of"] == "2026-09-12T07:00:00Z"
+
+    seq_b = tmp_path / "seq_b.json"
+    seq_b.write_text(json.dumps(_SEQ_B), encoding="utf-8")
+    rc_b = vag.main(["--body-file", str(body_file), "--merged-prs-file", str(seq_b)])
+    green = json.loads(capsys.readouterr().out)
+
+    # Etat 2 (le recalcul apres merge de la meme lane) : passant, prevourseur
+    # deplace, sequence datee au merge basculeur -- les deux verdicts
+    # distinguish un rouge vivant d'un rouge perime par leur referentiel.
+    assert rc_b == 0
+    assert green["guard_pass"] is True
+    assert green["prev_pr"] == 15687
+    assert green["prev_genre"] == "notebook-python"
+    assert green["sequence_as_of"] == "2026-09-12T08:15:17Z"
+
+
+def test_15739_sequence_as_of_null_sans_fenetre(tmp_path, capsys):
+    """Sans fenetre de merges, le verdict repose sur l'axe declared : pas de
+    sequence a dater, le champ est null (jamais une date fabriquee)."""
+    body_file = tmp_path / "body.txt"
+    body_file.write_text(_FOUNDER_BODY, encoding="utf-8")
+    rc = vag.main(["--body-file", str(body_file)])
+    verdict = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert verdict["prev_source"] == "declared"
+    assert verdict["sequence_as_of"] is None
+
+
+def test_15739_argv_sans_body_ni_pr_nombre():
+    """La validation d'argv echoue proprement (exit 2) quand aucun mode n'est
+    fourni -- pas de crash silencieux en aval."""
+    try:
+        vag.main([])
+    except SystemExit as e:
+        assert e.code == 2
+    else:
+        raise AssertionError("main([]) doit sortir en argparse error")


### PR DESCRIPTION
## Ce que corrige cette PR

Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15744

#15739 : un rouge d'adjacence G-VAR-3 est une fonction de **la séquence de merges au moment où le check tourne**. Dès qu'une autre PR de la même lane merge, le rouge affiché devient **périmé sans que rien ne le re-tourne** — le cas fondateur mesuré : dix PRs `LIGHT/docs` de `myia-po-2025:CoursIA` rouges, toutes devenues vertes au recalcul après le merge de #15687 (08:15:17Z) qui déplaçait le prédécesseur. Le worker comme le coordinateur traitaient ces rouges périmés comme des défauts à réparer (diagnostic faux reconduit sur plusieurs cycles).

Le choix de l'issue : rendre la péremption **visible** plutôt que tenter de la supprimer (re-tourner tous les checks de la lane à chaque merge serait coûteux et fragile). La sweep horaire (`refresh_stale_adjacency.py`, suppression par re-trigger) existait déjà ; il manquait la **disclosure**.

## Le fix — trois gestes

1. **`sequence_as_of` dans le verdict** (`scripts/ci/variation_adjacency_guard.py`) : le `mergedAt` du merge le plus frais de la fenêtre utilisée — la **frontière de péremption**. Tout merge same-lane postérieur à ce timestamp date d'après le référentiel du verdict et a pu déplacer le prédécesseur. `null` quand le verdict repose sur l'axe `declared` (pas de séquence à dater — jamais une date fabriquée). Le JSON portait déjà `prev_pr`/`prev_genre`/`prev_source` ; ils remontent maintenant avec leur horodatage. Stamped aussi dans le verdict simulé de la sweep (`refresh_stale_adjacency.py`, import direct — pas de ré-assemblage).
2. **Le rouge nomme son référentiel** (workflow `always-on-guards.yml`) : le `::error` porte `[prev: #N <genre> via <source> ; séquence de merges au <ts>]`, et le commentaire PR gagne un bloc **« Référentiel du verdict (#15739) »** avec la phrase exigée verbatim (« un merge postérieur de la même lane peut l'avoir invalidé — recalculer avec : ») et **la commande de recalcul dans le message**, pas dans une doc à retrouver.
3. **La commande de recalcul marche en copier-coller** : `python scripts/ci/variation_adjacency_guard.py --pr-number N` est désormais **autonome** (avant : `--body-file` requis, la commande de l'acceptation n'existait pas). Le mode fetch lui-même son body, ses commentaires (marqueurs OVERRIDE) et sa fenêtre de merges via `fetch_merged_prs_since` (réutilisé par import — l'incident `--page` est venu d'une telle ré-derivation). Un fetch qui échoue est **bruyant** (exit 2) — jamais un repli silencieux sur l'axe `declared`, qui ferait recalculer le worker contre le mauvais axe en croyant tenir le frais.

## Contrôle positif (acceptance) — le cas fondateur reproduit

Test déterministe `test_15739_deux_etats_du_cas_fondateur` avec les vraies valeurs mesurées : séquence A (prédécesseur #15723 `docs` @07:00Z) → **rouge bloquant** nommant `prev: #15723 docs via merged-sequence, sequence_as_of 07:00Z` ; séquence B (+ #15687 `notebook-python` @08:15:17Z) → **pass** nommant `prev: #15687, sequence_as_of 08:15:17Z`. Les deux verdicts se distinguent par leur référentiel — c'est exactement « la sortie du check nomme les deux états ».

**Contrôle live** (commande autonome, vraie PR) :

```
$ python scripts/ci/variation_adjacency_guard.py --pr-number 15744
{"guard_pass": true, ..., "prev_pr": 15711, "prev_source": "merged-sequence",
 "sequence_as_of": "2026-09-12T10:38:25Z"}
```

Fetch complet (body + comments + fenêtre 21 jours slicée), prédécesseur résolu sur la séquence réelle, frontière de péremption datée. Un worker lisant un rouge peut coller cette commande et savoir si son rouge est vivant.

## Validation

- **4 tests neufs** (64 passed au total sur la suite) : deux-états du cas fondateur, helper `sequence_as_of` (None/liste/max), `sequence_as_of` null sans fenêtre, argv sans mode → exit 2 propre.
- Suites voisines : `test_refresh_stale_adjacency` + `test_pick_idle_grain` (126 passed — le stamp sweep ne casse rien).
- YAML valide ; périmètre 4 fichiers ; catalogue byte-identique à main.

## Hors périmètre (respecté)

- `Always-on guards` reste `isRequired=false` — pas de blocage dur.
- La résolution du prédécesseur (#12095) est intacte.

Closes #15739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
