### PR TITLE
fix(collision,#15768): le verdict terminal enonce un fait, plus une consommation de substance

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -59,8 +59,8 @@ Terminal verdict: a merged side (#15578)
 ----------------------------------------
 The candidate pool was ``--state open`` exclusively, so a collision *vanished
 from the report at the exact moment it became irreversible*: when one side
-merged. The organ was loudest while the risk was theoretical, and mute once
-the substance was on ``main``.
+merged. The organ was loudest while the risk was theoretical, and mute once one
+side was on ``main``.
 
 Measured on the founding instance: at 2026-09-10T23:18Z the advisory posted a
 ``faible`` collision between #15513 and #15455 over five identical paths --
@@ -73,8 +73,13 @@ The pool therefore also carries PRs merged within a bounded window
 (``--merged-window-days`` -- an argument, never a buried constant):
 
 - a pair with ONE merged side is **terminal**. It is not graduated and not
-  tiered: the substance is already on ``main``, and the comment says exactly
-  that. Terminal *replaces the silence*, it does not inflate the open tiers;
+  tiered: one side is already on ``main``, and the comment says exactly that --
+  and nothing more. What the organ observes is a shared PATH; two PRs can
+  overlap on every path and still deliver disjoint substance (#15454/#15502
+  shared 1 of 1 path on both sides -- the gate's maximum -- and nothing else).
+  "The substance is consumed" would be a content comparison this organ never
+  performs, so the terminal comment does not make it. Terminal *replaces the
+  silence*, it does not inflate the open tiers;
 - a pair with BOTH sides merged carries no signal (both are already on
   ``main``: history, not a collision) and is excluded, like stacked pairs;
 - the tier of OPEN/OPEN pairs is untouched (#15578 acceptance 4). The lesson
@@ -172,12 +177,16 @@ MERGED_STATE = "merged"
 # ``--merged-window-days`` (the bound is an argument, not a buried constant).
 DEFAULT_MERGED_WINDOW_DAYS = 3
 
-# A merged side is TERMINAL only when the two deliveries actually overlap --
-# the "full double delivery" of #15578, never a coincidental shared
-# ``.gitignore``. The measure is the share of EACH side's signal paths that is
-# covered by the shared ones: BOTH sides must be substantially covered, which
-# is what separates "the same substance delivered twice" from "a long-lived PR
-# that merely neighbours a small merge".
+# A merged side is TERMINAL only when the two PRs share a substantial portion
+# of their PATHS -- never for a coincidental shared ``.gitignore``. The measure
+# is the share of EACH side's signal paths that is covered by the shared ones.
+#
+# This gate cuts NOISE. It does NOT establish that the two deliveries overlap in
+# substance, and the comment must never say that it does: #15454/#15502 shared
+# 1 of 1 path on both sides -- a perfect 1.00, this gate's maximum -- while
+# delivering entirely disjoint content (one coloured a mermaid block, the other
+# split a wall paragraph). Path overlap is not content overlap, so no threshold
+# on this quantity could have separated them.
 #
 # Calibrated on ONE live snapshot (2026-09-11, 64 open + 282 merged, 3-day
 # window; the pool drifts, so these are that snapshot's numbers): ungated, 96
@@ -187,6 +196,12 @@ DEFAULT_MERGED_WINDOW_DAYS = 3
 # #15513/#15455 duplicate scores 0.83 (5 shared, out of 5 and of 6).
 # Rejected alternative, measured: ``shared / min(sizes)`` keeps the same ~37 --
 # a 1-file merged PR sharing its only file scores 1.00 for trivial reasons.
+#
+# Note that the RETAINED measure admits that same trivial case: when BOTH sides
+# are single-file on the same path, min coverage is 1.00 and the pair passes.
+# #15454/#15502 is exactly that shape. The gate is right to let it through --
+# dropping it would re-open the muteness #15578 fixed -- which is why the fix
+# for that pair is the comment's WORDING, not the threshold.
 TERMINAL_MIN_OVERLAP_RATIO = 0.5
 
 # The synthetic positive control. NOT a live repo pair (those are volatile:
@@ -232,6 +247,22 @@ FOUNDING_TERMINAL_PAIR: tuple[int, int, tuple[str, ...], str] = (
     "scripts/ci/check_self_hosted_runner_policy.py",
 )
 
+# The founding instance of the OVERCLAIM (#15768), replayed at its state of
+# then, and the sharpest fixture this suite has: both PRs touch EXACTLY ONE
+# path -- the same one -- so the overlap ratio is a PERFECT 1.00, the gate's
+# maximum. And the two deliveries share no substance at all:
+#
+#   #15454  docs(probas,#14871)  split a 3336-char wall paragraph in README.md
+#   #15502  fix(probas,#15022)   explicit mermaid node text colour, same file
+#
+# The issues are DISJOINT, and the paths identical. No threshold on path
+# overlap could separate them, because path overlap is not content overlap --
+# which is why the fix is the verdict's WORDING, not the gate.
+# Paths read from `gh api .../pulls/<n>/files`; issues from the two titles.
+FOUNDING_OVERCLAIM_PAIR: tuple[int, int, str, int, int] = (
+    15454, 15502, "MyIA.AI.Notebooks/Probas/README.md", 14871, 15022,
+)
+
 # Generated artifacts with permanent structural overlap and zero signal
 # (#13615: a guard that reports everything reports nothing).
 EXCLUDED_EXACT_PATHS = frozenset({
@@ -263,8 +294,8 @@ class PathCollision:
     """An unordered pair of PRs sharing at least one signal file path.
 
     ``merged_side`` is set only for a terminal pair (#15578): it names the side
-    already on ``main``, so the comment can say which number is consumed
-    instead of guessing from the tier. ``overlap_ratio`` carries the measured
+    already on ``main``, so the comment names that number instead of guessing
+    it from the tier. ``overlap_ratio`` carries the measured
     ``min`` coverage that put the pair over ``TERMINAL_MIN_OVERLAP_RATIO``, so
     a reader can audit the gate's decision instead of trusting it.
     """
@@ -394,15 +425,21 @@ class ScanResult:
 
     @property
     def terminal_collisions(self) -> list[PathCollision]:
-        """Pairs whose substance is already on ``main`` (#15578)."""
+        """Pairs with ONE side already merged (#15578).
+
+        The verdict is the merged state plus a high PATH overlap -- not a
+        substance comparison, which this organ cannot make (#15454).
+        """
         return [c for c in self.collisions if c.tier == TIER_TERMINAL]
 
     def actionable_collisions(self) -> list[PathCollision]:
         """Pairs worth posting when the caller wants the noise cut.
 
         STRONG and TERMINAL, never the open tiers' weak family-README noise.
-        A terminal pair is by definition not that noise: the substance is
-        already merged, which is the strongest thing this organ can observe.
+        A terminal pair is not that noise either: one side is already on
+        ``main``, which is the strongest FACT this organ can observe -- a fact
+        about paths and PR state, never a proof that the two deliveries
+        overlap (#15454).
         """
         return [c for c in self.collisions if c.tier in (TIER_STRONG, TIER_TERMINAL)]
 
@@ -533,9 +570,10 @@ def strong_collisions(collisions: Iterable[PathCollision]) -> list[PathCollision
 def render_comment(number: int, title: str, own_collisions: list[PathCollision]) -> str:
     """Build the advisory comment body for PR ``number``.
 
-    Names each colliding PR by number, its tier, the shared paths, and (for
-    the strong tier) the common cited issues. Marker-framed so a re-run can
-    find, refresh, or retract it in place.
+    Names each colliding PR by number, its tier, the shared paths, and the
+    common cited issues whenever there are any -- on the terminal tier too,
+    where they are the one honest hint that the two deliveries might overlap.
+    Marker-framed so a re-run can find, refresh, or retract it in place.
 
     The open-pair rendering is byte-identical to the pre-#15578 one, so the
     widened pool does not churn a single existing comment: only a pair that
@@ -557,16 +595,22 @@ def render_comment(number: int, title: str, own_collisions: list[PathCollision])
     for c in sorted(own_collisions, key=lambda c: c.other(number)):
         other = c.other(number)
         if c.tier == TIER_TERMINAL:
-            consumed = c.merged_side if c.merged_side is not None else other
+            merged = c.merged_side if c.merged_side is not None else other
             ratio = (
-                f" (recouvrement {c.overlap_ratio:.0%})"
+                f", recouvrement de chemins {c.overlap_ratio:.0%}"
                 if c.overlap_ratio is not None else ""
             )
             line = (
                 f"- **terminal** -- **#{other}** partage : "
-                f"{', '.join(c.shared_paths)}{ratio} -- **#{consumed}** est "
-                "deja sur `main`, la substance est consommee."
+                f"{', '.join(c.shared_paths)}{ratio} -- **#{merged}** est "
+                "deja sur `main`."
             )
+            # The one honest hint that the two might overlap. Dropping it was
+            # the same mistake one level down: measured and stated, it is a
+            # reason to look; absent, the reader has only the tier.
+            if c.common_issues:
+                issues = ", ".join(f"#{i}" for i in c.common_issues)
+                line += f" (issues communes : {issues})"
         else:
             tier_fr = "fort" if c.tier == TIER_STRONG else "faible"
             line = (
@@ -580,9 +624,12 @@ def render_comment(number: int, title: str, own_collisions: list[PathCollision])
     if any(c.tier == TIER_TERMINAL for c in own_collisions):
         lines.append("")
         lines.append(
-            "Le verdict **terminal** (#15578) signifie que la substance est "
-            "deja sur `main` : le cote merge n'est plus une collision a "
-            "arbitrer, c'est du travail deja integre."
+            "Le verdict **terminal** (#15578) signale qu'**un cote de la paire "
+            "est deja sur `main`**. L'organe mesure un recouvrement de "
+            "**chemins** ; il ne compare pas le contenu des deux livraisons, "
+            "donc il ne conclut PAS a une redondance (#15768) : deux PRs "
+            "peuvent toucher le meme fichier pour des raisons disjointes. "
+            "L'arbitrage reste a la lane ou au coordinateur."
         )
     lines.append("")
     lines.append("<!-- PR-PATH-COLLISION:END -->")
@@ -1082,9 +1129,37 @@ def _self_test() -> int:
           and (900070, 900071) in low.merged_low_overlap_excluded)
 
     # ... and a terminal pair is NOT dropped by the --same-issue-only filter:
-    # the substance being already merged is the loudest thing this organ sees.
+    # one side being already merged is the loudest FACT this organ sees.
     check("terminal survives the actionable (same-issue-only) selector",
           [c.tier for c in founding.actionable_collisions()] == [TIER_TERMINAL])
+
+    # #15768 acceptance 1+3: the OVERCLAIM instance. A PERFECT path overlap
+    # (1 of 1 on both sides) over two DISJOINT issues must still land terminal
+    # -- and the rendered comment must not conclude that the substance is
+    # consumed. Reverting the wording turns this red: the pre-fix body said
+    # "la substance est consommee".
+    o_open, o_merged, o_path, o_open_issue, o_merged_issue = FOUNDING_OVERCLAIM_PAIR
+    overclaim = detect_path_collisions([
+        PrRow(number=o_open, title=f"docs(probas,#{o_open_issue}): segmenter",
+              paths=(o_path,)),
+        PrRow(number=o_merged,
+              title=f"fix(probas,#{o_merged_issue}): couleur mermaid",
+              paths=(o_path,), state=MERGED_STATE),
+    ])
+    oc = next((c for c in overclaim.collisions
+               if {c.a_number, c.b_number} == {o_open, o_merged}), None)
+    check(f"overclaim #{o_open}/#{o_merged}: perfect path overlap is terminal",
+          oc is not None
+          and oc.tier == TIER_TERMINAL
+          and oc.overlap_ratio == 1.0
+          and oc.common_issues == ())
+    body = render_comment(o_open, "docs(probas): segmenter",
+                          collisions_for_pr(o_open, overclaim.collisions))
+    check("overclaim: the terminal comment does NOT claim the substance is "
+          "consumed",
+          "substance est consommee" not in body
+          and "deja integre" not in body
+          and "deja sur" in body)
 
     # Negative: TWO merged sides are history, not a collision -> NOTHING.
     both_merged = detect_path_collisions([
@@ -1239,8 +1314,8 @@ def _cli(argv: list[str] | None = None) -> int:
 
     if args.same_issue_only and result.collisions:
         # STRONG and TERMINAL (#15578): a terminal pair is not the family-
-        # README noise this flag exists to cut, it is the loudest signal the
-        # organ has -- the substance is already on main.
+        # README noise this flag exists to cut, it is the loudest FACT the
+        # organ has -- one side is already on main.
         result.collisions = result.actionable_collisions()
         result.colliding_prs = sorted(
             {n for c in result.collisions for n in (c.a_number, c.b_number)}

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -411,7 +411,7 @@ class TestTerminalMergedPairs(unittest.TestCase):
         )
 
     def test_terminal_render_names_the_merged_side_and_main(self):
-        """Acceptance 2: the comment SAYS the substance is already on main."""
+        """Acceptance 2: the comment NAMES the merged side and says `main`."""
         f_open, f_merged, f_paths, _ = _mod.FOUNDING_TERMINAL_PAIR
         result = detect_path_collisions([
             _pr(f_open, list(f_paths), title="tooling(notebook): detecteur"),
@@ -461,6 +461,130 @@ class TestTerminalMergedPairs(unittest.TestCase):
                                  collisions_for_pr(1, after.collisions))
         self.assertEqual(b_before, b_after)
         self.assertNotIn("terminal", b_before)
+
+
+class TestTerminalVerdictDoesNotOverclaim(unittest.TestCase):
+    """#15768: the terminal verdict must state a FACT, not a conclusion.
+
+    The gap being closed: the organ observes a shared PATH and asserted a
+    consumed SUBSTANCE. `grep` on the module shows no `diff`/`blob`/`hunk`/
+    `additions`/`deletions` anywhere -- there is no content comparison to base
+    the conclusion on. The founding instance is #15454/#15502, and it is the
+    sharpest possible one: both PRs touch exactly ONE path -- the same one --
+    so the overlap ratio is a PERFECT 1.00 while the deliveries are disjoint.
+    No threshold could have saved it; only the wording can.
+    """
+
+    def _overclaim_rows(self, merged_issue: int, open_issue: int,
+                        state: str = "merged"):
+        n_open, n_merged, path, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        return [
+            _pr(n_open, [path], title=f"docs(probas,#{open_issue}): segmenter"),
+            _pr(n_merged, [path], title=f"fix(probas,#{merged_issue}): couleur",
+                state=state),
+        ]
+
+    def test_overclaim_instance_is_terminal_at_a_perfect_path_overlap(self):
+        """Measured fixture: 1 of 1 path on BOTH sides -> ratio exactly 1.00."""
+        n_open, n_merged, path, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        result = detect_path_collisions(self._overclaim_rows(15022, 14871))
+        self.assertEqual(result.n_collisions, 1)
+        c = result.collisions[0]
+        self.assertEqual((c.a_number, c.b_number), (n_open, n_merged))
+        self.assertEqual(c.tier, "terminal")
+        self.assertEqual(c.merged_side, n_merged)
+        self.assertAlmostEqual(c.overlap_ratio, 1.0)
+        self.assertEqual(c.shared_paths, (path,))
+
+    def test_the_fixture_path_really_exists_in_the_checkout(self):
+        """A measured fixture, not an invented one: the path is a real file."""
+        _, _, path, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        proc = _subprocess.run(
+            ["git", "cat-file", "-e", f"HEAD:{path}"],
+            capture_output=True,
+        )
+        self.assertEqual(proc.returncode, 0, f"{path} not in the checkout")
+
+    def test_terminal_render_does_not_claim_the_substance_is_consumed(self):
+        """Acceptance 1: the unprovable claim is out of the output vocabulary."""
+        n_open, n_merged, _, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        result = detect_path_collisions(self._overclaim_rows(15022, 14871))
+        body = render_comment(
+            n_open, "docs(probas,#14871): segmenter",
+            collisions_for_pr(n_open, result.collisions),
+        )
+        for banned in ("substance est consommee", "deja integre",
+                       "travail deja", "is consumed", "already integrated"):
+            self.assertNotIn(banned, body, f"unprovable claim: {banned!r}")
+        # ... while still rendering the FACT it can prove.
+        self.assertIn("terminal", body)
+        self.assertIn(f"**#{n_merged}**", body)
+        self.assertIn("est deja sur", body)
+
+    def test_both_sides_render_the_same_fact_without_a_conclusion(self):
+        """The merged side's thread gets the fact too, not a verdict."""
+        _, n_merged, _, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        result = detect_path_collisions(self._overclaim_rows(15022, 14871))
+        body = render_comment(
+            n_merged, "fix(probas,#15022): couleur",
+            collisions_for_pr(n_merged, result.collisions),
+        )
+        self.assertIn(f"**#{n_merged}**", body)
+        self.assertNotIn("substance est consommee", body)
+        self.assertNotIn("deja integre", body)
+
+    def test_a_common_issue_is_rendered_on_the_terminal_tier(self):
+        """Acceptance 4: the one honest hint is no longer silently dropped."""
+        n_open, n_merged, _, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        # Both sides cite the SAME issue -- the strongest overlap evidence
+        # this organ can hold. Pre-fix it was computed, serialized to JSON,
+        # and omitted from the comment.
+        result = detect_path_collisions(self._overclaim_rows(14871, 14871))
+        c = result.collisions[0]
+        self.assertEqual(c.tier, "terminal")
+        self.assertEqual(c.common_issues, (14871,))
+        body = render_comment(
+            n_open, "docs(probas,#14871): segmenter",
+            collisions_for_pr(n_open, result.collisions),
+        )
+        self.assertIn("#14871", body)
+        # ... but a shared issue is still EVIDENCE, not proof: the verdict
+        # must not harden into the redundancy claim it cannot support.
+        self.assertNotIn("substance est consommee", body)
+
+    def test_disjoint_issues_leave_no_common_issue_marker(self):
+        """The founding instance cites disjoint issues, and says so by silence."""
+        n_open, _, _, _, _ = _mod.FOUNDING_OVERCLAIM_PAIR
+        result = detect_path_collisions(self._overclaim_rows(15022, 14871))
+        c = result.collisions[0]
+        self.assertEqual(c.tier, "terminal")
+        self.assertEqual(c.common_issues, ())
+        body = render_comment(
+            n_open, "docs(probas,#14871): segmenter",
+            collisions_for_pr(n_open, result.collisions),
+        )
+        self.assertNotIn("issues communes", body)
+
+    def test_open_tier_rendering_is_untouched_by_the_wording_change(self):
+        """Acceptance 5: no open/open pair changes body or tier."""
+        result = detect_path_collisions([
+            _pr(1, ["a/x.ipynb"], title="fix(#7): a"),
+            _pr(2, ["a/x.ipynb"], title="fix(#7): b"),
+            _pr(3, ["a/x.ipynb"], title="docs(#9): c"),
+            _pr(4, ["gone/y.md"], title="fix(#8): d", state="merged"),
+        ])
+        strong = [c for c in result.collisions if c.tier == "strong"]
+        weak = [c for c in result.collisions if c.tier == "weak"]
+        self.assertEqual(len(strong), 1)
+        self.assertEqual(len(weak), 2)
+        body = render_comment(1, "fix(#7): a",
+                              collisions_for_pr(1, result.collisions))
+        # The open-tier lines are byte-identical to pre-#15768: no ratio, no
+        # terminal prose, no closing note.
+        self.assertNotIn("terminal", body)
+        self.assertNotIn("recouvrement de chemins", body)
+        self.assertIn("- **fort** --", body)
+        self.assertIn("- **faible** --", body)
 
 
 class TestMergedPoolWiring(unittest.TestCase):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/guard #15765

## Summary

Pour une paire dont **un cote est merge**, `check_pr_path_collisions.py` rend le verdict `TIER_TERMINAL` (#15578) et **affirme une conclusion semantique** — « la substance est consommee », « du travail deja integre » — a partir d'une observation **purement syntaxique** : les deux PRs partagent des chemins, et le recouvrement depasse `TERMINAL_MIN_OVERLAP_RATIO = 0.5`.

Or l'organe ne compare **jamais le contenu**. Mesure sur `origin/main` (`b5e15b39b5`) : **aucune** occurrence de `diff`, `patch`, `blob`, `hunk`, `additions`, `deletions` dans le fichier. Les seules mesures sont l'**ensemble des chemins partages** et leur **ratio**.

Un verdict qu'un organe ne peut pas prouver ne doit pas etre dans son vocabulaire de sortie.

## L'instance — et pourquoi elle est la plus tranchante possible

| Quand (UTC) | Fait |
|---|---|
| 2026-09-10T21:14:12Z | le garde rend sur **#15454** : « #15502 est deja sur main, la substance est consommee... travail deja integre » |
| 2026-09-11T04:17:52Z | **#15502** merge — `fix(probas,#15022)` : *couleur de texte explicite sur les noeuds mermaid styles* — un fix de **couleur** |
| 2026-09-11T23:39Z | ai-01 mesure : le paragraphe-mur fait **3246 c**, **integralement sur `main`** |
| 2026-09-12T00:17:28Z | **#15454** merge (`7e72a3d510`) — `docs(probas,#14871)` : *segmenter le paragraphe-mur de l'intro serie (3336 c -> 6 paragraphes aeres)* |

Mesure de cloture sur `origin/main` : le paragraphe portant la phrase citee fait desormais **563 c** (172 paragraphes, plus long : 2521 c). **#15454 a livre sa substance 3 h apres que le garde l'ait declaree « deja integree ».**

**Les deux PRs sont mono-fichier, sur le meme chemin** — `gh api .../pulls/<n>/files`, les deux rendent `modified MyIA.AI.Notebooks/Probas/README.md`. Le ratio de recouvrement vaut donc **1.00**, le **maximum** que cette porte puisse rendre. Et les deux livraisons n'ont **rien** en commun : l'une colore un bloc mermaid, l'autre scinde un paragraphe-mur. Les issues citees sont disjointes (`#15022` contre `#14871`).

Aucun seuil sur cette quantite n'aurait pu les separer : un recouvrement de **chemins** n'est pas un recouvrement de **contenu**. C'est pourquoi le correctif porte sur le **vocabulaire du verdict**, pas sur la porte.

Consequence operationnelle, mesuree par ai-01 : la lecture naturelle du fil de #15454 menait a fermer une PR valide, seul correctif existant de #14871 ; une correction explicite (`#15454 issuecomment-5641862746`) a du etre postee pour l'empecher.

## Ce qui etait deja en main, et jete

`common_issues` — l'intersection des issues citees par les deux PRs — est **deja** le discriminant qui separe `TIER_STRONG` de `TIER_WEAK` sur les paires ouvertes. Sur une paire **terminale**, il etait **calcule** (l.488-490), **stocke** (`PathCollision.common_issues`), **serialise dans le JSON** — et **jamais rendu dans le commentaire** : la branche terminale du template ne l'utilisait pas, la branche ouverte si. Le seul element qui rend la redondance *plausible* etait donc ecarte en silence, precisement dans la branche qui l'affirme.

Instance vivante mesuree ce jour dans le pool reel (`--dry-run --limit 12 --merged-window-days 1 --same-issue-only`) :

```
[terminal] #15722/#15751 paths=scripts/post_bake_slides.py, scripts/tests/test_post_bake_slides.py issues=#15452
```

Le commentaire poste sur ces deux PRs **omettait `#15452`**. Il le porte desormais.

## Le correctif

- **Verbatim retire** de tout le vocabulaire de sortie : « la substance est consommee », « du travail deja integre », « which is the strongest thing this organ can observe », « which number is consumed ». Sites : docstring de module, justification de la porte, `PathCollision`, `terminal_collisions`, `actionable_collisions`, template de commentaire, note de cloture, self-test, `_cli`.
- **Le verdict terminal reste** — la paire est un fait a rendre visible, et la suppression a rouverte la mutite que #15578 a fermee — mais il **decrit ce que l'organe sait** : chemins partages + cote merge + issues communes.
- **`common_issues` rendu sur une paire terminale** au lieu d'etre jete.
- **La note de cloture enonce la limite** au lieu de conclure : « l'organe mesure un recouvrement de **chemins** ; il ne compare pas le contenu des deux livraisons, donc il ne conclut PAS a une redondance ».
- **La porte n'est pas touchee.** `TERMINAL_MIN_OVERLAP_RATIO` reste 0.5 : le commentaire de calibration note desormais explicitement que la mesure retenue admet le cas mono-fichier a 1.00 (elle le doit — l'exclure rouvrirait la mutite), ce qui est precisement pourquoi le correctif est le **libelle**, pas le seuil.

## Verification

```
$ python scripts/check_pr_path_collisions.py --self-test
OK   overclaim #15454/#15502: perfect path overlap is terminal
OK   overclaim: the terminal comment does NOT claim the substance is consumed
SELF-TEST OK: all controls satisfied          (17 controles, exit 0)

$ python -m pytest scripts/tests/test_check_pr_path_collisions.py -q
72 passed                                     (65 avant, 7 neufs)

$ python -m pytest scripts/tests/test_check_pr_path_collisions.py scripts/tests/test_check_slot_reservation.py -q
91 passed
```

**Execution reelle** (`--dry-run`, chemin `gh` complet, rien poste) : exit 0, `collisions=3 (strong=1 weak=0 terminal=2)`, deux paires terminales rendues **sans** affirmation de consommation.

**Non-regression** : les 65 tests anterieurs restent verts, dont les 5 dedies a #15591 (`test_open_pair_tier_untouched_beside_a_merged_row`, `test_weak_open_pair_stays_weak_beside_a_merged_row`, `test_terminal_is_distinct_from_the_open_tiers`). Un test neuf verrouille l'acceptance 5 : le rendu des paires **ouvertes** est inchange (pas de ratio, pas de prose terminale, pas de note de cloture).

## Controle positif — les tests neufs rougissent contre `origin/main`

Module d'origine charge par `git show`, **jamais edite**. Meme entree, **meme appel** `render_comment(...)`, deux modules :

```
ORIGINE (origin/main)
  tier=terminal ratio=1.0 common_issues=()
  ligne terminale : - **terminal** -- **#15502** partage : MyIA.AI.Notebooks/Probas/README.md (recouvrement 100%) -- **#15502** est deja sur `main`, la substance est consommee.
  affirmations non prouvables presentes : ['substance est consommee', 'deja integre', 'travail deja']

CORRIGE (arbre de travail)
  tier=terminal ratio=1.0 common_issues=()
  ligne terminale : - **terminal** -- **#15502** partage : MyIA.AI.Notebooks/Probas/README.md, recouvrement de chemins 100% -- **#15502** est deja sur `main`.
  affirmations non prouvables presentes : AUCUNE
```

Meme ratio, meme verdict, meme cible : seule la **formulation** change. Les tests neufs rougissent par ailleurs a l'import contre l'origine (`AttributeError: FOUNDING_OVERCLAIM_PAIR`, 6 failed) — mecanique. Le controle comportemental ci-dessus est celui qui mesure.

## Effet de bord assume : une mise a jour unique des commentaires terminaux

Le corps du commentaire terminal change, donc le prochain passage reel **met a jour** (verbe `update`, protocole par marqueur) les PRs ouvertes qui portent deja un verdict terminal — `#15751`, `#15722` dans le snapshot du jour. C'est le but : ces corps affirment aujourd'hui une consommation de substance qui peut faire fermer du travail valide. Les paires **ouvertes** ne sont pas touchees (test dedie).

## Provenance

Residuel du commentaire ai-01 sur #15578, dont l'instance #15454 est ici **remesuree firsthand** et renforcee (ratio 1.00, pas 0.83). **#15578 lui-meme est resolu sur `main` par #15591** (vivier elargi aux mergees + verdict terminal) et close-ready — ce defaut-ci est distinct : la **formulation** du verdict introduit, pas son existence. Un `Closes #15578` aurait donc ete faux ; d'ou le tracker separe #15768.

Hors scope, deja nomme par l'organe : la similarite **semantique** (meme substance, chemins differents) demande un autre outil.

Closes #15768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

