### PR TITLE
fix(harness,#15726): le verdict DWELL cesse de prescrire l'attente

### DIFF
--- a/scripts/ci/merge_dwell.py
+++ b/scripts/ci/merge_dwell.py
@@ -40,16 +40,24 @@ organes deja en place rejouent precisement ce cas de figure, sans qu'aucun ne
 soit a ecrire :
 
   * `pr-gate-rerun.yml` -- `workflow_run` sur la fin d'un garde ;
-  * `pr-gate-stale-sweep.yml` -- balayage horaire (`cron: '7 * * * *'`) qui
+  * `pr-gate-stale-sweep.yml` -- balayage periodique (`cron: '7 * * * *'`,
+    mais cadence REELLE mesuree 2 h 33 - 5 h 18 entre tirs, #15197) qui
     selectionne exactement « une jambe `PR gate` rouge alors que tout le reste
     est vert », c'est-a-dire l'etat qu'une PR en attente de plancher presente,
     et **re-lance le run d'origine** (un POST d'un check-run homonyme atterrit
     dans une suite etrangere et GitHub ANDe les deux -- mesure #11519).
 
 Consequence a assumer et a dire : le plancher est un PLANCHER, pas une
-horloge. Une PR devient mergeable au premier balayage horaire suivant
-l'ecoulement des 2 h -- donc entre 2 h 00 et 3 h 00 apres son dernier commit,
-pas a 2 h 00 pile.
+horloge. Une PR devient mergeable au premier balayage suivant l'ecoulement
+des 2 h -- donc, a la cadence mesuree, entre 2 h 00 et ~7 h 20 apres son
+dernier commit, pas a 2 h 00 pile et pas a 3 h 00 non plus.
+
+Et la consequence qui compte pour une lane : cette fenetre est trop large
+pour etre attendue. Le verdict le dit donc explicitement -- on enchaine un
+autre grain, et on rejoue la jambe soi-meme apres l'ecoulement si on veut
+la merger sans attendre le balayage. Le message NE DOIT PAS dire qu'aucun
+geste n'est requis : c'etait faux (le balayage n'est pas horaire) et cela
+transformait un minuteur en instruction d'attente. Voir #15726.
 
 La date lue est celle du COMMITTER, pas de l'auteur
 ---------------------------------------------------
@@ -147,11 +155,16 @@ def evaluate(
         "%Y-%m-%dT%H:%M:%SZ"
     )
     return False, remaining, (
-        "tete du {}, {:.0f} min -- plancher {:.0f} min, reste {:.0f} min, "
-        "leve au premier balayage suivant {}. "
-        "Le balayage horaire (pr-gate-stale-sweep.yml, cron '7 * * * *') "
-        "re-agrege cette jambe des que le plancher est ecoule ; aucun geste "
-        "manuel n'est requis. Urgence (main rouge) : poser le label `{}` sur "
+        "tete du {}, {:.0f} min -- plancher {:.0f} min, reste {:.0f} min ; "
+        "ecoule a {}. "
+        "Rien a corriger dans le code : cette jambe est un minuteur. "
+        "NE PAS ATTENDRE -- enchainer un autre grain ; c'est la candidate "
+        "qui attend, pas la lane. Passe cette heure, la jambe se re-agrege "
+        "au balayage suivant (pr-gate-stale-sweep.yml ; cadence MESUREE "
+        "2 h 33 - 5 h 18 entre tirs, pas horaire malgre son cron "
+        "'7 * * * *' -- #15197), ou tout de suite en la rejouant soi-meme "
+        "(`gh run rerun <run_id> --job <job_id>`). "
+        "Urgence (main rouge) : poser le label `{}` sur "
         "la PR.".format(stamp, age_min, dwell_min, remaining, lift, WAIVER_LABEL)
     )
 

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -1171,9 +1171,14 @@ def verdict_body(message: str, advisory: Sequence[str] = ()) -> str:
     if message.startswith("DWELL"):
         lines += [
             "",
-            "Plancher mecanique -- rien a reparer dans la PR. Ne pas "
-            "re-pusher (un re-push remet le plancher a zero depuis la "
-            "nouvelle tete) ; le balayage horaire leve seul.",
+            "Plancher mecanique -- rien a reparer dans la PR, et rien "
+            "a attendre : enchainer un autre grain, c'est la candidate "
+            "qui attend, pas la lane. Ne pas re-pusher (un re-push "
+            "remet le plancher a zero depuis la nouvelle tete). Une "
+            "fois le plancher ecoule, rejouer cette jambe "
+            "(`gh run rerun <run_id> --job <job_id>`) ou laisser le "
+            "balayage la reprendre -- sa cadence mesuree est de 2 h 33 "
+            "a 5 h 18, pas horaire (#15197).",
         ]
     if advisory:
         lines += ["", "Advisory (not blocking):"]
@@ -1321,7 +1326,10 @@ def main(argv: Iterable[str] | None = None) -> int:
             "merge (mandat user 2026-09-07 : 120). 0 = desactive. Evalue "
             "APRES que les constituants ont conclu verts, hors de la boucle "
             "d'attente : aucun runner n'est tenu a dormir. Le rouge se leve "
-            "seul au balayage horaire de pr-gate-stale-sweep.yml. Voir "
+            "seul au balayage periodique de pr-gate-stale-sweep.yml "
+            "(cadence mesuree 2 h 33 - 5 h 18, pas horaire -- #15197), "
+            "ou en rejouant la jambe. Une lane n'attend jamais ce "
+            "balayage : elle enchaine un autre grain (#15726). Voir "
             "scripts/ci/merge_dwell.py."
         ),
     )
@@ -1406,7 +1414,9 @@ def main(argv: Iterable[str] | None = None) -> int:
     # Le plancher n'entre PAS dans la boucle d'attente. `wait_and_decide`
     # tient un slot de runner tant qu'il poll ; l'y faire dormir 120 min
     # tiendrait ce slot 120 min par PR. Le rouge rendu ici est rejoue par
-    # pr-gate-stale-sweep.yml (cron horaire) des que le plancher est ecoule.
+    # pr-gate-stale-sweep.yml des que le plancher est ecoule -- a une
+    # cadence mesuree de 2 h 33 a 5 h 18, pas horaire malgre son cron
+    # (#15197) : la lane rejoue la jambe elle-meme si elle veut merger.
     if code == 0 and args.dwell_min > 0:
         if _merge_dwell is None:
             # Rule 1 ne s'applique pas a une capacite absente : le module

--- a/scripts/tests/test_merge_dwell.py
+++ b/scripts/tests/test_merge_dwell.py
@@ -168,3 +168,26 @@ def test_check_bout_en_bout_accepte_une_tete_agee():
     ok, msg = merge_dwell.check("o/r", "abc", 42, 120.0, now=NOW, fetch=fetch)
     assert ok is True
     assert "dwell ecoule" in msg
+
+
+def test_le_verdict_ne_dit_jamais_d_attendre():
+    """#15726 : le message d'un plancher non ecoule ne doit pas fabriquer de l'attente.
+
+    Ce test asserte des ABSENCES, et c'est voulu : la regression qu'il attrape
+    n'est pas un calcul faux, c'est une PHRASE qui revient. Le verdict etait
+    juste (`False`) tout en disant « aucun geste manuel n'est requis » -- une
+    instruction d'attente, machine-emise sur chaque gate rouge, adossee a un
+    balayage annonce horaire dont la cadence mesuree est de 2 h 33 a 5 h 18
+    (#15197). Un organe qui dit au worker de ne rien faire est le frein que le
+    mandat user du 2026-09-12 demande de retirer.
+    """
+    _, _, msg = merge_dwell.evaluate(
+        datetime(2026, 9, 7, 11, 55, tzinfo=timezone.utc), NOW, 120.0, waived=False
+    )
+    assert "aucun geste" not in msg
+    assert "geste manuel n'est requis" not in msg
+    # Le mot « horaire » seul re-annonce la cadence fausse que #15197 mesure.
+    assert "balayage horaire" not in msg
+    # Et ce qui doit y etre : la lane continue, et peut rejouer elle-meme.
+    assert "NE PAS ATTENDRE" in msg
+    assert "rerun" in msg

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1634,6 +1634,29 @@ def test_step_summary_dwell_guides_against_repush(tmp_path, monkeypatch):
     assert "Ne pas re-pusher" in text
 
 
+def test_verdict_body_dwell_ne_prescrit_pas_l_attente():
+    """#15726 : la consigne DWELL publiee ne doit pas fabriquer de l'attente.
+
+    Cette assertion porte sur des ABSENCES, et c'est voulu -- la regression
+    qu'elle attrape n'est pas un calcul faux mais une PHRASE. Le verdict
+    etait juste (`False`) tandis que le corps publie disait « le balayage
+    horaire leve seul » : faux sur la cadence (mesuree 2 h 33 - 5 h 18 entre
+    tirs, #15197) et, surtout, une instruction d'attente machine-emise sur
+    chaque gate rouge. Depuis #15693 ce corps est aussi le `summary` du
+    check-run : il est lu dans l'UI par chaque lane, pas seulement en log.
+    """
+    body = pr_gate.verdict_body("DWELL -- tete du 2026-09-07T11:55:00Z")
+    assert "balayage horaire" not in body
+    assert "leve seul" not in body
+    # Ce que le retrait laisse ouvert, et rien de plus : que fait la lane.
+    assert "enchainer un autre grain" in body
+    assert "rerun" in body
+    # La garde anti-re-push de #15693 survit au retrait.
+    assert "Ne pas re-pusher" in body
+    # Controle negatif : hors DWELL, aucune de ces consignes n'est ajoutee.
+    assert "enchainer un autre grain" not in pr_gate.verdict_body("FAIL -- x")
+
+
 def test_step_summary_fork_short_circuit(tmp_path, monkeypatch):
     """The fork PASS publishes too (#10072) -- a student PR's check-run
     should not be the only one whose summary stays null."""


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/docs #15567

## Summary

`#15726` retire les lignes de **prose** qui rendent l'attente rationnelle. Cette PR en retire une **quatrième**, qui n'est pas de la prose : elle est émise par un organe, sur chaque `PR gate` rouge de tête jeune, et elle dit au worker de ne rien faire.

`scripts/ci/merge_dwell.py:144-146` construisait :

> « Le balayage horaire (pr-gate-stale-sweep.yml, cron `'7 * * * *'`) re-agrege cette jambe des que le plancher est ecoule ; **aucun geste manuel n'est requis.** »

## Mesure — « horaire » est faux, et c'est ce qui portait la promesse

8 derniers tirs `schedule` de `pr-gate-stale-sweep.yml` (`gh run list --workflow pr-gate-stale-sweep.yml`, 2026-09-12T11:0xZ) :

| Tir (UTC) | Écart avec le précédent |
|---|---|
| 2026-09-12T10:39:33Z | 4 h 56 |
| 2026-09-12T05:43:36Z | 4 h 40 |
| 2026-09-12T01:03:49Z | 2 h 33 |
| 2026-09-11T22:30:36Z | 2 h 53 |
| 2026-09-11T19:37:32Z | 3 h 14 |
| 2026-09-11T16:23:44Z | 5 h 12 |
| 2026-09-11T11:11:45Z | 5 h 18 |
| 2026-09-11T05:53:50Z | — |

**Écarts 2 h 33 – 5 h 18 contre 1 h déclarée. Aucun tir à `:07`.** Le taux de tir `schedule` est déjà mesuré par #15197 ; cette PR ne le répare pas — elle cesse de s'**appuyer dessus pour promettre**.

## Le défaut qui compte

Le verdict était **juste** (`False`, fail-closed) tout en prescrivant l'attente. Un worker dont la PR est rouge lit, d'un organe, que rien n'est requis de lui — et que ça se lèvera tout seul dans l'heure. La cadence réelle rend la fenêtre de 2 h 00 à ~7 h 20 après le dernier commit : trop large pour être attendue.

Contrôle mesuré sur #15725 (tête `feed8e51c3`) : `[pr-gate] settled: 18 check(s) green` puis `DWELL -- reste 60 min`. **18 checks verts, zéro rouge de code**, et un message qui dit d'attendre.

## Ce que le message dit maintenant

> tête du …, 60 min -- plancher 120 min, reste 60 min. **Rien a corriger dans le code : cette jambe est un minuteur. NE PAS ATTENDRE -- enchainer un autre grain ; c'est la candidate qui attend, pas la lane.** La jambe se re-agrege au balayage suivant (…cadence MESUREE 2 h 33 - 5 h 18…, pas horaire malgre son cron `'7 * * * *'` -- #15197), ou tout de suite apres l'ecoulement en rejouant la jambe soi-meme (`gh run rerun <run_id> --job <job_id>`). Urgence (main rouge) : poser le label `merge-dwell-waived`.

Principe « pas de pendule » (CLAUDE.md global) : la phrase fautive est **retirée**, pas remplacée par son opposé. Ce qui est ajouté comble les deux trous réels que le retrait laisse — *est-ce mon code qui est cassé ?* (non, c'est un minuteur) et *que fais-je à la place ?* (un autre grain, et je peux rejouer la jambe moi-même).

## Le verdict est inchangé — fail-closed intact

| Cas | Avant | Après |
|---|---|---|
| plancher non écoulé | `False` | `False` |
| plancher écoulé | `True` | `True` |
| label `merge-dwell-waived` | levée | levée |

Seul le texte bouge. `evaluate()` rendu firsthand sur la tête réelle de #15725 (08:02:22Z, 120 min, now=09:02:17Z) → `ok=False remaining=60`.

## Test — asserté par ses ABSENCES, contrôle positif montré

La régression à attraper n'est pas un calcul faux, c'est une **phrase qui revient**. `test_le_verdict_ne_dit_jamais_d_attendre` asserte `"aucun geste" not in msg`, `"balayage horaire" not in msg`, plus la présence de `NE PAS ATTENDRE` et `rerun`.

Un test d'absence ne vaut que par son contrôle positif — **rouge sur le code d'avant**, montré :

```
scripts\tests\test_merge_dwell.py:174: in test_le_verdict_ne_dit_jamais_d_attendre
    assert "aucun geste" not in msg
E   AssertionError: assert 'aucun geste' not in 'tete du 202...` sur la PR.'
E     'aucun geste' is contained here:
E        ecoule ; aucun geste manuel n'est requis. Urgence (main rouge) : poser le label ...
FAILED scripts/tests/test_merge_dwell.py::test_le_verdict_ne_dit_jamais_d_attendre
====================== 1 failed, 15 deselected in 0.08s =======================
```

Après correctif : **16/16** sur `test_merge_dwell.py`, **109/109** sur `test_pr_gate.py` + `test_pr_gate_sweep_timing.py` + `test_pr_gate_sweep_select.py`.

## Troisième site, même phrase

`scripts/pr_gate.py:997` (aide `--dwell-min`) disait aussi « le rouge se lève seul au balayage **horaire** ». Corrigé dans le même geste : cadence mesurée + « une lane n'attend jamais ce balayage ».

## Ce que cette PR ne fait pas

- Elle ne touche **aucun** fichier de `.claude/rules/**` — pas de sign-off §A requis (contrairement à #15727, qui en touche trois et que je ne peux donc pas auto-merger).
- Elle ne répare pas le taux de tir du `schedule` (#15197).
- Elle ne change pas le plancher de 120 min (mandat user 2026-09-07).

See #15726. See #15197. See #15725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
