### PR TITLE
fix(guard,#14850): scope-emetteur par role — voie nue par meme login protegee contre levee par prefixe de lane/role

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -159,6 +159,44 @@ _PERSONA_MARKERS_RE = re.compile(
     # le backtick reste EXCLU : `` `[Hermes]` `` est une citation (#13030).
     r"(?m)(?:^|[\s*])\[(?:Hermes|NanoClaw|Hermes self-bot)(?:\s+[^\]]*)?\]"
 )
+# #14850 — prefixe de lane tierce : voie distincte d'un autre agent du cluster
+# qui pousse sous le meme login partage `jsboige`. Le format canonique est
+# `[machine-po-YYYY:CoursIA-2]` (Tell c.677-L4 body PR HORS worktree +
+# convention owner:workspace du `[CLAIMED]` lane). Le complement facultatif
+# ` (...)` peut suivre. La voie NUЕ par meme login (commentaire ordinaire
+# SANS prefixe) n'a aucune signature distincte et reste indiscernable d'une
+# auto-reponse de l'auteur de la reserve -- c'est exactement le defaut de
+# discrimination que #14850 nomme.
+_CROSS_LANE_LIFT_RE = re.compile(
+    # #14850 — la lane est en-tete de paragraphe (apres decoration `* ` ou
+    # `# ` admise). Caracteres autorises : lettres, chiffres, tirets, points,
+    # underscores, deux-points (format `owner:workspace`). Refuse les crochets
+    # ULTERIEURS (` > [lane]`) par l'ancre `^` + decoration de debut de ligne.
+    r"(?m)^[#>*+\-\s]*\[\s*[A-Za-z][\w.\-]*:\s*[A-Za-z][\w.\-]*(?:\s+[^\]]+)?\]"
+)
+# #14850 — prefixe de ROLE GENERIQUE : `[ai-01]`, `[po-2026]`, etc. Le format
+# est `[identifiant]` (un seul token, sans `:` ni whitespace), pose en tete
+# de paragraphe apres decoration `* ` ou `# `. Distinct des personas
+# (Hermes/NanoClaw, L156) et des lanes (owner:workspace, L170) : un prefixe
+# role comme `[ai-01]` est l'identite de l'agent qui pousse sous un login
+# partage (typiquement `jsboige` ou `clusterManager-Myia`). Le scope d'un
+# tel lift est SA voix, pas la voie nue -- sans le reconnaitre, le filet
+# accepte une levee `[ai-01] Je leve ma propre reserve` par `jsboige` comme
+# levant une reserve user voix nue de `jsboige` (incident fondateur #14795,
+# 21:11:29Z).
+#
+# Les TAGS DE PROTOCOLE (`[DONE]`, `[INFO]`, `[WARN]`, `[ASK]`, `[REPLY]`,
+# `[ACK]`, `[TASK]`, `[BLOCKED]`, `[CLAIMED]`, `[DISPATCH→inbox]`,
+# `[ESCALATION]`, ...) ne sont PAS des prefixes de role : ils qualifient
+# le TYPE du commentaire, pas l'emetteur. Un `[DONE] les 2 nits sont
+# adresses, commit abc123.` reste voie nue de l'auteur -- le tag est
+# un attribut de workflow, pas une identite d'agent.
+_ROLE_PREFIX_RE = re.compile(
+    r"(?m)^[#>*+\-\s]*\[\s*(?!Hermes\b|NanoClaw\b|Hermes self-bot\b|OVERRIDE\b"
+    r"|DONE\b|INFO\b|WARN\b|ERROR\b|ASK\b|REPLY\b|ACK\b|TASK\b|BLOCKED\b"
+    r"|CLAIMED\b|ESCALATION\b|PROPOSAL\b|GRAIN\b)"
+    r"[A-Za-z][\w.\-]*\s*\]"
+)
 # #14503 — reserves enoncees en PROSE ordinaire par une persona, sans aucun
 # prefixe de verdict (CONCERN_MARKERS muet). Jeu SERRE, mesure sur le corpus
 # des 200 dernieres PRs mergees (controle 3 de l'issue) : le fail-CLOSED pur
@@ -3540,31 +3578,159 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
     def _lift_eligible(lift_author: str, nit_author: str,
                        lift_body: str = "", nit_body: str = "") -> bool:
         if lift_author == nit_author:
-            # #14947 -- meme login n'est pas meme voix. `jsboige` est A LA FOIS
-            # le compte du user et l'identite de poussee des personas (#13316).
-            # Une levee marquee `[Hermes]` / `[NanoClaw]` signe la revue de la
-            # persona sur SON propre travail ; elle ne repond pas a une remarque
-            # ecrite en voix nue par le user sous le meme login. B.0 : « se lever
-            # soi-meme une reserve d'autrui n'est pas y repondre, c'est la
-            # declarer repondue ».
+            # #14947 ET #14850 -- meme login n'est pas meme voix. `jsboige`
+            # est A LA FOIS le compte du user, l'identite de poussee partagee
+            # des personas (#13316), ET le login sous lequel les lanes
+            # cross-poussent. Le discriminateur de B.0 -- « une levee
+            # emise sous un prefixe de role ne doit pas eteindre une reserve
+            # user » (acceptance 1 de #14850) -- impose que la levee soit
+            # SCOPEE A L'EMETTEUR (acceptance 2) : un LGTM `[Hermes]` leve
+            # les reserves `[Hermes]`, pas les reserves user voix nue ;
+            # un commentaire `[myia-po-2024:CoursIA-2]` leve les reserves de
+            # CETTE lane, pas les reserves user voix nue.
             #
-            # Le discriminant n'est pas neuf : #13609 tient deja le marqueur de
-            # persona pour une identite CROSS-login (la persona leve sa propre
-            # reserve sous l'autre login). Il vaut a fortiori SAME-login, ou la
-            # borne d'auteur #11145 ne discrimine plus rien.
+            # Le discriminant par ROLE du lift determine a quelles reserves
+            # il peut s'appliquer. Sans discriminant de role, la levee est
+            # voix nue -- elle ne leve que les reserves VOIX NUE de meme
+            # auteur (le self-lift nominatif de B.0).
             #
-            # Incident fondateur #14937 : nit user 19:20:05Z (« Concern: le
-            # notebook ne devrait-il pas etre une accretion... »), review
-            # `[Hermes]` a 19:26:40Z terminee par un « RAS » nu -- six minutes
-            # plus tard, sur un tout autre objet (re-execution des cellules).
-            # Le RAS eteignait le nit : rc=0, PR mergeable, remarque user perdue.
-            # La levee etant PAR PR et non par reserve, un acquit de routine de
-            # la persona suffisait a solder la voix du user.
-            if (_PERSONA_MARKERS_RE.search(_strip_quoted(lift_body or ""))
-                    and not _PERSONA_MARKERS_RE.search(
-                        _strip_quoted(nit_body or ""))):
-                return False
-            return True
+            # Incident fondateur #14937 (persona leve sa propre voix) :
+            # nit user 19:20:05Z (« Concern: ... »), review `[Hermes]` a
+            # 19:26:40Z terminee par un « RAS » -- le RAS eteignait le nit
+            # user voix nue. Defaut fondateur de la voie PERSONA levee en
+            # voix nue.
+            #
+            # Incident fondateur #14850 (voie nue par meme login eteint
+            # reserve user, mesure sur #14795 head `2510e3a4`) : la review
+            # Hermes de 18:29:00Z terminee par « Verdict : LGTM » eteignait
+            # la reserve user voix nue posee a 18:09:49Z. PR #14949 a cru
+            # fermer ce cas en verifiant que le lift porte `[Hermes]` mais
+            # que le nit ne le porte pas -- mais le filet ne discriminait
+            # pas le SCOPE complet : un LGTM `[Hermes]` etait compte
+            # comme lift PR-wide. Le present fix ferme la discrimination
+            # par ROLE du lift :
+            #
+            #   * Lift voix nue par `jsboige` ne leve que les reserves
+            #     voix nue du MEME auteur. Sur le cas fondateur #14850,
+            #     le LGTM `[Hermes]` 18:29:00Z de `jsboige` ne leve PAS
+            #     la reserve `Concern:` voix nue 18:09:49Z de `jsboige` :
+            #     les roles sont distincts (Hermes vs user).
+            #
+            #   * Lift `[Hermes]` / `[NanoClaw]` par `jsboige` ne leve que
+            #     les reserves `[Hermes]` / `[NanoClaw]` (par SCOPE EMETTEUR).
+            #     Si la reserve est voix nue (`Concern:`), elle est HORS
+            #     scope persona -- le LGTM persona ne l'eteint pas.
+            #
+            #   * Lift `[machine:workspace]` (cross-lane) par `jsboige`
+            #     ne leve que les reserves `[machine:workspace]` (meme
+            #     lane). Si la reserve est voix nue user, elle est HORS
+            #     scope de la lane tierce -- cf. mesure #14850 sur le
+            #     commentaire 18:28:07Z `[myia-po-2024:CoursIA-2]` qui
+            #     etait compte comme levee alors qu'il eteignait la
+            #     reserve user voix nue.
+            #
+            #   * Lift `[OVERRIDE] lane <machine>` par coordinateur leve
+            #     tout (autorite coordinateur, Tell c.11639). La voie
+            #     override reste ouverte comme echappatoire nommee.
+            stripped_lift = _strip_quoted(lift_body or "")
+            stripped_nit = _strip_quoted(nit_body or "")
+            # Voie 0 -- override coordinateur (Tell c.11639). Meme login
+            # ou pas, l'arbitre tiers nomme par `[OVERRIDE] lane <machine>`
+            # leve. Fail-CLOSED sur la pose en tete (#13030). Premier
+            # discriminant verifie pour ne pas etre bloque par les voies
+            # 1-3 : un override par coordinateur sur sa propre reserve
+            # voix nue doit lever (autorite coordinateur).
+            if OVERRIDE_LANE.search(stripped_lift):
+                return True
+            # Voie 1 -- lift PERSONA scope aux reserves PERSONA.
+            # Si la reserve est voix nue (pas de marqueur persona), elle
+            # est HORS scope persona -- bloque. Si elle porte persona,
+            # elle est dans le scope persona -- leve. Discriminant
+            # symetrique de #14947 (persona leve sa propre voix) ETENDU
+            # au scope par role de #14850 : la persona peut lever SA
+            # reserve posee en persona, mais pas la reserve user voix nue
+            # posee sous meme login partage.
+            lift_has_persona = bool(_PERSONA_MARKERS_RE.search(stripped_lift))
+            nit_has_persona = bool(_PERSONA_MARKERS_RE.search(stripped_nit))
+            if lift_has_persona and nit_has_persona:
+                return True
+            if lift_has_persona and not nit_has_persona:
+                return False  # #14850 scope : lift persona ne leve pas user
+            # Voie 2 -- lift CROSS-LANE scope aux reserves CROSS-LANE.
+            # Un commentaire preface d'une lane tierce `[owner:workspace]`
+            # ne leve que les reserves de CETTE lane. Si la reserve est
+            # voix nue user ou persona, elle est HORS scope de la lane
+            # tierce -- bloque. Accepte le prefixe en debut de ligne
+            # (Tell c.677-L4 body PR HORS worktree), refuse la citation
+            # ulterieure (` > [lane]`) par l'ancre `^`.
+            lift_has_lane = bool(_CROSS_LANE_LIFT_RE.search(stripped_lift))
+            nit_has_lane = bool(_CROSS_LANE_LIFT_RE.search(stripped_nit))
+            if lift_has_lane and nit_has_lane:
+                return True
+            if lift_has_lane and not nit_has_lane:
+                return False  # #14850 scope : lift lane tierce ne leve pas user
+            # Voie 3 -- self-lift voix nue par l'auteur de SA reserve voix nue.
+            # L'auteur leve SA PROPRE reserve voix nue par une phrase de
+            # levee NOMINATIVE (`EXPLICIT_LIFT_MARKERS` : « Je leve »,
+            # « Levee de », « Lève la »). C'est la voie legitime que B.0
+            # preserve (« ce qui leve une remarque est une phrase ») et
+            # que la borne d'auteur #11145 preservait. Sans phrase
+            # nominative, c'est une declaration de verdict globale qui
+            # n'eteint pas la reserve voix nue specifique -- le cas
+            # fondateur #14850 LGTM voix nue de Hermes vs user.
+            #
+            # Anti-regression couverte : la self-levee explicite
+            # (« Levée de ma reserve : cellule 12 corrigee »,
+            # test_13316_self_lift_jsboige_sur_sa_propre_reserve_leve) et
+            # le self-lift par meme persona (`clusterManager-Myia` levant
+            # SA reserve `[Hermes]` par un « RAS sur le fond »,
+            # test_ras_francais_leve_dans_une_reponse) doivent rester
+            # valides. Les deux sont portes par `EXPLICIT_LIFT_MARKERS`
+            # ou un LIFT_MARKER faible DANS LE CONTEXTE d'une reserve
+            # deja persona-membre (couvert par voie 1 ci-dessus).
+            #
+            # #14850 -- defense en profondeur : un prefixe de ROLE generique
+            # (`[ai-01]`, `[po-2026]`, etc.) dans le lift, meme accompagne
+            # d'un LIFT_MARKER, ne leve PAS une reserve voix nue du meme
+            # login partage. Le lift `[ai-01] Je leve ma propre reserve`
+            # par `jsboige` n'a pas voix sur la reserve user voix nue de
+            # `jsboige` (incident fondateur #14795 21:11:29Z). Le reserve
+            # voix nue exige une levee voix nue -- la discrimination de voie
+            # par ROLE tient par symetrie : persona, lane, override ET
+            # role-prefix sont HORS scope de la voie nue.
+            #
+            # Note -- un LIFT_MARKER (broad, pas seulement EXPLICIT) suffit
+            # ici : le test de discrimination est sur le PREFIXE du lift,
+            # pas sur la force du marqueur. Une levee voie nue par l'auteur
+            # de la reserve voie nue peut employer « sont adresses »,
+            # « RAS », « LGTM » -- c'est l'ancien comportement preserve
+            # (#12319). La discrimination #14850 ajoute : un lift avec
+            # PREFIXE de role ne leve PAS une reserve voie nue du meme
+            # login partage, meme avec un LIFT_MARKER fort.
+            #
+            # Anti-regression couverte : `test_auteur_du_nit_leve_son_nit`
+            # (clusterManager-Myia leve SA reserve `[Hermes]` par un
+            # « reserve levee » voix nue). Le discriminant est sur le
+            # PREFIXE du LIFT, pas sur celui de la reserve -- une reserve
+            # `[Hermes]` n'est pas une reserve « user voix nue » au sens
+            # strict, mais elle est levee par la voie nue de l'auteur de
+            # la persona (clusterManager-Myia, voie nue, LIFT_MARKER).
+            # Voie 3 leve donc si le lift est voie nue (pas de prefixe
+            # distinct), independamment du scope du nit (la garde
+            # persona-vs-user est deja portee par voie 1).
+            stripped_lift_role = stripped_lift
+            lift_has_role = bool(_ROLE_PREFIX_RE.search(stripped_lift_role))
+            if (lift_has_persona is False
+                    and lift_has_lane is False
+                    and lift_has_role is False
+                    and has_live_lift(lift_body or "")):
+                return True
+            # Voie nue par meme login, sans discriminant de ROLE ni
+            # phrase de levee EXPLICITE : voie NUE par l'auteur de la
+            # reserve, sans signature distincte. C'est l'auto-reponse
+            # de l'auteur de la reserve sur sa propre remarque -- le cas
+            # fondateur #14850 LGTM voix nue de Hermes sur reserve user.
+            return False
         # #13609 -- alias de persona Hermes/NanoClaw cross-login. La persona
         # parle sous clusterManager-Myia ET jsboige. Quand elle leve SA
         # propre reserve sous l'autre login, c'est sa levee. Le marqueur

--- a/scripts/tests/test_check_unaddressed_nits_14850.py
+++ b/scripts/tests/test_check_unaddressed_nits_14850.py
@@ -1,0 +1,333 @@
+"""Tests pour la discrimination de voie par meme login (#14850).
+
+L'organe `check_unaddressed_nits.analyse` doit distinguer les LEVEES
+legitimes par un auteur de meme login (persona, lane tierce, override
+coordinateur) d'une VOIE NUE ordinaire, qui equivaut a une auto-reponse
+de l'auteur de la reserve. Sans discrimination, une review `LGTM` voix
+nue de `jsboige` eteint la reserve user posee en voix nue par `jsboige`.
+
+Incident fondateur : PR #14795. Le commentaire `[myia-po-2024:CoursIA-2]
+Reponse a la reserve user du 2026-09-05T18:09:49Z` etait comptabilise
+comme levee alors qu'il n'etait qu'une voie nue sous meme login prefixee
+d'une lane tierce -- sans que la clause de discrimination ne soit posee.
+
+Acceptance :
+  1. Voie NUE par meme login (LGTM, Verdict: OK, RAS, sans prefixe de
+     role) ne leve PAS une reserve user en voix nue sous meme login.
+  2. Un prefixe de LANE TIERCE `[machine:workspace]` leve la reserve
+     (voie distincte, pas par le login mais par la lane prefixee).
+  3. Un prefixe PERSONA `[Hermes]` / `[NanoClaw]` leve la reserve UNIQUEMENT
+     si le nit est aussi en persona (extension de #14947 -- persona leve
+     SA voix, pas celle du user nu).
+  4. Un OVERRIDE coordinateur `[OVERRIDE] lane <machine>` leve la reserve
+     (arbitre tiers nomme).
+"""
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+
+spec = importlib.util.spec_from_file_location("check_unaddressed_nits", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_unaddressed_nits"] = mod
+spec.loader.exec_module(mod)
+
+
+def at(hour: int) -> str:
+    return f"2026-09-05T{hour:02d}:00:00Z"
+
+
+MERGED = datetime(2026, 9, 6, 18, 0, tzinfo=timezone.utc)
+
+# Reserve user voix nue, posee 18:09:49Z (issue #14850, PR #14795 head).
+# Le marqueur CONCERN_LABEL « Concern: » est en debut de paragraphe, ce qui
+# satisfait la regex `^[\s*_#>\-]*concerns?\s*\d*\s*:` (L2375).
+USER_RESERVE_NUE = {
+    "author": {"login": "jsboige"},
+    "createdAt": "2026-09-05T18:09:49Z",
+    "body": "Concern: le retrait du S8 doit etre rebase-propre avant merge.\n"
+            "Le contenu du carnet derive et le merge de la tranche D2 ne le "
+            "corrige pas. Il va falloir rebaser proprement avant de merger.",
+}
+
+
+def run(comments, commits=None, threads=None, reviews=None, pr_author="jsboige",
+        **extra):
+    data = {
+        "number": 0,
+        "title": "t",
+        "author": {"login": pr_author},
+        "comments": comments,
+        "reviews": reviews if reviews is not None else [],
+        "commits": commits if commits is not None else [{"committedDate": at(17)}],
+    }
+    data.update(extra)
+    return mod.analyse(data, threads or [], MERGED)
+
+
+# -----------------------------------------------------------------------------
+# Acceptance 1 -- Lift avec prefixe de ROLE (`[ai-01]`, etc.) NE leve PAS la
+# reserve user nue sous meme login partage. Discrimination par scope-emetteur :
+# la voie nue par meme login reste preservee (#12319) ; un prefixe de ROLE
+# distinct du user (coordinateur, lane, autre agent) cree un scope distinct
+# qui n'a pas voix sur la reserve voie nue du user.
+# -----------------------------------------------------------------------------
+
+def test_role_prefix_meme_login_ne_leve_pas_reserve_user_nue():
+    """#14850 cas fondateur (21:11:29Z PR #14795) -- un `[ai-01] Je leve ma
+    propre reserve` par `jsboige` n'eteint PAS la reserve user voix nue
+    posee par `jsboige`. Le prefixe `[ai-01]` identifie un EMETTEUR distinct
+    du user -- c'est le coordinateur lane, pas la voix du user.
+
+    Avant le fix : la voie nue par meme login etait consideree comme
+    self-lift legitime (voie 3 de l'ancien code `return True`) ; le filet
+    acceptait une levee `[ai-01]` par `jsboige` comme eteignant la reserve
+    voix nue de `jsboige`. Apres le fix : tout prefixe de ROLE generique
+    dans le lift exclut la voie nue (scope-emetteur)."""
+    lift_ai01 = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-06T21:11:29Z",
+        "body": "[ai-01] Je leve ma propre reserve -- elle est perimee, et "
+                "c'est ma mesure qui l'a posee.",
+    }
+    res = run([USER_RESERVE_NUE, lift_ai01])
+    assert res["blocked"] is True, (
+        "Un prefixe de ROLE `[ai-01]` (coordinateur lane) dans le lift, "
+        "meme avec EXPLICIT_LIFT_MARKER, n'a pas voix sur la reserve user "
+        "voix nue sous meme login partage. C'est exactement le scope-emetteur "
+        "de l'acceptance 1 de #14850 (incidente fondateur : PR #14795 "
+        "commentaire 21:11:29Z)."
+    )
+
+
+def test_hold_directive_role_prefix_ne_leve_pas_reserve_user_nue():
+    """Extension : un `[ai-01] HOLD merge` (directive de blocage) ne leve
+    pas non plus la reserve user. Le prefixe de ROLE reste hors scope de
+    la voie nue."""
+    lift_hold = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-06T02:35:35Z",
+        "body": "[ai-01] HOLD merge -- la reserve user du 18:09:49Z n'est "
+                "pas levee. Verdict protocole.",
+    }
+    res = run([USER_RESERVE_NUE, lift_hold])
+    assert res["blocked"] is True, (
+        "Un `[ai-01] HOLD merge` est un signal de protocole (directive "
+        "coordinateur), pas une levee. Il ne leve pas une reserve user "
+        "voix nue. Cf #14850 acceptance 1."
+    )
+
+
+# -----------------------------------------------------------------------------
+# Acceptance 2 -- Cross-lane `[machine:workspace]` est SCOPEE a sa lane.
+# -----------------------------------------------------------------------------
+# Acceptance 2 dit "scoper la levee a l'emetteur, pas a la PR" (#14850 body).
+# Un prefixe de lane tierce `[machine:workspace]` identifie un EMETTEUR
+# distinct du user, mais PAS l'emetteur de la reserve voix nue. La levee
+# est scopee a la lane -- elle leve les reserves de CETTE lane, pas les
+# reserves user voix nue. Avant le fix, ce commentaire etait comptabilise
+# comme levee PR-wide ; apres le fix, il est SCOPE a la lane.
+#
+# Reproduit le commentaire reel de #14795 :
+# `[myia-po-2024:CoursIA-2] Reponse a la reserve user du 18:09:49Z`
+# -- qui ne leve PAS la reserve voix nue de l'utilisateur, mais leverait
+# une reserve `[myia-po-2024:CoursIA-2]` sur la meme PR.
+
+def test_cross_lane_meme_login_ne_leve_pas_reserve_user_nue():
+    """#14850 acceptance 2 : une levee prefixee d'une lane tierce
+    (`[myia-po-2024:CoursIA-2]`) est SCOPEE a cette lane -- elle ne leve
+    PAS une reserve voix nue user posee sous le meme login partage.
+
+    Reproduit le cas fondateur #14795 : le commentaire 18:28:07Z
+    `[myia-po-2024:CoursIA-2] Reponse a la reserve user du 18:09:49Z`
+    etait comptabilise comme levee avant le fix (le filet acceptait la
+    voie nue sous meme login comme levee PR-wide). Apres le fix, le
+    prefixe de lane SCOPE la levee : cette lane ne leve que SES reserves.
+    """
+    lift_cross_lane = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:28:07Z",
+        "body": "[myia-po-2024:CoursIA-2] Reponse a la reserve user du "
+                "2026-09-05T18:09:49Z. La tranche D2 est livree par "
+                "668df097a2, kernel gametheory-wsl installe, 14/14 "
+                "cellules OK. La reserve est levee.",
+    }
+    res = run([USER_RESERVE_NUE, lift_cross_lane])
+    assert res["blocked"] is True, (
+        "Une levee prefixee `[machine:workspace]` est scopee a CETTE lane. "
+        "Elle ne leve pas une reserve voix nue du user -- c'est exactement "
+        "le scope-emetteur de la voie 2 du fix #14850. Le cas fondateur "
+        "#14795 18:28:07Z doit rendre blocked=True."
+    )
+
+
+def test_cross_lane_meme_login_leve_reserve_de_la_lane():
+    """#14850 acceptance 2 (jumeau) : la levee scopee par lane leve
+    les reserves DE CETTE LANE. Une reserve posee par la meme lane
+    (avec le meme prefixe `[machine:workspace]`) est levee par une
+    levee de meme lane -- c'est la voie 2 du fix, dans son volet
+    levant (non-bloquant).
+    """
+    reserve_de_la_lane = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:09:49Z",
+        "body": "[myia-po-2024:CoursIA-2] Concern: la tranche D2 du "
+                "carnet n'est pas alignee avec le merge prevu.",
+    }
+    lift_de_la_lane = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:28:07Z",
+        "body": "[myia-po-2024:CoursIA-2] Tranche D2 livree par "
+                "668df097a2, kernel gametheory-wsl installe, 14/14 "
+                "cellules OK. La reserve est levee.",
+    }
+    res = run([reserve_de_la_lane, lift_de_la_lane])
+    assert res["blocked"] is False, (
+        "Une levee scopee `[machine:workspace]` leve les reserves "
+        "DE CETTE lane. La voie 2 du fix #14850 a un volet levant "
+        "(meme lane)."
+    )
+
+
+# -----------------------------------------------------------------------------
+# Acceptance 3 -- Extension de la garde #14947 : PERSONA leve SA voix,
+# pas la voie nue du user. Si la reserve est nue, la levee persona est
+# BLOQUEE (cf Voie 1 du fix).
+# -----------------------------------------------------------------------------
+
+def test_persona_meme_login_reserve_nue_bloquee():
+    """#14947 (etendu #14850) -- une levee `[Hermes]` ne peut pas
+    eteindre une reserve voix nue du user sous meme login. La garde
+    #14947 tient ; la voie nue n'etait qu'un cas particulier que
+    #14850 nommait explicitement."""
+    lift_persona = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-06T15:56:45Z",
+        "body": "[Hermes] RAS sur le merge de la tranche D2, OK pour moi.",
+    }
+    res = run([USER_RESERVE_NUE, lift_persona])
+    assert res["blocked"] is True, (
+        "La persona leve SA propre voix, pas la voie nue du user. La "
+        "garde #14947 doit rester effective ici -- sinon on reintroduit "
+        "le defaut fondateur de #14937."
+    )
+
+
+def test_persona_meme_login_reserve_persona_leve():
+    """Cas ou la persona leve SA reserve posee en persona sous meme login :
+    voie 1 du fix -- la garde de #14947 tient (persona leve personne)."""
+    user_reserve_persona = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:09:49Z",
+        "body": "[Hermes] Concern: l'attribution est ambigue, il faudrait "
+                "un lemma dedie.",
+    }
+    lift_persona_qui_leve = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T19:26:40Z",
+        "body": "[Hermes] Lemma dedie ajoute, attribution clarifiee.",
+    }
+    res = run([user_reserve_persona, lift_persona_qui_leve])
+    assert res["blocked"] is False, (
+        "La persona leve SA reserve posee en persona : voie 1 du fix, "
+        "compatible avec la garde de #14947."
+    )
+
+
+# -----------------------------------------------------------------------------
+# Acceptance 4 -- OVERRIDE coordinateur leve la reserve, meme login.
+# -----------------------------------------------------------------------------
+
+def test_override_coordinateur_leve_reserve_nue():
+    """L'arbitre tiers nomme par `[OVERRIDE] lane <machine>` leve la
+    reserve. Meme login ou pas, le discriminant OVERRIDE est le 3e voie
+    du fix #14850. Tell c.11639."""
+    lift_override = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-06T15:56:45Z",
+        "body": "[OVERRIDE] lane myia-ai-01 : la reserve est levee par "
+                "autorite coordinateur.",
+    }
+    res = run([USER_RESERVE_NUE, lift_override])
+    assert res["blocked"] is False, (
+        "L'override coordinateur est le 3e voie du fix #14850 (Tell "
+        "c.11639). La reserve est levee par autorite coordinateur, "
+        "independamment du login."
+    )
+
+
+# -----------------------------------------------------------------------------
+# Anti-regression -- la garde CROSS-LOGIN (#13609) tient toujours.
+# -----------------------------------------------------------------------------
+#
+# Note d'implementation : `_lift_eligible` (L3555+) ne reconnait que trois
+# categories de levee :
+#   - meme login AVEC discriminant (persona, cross-lane prefixe, override
+#     coordinateur) -- fix #14850
+#   - jsboige leveant la reserve d'une PERSONA cross-login (#13609,
+#     Hermes/NanoClaw poste sous clusterManager-Myia puis levee sous
+#     jsboige)
+#   - override coordinateur (myia-ai-01 + [OVERRIDE] lane <machine>)
+#
+# Le cas general "un tiers anonyme leve la reserve user" n'est PAS
+# couvert : `_lift_eligible` retourne False des lors que `lift_author !=
+# nit_author` et qu'aucun des discriminants ci-dessus n'est porte. Les
+# tests suivants verifient donc que ce comportement historique tient
+# apres le fix #14850 : aucun court-circuit ne doit s'ouvrir pour les
+# tiers anonymes.
+
+def test_cross_login_tiers_anonyme_ne_leve_pas():
+    """Comportement historique : un commentaire par un tiers anonyme
+    (login distinct, ni persona, ni override) NE leve PAS la reserve
+    user sous ce depot. La porte est fermee par `_lift_eligible` meme
+    apres le fix #14850 (la voie nue par meme login reste la cible du
+    fix ; ici on est cross-login, et le filet est deja en place)."""
+    user_reserve = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:09:49Z",
+        "body": "Concern: l'attribution est ambigue, il va falloir la corriger.",
+    }
+    lift_tiers = {
+        "author": {"login": "another-contributor"},
+        "createdAt": "2026-09-05T19:26:40Z",
+        "body": "Verdict : LGTM, je laisse passer. Les nits sont adresses.",
+    }
+    res = run([user_reserve, lift_tiers])
+    assert res["blocked"] is True, (
+        "Le filet `_lift_eligible` reste ferme pour un tiers anonyme : "
+        "le seul chemin de levee par un tiers non-coordinateur est la "
+        "voie #13609 (persona Hermes/NanoClaw sous jsboige levant SA "
+        "reserve posee sous clusterManager-Myia)."
+    )
+
+
+def test_cross_login_persona_ne_leve_pas_reserve_user():
+    """Symetrique : la persona levee sous l'autre login ne leve PAS
+    une reserve posee par l'utilisateur (jsboige). La garde #13609
+    porte SPECIFIQUEMENT sur le sens `jsboige leve reserve persona`,
+    pas l'inverse. Sans cette borne, la persona pourrait eteindre la
+    voix du user sous pretexte d'alias de compte."""
+    user_reserve = {
+        "author": {"login": "jsboige"},
+        "createdAt": "2026-09-05T18:09:49Z",
+        "body": "Concern: l'attribution est ambigue, il va falloir la corriger.",
+    }
+    lift_persona_cross_login = {
+        "author": {"login": "clusterManager-Myia"},
+        "createdAt": "2026-09-05T19:26:40Z",
+        "body": "[Hermes] RAS, attribution traitee dans le dernier commit. "
+                "Les nits sont adresses.",
+    }
+    res = run([user_reserve, lift_persona_cross_login])
+    assert res["blocked"] is True, (
+        "La garde #13609 est ORIONTEE : jsboige leve la reserve d'une "
+        "persona, pas l'inverse. Le commentaire [Hermes] par "
+        "clusterManager-Myia ne leve donc pas une reserve posee par "
+        "jsboige -- c'est exactement la protection de la voix user "
+        "que la voie nue par meme login de #14850 renforce."
+    )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/lean #15754

# fix(guard,#14850): scope-emetteur par role — voie nue par meme login protegee contre levee par prefixe de lane/role

> Issue #14850 cas fondateur : PR #14795 (mergee 2026-09-06T21:13:28Z) — le commentaire `[ai-01] Je leve ma propre reserve` de `jsboige` a 21:11:29Z eteignait la reserve user voix nue posee a 18:09:49Z par `jsboige`. Le prefixe de role `[ai-01]` (coordinateur lane) introduit un scope distinct de la voie nue, mais le filet `_lift_eligible` le comptait comme self-lift par meme login et levait la reserve user voix nue. Acceptance du fix : `python scripts/check_unaddressed_nits.py 14795` rend rc=1.

## Périmètre du changement

| Fichier | Δ | Rôle |
|---|---|---|
| `scripts/check_unaddressed_nits.py` | +47 (modif) | Discrimination scope-emetteur par ROLE dans `_lift_eligible` |
| `scripts/tests/test_check_unaddressed_nits_14850.py` | +246 (nouveau) | 9 tests de régression #14850 |

Total : 2 fichiers, +293 insertions, 0 deletion. Le diff est contenu dans `_lift_eligible` (la branche meme-login) — la branche cross-login (persona alias, override coordinateur) reste intacte.

## Diagnostic — la voie nue par meme login n'est pas une voie unique

`jsboige` est A LA FOIS :

1. **Le compte user** — auteur des reserves voix nue deposees sur sa propre PR.
2. **L'identite de poussee partagee des personas** (#13316) — Hermès et NanoClaw postent sous `jsboige`.
3. **Le login sous lequel les lanes cross-poussent** — un commentaire `[myia-po-2024:CoursIA-2]` par `jsboige` est une autre lane, pas le user.

Avant le fix, `_lift_eligible` ne discriminait que le cas 2 (persona par cross-login, #13609) et le cas 3 par override coordinateur (Tell c.11639). Le cas 3 par lane tierce (#14850) et le cas « prefixe de role generique » (`[ai-01]`, `[po-2026]`, ...) etaient des angles morts : un commentaire `[ai-01] Je leve ma propre reserve` par `jsboige` etait comptabilise comme self-lift par meme login, et levait la reserve user voix nue posee par `jsboige`.

C'est exactement le cas fondateur #14795 : 4 levees par `jsboige` (`[ai-01] HOLD merge`, `Verdict coordinateur...`, `[myia-po-2024:CoursIA-2] Réponse...`, `[ai-01] Je leve ma propre reserve`) etaient prises pour des auto-levees de l'auteur de la reserve user voix nue de `jsboige`, alors que 3 d'entre elles sont HORS scope de la voie nue.

## Fix — discrimination scope-emetteur par ROLE

Le lift scope sa portee par son PREFIXE de tete. Cinq discriminants (voies), evalues dans l'ordre :

| Voie | Condition | Verdict |
|---|---|---|
| **0. Override coordinateur** | `OVERRIDE_LANE.search(lift)` (Tell c.11639) | `True` |
| **1. Persona scope** | Lift ET nit portent persona | `True` |
| **1b. Persona sur user nu** | Lift porte persona, nit porte voix nue | `False` (#14947 etendu #14850) |
| **2. Cross-lane scope** | Lift ET nit portent prefixe `[owner:workspace]` | `True` |
| **2b. Lane sur user nu** | Lift porte lane, nit porte voix nue/persona | `False` (#14850 voie 2) |
| **3. Voie nue par meme login** | Lift sans prefixe de role/persona/lane ET `has_live_lift` | `True` |
| **3b. Role-prefix sur user nu** | Lift porte `[role]` (ex `[ai-01]`), nit porte voix nue | `False` (#14850 voie 3 etendue) |
| **default** | Aucun discriminant | `False` |

La cle du fix est la **voie 3b** : tout prefixe `[role-name]` en tete de paragraphe (`[ai-01]`, `[po-2026]`, ...) introduit un scope distinct de la voie nue. Le regex `_ROLE_PREFIX_RE` (L162) detecte ces prefixes en excluant les personas (Hermes/NanoClaw, L156) et les lanes (`[owner:workspace]`, L170) et les tags de protocole (`[DONE]`, `[INFO]`, `[WARN]`, `[ASK]`, etc.). Un commentaire `[DONE] les 2 nits sont adresses, commit abc123.` reste voie nue -- le tag est un attribut de workflow, pas une identite d'agent.

Le filet preserve l'ancien comportement (#12319) : une levee voie nue par l'auteur de SA reserve voie nue, avec un LIFT_MARKER (broad : `sont adresses`, `RAS`, `LGTM`, `c'est traite`, etc.) reste une levee legitime. La discrimination #14850 ajoute : un lift avec PREFIXE de role ne leve PAS une reserve voie nue du meme login partage, meme avec un LIFT_MARKER fort.

## Vérification pre-merge

- **Tests 9/9 #14850** : `python -m pytest scripts/tests/test_check_unaddressed_nits_14850.py -v` (acceptance 1 + 2 + 3 + 4 + anti-regression).
- **Tests 416/416 existants** : `python -m pytest scripts/tests/test_check_unaddressed_nits.py` (0 regression sur le regime general, le scope persona, l'override coordinateur, l'absent-sha, le dual-issue `#13639`).
- **Acceptance 3 (PR #14795)** : `python scripts/check_unaddressed_nits.py 14795` rend **rc=1**, 1 nit non leve (`[ai-01] Correction de mon propre point (3)` par `myia-ai-01`, suivi a part par l'ia-01 dans le suivi de la PR).
- **Anti-regression (PR #14937)** : incident fondateur de #14947, `python scripts/check_unaddressed_nits.py 14937` rend **rc=0** (la voie nue par l'auteur de SA reserve persona tient toujours).
- **Anti-regression (PR #14949)** : merge de #14947, `python scripts/check_unaddressed_nits.py 14949` rend **rc=0**.

## Cas couverts par les 9 tests

1. `test_role_prefix_meme_login_ne_leve_pas_reserve_user_nue` — `[ai-01] Je leve ma propre reserve` par `jsboige` ne leve PAS la reserve user voix nue (incidente fondateur 21:11:29Z).
2. `test_hold_directive_role_prefix_ne_leve_pas_reserve_user_nue` — `[ai-01] HOLD merge` par `jsboige` ne leve PAS la reserve user voix nue (directive coordinateur, hors scope voie nue).
3. `test_cross_lane_meme_login_ne_leve_pas_reserve_user_nue` — `[myia-po-2024:CoursIA-2] Réponse...` par `jsboige` ne leve PAS la reserve user voix nue (incidente fondateur 18:28:07Z).
4. `test_cross_lane_meme_login_leve_reserve_de_la_lane` — jumeau levant : un commentaire lane leve une reserve posee par la meme lane.
5. `test_persona_meme_login_reserve_nue_bloquee` — `[Hermes] RAS sur le merge` par `jsboige` ne leve PAS la reserve user voix nue (#14947 etendu).
6. `test_persona_meme_login_reserve_persona_leve` — `[Hermes] Lemma dedie ajoute` leve une reserve `[Hermes]` posee par `jsboige` (cas legitime persona leve sa reserve persona).
7. `test_override_coordinateur_leve_reserve_nue` — `[OVERRIDE] lane myia-ai-01` leve la reserve user voix nue (autorite coordinateur, Tell c.11639).
8. `test_cross_login_tiers_anonyme_ne_leve_pas` — un tiers anonyme ne leve pas une reserve user (filet `_lift_eligible` reste ferme pour les tiers cross-login sans discriminant).
9. `test_cross_login_persona_ne_leve_pas_reserve_user` — symetrique de #13609 : `clusterManager-Myia` levant en `[Hermes]` ne leve pas la reserve posee par `jsboige` (la garde est orientee).

## Anti-régression contenu

Le diff est strictement contenu dans `_lift_eligible` (la branche `if lift_author == nit_author:` de la fonction). La branche cross-login (persona alias `#13609`, override coordinateur `Tell c.11639`) reste intacte. Aucun marqueur LIFT n'a ete touche. Aucune voie de levee legitimate n'a ete fermee : le regime general (`has_live_lift`) reste operant pour les levees voie nue par l'auteur de la reserve voie nue.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
