### PR TITLE
fix(guard,#15749): own_job_id pagine la liste des jobs du run (>100 jobs, motif fetch_checks)

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -799,18 +799,39 @@ def own_job_id(
     `run_attempt` filters out the superseded attempts a re-run leaves in the
     same listing; without it the first name match could be a previous
     attempt's check-run, whose output nothing will ever read again.
+
+    The listing is paged through (per_page=100): our job may sit past the
+    first hundred (#15749). Exhausting the pages without a match still
+    yields None -- the degradation is unchanged, never a verdict flip.
     """
     api = fetch if fetch is not None else _gh_api
-    payload = api(f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
-    if not isinstance(payload, dict):
-        raise GateError(f"unexpected jobs payload for run {run_id}")
-    for job in payload.get("jobs") or []:
-        if not isinstance(job, dict):
-            continue
-        if run_attempt is not None and str(job.get("run_attempt")) != str(run_attempt):
-            continue
-        if job.get("name") == job_name:
-            return job.get("id")
+    # Paginate the jobs listing (per_page=100 cap) with the same motif as
+    # fetch_checks below: a run carrying more than 100 jobs would leave our
+    # job off page 1 and the verdict motif would silently go unpublished
+    # again (#15749). total_count is the authoritative stop condition; a
+    # partial page (< 100 jobs) is the defensive fallback that also keeps
+    # total_count-less payloads terminating.
+    page = 1
+    while True:
+        payload = api(
+            f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}"
+        )
+        if not isinstance(payload, dict):
+            raise GateError(f"unexpected jobs payload for run {run_id}")
+        jobs = payload.get("jobs") or []
+        for job in jobs:
+            if not isinstance(job, dict):
+                continue
+            if run_attempt is not None and str(job.get("run_attempt")) != str(run_attempt):
+                continue
+            if job.get("name") == job_name:
+                return job.get("id")
+        if len(jobs) < 100:
+            break
+        total = payload.get("total_count")
+        if total is not None and page * 100 >= total:
+            break
+        page += 1
     return None
 
 

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1711,6 +1711,35 @@ def test_own_job_id_is_none_when_the_name_is_absent():
     ) is None
 
 
+def test_own_job_id_paginates_past_the_first_hundred_jobs():
+    """#15749: the jobs listing caps at per_page=100 and own_job_id did NOT
+    page through. A run carrying more than 100 jobs leaves OUR job off page
+    1, the lookup degrades to None, and the verdict motif silently goes
+    unpublished again -- the exact repair #15693 made, disarmed. fetch_checks
+    paginates correctly in this same file; own_job_id now reuses the motif."""
+    from urllib.parse import parse_qs, urlparse
+
+    target = {"id": 777, "name": pr_gate.DEFAULT_SELF_NAME, "run_attempt": "3"}
+    filler = [{"id": i, "name": f"matrix {i}", "run_attempt": "3"}
+              for i in range(100)]
+    fetched = []
+
+    def paged(path):
+        q = parse_qs(urlparse(path).query)
+        page = int(q.get("page", ["1"])[0])
+        assert q.get("per_page") == ["100"], path
+        fetched.append(page)
+        if page == 1:
+            return {"jobs": list(filler), "total_count": 101}
+        assert page == 2, f"unexpected page {page}"
+        return {"jobs": [target], "total_count": 101}
+
+    got = pr_gate.own_job_id("o/r", "99", pr_gate.DEFAULT_SELF_NAME, "3",
+                             fetch=paged)
+    assert got == 777
+    assert fetched == [1, 2], fetched
+
+
 def test_check_run_output_is_patched_with_the_verdict(monkeypatch):
     """Acceptance 1 on the surface it names: the REQUIRED check carries the
     motive, as the exact verdict string (log == summary). PATCH, not POST --


### PR DESCRIPTION
## Ce que corrige cette PR

Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #15751

#15749 (levée B.0 nommée avant le merge de #15725, résidu de la livraison de cette lane) : `own_job_id()` (`scripts/pr_gate.py`) interrogeait `actions/runs/<id>/jobs?per_page=100` **sans boucle de pagination**. Un run portant plus de 100 jobs pouvait laisser notre job hors de la première page → lookup `None` → **le motif du verdict redevient silencieusement invisible**, la réparation même que #15725 vient d'apporter se désarme sans le dire. La dissymétrie était interne : `fetch_checks` boucle correctement ses pages dans le même fichier.

## Le fix

`own_job_id` reprend le motif de boucle de `fetch_checks` : `page` incrémenté, `total_count` comme condition d'arrêt autoritaire, **plus** l'arrêt sur page partielle (`len(jobs) < 100`) — le fallback défensif qui fait aussi terminer les payloads sans `total_count` (les fixtures existantes d'#15725 n'en portent pas : sans cet arrêt, la boucle serait infinie sur elles). Docstring documente la pagination et la dégradation inchangée.

## Contrôle positif — test rouge d'abord

Avant correctif, pytest verbatim :

```
test_own_job_id_paginates_past_the_first_hundred_jobs FAILED
E   assert None == 777          # le job cible est en page 2, jamais lue
```

Le test : 100 jobs de remplissage en page 1 (`total_count: 101`), la cible seule en page 2 ; le fake `fetch` décode `page=` de l'URL (`urllib.parse`) — le code actuel ne fetchait QUE la page 1. Après correctif : **105 passed** sur la suite complète (les 3 tests `own_job_id` + les 6 pins de dégradation #15725 — `False` + WARN, jamais de flip du verdict — + le reste du module inchangé).

## Acceptance (3/3)

- [x] `own_job_id` itère les pages jusqu'à épuisement, motif repris de `fetch_checks` (pas une seconde boucle réinventée).
- [x] Test >100 jobs, cible hors première page, **rouge sur le code non paginé** (sortie collée ci-dessus), vert après ; assertion bonus `fetched == [1, 2]`.
- [x] Dégradation inchangée : job introuvable après épuisement → `None` → `False` + WARN (test existant `test_check_run_output_patch_failure_never_flips_the_verdict` et voisins, verts).

## Hors périmètre (respecté)

- Aucun changement de verdict, de gate, ni du mécanisme PATCH (surface #15725 intacte).
- Périmètre : 2 fichiers (+60/−10) ; catalogue byte-identique à main.

See #15725. See #15693.

Closes #15749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
