### PR TITLE
fix(slides,#15747): %20 est une espace encodée, pas un séparateur — émission in-root préserve l'encodage (empilée sur #15452)

### DIFF
--- a/scripts/post_bake_slides.py
+++ b/scripts/post_bake_slides.py
@@ -63,6 +63,15 @@ contract, decided on #15703:
   - `%20` normalization is bounded to the absolute-path context: prose
     `Program%20Files` survives the bake untouched.
 
+Tell #15747 ★ NEW : `%20` is the URL encoding of a SPACE, not a path
+separator. The canonical form decodes it to a space on both sides of the
+build-root comparison, and the emitted in-root tail keeps its original
+encoding (`mon%20image.png` in -> `mon%20image.png` out, resolving to the
+spaced filename on disk; the pre-#15747 `%20 -> /` decode rewrote it to
+`mon/image.png`, a silent 404). A build root containing a literal space
+(the `Jean Dupont` class) now bakes successfully instead of failing
+closed. Prose `%20` still survives untouched (#15703 acceptance 4).
+
 This module:
   - rewrites the build-root prefix of every absolute Windows path
     (`C:/...`, `C:\\...`, `%20`-encoded) baked into the output;
@@ -110,20 +119,35 @@ def _is_target(fn: str) -> bool:
 
 
 def _canonical(path: str) -> str:
-    """Canonical emission form: URL-encoded `%20` separators and native
-    backslashes to `/`, case PRESERVED (the rewritten rest of an in-root
-    path keeps its original case)."""
-    return path.replace("%20", "/").replace("\\", "/")
+    """Canonical comparison form: URL-encoded `%20` decoded to a SPACE
+    (it is the encoding of one, never a path separator, #15747) and
+    native backslashes to `/`, case PRESERVED."""
+    return path.replace("%20", " ").replace("\\", "/")
+
+
+def _original_prefix_end(token_str: str, canon_len: int) -> int:
+    """Index in `token_str` where its canonical form reaches `canon_len`
+    characters. `%20` compresses 3 chars to 1 when canonicalized, so the
+    root boundary cannot be sliced off the canonical string: walk the
+    original instead, so the emitted tail keeps its original encoding
+    (#15747 -- a `%20` coming in goes out as `%20`)."""
+    clen = 0
+    i = 0
+    n = len(token_str)
+    while i < n and clen < canon_len:
+        i += 3 if token_str.startswith("%20", i) else 1
+        clen += 1
+    return i
 
 
 def _norm(path: str) -> str:
     """Normalize a path for build-root comparison: the canonical form
     case-folded (Windows paths are case-insensitive). Applied to BOTH
     the build root and each candidate token, so the prefix comparison is
-    encoding- and case-agnostic. A build root containing a literal space
-    can never match a baked token (tokens are whitespace-bounded, and
-    `%20` canonicalizes to `/`), so such roots fail closed -- consistent
-    with the reject-don't-rewrite posture of #15703."""
+    encoding- and case-agnostic. `%20` in a token decodes to a space, so
+    a build root containing a literal space (the `Jean Dupont` class)
+    matches its `%20`-encoded baked tokens and the bake SUCCEEDS
+    (#15747 -- previously such roots failed closed)."""
     return _canonical(path).lower()
 
 
@@ -133,10 +157,12 @@ def _rewrite(content: bytes, build_root: str) -> bytes:
 
     `build_root` is the absolute path of the build output directory (the
     form `os.path.abspath(ROOT)` produces on the bake machine). The
-    comparison is case-insensitive with `%20` and backslash separators
-    normalized to `/` on both sides, so `<root>/assets/app.js` becomes
-    `./assets/app.js` byte-exactly, and a token equal to the root itself
-    becomes `.`.
+    comparison is case-insensitive with `%20` decoded to a space and
+    backslash separators normalized to `/` on both sides, so
+    `<root>/assets/app.js` becomes `./assets/app.js` byte-exactly, a
+    token equal to the root itself becomes `.`, and the emitted tail
+    keeps its ORIGINAL encoding (`%20` in, `%20` out -- the reference
+    stays valid for the on-disk spaced filename, #15747).
 
     Raises `OutOfRootPathError` naming the path when `content` carries an
     absolute path that is NOT under `build_root` -- the caller fails the
@@ -149,11 +175,13 @@ def _rewrite(content: bytes, build_root: str) -> bytes:
         token_str = token.decode("utf-8", "replace")
         token_n = _norm(token_str)
         if token_n == root_n or token_n.startswith(root_n + "/"):
-            # In-root: slice the CASE-PRESERVING canonical form -- the
-            # match guarantees its first len(root_n) chars lowercase to
-            # the root, so the offset is exact and the rest keeps its
-            # original case (only %20/backslash are canonicalized).
-            rest = _canonical(token_str)[len(root_n):]
+            # In-root: slice the ORIGINAL token at the root boundary --
+            # `_original_prefix_end` tracks the 3:1 `%20` compression so
+            # the offset is exact -- then canonicalize only the
+            # separators of the tail. Case and `%20` encoding of the
+            # rest are preserved verbatim (#15747).
+            cut = _original_prefix_end(token_str, len(root_n))
+            rest = token_str[cut:].replace("\\", "/")
             return b"." + rest.encode("utf-8", "replace")
         raise OutOfRootPathError(
             "absolute path outside the build root: " + token_str

--- a/scripts/tests/test_post_bake_slides.py
+++ b/scripts/tests/test_post_bake_slides.py
@@ -21,6 +21,12 @@ Three generations of pins live in this file:
     5. the docstring describes what the code does (the obsolete
        `./nodejs/...` promise is gone).
 
+  - #15747: `%20` is an encoded SPACE, not a separator. Decoded to a
+    space on both sides of the comparison, and the emitted in-root tail
+    keeps its original encoding (`%20` in, `%20` out -- the pre-#15747
+    `%20 -> /` decode produced a silent 404). A build root with a
+    literal space now bakes successfully.
+
 Each test materializes a fake `dist/` tree under a `tmp_path` (or calls
 the pure functions directly) and asserts on byte-exact content, the
 reported counters, and the process exit code. The tests are positive
@@ -74,9 +80,10 @@ def test_rewrite_replaces_build_root_prefix_byte_exact() -> None:
         (b'x "D:/deck/dist"', b'x "."'),
         # deep rest preserved verbatim
         (b'"D:/deck/dist/a/b/c.js"', b'"./a/b/c.js"'),
-        # %20 INSIDE the path context is normalized (bounded, acceptance 4)
+        # %20 is an encoded SPACE: decoded for comparison, PRESERVED in
+        # the emission (#15747 supersedes the old %20->/ normalization)
         (b'href="D:/deck/dist/Program%20Files/x.js"',
-         b'href="./Program/Files/x.js"'),
+         b'href="./Program%20Files/x.js"'),
     ]
     for src, expected in cases:
         out = _rewrite(src, DECK_ROOT)
@@ -168,6 +175,53 @@ def test_rewrite_does_not_eat_markup() -> None:
 
 # --- acceptance 4: %20 bounded to the path context -------------------------
 
+# --- #15747: %20 is an encoded SPACE, not a separator ----------------------
+
+def test_15747_pct20_decodes_as_space_and_emission_preserves_encoding() -> None:
+    """#15747 acceptance: `_canonical` decodes `%20` to a SPACE (it is the
+    URL encoding of one, never a path separator), and the emitted in-root
+    tail keeps its ORIGINAL encoding -- a `%20` coming in goes out as
+    `%20`, so the reference still resolves to the on-disk spaced
+    filename. The pre-#15747 code rewrote `mon%20image.png` to
+    `mon/image.png`: a silent 404."""
+    from scripts.post_bake_slides import _rewrite
+
+    assert (
+        _rewrite(b'<img src="D:/deck/dist/images/mon%20image.png">', DECK_ROOT)
+        == b'<img src="./images/mon%20image.png">'
+    )
+
+
+def test_15747_bake_with_spaced_root_succeeds(tmp_path: Path) -> None:
+    """#15747 acceptance: a build root containing a literal space bakes
+    successfully -- the `%20`-encoded token matches the spaced root once
+    `%20` decodes to a space -- and the emitted path resolves on disk
+    (`./images/mon%20image.png` -> `images/mon image.png`)."""
+    base = tmp_path / "Jean Dupont" / "deck"
+    dist = base / "dist"
+    # the realistic baked form: a bundler URL-encodes EVERY space of the
+    # machine path, the on-disk build root keeps its literal spaces
+    base_posix = str(base).replace(os.sep, "/").replace(" ", "%20")
+    _write(
+        dist / "index.html",
+        f'<img src="{base_posix}/dist/images/mon%20image.png">'.encode(),
+    )
+    _write(dist / "images" / "mon image.png", b"PNGDATA")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=base,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (
+        f"exit={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    out = (dist / "index.html").read_bytes()
+    assert b'src="./images/mon%20image.png"' in out, out
+    # the emitted relative reference resolves against the on-disk spaced name
+    assert (dist / "images" / "mon image.png").is_file()
+
+
 def test_prose_percent20_survives() -> None:
     """#15703 acceptance 4 (unit): `Program%20Files` in prose (no
     drive-letter context) survives the rewrite byte-identically. The
@@ -210,8 +264,9 @@ def test_check_residue_reads_each_file_once(tmp_path: Path) -> None:
     out_a = (tmp_path / "dist" / "a.html").read_bytes()
     out_b = (tmp_path / "dist" / "b.html").read_bytes()
     assert b"./lib/app.js" in out_a, out_a
-    # %20 normalized INSIDE the path context (bounded), never in prose.
-    assert b"./Program/Files/lib/app.js" in out_b, out_b
+    # %20 = encoded space: PRESERVED in the emission, never touched in
+    # prose (#15747).
+    assert b"./Program%20Files/lib/app.js" in out_b, out_b
 
 
 def test_map_files_are_rewritten(tmp_path: Path) -> None:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-python #15750

## Ce que corrige cette PR


#15747 (fille de #15703, résidu latent de la PR #15722) : `_canonical()` décodait `%20` en **séparateur** (`path.replace("%20", "/")`). Or `%20` est l'encodage URL d'une **espace**. Conséquence mesurée : `<img src="D:/deck/dist/images/mon%20image.png">` sortait `./images/mon/image.png` alors que le fichier sur disque s'appelle `mon image.png` — **404 silencieux**, précisément la classe de défaut que #15703 existe pour supprimer (« refuser plutôt que réécrire en silence » : la branche in-root réécrivait en chemin faux). Latent — zéro asset versionné portant une espace aujourd'hui — il s'active au premier asset nommé avec une espace.

**Base actuelle = `main`.** La pile #15452 a atterri par merge commit, puis cette branche a intégré cette base sans réécrire le commit fonctionnel. Le delta propre reste limité à 2 fichiers (+104/−21). `Closes #15747` s’appliquera au merge de cette PR.

## Le fix — trois gestes

1. **`_canonical` décode `%20` en espace** (`replace("%20", " ")`) — la comparaison build-root vs token se fait sur la forme décodée des deux côtés.
2. **L'émission préserve l'encodage d'origine** : `_original_prefix_end()` suit la compression 3:1 de `%20` pour trancher le token **original** à la frontière du root, puis ne canonicalise que les séparateurs du reste (`\`→`/`). Un `%20` entrant ressort `%20` — le HTML reste valide et la référence résout vers le nom espacé sur disque.
3. **Effet de bord gratuit** (attendu par l'issue) : une racine de build à espace littéral (`Jean Dupont`) matche désormais ses tokens `%20`-encodés → le bake **réussit** au lieu de fail-closed. L'ancien docstring `_norm` le déclarait « assumé » ; l'issue le contestait comme corrigeable gratuitement — le docstring est mis à jour en conséquence.

## Contrôle positif — test rouge d'abord (précédent #15722)

Avant correctif, pytest verbatim :

```
test_15747_pct20_decodes_as_space_and_emission_preserves_encoding FAILED
E   assert b'<img src="....n/image.png">' == b'<img src="....20image.png">'
E     At index 22 diff: b'/' != b'%'
E     - (b'<img src="./images/mon%20image.png">')
E     + (b'<img src="./images/mon/image.png">')      # le 404 silencieux

test_15747_bake_with_spaced_root_succeeds FAILED
E   AssertionError: exit=1 ... stderr=b'FAIL: dist\index.html: absolute path
E     outside the build root: C:/Users/.../Jean'    # fail-closed à tort
```

Après correctif : **14 passed** (12 existants — dont 2 pins mis à jour vers le nouveau contrat, annotés `#15747 supersedes` — + 2 neufs).

## Acceptance (5/5)

- [x] `_canonical`/`_norm` décodent `%20` en espace pour la comparaison (test égalité + bake espacé).
- [x] L'émission du reste in-root préserve l'encodage d'origine (`%20` in → `%20` out).
- [x] Test d'égalité exact de l'acceptance, rouge d'abord (sortie collée ci-dessus).
- [x] Bake dont la racine contient une espace réussit et produit des chemins qui résolvent (`tmp_path` à segment espacé, `mon image.png` créé sur disque, émission `./images/mon%20image.png` vérifiée).
- [x] La prose `%20` reste intacte (test #15703 `test_prose_percent20_survives` inchangé, vert).

## Hors scope (respecté)

- `ABSPATH_RE` et la posture `OutOfRootPathError` intacts (tests out-of-root jamais touchés, verts).
- Aucun renommage d'asset — c'est le script qui devient juste.

Closes #15747

🤖 Generated with [Claude Code](https://claude.com/claude-code)