### PR TITLE
fix(audio,#15002): P0 repair — routage SearXNG local, cap 16384, coercion relationships

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/llm_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/llm_client.py
@@ -185,7 +185,11 @@ def call_structured(
                 "model": _MODEL,
                 "messages": messages,
                 "response_format": response_format,
-                "max_completion_tokens": 32768,
+                # 16384 is within the output cap of every model this client
+                # can target (gpt-4o-mini default AND the .env-configured
+                # model); 32768 was rejected against the default (32768 >
+                # 16384). Valid for both, so no env knob.
+                "max_completion_tokens": 16384,
             }
             resp = requests.post(
                 f"{_API_BASE}/chat/completions",

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p0_narrative_research.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p0_narrative_research.py
@@ -66,30 +66,40 @@ def run_searxng_searches() -> list[dict]:
 
 
 def _search_via_requests() -> list[dict]:
-    """Fallback: search via direct HTTP to SearXNG instance."""
+    """Fallback: search via direct HTTP to the SearXNG instance.
+
+    The working instance is the local container (searxng/searxng on :8181).
+    ``https://search.myia.io`` is a Basic-auth reverse proxy (401 measured
+    2026-09-12, ``WWW-Authenticate: Basic realm="myia"`` behind IIS): pointing
+    there by default silently degraded every query to an empty result. The URL
+    comes from the environment; the default is the local instance, never a
+    hardcoded edge.
+    """
+    import os
+
     import requests
 
-    searxng_url = "https://search.myia.io"
+    searxng_url = os.getenv("SEARXNG_URL", "http://localhost:8181").rstrip("/")
     all_results = []
     for query in SEARCH_QUERIES:
         print(f"  [P0] Searching: {query}")
-        try:
-            resp = requests.get(
-                f"{searxng_url}/search",
-                params={"q": query, "format": "json", "language": "fr"},
-                timeout=30,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            for r in data.get("results", [])[:10]:
-                all_results.append({
-                    "query": query,
-                    "title": r.get("title", ""),
-                    "url": r.get("url", ""),
-                    "snippet": r.get("content", ""),
-                })
-        except Exception as e:
-            print(f"  [P0] Search error: {e}")
+        resp = requests.get(
+            f"{searxng_url}/search",
+            params={"q": query, "format": "json", "language": "fr"},
+            timeout=30,
+        )
+        # A routing failure (401/5xx/timeout) must NOT look like a search that
+        # returned zero results: an empty list here poisons the whole P0
+        # synthesis downstream. Fail loud, let the pipeline report it.
+        resp.raise_for_status()
+        data = resp.json()
+        for r in data.get("results", [])[:10]:
+            all_results.append({
+                "query": query,
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": r.get("content", ""),
+            })
     return all_results
 
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/schemas.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/schemas.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # ── Canonical speaker enum ──
@@ -70,6 +70,33 @@ class CharacterProfile(BaseModel):
     emotional_arc: dict[str, str]
     prosody_defaults: list[str]
     relationships: dict[str, str]
+
+    @field_validator("relationships", mode="before")
+    @classmethod
+    def _relationships_from_list(cls, value):
+        """Accept the LLM's observed "Name : description" list form.
+
+        Strict JSON Schema mode is off for NarrativeContext (its nested
+        ``additionalProperties`` objects force loose mode in
+        ``build_json_schema_response_format``), so the model's shape is not
+        enforced server-side. Measured on the 2026-09-12 gpt-5.2 run: all 11
+        characters came back with ``relationships`` as a list of
+        ``"Name : description"`` strings while every other dict[str, str]
+        field conformed. Split on the FIRST separator so descriptions
+        containing " : " stay intact; strings without one become the key
+        with an empty description.
+        """
+        if not isinstance(value, list):
+            return value
+        out: dict[str, str] = {}
+        for item in value:
+            if not isinstance(item, str):
+                continue
+            name, sep, desc = item.partition(" : ")
+            if not sep:
+                name, sep, desc = item.partition(": ")
+            out[name.strip()] = desc.strip() if sep else ""
+        return out
 
 
 class NarrativeContext(BaseModel):

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/tests/test_p0_relationships_coercion.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/tests/test_p0_relationships_coercion.py
@@ -1,0 +1,67 @@
+"""CharacterProfile.relationships coercion (Issue #15002 P0) — offline tests.
+
+The 2026-09-12 gpt-5.2 P0 run returned ``relationships`` as a list of
+"Name : description" strings for all 11 characters (strict mode is off for
+NarrativeContext), which pydantic rejected. These tests pin the before-
+validator that absorbs the observed form. Run from the v4 directory:
+
+    python -m pytest tests/test_p0_relationships_coercion.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_V4 = Path(__file__).resolve().parent.parent
+if str(_V4.parent) not in sys.path:
+    sys.path.insert(0, str(_V4.parent))
+
+from v4.schemas import CharacterProfile  # noqa: E402
+
+
+def _profile(relationships) -> CharacterProfile:
+    return CharacterProfile(
+        name="Loiseau",
+        aliases=["M. Loiseau"],
+        traits=["roublard"],
+        voice_register="baryton nasillard",
+        emotional_arc={"act1": "enjoué"},
+        prosody_defaults=["chuckling"],
+        relationships=relationships,
+    )
+
+
+class TestRelationshipsCoercion:
+    def test_dict_form_is_untouched(self):
+        """The schema-conformant dict stays byte-identical."""
+        p = _profile({"Elizabeth Rousset": "protecteur intéressé"})
+        assert p.relationships == {"Elizabeth Rousset": "protecteur intéressé"}
+
+    def test_observed_list_form_is_coerced(self):
+        """The measured gpt-5.2 shape: a list of "Name : description"."""
+        p = _profile([
+            "Elizabeth Rousset : protège, puis rejoint le mépris",
+            "Mme Loiseau : complicité marchande",
+        ])
+        assert p.relationships == {
+            "Elizabeth Rousset": "protège, puis rejoint le mépris",
+            "Mme Loiseau": "complicité marchande",
+        }
+
+    def test_separator_inside_description_survives(self):
+        """Split on the FIRST separator only."""
+        p = _profile(["Cornudet : camarade : puis distance politique"])
+        assert p.relationships == {
+            "Cornudet": "camarade : puis distance politique",
+        }
+
+    def test_string_without_separator_keeps_empty_description(self):
+        p = _profile(["Comtesse"])
+        assert p.relationships == {"Comtesse": ""}
+
+    def test_non_string_items_are_dropped(self):
+        p = _profile(["Loiseau : complice", 42, None])
+        assert p.relationships == {"Loiseau": "complice"}
+
+    def test_empty_list_is_allowed(self):
+        assert _profile([]).relationships == {}


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #15029

## Summary

Reparation du passe **P0** du pipeline audiobook v4, suivant le DM coordinateur du 2026-09-12T13:07Z (claim amend **ACCORDE** sur `llm_client.py:188` + diagnostic corrige sur le 401). Trois reparations, chacune mesuree firsthand avant et apres. Le P0 est **re-execute de bout en bout** en fin de PR : exit 0, artefact reel.

## Verdict SOTA : **RECOVERABLE-LOCAL**

Ecrit comme tranche par le coordinateur, et confirme par l'execution : rien n'a exige d'infra externe, de cle a provisionner ni d'action user. L'instance SearXNG qui marche etait **locale et demarree** sur cette machine.

## 1. Le 401 n'etait pas une cle manquante — l'URL etait codee en dur sur l'edge authentifie

Mesures firsthand (cette machine, ce jour) :

| Cible | Resultat |
|---|---|
| `https://search.myia.io/` | **401**, `WWW-Authenticate: Basic realm="myia"`, `Server: Microsoft-IIS/10.0` — un reverse-proxy en **Basic auth**, pas une API SearXNG gatee |
| conteneur local `searxng/searxng:latest` (`0.0.0.0:8181->8080`) | `GET /` → **200**, `GET /search?q=…&format=json` → **200** — l'instance reelle, sans cle |

Dans `_search_via_requests` : `searxng_url = "https://search.myia.io"` en dur, et un `except Exception` qui imprimait l'erreur puis continuait — **6 requetes en 401 avalees, `[]` rendu a l'appelant**. Une liste vide ici empoisonne toute la chaine P0 (selection sur ensemble vide → lecture vide → synthese sur rien).

**Controle positif contre `origin/main`** (les trois fichiers du passe charges par `git show`, jamais edites, executes dans un package isole) :

```
>>> ORIGINE rend 0 resultat(s)
>>> VERDICT : DEFECT VIVANT — 6 echecs 401 avales, liste vide rendue a l'appelant
```

**Correctif** : `os.getenv("SEARXNG_URL", "http://localhost:8181").rstrip("/")` — jamais un edge en dur ; et le `except Exception` par requete est **retire** : `resp.raise_for_status()` leve, un echec de routage ne ressemble plus a une recherche vide.

**Apres** :

```
>>> CORRIGE rend 60 resultat(s) sur 6 requete(s)   (10 par requete)
>>> echantillon : Boule de Suif {analyse et résumé} - Les Sherpas | https://sherpas.com/blog/boule-de-suif-analyse/
```

## 2. `max_completion_tokens: 32768 > 16384` — claim amend ACCORDE

`llm_client.py:188` portait `32768`. Le modele **par defaut** du client est `gpt-4o-mini` (cap sortie 16384) ; le `.env` configure `gpt-5.2`. **16384 est valide pour les deux** — la valeur est abaissee a 16384 sans knob env (aucun des deux modeles n'exige plus, et la valeur fautive ne passait pas le defaut).

Preuve d'execution : les appels LLM de la selection (etape 2) et de la synthese (etape 4) passent contre le modele configure — voir le run complet ci-dessous.

## 3. Le run reel a exhume le blocage suivant : `relationships` en liste

Une fois les recherches et le LLM debloques, `NarrativeContext(**result)` a rejete la sortie : **les 11 personnages** rendaient `relationships` en **liste de `"Nom : description"`** la ou le schema exige `dict[str, str]` (11 erreurs pydantic, toutes sur ce seul champ — `emotional_arc`, l'autre `dict[str, str]`, conformait).

Cause racine : `build_json_schema_response_format` desactive le **mode strict** des que le schema porte des `additionalProperties` imbriques (ce que `dict[str, str]` produit) — la forme n'est donc pas enforcee cote API, et le modele derive. C'est exactement le contrat de la claim de la tranche residuelle : « ne modifier un source que si le run reproduit un bloqueur exact, avec test post-fix ». Le run l'a reproduit ; le test post-fix suit.

**Correctif** : validateur `mode="before"` sur `CharacterProfile.relationships` qui convertit la forme observee (split sur le **premier** separateur, pour que les descriptions contenant `" : "` survivent). Les consommateurs (`context_injector.py`) iterent `.items()` — le contrat dict est preserve. **+6 tests** (`tests/test_p0_relationships_coercion.py`) : forme dict inchangee, forme liste convertie, separateur interne, absence de separateur, items non-chaines, liste vide.

## Preuve — P0 re-execute de bout en bout

```
[P0] Step 1: SearXNG searches...   Found 60 results
[P0] Step 2: Selecting best sources...   Selected 11 sources     (via LLM reel)
[P0] Step 3: Deep reading...   Read 10 articles
[P0] Step 4: LLM synthesis...
[P0] Saved: .../v4/outputs/narrative_context.json
  Characters: 11   Acts: 4   Sources: 9
exit=0    (234 s ; artefact 18752 o, gitignore, non committe)
```

Aucune degradation silencieuse residuelle dans le log : zero « Search error », zero « selection error », zero « Read error ». Le seul message restant est l'annonce attendue du fallback (`mcp_searxng not available, using requests fallback`) — et ce fallback est maintenant correct.

## Tests

```
$ python -m pytest tests/ -q          (depuis v4/)
135 passed                            (129 avant, 6 neufs)
```

Les 4 fichiers du passe P0 (`p0_narrative_research.py`, `llm_client.py`, `schemas.py`, test neuf) — aucun autre source touche, aucun binaire committe.

## Provenance

DM coordinateur `msg-20260912T130711-wkykm5` (HIGH) : claim amend sur `llm_client.py:188` accorde ; verdict RECOVERABLE-MACHINE **retire** au profit de RECOVERABLE-LOCAL, cause remesuree et confirmee par ce run. Les criteres #3 (WER) et #4 (MP3/M4B) de #15002 restent dus a la tranche residuelle — cette PR debloque le P0 qu'elle emprunte.

See #15002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
