### PR TITLE
fix(picker,#15763): un agregateur rouge par constituants coupes n'est plus assigne comme reparable

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1159,6 +1159,21 @@ RED_COUNT_DEFAULT = 3
 # faux positif qui rend un garde de cascade inutilisable.
 CHECK_FAILED = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR"}
 
+# Quatre conclusions ne mesurent RIEN du code : le check a ete COUPE
+# (`timeout-minutes`, `cancel-in-progress`, famine de runner) ou n'a jamais
+# demarre. Meme taxonomie que `CONCLUSION_UNCONCLUDED` de scripts/pr_gate.py,
+# qui separe deja les deux dans SON message depuis #15693.
+#
+# `CANCELLED` n'est deliberement PAS dans CHECK_FAILED -- un run coupe par
+# `concurrency` n'est pas un echec (69 `cancelled` pour 0 echec reel sur un
+# SHA de main le 2026-08-21, cf test_cancelled_is_not_a_failure). Il est ici
+# parce qu'un AGREGATEUR qui le ANDe, lui, rend FAILURE : l'exclusion qui
+# protege le cas simple laisse passer le cas agrege.
+CHECK_UNCONCLUDED = {"CANCELLED", "TIMED_OUT", "STALE", "STARTUP_FAILURE"}
+
+# Les rouges dont une lane peut vraiment faire quelque chose.
+CHECK_REALLY_RED = CHECK_FAILED - CHECK_UNCONCLUDED
+
 # #13420 : un check "en vol" est celui dont la file peut encore bouger. C'est
 # lui qui date la saturation -- pas la PR qui le porte. La chaine vide couvre
 # le CheckRun reel, dont `conclusion` est `null` tant qu'il n'a pas conclu.
@@ -1438,6 +1453,38 @@ def _has_failed_check(state: dict | None) -> bool:
                for c in contexts)
 
 
+def cut_constituents(contexts: list[dict]) -> tuple[list[str], bool]:
+    """Constituants COUPES, et « un vrai rouge existe-t-il ailleurs ? ».
+
+    Rend `(noms_coupes, un_vrai_rouge_existe)` en ne regardant QUE les checks
+    non-agregateurs : un agregateur rouge ne peut pas etre sa propre preuve.
+
+    C'est le discriminant de #15763. Mesure du 2026-09-12 sur #15657 et #15660,
+    lues sur le head exact :
+
+        PR gate             | conclusion=FAILURE   | isRequired=true
+        ICT tests/ (55)     | conclusion=CANCELLED | isRequired=false
+        Scripts Tests (CPU) | conclusion=CANCELLED | isRequired=false
+
+    `CANCELLED` etant hors de CHECK_FAILED, ces deux constituants ne tombaient
+    NI dans `causes` NI dans `advisory` : le picker ne les mis-attribuait meme
+    pas, il les rendait INVISIBLES, et la lane recevait `check requis en echec :
+    PR gate` tout court -- un agregateur a reparer, sans rien qui dise quoi.
+    """
+    cut: list[str] = []
+    real_red = False
+    for ctx in contexts:
+        name = ctx.get("name") or ctx.get("context") or "?"
+        if is_aggregator_check(name):
+            continue
+        verdict = (ctx.get("conclusion") or ctx.get("state") or "").upper()
+        if verdict in CHECK_REALLY_RED:
+            real_red = True
+        elif verdict in CHECK_UNCONCLUDED and name not in cut:
+            cut.append(name)
+    return cut, real_red
+
+
 def blocking_causes(state: dict, *, age_hours: float | None = None,
                     saturation_hours: float | None = None,
                     inherited: set[str] | None = None,
@@ -1472,6 +1519,7 @@ def blocking_causes(state: dict, *, age_hours: float | None = None,
     commits = state.get("commits", {}).get("nodes") or []
     rollup = (commits[0]["commit"].get("statusCheckRollup") if commits else None) or {}
     contexts = drop_superseded((rollup.get("contexts", {}) or {}).get("nodes") or [])
+    cut, real_red = cut_constituents(contexts)
     for ctx in contexts:
         name = ctx.get("name") or ctx.get("context") or "?"
         verdict = (ctx.get("conclusion") or ctx.get("state") or "").upper()
@@ -1488,7 +1536,32 @@ def blocking_causes(state: dict, *, age_hours: float | None = None,
             if keys <= inherited:
                 continue
         if ctx.get("isRequired"):
-            cause = f"check requis en echec : {name}"
+            # #15763 : un AGREGATEUR requis rouge dont aucun constituant n'est
+            # un vrai rouge, mais dont au moins un a ete COUPE, n'est pas
+            # reparable par cette lane. Le dire, avec le geste qui le leve --
+            # meme forme que `file_saturation` ci-dessous, qui traite deja un
+            # faux-rouge non-reparable sans pour autant dispenser la lane de
+            # la justification ecrite qu'exige `--ignore-red`.
+            #
+            # Fail-CLOSED dans le bon sens : des qu'UN constituant porte un
+            # vrai rouge (FAILURE / ACTION_REQUIRED / ERROR), la cause reste
+            # « check requis en echec » et la lane repare. On ne dispense
+            # jamais d'une reparation reelle ; on cesse seulement d'en
+            # prescrire une qui n'existe pas.
+            if is_aggregator_check(name) and cut and not real_red:
+                cause = (
+                    f"{name} rouge par constituant(s) COUPE(S), pas par un "
+                    f"defaut de code : {', '.join(cut[:3])} -- NON REPARABLE "
+                    f"par la lane (un kill `timeout-minutes` ou un "
+                    f"`cancel-in-progress` rend `cancelled`, jamais `failure` : "
+                    f"la couleur ne distingue pas « le code est faux » de « la "
+                    f"machine a ete coupee »). Geste : rejouer la jambe "
+                    f"(`gh run rerun <run_id> --job <job_id>`), ou commenter la "
+                    f"PR pour imputer le rouge a la base puis `--ignore-red`. "
+                    f"Ne PAS chercher quoi corriger dans le diff."
+                )
+            else:
+                cause = f"check requis en echec : {name}"
             if cause not in causes:
                 causes.append(cause)
         elif name not in advisory:

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -284,6 +284,99 @@ def test_cancelled_is_not_a_failure():
     assert pig.blocking_causes(_state(checks=[("PR gate", "NEUTRAL", True)])) == []
 
 
+def test_aggregator_red_by_cancelled_constituents_is_not_repairable():
+    """#15763 -- controle POSITIF, reproduit #15657 et #15660 a la lettre.
+
+    Lecture GraphQL du 2026-09-12 sur leurs heads exacts (`751fa1bd54df` et
+    `4e1ab883e715`) : l'agregateur requis rend FAILURE parce qu'il ANDe deux
+    constituants `cancelled`. Avant ce fix, la lane recevait « check requis en
+    echec : PR gate » et RIEN d'autre -- les deux constituants coupes etant
+    hors de CHECK_FAILED, ils ne tombaient ni dans les causes ni meme dans la
+    clause diagnostique `advisory`. Pas une mis-attribution : une INVISIBILITE.
+
+    Un kill `timeout-minutes` et un `cancel-in-progress` rendent tous deux
+    `cancelled`, jamais `failure` : la couleur seule ne peut pas distinguer
+    « le code est faux » de « la machine a ete coupee ». Prescrire une
+    reparation dans le diff pour ce rouge-la, c'est la pedale de frein.
+    """
+    state = _state(checks=[
+        ("PR gate", "FAILURE", True),
+        ("ICT tests/ (55)", "CANCELLED", False),
+        ("Scripts Tests (CPU)", "CANCELLED", False),
+    ])
+    causes = pig.blocking_causes(state)
+    assert len(causes) == 1, causes
+    cause = causes[0]
+    assert "NON REPARABLE" in cause
+    # les constituants sont NOMMES : c'est ce qui manquait entierement.
+    assert "ICT tests/ (55)" in cause
+    assert "Scripts Tests (CPU)" in cause
+    # et le geste qui le leve est donne, comme pour `file_saturation`.
+    assert "rerun" in cause and "--ignore-red" in cause
+    # controle de non-regression du message : la vieille phrase, qui envoyait
+    # chercher un defaut dans le diff, ne doit plus etre rendue.
+    assert "check requis en echec : PR gate" not in causes
+
+
+def test_one_genuine_failure_keeps_the_red_repairable():
+    """Controle NEGATIF -- le fail-closed va dans le bon sens.
+
+    Des qu'UN constituant porte un vrai rouge, la cause redevient
+    « check requis en echec » et la lane repare, meme si d'autres
+    constituants ont ete coupes a cote. On ne dispense jamais d'une
+    reparation reelle ; on cesse seulement d'en prescrire une qui n'existe
+    pas."""
+    state = _state(checks=[
+        ("PR gate", "FAILURE", True),
+        ("ICT tests/ (55)", "CANCELLED", False),
+        ("Scripts Tests (CPU)", "FAILURE", False),
+    ])
+    causes = pig.blocking_causes(state)
+    assert "check requis en echec : PR gate" in causes
+    assert not any("NON REPARABLE" in c for c in causes)
+    # et le vrai rouge reste nomme comme diagnostic.
+    assert any("non bloquant" in c and "Scripts Tests (CPU)" in c for c in causes)
+
+
+def test_aggregator_red_without_any_constituent_stays_repairable():
+    """Un agregateur seul rouge, sans constituant coupe, n'est pas exempte.
+
+    Sans ce controle, la branche #15763 pourrait avaler n'importe quel
+    `PR gate` rouge -- y compris celui d'un DWELL ou d'une regle interne du
+    gate -- et rendre toute la classe non-reparable par accident."""
+    causes = pig.blocking_causes(_state(checks=[("PR gate", "FAILURE", True)]))
+    assert causes == ["check requis en echec : PR gate"]
+
+
+def test_a_cut_constituent_does_not_exempt_a_non_aggregator_red():
+    """Un check requis ORDINAIRE rouge reste a reparer par la lane.
+
+    L'exemption est attachee a la laundering d'un agregateur, pas a la
+    presence d'un `cancelled` quelque part sur la PR."""
+    state = _state(checks=[
+        ("Scripts Tests (CPU)", "FAILURE", True),
+        ("ICT tests/ (55)", "CANCELLED", False),
+    ])
+    causes = pig.blocking_causes(state)
+    assert "check requis en echec : Scripts Tests (CPU)" in causes
+    assert not any("NON REPARABLE" in c for c in causes)
+
+
+def test_cut_constituents_ignores_the_aggregator_itself():
+    """Un agregateur ne peut pas etre sa propre preuve de coupure.
+
+    Si `PR gate` comptait comme constituant coupe de lui-meme, un `PR gate`
+    `TIMED_OUT` s'auto-exempterait."""
+    contexts = [
+        {"name": "PR gate", "conclusion": "TIMED_OUT"},
+        {"name": "Always-on guards / lint", "conclusion": "CANCELLED"},
+        {"name": "ICT tests/ (55)", "conclusion": "SUCCESS"},
+    ]
+    cut, real_red = pig.cut_constituents(contexts)
+    assert cut == [], "ni l'agregateur nomme ni le prefixe agregateur"
+    assert real_red is False
+
+
 def test_conflicts_are_a_red():
     causes = pig.blocking_causes(_state(mergeable="CONFLICTING"))
     assert causes == ["conflits avec main -> rebaser"]


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #15762

Closes #15763

## Ce que ce PR corrige

Le picker assignait a une lane, **comme grain de reparation en premiere action**, un `PR gate` rouge dont la cause n'est **pas reparable par elle**. La lane brulait son cycle a chercher dans son diff un defaut qui n'y etait pas.

Troisieme surface du meme mecanisme : #15726 et #15748 en sont les deux premieres. Celle-ci est dans l'**organe**, pas dans la prose.

## La mesure — 2026-09-12, heads exacts

`#15657` (head `751fa1bd54df`) et `#15660` (head `4e1ab883e715`), lecture GraphQL :

```
PR gate             | conclusion=FAILURE   | isRequired=true
ICT tests/ (55)     | conclusion=CANCELLED | isRequired=false
Scripts Tests (CPU) | conclusion=CANCELLED | isRequired=false
```

Ce que la lane recevait : `check requis en echec : PR gate`. **Et rien d'autre.**

## Pas une mis-attribution — une invisibilite

`CHECK_FAILED` (l.1160) n'inclut **pas** `CANCELLED`, et c'est **correct** : un run coupe par `concurrency` n'a rien mesure — le 2026-08-21 un SHA de `main` portait 69 `cancelled` pour 0 echec reel (`test_cancelled_is_not_a_failure` epingle ce cas, et **ce PR ne le touche pas**).

Mais l'exclusion qui protege le cas simple **laisse passer le cas agrege**. L'agregateur qui ANDe ces constituants, lui, rend `FAILURE`. Consequence exacte :

- les constituants coupes ne tombent **ni** dans `causes` (hors `CHECK_FAILED`),
- **ni** dans `advisory` — donc pas meme dans la clause finale `(diagnostic, non bloquant : ...)`.

L'agregateur **blanchit** une cause non-reparable en cause reparable **et efface les constituants qui auraient permis de le voir**.

## Pourquoi la couleur ne peut pas trancher

Un kill `timeout-minutes` et un `cancel-in-progress` rendent tous deux **`cancelled`**, jamais `failure`. La couleur seule ne distingue pas « le code est faux » de « la machine a ete coupee ». Sur ces deux PRs la cause etait le plafond ICT de 30 min sur runner charge (#14598, traite par #15761/#15762) : meme commande, meme pool, **15,23 min** a vide contre **29,13 min** sous charge.

## Le fix

Un **second** ensemble, utilise pour ce seul diagnostic — `CHECK_FAILED` est laisse intact :

```python
CHECK_CUT = {"CANCELLED", "TIMED_OUT", "STALE", "STARTUP_FAILURE"}
CHECK_REALLY_RED = CHECK_FAILED - CHECK_CUT
```

C'est **exactement** la taxonomie que `scripts/pr_gate.py` publie deja depuis #15693 (`CONCLUSION_UNCONCLUDED`). Le nom distinct `CHECK_CUT` preserve en parallele `CHECK_UNCONCLUDED` de #15769 (`CANCELLED`/`STALE`/`SKIPPED`/`NEUTRAL`), qui classe les checks requis termines non conclus. Les deux comportements coexistent sans union semantique.

Puis, dans `blocking_causes` : quand un **agregateur requis** est rouge, qu'**aucun** constituant ne porte un vrai rouge et qu'**>=1** est coupe, la cause **nomme les constituants** et se declare non-reparable, avec le geste qui la leve — meme forme que `file_saturation`, qui traite deja un faux-rouge non-reparable sans dispenser de la justification ecrite qu'exige `--ignore-red`.

`cut_constituents()` ignore les agregateurs : **un agregateur ne peut pas etre sa propre preuve de coupure**, sinon un `PR gate` `TIMED_OUT` s'auto-exempterait.

## Fail-closed — dans le bon sens

Des qu'**un** constituant porte un vrai rouge (`FAILURE`/`ACTION_REQUIRED`/`ERROR`), la cause reste `check requis en echec` et la lane repare. **On ne dispense jamais d'une reparation reelle** ; on cesse seulement d'en prescrire une qui n'existe pas.

## Verification

`python -m pytest scripts/tests/test_pick_idle_grain.py -q` -> **130 passed** au head `54c5f99ad98774ec07b388d23bb99fdbedbb8394`; suites connexes (`test_pick_idle_grain_cache.py`, `test_pr_gate.py`, `test_remeasure_bad_pending.py`, `test_series_saturation.py`) -> **200 passed**, dont les deux cas a ne pas regresser (`test_cancelled_is_not_a_failure`, `test_failing_required_check_is_a_red_and_names_the_advisory_as_diagnostic`) et 5 nouveaux : controle positif (#15657/#15660 a la lettre), controle negatif (un vrai rouge garde le red reparable), agregateur seul sans constituant, check requis ordinaire, et auto-exemption d'agregateur.

**Controle sur donnees reelles** — `blocking_causes` execute sur l'etat GraphQL live des deux PRs :

```
=== PR #15657 ===
  -> cut=['ICT tests/ (55)', 'Scripts Tests (CPU)'] real_red=False
  CAUSE: PR gate rouge par constituant(s) COUPE(S), pas par un defaut de code :
         ICT tests/ (55), Scripts Tests (CPU) -- NON REPARABLE par la lane [...]
  CAUSE: conflits avec main -> rebaser
```

Le second cause est le controle qui compte : les deux PRs sont **aussi** `CONFLICTING`, un rouge genuinement reparable — il est toujours rendu. Le fix ne rend pas une PR « propre », il cesse de prescrire la mauvaise reparation.

## Ce que ce PR ne fait pas

Il ne traite pas le **DWELL** — l'autre cause non-reparable qu'un `PR gate` rouge peut porter (un minuteur, pas un defaut). `pr_gate.py` la phrase deja correctement ; la rendre lisible cote picker demande de lire le **texte** du check-run, pas sa conclusion. A traiter separement, et c'est ecrit dans #15763.

## Intégration de main

Le conflit apparu avec #15769 a été résolu délibérément au head `54c5f99ad98774ec07b388d23bb99fdbedbb8394` : les deux taxonomies distinctes et leurs tests sont préservés. Le diff effectif reste limité aux deux fichiers picker/tests annoncés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Réparation causale — commit `42d5cb5f6a1c` (réponse au 🔴 BLOCKING issuecomment-5702614885, lane transférée po-2027)

Le BLOCKING est traité : `cut_constituents` ne décrète plus « NON REPARABLE » sur la seule coexistence d'un CANCELLED dans le rollup.

- **Preuve causale bornée** : l'exemption exige désormais le **message FAIL du gate lui-même** (annotations du check-run, `fetch_gate_cut_evidence`), qui NOMME ses constituants clause par clause (`parse_gate_failure` sur le format réel de `verdict()` #15693/#15905 : « failing checks: » / « declared timeout-minutes » / « never concluded »). Exemption ssi **aucune** clause « failing checks » **et** des coupés nommés **présents dans CE rollup** (l'intersection lie la preuve à ce head).
- **Fail-closed partout ailleurs** : sans `gate_evidence` (annotation non lisible, verdict DWELL/STARVED, pas de `databaseId`), un vrai rouge nommé, ou des coupés étrangers au rollup — la cause reste « check requis en échec » et la lane répare.
- **Coût borné** : l'appel d'annotations n'est payé QUE sur configuration candidate (coupé présent + aucun vrai rouge + agrégateur requis FAILURE), cache par check-run (`gate_evidence_for`).
- **Tests** : contre-exemple causal exact de la review (`PR gate FAILURE + Unrelated advisory CANCELLED` sans preuve → réparable) ; contrôle positif evidence-backed (gate nomme ses deux coupés → exemption, constituants nommés) ; preuve défavorable (clause failing) → pas d'exemption ; coupés étrangers au rollup → pas d'exemption ; `parse_gate_failure` unit-testé sur un message multi-clauses réaliste (annotation `(cancelled, 29m13s)` avec virgule interne, guidance `--` de la clause timeout) et sur DWELL → `([], [])`. **134 passed**.
