### PR TITLE
fix(ci,#14598): re-poser le plafond ICT contre la mesure (30 -> 60 min)

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -67,13 +67,47 @@ jobs:
     # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
     if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
-    # Timeout etire 15 -> 30 min (#14598 acceptance Option A) : diagnostic
-    # first-hand 30 derniers runs montre success 353-951s (mediane ~800s),
-    # cancelled des 925s (=hit timeout 15 min). Pas de drift temporel, juste
-    # variabilite charge partagee conteneur Docker self-heberge po-2024.
-    # Step Run lui-meme timeout 12 min legitimes sous charge. Fix orthogonal
-    # a #14571 (defaut install FIXE par #14595 venv per-job).
-    timeout-minutes: 30
+    # Plafond 15 -> 30 (#14598 Option A) -> 60 min. Le passage a 30 avait
+    # DEPLACE le mur, pas mesure sa position : trois PRs de CONTENU sont mortes
+    # dessus le 2026-09-12 (#15657, #15660, #15609 -- 30,5 / 30,4 / 30,4 min,
+    # toutes `cancelled`, aucune `failure`).
+    #
+    # Le 60 est choisi CONTRE une mesure, pas contre une marge de confort.
+    # Sonde hors plafond `ict-tests-profile.yml` (timeout 90 min, MEME commande,
+    # MEME pool de runners), job 103508457858 / run 34676978324, runner
+    # po-2024-linux-docker-2 :
+    #
+    #     1076 passed, 3 skipped, 7 warnings in 890.36s (0:14:50)
+    #     step `Run` = 15,23 min mur
+    #
+    # Run tue (#15609, job 103531764037, runner po-2024-linux-docker-4), compare
+    # sur le PREFIXE STRICTEMENT IDENTIQUE de la suite -- memes deux items
+    # d'ancrage dans les deux logs (test_active_inference.py::
+    # test_belief_pdf_normalized -> test_pregnance_animat.py::
+    # test_behavioral_reversibility_verdict) :
+    #
+    #     prefixe sonde  =  847,22 s        prefixe tue = 1737,00 s
+    #     ratio          =  2,050 x         <- variance RUNNER, pas derive de suite
+    #
+    # Extrapole au total : 30,42 min contre un budget de step de 28,94 min
+    # (30 min de job - 1,06 min d'install). DEFICIT 89 s, soit 5,1 % : le
+    # plafond de 30 etait pose SUR la frontiere, pas au-dessus. Le run tue
+    # progressait normalement, a 58 % de la suite, une seconde avant la coupe.
+    #
+    # 60 min = 3,94 x le nominal mesure (15,23 min) et 1,97 x le pire cas
+    # observe (30,42 min). Ce n'est PAS le correctif de fond -- la suite met
+    # 89 % de son temps dans 25 items sur 6 modules, et `-n --dist loadscope`
+    # ramene le chemin critique a ~4,25 min nominal (mesure #14598). C'est le
+    # plafond qui cesse de tuer du contenu pendant que ce correctif se valide.
+    #
+    # A RELIRE quand la parallelisation atterrit : un plafond dimensionne pour
+    # une suite sequentielle de 30 min n'a plus de sens sur une suite de 9 min.
+    #
+    # Ce qu'un `cancelled` ne dit pas : un kill par `timeout-minutes` rend
+    # conclusion `cancelled`, JAMAIS `failure`. La couleur ne distingue pas
+    # « le code est faux » de « la machine a ete coupee » -- ne pas imputer a
+    # une lane un rouge produit par cette ligne.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/guard #15732

## Résumé

`ict-tests.yml` porte `timeout-minutes: 30` au niveau du **job**. Le 2026-09-12, **trois PRs de contenu** sont mortes dessus — #15657 (30,5 min), #15660 (30,4 min), #15609 (30,4 min) — sur **trois lanes** et deux workspaces, toutes rendues `cancelled`, aucune `failure`, et toutes porteuses d'un grain `notebook-python`. **L'organe d'infrastructure tuait exactement le contenu que le protocole demande de produire.**

Le passage 15 → 30 (#14598 Option A) avait **déplacé** le mur sans mesurer sa position. Cette PR la mesure, puis pose le plafond contre la mesure.

## La mesure

**Sonde hors plafond** — `ict-tests-profile.yml` (`timeout-minutes: 90`), **même commande** (`pytest tests`, matrice `test-args: tests`), **même `test-cwd`**, **même pool de runners** (`[self-hosted, coursia-ephemeral, coursia-linux]`). Job `103508457858`, run `34676978324`, runner `myia-po-2024-linux-docker-2` :

```
1076 passed, 3 skipped, 7 warnings in 890.36s (0:14:50)
step `Run` = 15,23 min mur
```

**Run tué** — #15609, job `103531764037`, runner `myia-po-2024-linux-docker-4`, step `Run` 29,13 min, coupé à **58 %** de la suite.

Les deux runs ne parcourent pas la même portion de la suite : comparer leurs totaux n'aurait aucun sens. La comparaison est donc faite sur le **préfixe strictement identique**, avec les **mêmes deux items d'ancrage** présents dans les deux logs :

| ancre | sonde | tué |
|---|---|---|
| `test_active_inference.py::test_belief_pdf_normalized` | 06:01:52 | 09:47:38 |
| `test_pregnance_animat.py::test_behavioral_reversibility_verdict` | 06:15:59 | 10:16:35 |
| **préfixe** | **847,22 s** | **1737,00 s** |

**Ratio = 2,050 ×.** C'est une variance **de runner**, pas une dérive de la suite : même commande, même code, même pool.

Extrapolé au total : **30,42 min** contre un budget de step de **28,94 min** (30 min de job − 1,06 min d'install).

> **Déficit : 89 s, soit 5,1 %.** Le plafond de 30 était posé **sur** la frontière, pas au-dessus. Le run tué progressait normalement, une seconde avant la coupe.

## Le choix du 60

| | valeur | marge à 60 min |
|---|---|---|
| nominal mesuré | 15,23 min | **3,94 ×** |
| pire cas observé | 30,42 min | **1,97 ×** |

Choisi contre la mesure, pas contre une marge de confort.

## Ce que cette PR n'est pas

**Ce n'est pas le correctif de fond.** La concentration mesurée sur la sonde (`--durations=25 --durations-min=0`) :

| | durée | part |
|---|---:|---:|
| top-25 items | 792,56 s | **89,0 %** |
| top-4 items | 407,95 s | 45,8 % |
| les 1054 autres | 97,80 s | 11,0 % |

Les 25 items vivent dans **6 modules** ; sous `-n --dist loadscope` le chemin critique tombe à **~4,25 min** nominal (~8,7 min à 2,05 ×). C'est la suite (#14598 lever (b)), à mon nom également.

Le plafond posé ici est **ce qui cesse de tuer du contenu pendant que la parallélisation se valide** — et le commentaire du fichier le dit explicitement : *« A RELIRE quand la parallelisation atterrit : un plafond dimensionne pour une suite sequentielle de 30 min n'a plus de sens sur une suite de 9 min. »*

## Portée du diff — zéro conflit avec les cinq PRs ouvertes

Cinq PRs ouvertes touchent `ict-tests.yml` : #15665, #15660, #15657, #15627, #15547. **Toutes** éditent le bloc de prose des floors (lignes 12-32) et/ou la matrice (lignes 90-110), avec des valeurs mutuellement contradictoires (678 / 681 / 686 / 686 / 703) issues d'une base où le floor valait 670.

Ce diff est **confiné aux lignes 70-76**. Vérifié hunk par hunk sur les cinq : aucun ne touche cette région. Elles ne prennent donc aucun conflit de ma part.

Le fait que cinq PRs doivent toutes réécrire les mêmes quatre lignes de prose pour ajouter des tests est un **aimant à conflits** structurel — la prose duplique un nombre qui vit dans la matrice, donc elle ne peut que dériver (elle dit aujourd'hui `1046/670` contre `1071/692` en matrice). Je le traite **séparément et après** ces cinq merges, pour ne pas imposer un rebase à des PRs de contenu déjà bloquées.

## Validation

- `python -c "import yaml; …"` → `timeout-minutes = 60`, YAML valide.
- `python scripts/ci/check_self_hosted_runner_policy.py` → `OK -- all self-hosted jobs satisfy isolation policy` (`workflows=159 jobs=202 self_hosted=131`).
- Le job lui-même se valide en s'exécutant : la jambe `ICT tests/ (56)` de cette PR **est** le contrôle.

## Note de lecture pour les lanes

Un kill par `timeout-minutes` rend conclusion **`cancelled`**, jamais `failure`. La couleur ne distingue pas « le code est faux » de « la machine a été coupée ». Le commentaire du fichier porte désormais cet avertissement, pour qu'aucune lane ne se voie imputer un rouge produit par cette ligne.

See #14598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
