### PR TITLE
fix(rag,#15677): RAG-03 exercices 1 et 2 — étiquetage depuis le vocabulaire de l'élève, perte normalisée par terme

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/03-Embeddings-From-Scratch.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/03-Embeddings-From-Scratch.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "id": "9779e2ae",
    "metadata": {
+    "papermill": {
+     "duration": 0.004741,
+     "end_time": "2026-09-12T11:48:22.397097",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.392356",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -20,6 +27,13 @@
    "cell_type": "markdown",
    "id": "aabecd91",
    "metadata": {
+    "papermill": {
+     "duration": 0.002753,
+     "end_time": "2026-09-12T11:48:22.403311",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.400558",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -42,10 +56,17 @@
    "id": "4eeb76ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:27:34.910805Z",
-     "iopub.status.busy": "2026-09-08T15:27:34.910281Z",
-     "iopub.status.idle": "2026-09-08T15:27:35.275703Z",
-     "shell.execute_reply": "2026-09-08T15:27:35.274817Z"
+     "iopub.execute_input": "2026-09-12T11:48:22.410013Z",
+     "iopub.status.busy": "2026-09-12T11:48:22.409693Z",
+     "iopub.status.idle": "2026-09-12T11:48:22.542740Z",
+     "shell.execute_reply": "2026-09-12T11:48:22.542113Z"
+    },
+    "papermill": {
+     "duration": 0.137547,
+     "end_time": "2026-09-12T11:48:22.543595",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.406048",
+     "status": "completed"
     },
     "tags": []
    },
@@ -126,6 +147,13 @@
    "cell_type": "markdown",
    "id": "7b86a64f",
    "metadata": {
+    "papermill": {
+     "duration": 0.002896,
+     "end_time": "2026-09-12T11:48:22.550291",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.547395",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -138,6 +166,13 @@
    "cell_type": "markdown",
    "id": "f4b75310",
    "metadata": {
+    "papermill": {
+     "duration": 0.002875,
+     "end_time": "2026-09-12T11:48:22.556416",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.553541",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -156,10 +191,17 @@
    "id": "9be29c41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:27:35.311839Z",
-     "iopub.status.busy": "2026-09-08T15:27:35.310332Z",
-     "iopub.status.idle": "2026-09-08T15:27:35.336501Z",
-     "shell.execute_reply": "2026-09-08T15:27:35.335494Z"
+     "iopub.execute_input": "2026-09-12T11:48:22.563959Z",
+     "iopub.status.busy": "2026-09-12T11:48:22.563537Z",
+     "iopub.status.idle": "2026-09-12T11:48:22.581616Z",
+     "shell.execute_reply": "2026-09-12T11:48:22.581054Z"
+    },
+    "papermill": {
+     "duration": 0.022945,
+     "end_time": "2026-09-12T11:48:22.582555",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.559610",
+     "status": "completed"
     },
     "tags": []
    },
@@ -203,6 +245,13 @@
    "cell_type": "markdown",
    "id": "f3c40639",
    "metadata": {
+    "papermill": {
+     "duration": 0.002984,
+     "end_time": "2026-09-12T11:48:22.588687",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.585703",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -215,6 +264,13 @@
    "cell_type": "markdown",
    "id": "7aa94c5a",
    "metadata": {
+    "papermill": {
+     "duration": 0.006183,
+     "end_time": "2026-09-12T11:48:22.597908",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.591725",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -236,10 +292,17 @@
    "id": "32c0a250",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:27:35.381049Z",
-     "iopub.status.busy": "2026-09-08T15:27:35.380050Z",
-     "iopub.status.idle": "2026-09-08T15:27:35.397307Z",
-     "shell.execute_reply": "2026-09-08T15:27:35.396740Z"
+     "iopub.execute_input": "2026-09-12T11:48:22.605738Z",
+     "iopub.status.busy": "2026-09-12T11:48:22.605283Z",
+     "iopub.status.idle": "2026-09-12T11:48:22.619276Z",
+     "shell.execute_reply": "2026-09-12T11:48:22.618832Z"
+    },
+    "papermill": {
+     "duration": 0.018902,
+     "end_time": "2026-09-12T11:48:22.620395",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.601493",
+     "status": "completed"
     },
     "tags": []
    },
@@ -254,7 +317,22 @@
     }
    ],
    "source": [
-    "# Paires (mot_centre, mot_contexte) pour le skip-gram + distribution de bruit (unigram).\npaires = set()\nfor phrase in phrases:\n    for i in range(len(phrase)):\n        for j in range(max(0, i - fenetre), min(len(phrase), i + fenetre + 1)):\n            if i != j:\n                paires.add((phrase[i], phrase[j]))\npaires = sorted(paires)\n\nw2i = {w: i for i, w in enumerate(vocabulaire)}\npaires_idx = [(w2i[a], w2i[b]) for a, b in paires]\nprobas = np.array([freq[w] for w in vocabulaire], dtype=float)\nprobas /= probas.sum()\nV = len(vocabulaire)\nprint(\"paires uniques :\", len(paires_idx))\nprint(\"taille vocab   :\", V)\n"
+    "# Paires (mot_centre, mot_contexte) pour le skip-gram + distribution de bruit (unigram).\n",
+    "paires = set()\n",
+    "for phrase in phrases:\n",
+    "    for i in range(len(phrase)):\n",
+    "        for j in range(max(0, i - fenetre), min(len(phrase), i + fenetre + 1)):\n",
+    "            if i != j:\n",
+    "                paires.add((phrase[i], phrase[j]))\n",
+    "paires = sorted(paires)\n",
+    "\n",
+    "w2i = {w: i for i, w in enumerate(vocabulaire)}\n",
+    "paires_idx = [(w2i[a], w2i[b]) for a, b in paires]\n",
+    "probas = np.array([freq[w] for w in vocabulaire], dtype=float)\n",
+    "probas /= probas.sum()\n",
+    "V = len(vocabulaire)\n",
+    "print(\"paires uniques :\", len(paires_idx))\n",
+    "print(\"taille vocab   :\", V)\n"
    ]
   },
   {
@@ -263,10 +341,17 @@
    "id": "1245f379",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:27:35.417465Z",
-     "iopub.status.busy": "2026-09-08T15:27:35.416960Z",
-     "iopub.status.idle": "2026-09-08T15:27:35.422232Z",
-     "shell.execute_reply": "2026-09-08T15:27:35.421165Z"
+     "iopub.execute_input": "2026-09-12T11:48:22.631157Z",
+     "iopub.status.busy": "2026-09-12T11:48:22.630827Z",
+     "iopub.status.idle": "2026-09-12T11:48:22.634648Z",
+     "shell.execute_reply": "2026-09-12T11:48:22.634096Z"
+    },
+    "papermill": {
+     "duration": 0.00953,
+     "end_time": "2026-09-12T11:48:22.635481",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.625951",
+     "status": "completed"
     },
     "tags": []
    },
@@ -289,10 +374,17 @@
    "id": "b8085a6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:27:35.434481Z",
-     "iopub.status.busy": "2026-09-08T15:27:35.434481Z",
-     "iopub.status.idle": "2026-09-08T15:28:06.090750Z",
-     "shell.execute_reply": "2026-09-08T15:28:06.089213Z"
+     "iopub.execute_input": "2026-09-12T11:48:22.643460Z",
+     "iopub.status.busy": "2026-09-12T11:48:22.643134Z",
+     "iopub.status.idle": "2026-09-12T11:48:37.579474Z",
+     "shell.execute_reply": "2026-09-12T11:48:37.578924Z"
+    },
+    "papermill": {
+     "duration": 14.941756,
+     "end_time": "2026-09-12T11:48:37.580302",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:22.638546",
+     "status": "completed"
     },
     "tags": []
    },
@@ -343,10 +435,17 @@
    "id": "e357f2d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:28:06.108894Z",
-     "iopub.status.busy": "2026-09-08T15:28:06.108894Z",
-     "iopub.status.idle": "2026-09-08T15:28:07.499044Z",
-     "shell.execute_reply": "2026-09-08T15:28:07.496929Z"
+     "iopub.execute_input": "2026-09-12T11:48:37.587761Z",
+     "iopub.status.busy": "2026-09-12T11:48:37.587432Z",
+     "iopub.status.idle": "2026-09-12T11:48:38.108951Z",
+     "shell.execute_reply": "2026-09-12T11:48:38.108277Z"
+    },
+    "papermill": {
+     "duration": 0.52617,
+     "end_time": "2026-09-12T11:48:38.109724",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:37.583554",
+     "status": "completed"
     },
     "tags": []
    },
@@ -381,6 +480,13 @@
    "cell_type": "markdown",
    "id": "9426bdd7",
    "metadata": {
+    "papermill": {
+     "duration": 0.003275,
+     "end_time": "2026-09-12T11:48:38.116387",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:38.113112",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -393,6 +499,13 @@
    "cell_type": "markdown",
    "id": "434bf9d7",
    "metadata": {
+    "papermill": {
+     "duration": 0.002939,
+     "end_time": "2026-09-12T11:48:38.122270",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:38.119331",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -407,10 +520,17 @@
    "id": "042ae84f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:28:07.576961Z",
-     "iopub.status.busy": "2026-09-08T15:28:07.576427Z",
-     "iopub.status.idle": "2026-09-08T15:28:07.590582Z",
-     "shell.execute_reply": "2026-09-08T15:28:07.588900Z"
+     "iopub.execute_input": "2026-09-12T11:48:38.129935Z",
+     "iopub.status.busy": "2026-09-12T11:48:38.129484Z",
+     "iopub.status.idle": "2026-09-12T11:48:38.138113Z",
+     "shell.execute_reply": "2026-09-12T11:48:38.137621Z"
+    },
+    "papermill": {
+     "duration": 0.01351,
+     "end_time": "2026-09-12T11:48:38.138947",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:38.125437",
+     "status": "completed"
     },
     "tags": []
    },
@@ -451,10 +571,16 @@
     "    n = np.linalg.norm(v, axis=1, keepdims=True)\n",
     "    return v / (n + 1e-9)\n",
     "\n",
-    "def plus_proches(vecteurs_normalises, indice, k=5):\n",
+    "def plus_proches(vecteurs_normalises, indice, k=5, etiquettes=None):\n",
+    "    # `etiquettes` : la liste des mots alignée sur les lignes de `vecteurs_normalises`.\n",
+    "    # Par défaut, le vocabulaire global de l'exemple. Un modèle entraîné sur un AUTRE\n",
+    "    # corpus (exercice 1, corpus étendu) DOIT passer SON vocabulaire : les indices y sont\n",
+    "    # décalés, donc les étiquettes globales rendraient des mots faux — et lèvent\n",
+    "    # IndexError dès qu'un indice dépasse l'ancien corpus.\n",
+    "    labels = vocabulaire if etiquettes is None else etiquettes\n",
     "    sims = vecteurs_normalises @ vecteurs_normalises[indice]\n",
     "    ordre = np.argsort(-sims)\n",
-    "    return [(vocabulaire[j], round(float(sims[j]), 3)) for j in ordre[1:k+1] if j != indice]\n",
+    "    return [(labels[j], round(float(sims[j]), 3)) for j in ordre[1:k+1] if j != indice]\n",
     "\n",
     "Wn_debut = normaliser(W_debut)\n",
     "Wn_apres = normaliser(W)\n",
@@ -472,10 +598,17 @@
    "id": "94c69140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:28:07.620832Z",
-     "iopub.status.busy": "2026-09-08T15:28:07.620299Z",
-     "iopub.status.idle": "2026-09-08T15:28:18.729688Z",
-     "shell.execute_reply": "2026-09-08T15:28:18.729688Z"
+     "iopub.execute_input": "2026-09-12T11:48:38.146531Z",
+     "iopub.status.busy": "2026-09-12T11:48:38.146184Z",
+     "iopub.status.idle": "2026-09-12T11:48:40.200968Z",
+     "shell.execute_reply": "2026-09-12T11:48:40.200444Z"
+    },
+    "papermill": {
+     "duration": 2.059675,
+     "end_time": "2026-09-12T11:48:40.201778",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:38.142103",
+     "status": "completed"
     },
     "tags": []
    },
@@ -520,6 +653,13 @@
    "cell_type": "markdown",
    "id": "bfcea328",
    "metadata": {
+    "papermill": {
+     "duration": 0.003425,
+     "end_time": "2026-09-12T11:48:40.208824",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:40.205399",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -535,6 +675,13 @@
    "cell_type": "markdown",
    "id": "dadff3fc",
    "metadata": {
+    "papermill": {
+     "duration": 0.003235,
+     "end_time": "2026-09-12T11:48:40.215270",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:40.212035",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -554,6 +701,13 @@
    "cell_type": "markdown",
    "id": "f360c77a",
    "metadata": {
+    "papermill": {
+     "duration": 0.003467,
+     "end_time": "2026-09-12T11:48:40.221805",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:40.218338",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -570,10 +724,17 @@
    "id": "451d7aae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:28:18.772220Z",
-     "iopub.status.busy": "2026-09-08T15:28:18.772220Z",
-     "iopub.status.idle": "2026-09-08T15:29:12.235493Z",
-     "shell.execute_reply": "2026-09-08T15:29:12.233985Z"
+     "iopub.execute_input": "2026-09-12T11:48:40.230121Z",
+     "iopub.status.busy": "2026-09-12T11:48:40.229644Z",
+     "iopub.status.idle": "2026-09-12T11:49:10.905717Z",
+     "shell.execute_reply": "2026-09-12T11:49:10.905335Z"
+    },
+    "papermill": {
+     "duration": 30.680586,
+     "end_time": "2026-09-12T11:49:10.906395",
+     "exception": false,
+     "start_time": "2026-09-12T11:48:40.225809",
+     "status": "completed"
     },
     "tags": []
    },
@@ -581,7 +742,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f83ca7dc185d40de850b1b262d576a72",
+       "model_id": "902d93f7c594492bb4fa901ce16f9d91",
        "version_major": 2,
        "version_minor": 0
       },
@@ -667,10 +828,17 @@
    "id": "5bba6e59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:29:12.254337Z",
-     "iopub.status.busy": "2026-09-08T15:29:12.253331Z",
-     "iopub.status.idle": "2026-09-08T15:29:12.620905Z",
-     "shell.execute_reply": "2026-09-08T15:29:12.620389Z"
+     "iopub.execute_input": "2026-09-12T11:49:10.914281Z",
+     "iopub.status.busy": "2026-09-12T11:49:10.913949Z",
+     "iopub.status.idle": "2026-09-12T11:49:11.068883Z",
+     "shell.execute_reply": "2026-09-12T11:49:11.068392Z"
+    },
+    "papermill": {
+     "duration": 0.159744,
+     "end_time": "2026-09-12T11:49:11.069626",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:10.909882",
+     "status": "completed"
     },
     "tags": []
    },
@@ -680,7 +848,7 @@
      "output_type": "stream",
      "text": [
       "phrase cible : 11 tokens ; lot aligne sur la plus longue : 155 tokens\n",
-      "pooling MASQUE : ecart max solo vs en-lot = 2.68e-07  -> invariante au lot\n",
+      "pooling MASQUE : ecart max solo vs en-lot = 2.53e-07  -> invariante au lot\n",
       "pooling BRUT   : ecart max solo vs en-lot = 1.397   -> l'embedding depend du lot\n"
      ]
     }
@@ -716,6 +884,13 @@
    "cell_type": "markdown",
    "id": "c577172d",
    "metadata": {
+    "papermill": {
+     "duration": 0.00344,
+     "end_time": "2026-09-12T11:49:11.076622",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.073182",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -730,6 +905,13 @@
    "cell_type": "markdown",
    "id": "6a931e4a",
    "metadata": {
+    "papermill": {
+     "duration": 0.003948,
+     "end_time": "2026-09-12T11:49:11.083933",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.079985",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -747,6 +929,13 @@
    "cell_type": "markdown",
    "id": "54b33f68",
    "metadata": {
+    "papermill": {
+     "duration": 0.003378,
+     "end_time": "2026-09-12T11:49:11.090798",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.087420",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -754,7 +943,9 @@
     "\n",
     "### Exercice 1 — Étendre le corpus\n",
     "\n",
-    "Le thème « cuisine » compte 18 mots. Ajoutez-en quelques-uns (par exemple `ananas`, `mangue`, `cannelle`) et observez si les voisins de `tarte` changent — **sans retoucher les cellules d'exemple** : l'expérience vit dans `voisins_apres_extension`, elle construit son propre corpus étendu et son propre modèle, et **retourne** les voisins à comparer avec ceux de la section 5.\n"
+    "Le thème « cuisine » compte 18 mots. Ajoutez-en quelques-uns (par exemple `ananas`, `mangue`, `cannelle`) et observez si les voisins de `tarte` changent — **sans retoucher les cellules d'exemple** : l'expérience vit dans `voisins_apres_extension`, elle construit son propre corpus étendu et son propre modèle, et **retourne** les voisins à comparer avec ceux de la section 5.\n",
+    "\n",
+    "**Piège d'étiquetage, à traiter dans la solution** : sur un corpus étendu, les indices de `w2i_exo` ne coïncident plus avec ceux du `vocabulaire` global — l'étiquetage des voisins doit venir de **`vocabulaire_exo`** (le vocabulaire que l'exercice reconstruit), via le paramètre `etiquettes` de `plus_proches`. Sans lui, les mots rendus sont décalés et les mots nouveaux lèvent `IndexError`.\n"
    ]
   },
   {
@@ -763,10 +954,17 @@
    "id": "708da467",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:29:12.701810Z",
-     "iopub.status.busy": "2026-09-08T15:29:12.701810Z",
-     "iopub.status.idle": "2026-09-08T15:29:12.707239Z",
-     "shell.execute_reply": "2026-09-08T15:29:12.706603Z"
+     "iopub.execute_input": "2026-09-12T11:49:11.099012Z",
+     "iopub.status.busy": "2026-09-12T11:49:11.098685Z",
+     "iopub.status.idle": "2026-09-12T11:49:11.102534Z",
+     "shell.execute_reply": "2026-09-12T11:49:11.102089Z"
+    },
+    "papermill": {
+     "duration": 0.009036,
+     "end_time": "2026-09-12T11:49:11.103175",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.094139",
+     "status": "completed"
     },
     "tags": []
    },
@@ -775,7 +973,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 à compléter : voisins de « tarte » après extension du thème (fonction autonome).\n"
+      "Exercice 1 à compléter : voisins de « tarte » après extension du thème (fonction autonome)."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -791,7 +996,11 @@
     "    # Étape 2 : reconstruire vocabulaire, paires de co-occurrence (fenêtre 2), w2i_exo et probas\n",
     "    #           unigram sur phrases_exo (mêmes gestes que les sections 3 et 4).\n",
     "    # Étape 3 : initialiser W_exo/Wc_exo, entraîner 30 époques (section 4), puis retourner\n",
-    "    #           plus_proches(normaliser(W_exo), w2i_exo[mot_sonde], k).\n",
+    "    #           plus_proches(normaliser(W_exo), w2i_exo[mot_sonde], k,\n",
+    "    #                        etiquettes=vocabulaire_exo).\n",
+    "    #           L'étiquetage DOIT venir de vocabulaire_exo : les indices de w2i_exo sont\n",
+    "    #           décalés par rapport au vocabulaire global — sans `etiquettes`, les mots\n",
+    "    #           rendus sont faux, et IndexError dès qu'un indice dépasse l'ancien corpus.\n",
     "    # Indice : les nouveaux mots n'apparaissent que dans les nouvelles phrases — c'est ce qui\n",
     "    #           fait bouger (ou pas) les voisins de mot_sonde.\n",
     "    result = None\n",
@@ -804,12 +1013,21 @@
    "cell_type": "markdown",
    "id": "e59511aa",
    "metadata": {
+    "papermill": {
+     "duration": 0.003391,
+     "end_time": "2026-09-12T11:49:11.110090",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.106699",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
     "### Exercice 2 — Jouer sur les hyperparamètres\n",
     "\n",
-    "La dimension `D` (50) et le nombre de négatifs `K` (5) structurent l'apprentissage. Comparez la **courbe de perte** pour plusieurs couples (`D`, `K`) — **sans retoucher les cellules d'exemple** : `entrainer_exo` ré-entraîne un modèle neuf à chaque appel et **retourne** sa perte par époque ; affichez les courbes côte à côte.\n"
+    "La dimension `D` (50) et le nombre de négatifs `K` (5) structurent l'apprentissage. Comparez la **courbe de perte** pour plusieurs couples (`D`, `K`) — **sans retoucher les cellules d'exemple** : `entrainer_exo` ré-entraîne un modèle neuf à chaque appel et **retourne** sa perte par époque ; affichez les courbes côte à côte.\n",
+    "\n",
+    "**Comparaison sur une perte normalisée par terme (`perte / (1 + K)`) — ou à `K` égaux en le disant.** La boucle de référence (section 4) accumule **1 + K termes** par paire : l'échelle de la perte brute suit donc mécaniquement `1 + K` (à l'initialisation, chaque terme vaut ≈ ln 2, donc la perte brute ≈ (1+K)·ln 2) — comparer des pertes brutes entre `K` différents lit cet artefact d'échelle, pas l'effet de l'hyperparamètre.\n"
    ]
   },
   {
@@ -818,10 +1036,17 @@
    "id": "6fe5ede8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:29:12.754529Z",
-     "iopub.status.busy": "2026-09-08T15:29:12.753524Z",
-     "iopub.status.idle": "2026-09-08T15:29:12.762082Z",
-     "shell.execute_reply": "2026-09-08T15:29:12.760570Z"
+     "iopub.execute_input": "2026-09-12T11:49:11.118113Z",
+     "iopub.status.busy": "2026-09-12T11:49:11.117878Z",
+     "iopub.status.idle": "2026-09-12T11:49:11.121887Z",
+     "shell.execute_reply": "2026-09-12T11:49:11.121468Z"
+    },
+    "papermill": {
+     "duration": 0.008815,
+     "end_time": "2026-09-12T11:49:11.122504",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.113689",
+     "status": "completed"
     },
     "tags": []
    },
@@ -839,15 +1064,19 @@
     "# L'expérience est autonome : W et Wc de l'exemple ne sont jamais réécrits.\n",
     "def entrainer_exo(D=50, K=5, epoques=30, graine=1):\n",
     "    # TODO étudiant : ré-entraîner un skip-gram de dimension D avec K négatifs par paire,\n",
-    "    # et retourner la liste perte_par_epoque (une valeur par époque).\n",
+    "    # et retourner la perte MOYENNE PAR TERME et par époque — perte_par_epoque / (1 + K)\n",
+    "    # (la perte brute accumule 1 + K termes par paire, cf section 4 : son échelle suit\n",
+    "    #  (1 + K) mécaniquement, ≈ (1+K)·ln 2 à l'initialisation).\n",
     "    # Étape 1 : rng_exo = np.random.RandomState(graine) ; W_exo = (rng_exo.rand(V, D) - 0.5) * 0.1 ;\n",
     "    #           Wc_exo = np.zeros((V, D)) — mêmes formes d'initialisation que la section 4.\n",
     "    # Étape 2 : recopier la boucle d'entraînement de la section 4 en écrivant dans W_exo/Wc_exo,\n",
     "    #           avec lr = 0.05 / (1 + 0.04 * ep) et les négatifs tirés par rng_exo (p=probas).\n",
-    "    # Étape 3 : retourner perte_par_epoque ; comparez par exemple entrainer_exo(30, 2),\n",
-    "    #           entrainer_exo(50, 5) et entrainer_exo(100, 10) — à époques égales.\n",
+    "    # Étape 3 : retourner la perte normalisée par terme ; comparez par exemple\n",
+    "    #           entrainer_exo(30, 2), entrainer_exo(50, 5) et entrainer_exo(100, 10) —\n",
+    "    #           à époques égales. Une comparaison de pertes BRUTES entre K différents\n",
+    "    #           mesurerait le compte de termes (1 + K), pas l'hyperparamètre.\n",
     "    # Indice : paires_idx et probas sont constants ; seul le travail par paire (K) et la\n",
-    "    #           capacité de l'espace (D) changent — la perte finale se compare à époques égales.\n",
+    "    #           capacité de l'espace (D) changent — à époques égales, sur la perte par terme.\n",
     "    result = None\n",
     "    return result\n",
     "\n",
@@ -858,6 +1087,13 @@
    "cell_type": "markdown",
    "id": "116a66f5",
    "metadata": {
+    "papermill": {
+     "duration": 0.003453,
+     "end_time": "2026-09-12T11:49:11.129372",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.125919",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -872,10 +1108,17 @@
    "id": "0d4eb2a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-08T15:29:12.810204Z",
-     "iopub.status.busy": "2026-09-08T15:29:12.810204Z",
-     "iopub.status.idle": "2026-09-08T15:29:12.817958Z",
-     "shell.execute_reply": "2026-09-08T15:29:12.816279Z"
+     "iopub.execute_input": "2026-09-12T11:49:11.137355Z",
+     "iopub.status.busy": "2026-09-12T11:49:11.137151Z",
+     "iopub.status.idle": "2026-09-12T11:49:11.140726Z",
+     "shell.execute_reply": "2026-09-12T11:49:11.140302Z"
+    },
+    "papermill": {
+     "duration": 0.008428,
+     "end_time": "2026-09-12T11:49:11.141381",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.132953",
+     "status": "completed"
     },
     "tags": []
    },
@@ -914,6 +1157,13 @@
    "cell_type": "markdown",
    "id": "9b37cf52",
    "metadata": {
+    "papermill": {
+     "duration": 0.003498,
+     "end_time": "2026-09-12T11:49:11.148186",
+     "exception": false,
+     "start_time": "2026-09-12T11:49:11.144688",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -949,12 +1199,24 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 54.026918,
+   "end_time": "2026-09-12T11:49:14.630365",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "03-Embeddings-From-Scratch.ipynb",
+   "output_path": "03-Embeddings-From-Scratch.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-12T11:48:20.603447",
+   "version": "2.7.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "1f067d7a8d6c43ba924f797604964407": {
+     "0c07b6d756d24e51a76358dd7a5e7df0": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1007,30 +1269,7 @@
        "width": null
       }
      },
-     "226d9b345a4042668311826e71b6bf7d": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_810d93bb93114eca8ad82c460f1aeb8a",
-       "placeholder": "​",
-       "style": "IPY_MODEL_ae6f25409faa4daba78578993d1246bc",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 199/199 [00:00&lt;00:00, 2682.90it/s]"
-      }
-     },
-     "506a24fd1e69422da9050628e835e1b3": {
+     "47249c7a796245099330af66f95821ed": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1083,84 +1322,7 @@
        "width": null
       }
      },
-     "63b13889a8714ad991b01a06d65d2c51": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_ceae07baa91a499cbf05b9bbfbc62637",
-        "IPY_MODEL_d07014cd8bab447aa3c7fe6431fc05c6",
-        "IPY_MODEL_226d9b345a4042668311826e71b6bf7d"
-       ],
-       "layout": "IPY_MODEL_506a24fd1e69422da9050628e835e1b3",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "810d93bb93114eca8ad82c460f1aeb8a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8569c5293f5a4670beaa816052b31eb8": {
+     "67f8ee96ec4640d2b2d23d9cbce9542b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -1178,117 +1340,7 @@
        "text_color": null
       }
      },
-     "ae6f25409faa4daba78578993d1246bc": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "bf91fecf533c48a7ae522c8bf42a8a60": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "cb45237d6b1746f3b8571777887e48b9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "ceae07baa91a499cbf05b9bbfbc62637": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_bf91fecf533c48a7ae522c8bf42a8a60",
-       "placeholder": "​",
-       "style": "IPY_MODEL_8569c5293f5a4670beaa816052b31eb8",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Loading weights: 100%"
-      }
-     },
-     "d07014cd8bab447aa3c7fe6431fc05c6": {
+     "70a5a8ffa00246bfb7f04c4b4f3755b9": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -1304,14 +1356,224 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_1f067d7a8d6c43ba924f797604964407",
+       "layout": "IPY_MODEL_71c1f09ddc1943769bc5beb7e2b5b716",
        "max": 199.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_cb45237d6b1746f3b8571777887e48b9",
+       "style": "IPY_MODEL_a9dfc9a6b9aa4c5eab9a7764bf33b7d3",
        "tabbable": null,
        "tooltip": null,
        "value": 199.0
+      }
+     },
+     "71c1f09ddc1943769bc5beb7e2b5b716": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "902d93f7c594492bb4fa901ce16f9d91": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_aed4f18db6a445d0b23630b3510621d3",
+        "IPY_MODEL_70a5a8ffa00246bfb7f04c4b4f3755b9",
+        "IPY_MODEL_fde4366ddfbb4fa9b8b752b6dc252705"
+       ],
+       "layout": "IPY_MODEL_0c07b6d756d24e51a76358dd7a5e7df0",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a9dfc9a6b9aa4c5eab9a7764bf33b7d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "aed4f18db6a445d0b23630b3510621d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_47249c7a796245099330af66f95821ed",
+       "placeholder": "​",
+       "style": "IPY_MODEL_d7084b5c65924fa1ae49fc2c050cb03b",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Loading weights: 100%"
+      }
+     },
+     "d7084b5c65924fa1ae49fc2c050cb03b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "ed637b135b7a4444b7ac68055abbb2fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fde4366ddfbb4fa9b8b752b6dc252705": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_ed637b135b7a4444b7ac68055abbb2fe",
+       "placeholder": "​",
+       "style": "IPY_MODEL_67f8ee96ec4640d2b2d23d9cbce9542b",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 199/199 [00:00&lt;00:00, 9993.97it/s]"
       }
      }
     },


### PR DESCRIPTION
## Ce que corrige cette PR

Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/guard #15753

#15677 : deux défauts confirmés dans `03-Embeddings-From-Scratch.ipynb`, tous deux
dans les exercices de la section 8 — l'énoncé donnait à l'élève une **instruction qui
plante** ou une **grandeur qui ne mesure pas ce qu'elle annonce**.

1. **Exercice 1 — étiquetage depuis le mauvais vocabulaire.** L'étape 3 demandait
   `plus_proches(normaliser(W_exo), w2i_exo[mot_sonde], k)`. Or `plus_proches` (cellule 14)
   étiquetait ses voisins depuis le `vocabulaire` **global** en dur, alors que `w2i_exo`
   indexe le corpus **étendu** de l'élève : indices décalés → mots rendus **faux**, et
   `IndexError` dès qu'un indice dépasse l'ancien corpus (les mots ajoutés y sont).
   Suivre l'énoncé à la lettre produisait donc soit un résultat silencieusement faux, soit
   un crash sur l'ajout de mots — le geste même de l'exercice.

2. **Exercice 2 — la comparaison lit un artefact d'échelle.** L'énoncé invitait à comparer
   les **courbes de perte brutes** entre couples `(D, K)` — dont `(30,2)` / `(50,5)` /
   `(100,10)`. La boucle de référence (section 4) accumule **1 + K termes** par paire :
   l'échelle de la perte brute suit mécaniquement `1 + K` (≈ `(1+K)·ln 2` à
   l'initialisation), donc comparer des pertes brutes entre `K` différents mesure le
   **compte de termes**, pas l'effet de l'hyperparamètre.

## Le fix

**Cellule 14** — `plus_proches` gagne un paramètre `etiquettes` **optionnel** :

```python
def plus_proches(vecteurs_normalises, indice, k=5, etiquettes=None):
    labels = vocabulaire if etiquettes is None else etiquettes
    ...
    return [(labels[j], round(float(sims[j]), 3)) for j in ordre[1:k+1] if j != indice]
```

Rétro-compatible : les appels existants (la cellule 14 elle-même, l'étape 1 de l'exercice 3
en cellule 28, qui travaillent sur le corpus **global**) gardent `vocabulaire` par défaut et
sont inchangés. Un commentaire explique le piège d'alignement indices↔étiquettes.

**Cellules 23 / 24** (exercice 1) — l'étape 3 devient
`plus_proches(normaliser(W_exo), w2i_exo[mot_sonde], k, etiquettes=vocabulaire_exo)`, et
l'énoncé gagne un paragraphe « **Piège d'étiquetage, à traiter dans la solution** » qui dit
pourquoi (indices décalés ; `IndexError` sur les mots nouveaux). L'exercice reste un
**stub** (C.1 : `result = None`, `# TODO`, `# Étape N` conservés) — c'est l'énoncé qui
devient correct, pas la solution qui est fournie.

**Cellules 25 / 26** (exercice 2) — la comparaison se fait sur une **perte normalisée par
terme** (`perte / (1 + K)`), avec l'artefact d'échelle expliqué dans l'énoncé et dans le
stub. Les exemples d'appel restent `entrainer_exo(30, 2)` / `(50, 5)` / `(100, 10)`,
« à époques égales ». Stub inchangé côté C.1.

## Validation

- **Ré-exécution complète** post-édit (cellules code modifiées → règle C.2), avec le
  **kernelspec déclaré** du notebook (`python3`), via
  `scripts/notebook_tools/notebook_tools.py execute` :

```
[03-Embeddings-From-Scratch.ipynb] (kernel: python3)
  [+] SUCCESS                                    (EXECUTION SUMMARY, 55.5s)

cell 10 (entraînement, inchangé — RNG semé) :
  perte : époque 1 = 2.824 →  époque finale = 2.25
cell 24 : Exercice 1 à compléter : voisins de « tarte » après extension du thème (fonction autonome).
cell 26 : Exercice 2 à compléter : la courbe de perte pour (D, K) au choix, par appel explicite.
```

- `validate_pr_notebooks.py origin/main` : **1/1 PASS** (13 cellules code).
- **13 cellules code**, `execution_count` 1..13 (aucun `null`), **0 erreur**.
- **C.1** : aucun `raise NotImplementedError` / `assert False` / `1/0` dans les sources ;
  les 3 stubs d'exercice gardent `result = None`, `# TODO`, `# Indice`, `# Étape N`.
- **Chemins machine** : la ré-exécution via papermill estampille `metadata.papermill` ; les
  `input_path`/`output_path` absolus (`D:\Dev\CoursIA-15677\...`) ont été ramenés au
  `basename` par l'outil canonique `scripts/notebook_tools/scrub_papermill_paths.py --apply`
  (normalisation de **metadata**, pas un scrub de sortie). Re-scan : 0 défaut. Scan des
  sorties (`--outputs`) : aucune fuite.

## Diff — ce qui bouge et pourquoi

Changement **sourcé** sur 5 cellules (14, 23, 24, 25, 26) : les 5 éditions ci-dessus.

Le reste du diff est le **churn inhérent à une ré-exécution** (C.2), vérifié cellule par
cellule contre `origin/main` :

| cellule | différence | nature |
|---------|-----------|--------|
| 11, 15 | **aucune** — images byte-identiques | matplotlib 3.10.3 = celui de la baseline |
| 19 | `model_id` du widget tqdm | UUID de comm, unique par exécution |
| 20 | `2.68e-07` → `2.53e-07` | ordre de réduction BLAS sur un lot de 155 tokens ; la conclusion de la cellule (« masqué ≈ 1e-7 invariant vs brut ≈ 1.4 ») est identique |
| 24 | sortie `stdout` scindée en 2 blocs | estampille papermill (newline final) |

Note : `03-Embeddings-From-Scratch.ipynb` ne portait **aucune** metadata papermill sur `main` ;
la ré-exécution en ajoute (notebook-level + par cellule). C'est la convention majoritaire de
la série (6/10 voisins la portent) et le produit direct de l'outil d'exécution du dépôt — je
le signale explicitement puisque cela élargit le diff au-delà des 5 cellules éditées.

## Hors périmètre (respecté)

- Aucune solution d'exercice fournie (les 3 stubs restent des stubs).
- Aucune cellule d'exemple touchée ; `W`, `Wc`, `vocabulaire`, `themes`, `phrases` inchangés.
- 1 fichier ; catalogue **byte-identique** à `main`.

See #15656 (PR ouverte touchant le même notebook, cellules non recouvrantes).

Closes #15677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
