### PR TITLE
fix(picker,#15769): un requis non conclu rend une cause distincte, pas le silence

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -98,6 +98,9 @@ Quatre causes, dont la derniere est arrivee en dernier et couvre le plus :
 1. **check requis en echec** -- lu sur le champ GraphQL `isRequired`, ce que la
    protection de branche exige vraiment, et non "au moins un check rouge", qui
    rougissait 52 PRs sur 55 le 2026-08-22 en comptant les advisories ;
+   variante #15769 : un requis **non conclu** (CANCELLED/STALE/SKIPPED/NEUTRAL)
+   rend la cause distincte « check requis non conclu » -- le geste est la
+   reprise coordinateur, jamais une reparation de lane ;
 2. **conflit avec main** ;
 3. **CHANGES_REQUESTED non leve** ;
 4. **point de review non leve** (mandat 2026-08-24 : "ne plus produire tant
@@ -1159,6 +1162,14 @@ RED_COUNT_DEFAULT = 3
 # faux positif qui rend un garde de cascade inutilisable.
 CHECK_FAILED = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR"}
 
+# #15769 : conclusions non concluantes d'un check TERMINE. Ni vert (un requis
+# dans cet etat empeche le merge) ni un echec de lane (imputer un CANCELLED a
+# la lane l'envoie chercher un rouge qui n'existe pas -- regime nominal sous
+# file chargee : `--timeout-min 45` du slot rend `cancelled`, jamais
+# `failure`). Rendu par `blocking_causes` comme cause DISTINCTE « non conclue »,
+# dont le geste (re-agregation par le coordinateur) n'est pas celui d'un echec.
+CHECK_UNCONCLUDED = {"CANCELLED", "STALE", "SKIPPED", "NEUTRAL"}
+
 # #13420 : un check "en vol" est celui dont la file peut encore bouger. C'est
 # lui qui date la saturation -- pas la PR qui le porte. La chaine vide couvre
 # le CheckRun reel, dont `conclusion` est `null` tant qu'il n'a pas conclu.
@@ -1476,6 +1487,17 @@ def blocking_causes(state: dict, *, age_hours: float | None = None,
         name = ctx.get("name") or ctx.get("context") or "?"
         verdict = (ctx.get("conclusion") or ctx.get("state") or "").upper()
         if verdict not in CHECK_FAILED:
+            # #15769 : un requis non conclu (CANCELLED/STALE/SKIPPED/NEUTRAL)
+            # empeche le merge sans que la lane puisse quoi que ce soit -- le
+            # `continue` historique le filtrait exactement comme un advisory
+            # vert, AVANT le test `isRequired` : la PR etait BLOCKED sans
+            # aucune cause rendue (7 PRs simultanees le 2026-09-12). Cause
+            # distincte d'un echec : le geste est la reprise coordinateur, pas
+            # une reparation de lane. Un advisory non conclu reste du bruit.
+            if verdict in CHECK_UNCONCLUDED and ctx.get("isRequired"):
+                cause = f"check requis non conclu : {name} ({verdict})"
+                if cause not in causes:
+                    causes.append(cause)
             continue
         if inherited:
             # #13545/#14537 : rouge impute a la base (cause commune corroboree

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -272,16 +272,48 @@ def test_failing_required_check_is_a_red_and_names_the_advisory_as_diagnostic():
     assert any("non bloquant" in c and "Papermill ratchet" in c for c in causes)
 
 
-def test_cancelled_is_not_a_failure():
-    """Un run annule par `concurrency` n'est pas un echec.
+def test_unconcluded_required_is_a_distinct_cause():
+    """#15769 : un requis annule n'est ni un vert ni un echec de lane.
 
-    Les confondre est le faux positif qui rend un garde de cascade
-    inutilisable : le 2026-08-21, un SHA de main portait 69 `cancelled`
-    pour 0 echec reel.
+    Un check requis CANCELLED empeche le merge sans que la lane puisse rien :
+    avant #15769, le `continue` sur `verdict not in CHECK_FAILED` le filtrait
+    exactement comme un advisory vert, AVANT le test `isRequired` -- la PR
+    etait BLOCKED sans aucune cause rendue (7 PRs simultanees le 2026-09-12).
+    La cause doit nommer l'etat et ne JAMAIS dire « echec » : imputer un
+    CANCELLED a la lane l'envoie chercher un rouge qui n'existe pas, le cycle
+    brule que la R0 de coordinator-discipline interdit.
     """
-    assert pig.blocking_causes(_state(checks=[("PR gate", "CANCELLED", True)])) == []
-    assert pig.blocking_causes(_state(checks=[("PR gate", "SKIPPED", True)])) == []
-    assert pig.blocking_causes(_state(checks=[("PR gate", "NEUTRAL", True)])) == []
+    assert pig.blocking_causes(_state(checks=[("PR gate", "CANCELLED", True)])) == [
+        "check requis non conclu : PR gate (CANCELLED)"]
+    assert pig.blocking_causes(_state(checks=[("PR gate", "STALE", True)])) == [
+        "check requis non conclu : PR gate (STALE)"]
+    assert pig.blocking_causes(_state(checks=[("PR gate", "SKIPPED", True)])) == [
+        "check requis non conclu : PR gate (SKIPPED)"]
+    assert pig.blocking_causes(_state(checks=[("PR gate", "NEUTRAL", True)])) == [
+        "check requis non conclu : PR gate (NEUTRAL)"]
+
+
+def test_unconcluded_failure_control_renders_en_echec():
+    """Controle positif (acceptance #15769.3) : meme entree, requis FAILURE.
+
+    Sans lui, un test vert ne distinguerait pas « la cause CANCELLED est
+    rendue » de « toutes les causes sont rendues » : le refus de confondre
+    CANCELLED avec FAILURE (2026-08-21 : 69 cancelled pour 0 echec sur un
+    SHA de main) doit SURVIVRE a l'ajout de la cause non conclue.
+    """
+    causes = pig.blocking_causes(_state(checks=[("PR gate", "FAILURE", True)]))
+    assert causes == ["check requis en echec : PR gate"]
+
+
+def test_unconcluded_advisory_is_still_silent():
+    """Le complement du garde d'origine : seul un REQUIS non conclu cause.
+
+    Un advisory annule reste du bruit que la lane ne doit pas reparer.
+    """
+    assert pig.blocking_causes(_state(checks=[
+        ("fast-lane (ombre): perimeter-review-guard", "CANCELLED", False),
+        ("PR gate", "SUCCESS", True),
+    ])) == []
 
 
 def test_conflicts_are_a_red():


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/guard #15771

## Summary

`blocking_causes()` rendait **aucune cause** pour un check **requis** a la conclusion `CANCELLED` (ou `STALE`/`SKIPPED`/`NEUTRAL`) : la PR etait `BLOCKED`, la lane lisait « rien ne bloque », le merge etait impossible, personne n'etait informe. Correctif : une cause **distincte d'un echec**, parce que le geste attendu n'est pas le meme.

## Le mecanisme, verifie firsthand sur `origin/main`

Le defect decrit dans l'issue est exact (ancrages remesures sur le tip `7f2e5a1ad3` — les numeros de l'issue avaient derive) :

- `CHECK_FAILED = {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR"}` (l.1160) — pas de `CANCELLED`, volontairement (un run annule par `concurrency` n'est pas un echec).
- Dans `blocking_causes()` (def l.1441), le `continue` sur `verdict not in CHECK_FAILED` (l.1479) s'execute **avant** le test `isRequired` (l.1490) : un requis annule est filtre exactement comme un advisory vert, et ne devient jamais une cause.

**Instance vivante du jour, vecue avant la lecture de l'issue** : #15759 — `PR gate` (requis) CANCELLED a 48 min + `Scripts Tests (CPU)` CANCELLED, PR BLOCKED, `gh pr checks` rend un « fail » que rien n'explique. Le picker, sur cet etat, ne rendait rien.

## Le correctif

```python
CHECK_UNCONCLUDED = {"CANCELLED", "STALE", "SKIPPED", "NEUTRAL"}
```

Dans la boucle de `blocking_causes()`, avant le `continue` historique : un verdict `CHECK_UNCONCLUDED` **requis** rend

```
check requis non conclu : PR gate (CANCELLED)
```

Trois choix deliberes :

1. **Cause distincte, jamais « en echec »** : imputer un `CANCELLED` a la lane l'envoie chercher un rouge qui n'existe pas — le cycle brule que la R0 de `coordinator-discipline.md` interdit. Le libelle porte l'etat (`(CANCELLED)`) : la reprise est coordinateur (re-agregation `pr-gate-stale-sweep.yml` ou dispatch manuel), pas une reparation de lane.
2. **`CHECK_FAILED` intact** : `impute_base_reds`, `_has_failed_check` et `file_saturation_cause` (les trois autres lecteurs de `CHECK_FAILED`) sont inchanges — ajouter `CANCELLED` au set aurait corrompu l'imputation base-vs-lane (un requis annule n'est pas un rouge de base corroborable) et le detecteur de saturation.
3. **L'advisory non conclu reste silencieux** : l'intention du garde d'origine (2026-08-21 : 69 `cancelled` pour 0 echec reel sur un SHA de main — les confondre rend un garde de cascade inutilisable) **survit** : seul un **requis** non conclu devient une cause.

## Acceptance 1-4, test par test

| # | Acceptance de l'issue | Test |
|---|---|---|
| 1 | PR dont le requis unique est `CANCELLED` rend une cause non vide | `test_unconcluded_required_is_a_distinct_cause` (les 4 etats) |
| 2 | La cause nomme l'etat et ne se confond pas avec « en echec » | idem — assert d'egalite exacte sur `check requis non conclu : PR gate (CANCELLED)`, jamais `en echec` |
| 3 | Controle positif : meme entree requis `FAILURE` rend toujours « en echec » | `test_unconcluded_failure_control_renders_en_echec` |
| 4 | Controle negatif : requis `SUCCESS` ne rend aucune cause | test existant `test_blocked_awaiting_review_is_not_a_red` (inchange, vert) |

Plus un garde complementaire : `test_unconcluded_advisory_is_still_silent` — un advisory `CANCELLED` a cote d'un requis `SUCCESS` ne rend toujours rien.

L'ancien `test_cancelled_is_not_a_failure` **epinglait le comportement defaut** (requis CANCELLED -> aucune cause) : remplace, son intention (jamais confondre avec FAILURE) conservee dans le controle positif et le garde advisory.

## Preuves d'execution

```
$ python -m pytest scripts/tests/test_pick_idle_grain.py -q
116 passed                    (113 avant, 3 neufs)

$ python -m pytest scripts/tests/test_pick_idle_grain.py \
    scripts/tests/test_fast_lane.py scripts/tests/test_check_lane_claim.py -q
481 passed, 1 skipped

$ python -m pytest scripts/tests/test_pick_admissibility.py \
    scripts/tests/test_pick_child_encoding.py scripts/tests/test_pick_claim_filter.py \
    scripts/tests/test_pick_delivered_gate.py scripts/tests/test_pick_drought_admission.py \
    scripts/tests/test_pick_filters.py scripts/tests/test_pick_idle_grain_cache.py \
    scripts/tests/test_check_pr_perimeter.py -q
312 passed
```

Consommateurs aval verifies : les cause-strings sont matchees par sous-chaine sur des marqueurs distincts (`file_saturation`, `point(s) de review`) — la nouvelle cause n'est matchee nulle part, elle rend dans `red_backlog` comme prose, ce qui est le but (la voir).

## Provenance

Issue ai-01 du 2026-09-12T13:10Z (mesure : 7 PRs simultanees dans cet etat). Le deuxieme site `isRequired` (l.1652, dans `file_saturation_cause`) est un detecteur #12830 distinct — un requis `CANCELLED` y est deja collecte dans `required_checks` sans stamp : hors scope, non touche.

Note de lignes : le commentaire de claim sur l'issue porte l'entete `myia-po-2023:CoursIA-2` (l'entete de session) ; le grain suit la lignee guard de la lane `myia-po-2023:CoursIA` (#15759 -> #15765 -> #15771 -> ici), que le garde `prev:` exige.

Closes #15769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-12T14:22:20Z -->

