### PR TITLE
fix(ci,#15775): le sweep relaie le constituant cancelled, pas le gate

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -8,10 +8,12 @@ name: PR gate stale-verdict sweep
 # (csharp)". Since #13510 a starved gate cancels its own run instead (leg
 # CANCELLED, exit still 1), so those legs now arrive here through the
 # `cancelled` half of the RED set below -- the founding FAILURE case below is
-# history, kept for the record. pr-gate-rerun.yml exists to re-aggregate
-# afterwards, but it is
-# driven by `workflow_run` and therefore can only listen to workflows that are
-# ADDRESSABLE BY NAME in this repository:
+# history, kept for the record. At the time, pr-gate-rerun.yml re-aggregated
+# afterwards, but it was
+# driven by `workflow_run` and could therefore only listen to workflows that
+# were ADDRESSABLE BY NAME in this repository -- an event path RETIRED by
+# #11860; that file is now a manual `workflow_dispatch` harness, and THIS
+# sweep is its schedule-mutualized replacement:
 #
 #   workflows: ["Variation Tag Guard", "Lane Claim Guard",
 #               "Notebook Execution Required", "Translation Drift Check",
@@ -53,9 +55,8 @@ name: PR gate stale-verdict sweep
 # fold concealed 52 of them, the majority of the blocked pool. The filter now
 # treats ANY red `PR gate` leg as a candidate.
 #
-# Why this sweep exists at all, given pr-gate-rerun.yml (#11546) now re-runs
-# on `workflow_run`: CodeQL runs in `default setup`, which is dynamic and does
-# not appear in the workflow list --
+# Why this sweep exists at all: CodeQL runs in `default setup`, which is dynamic
+# and does not appear in the workflow list --
 #   GET /repos/jsboige/CoursIA/actions/workflows?per_page=100
 #     -> total_count: 103, of which CodeQL: 0
 # -- so it cannot be named as a `workflow_run` trigger, and the event-driven
@@ -559,14 +560,16 @@ jobs:
             #
             # `gh run rerun` overwrites the run's check-run IN PLACE, in the same
             # suite -- the only mechanism that actually clears the red leg. Same
-            # remedy as pr-gate-rerun.yml (#11546); this sweep is its complement,
-            # because CodeQL runs in `default setup` and is NOT addressable as a
-            # `workflow_run` trigger, so the event-driven path cannot fire when
-            # CodeQL is the last check to settle -- the common case under
-            # saturation, since it is also the slowest.
+            # remedy as the retired pr-gate-rerun.yml (#11546) used; since #11860
+            # this sweep is its schedule-mutualized REPLACEMENT, because CodeQL
+            # runs in `default setup` and is NOT addressable as a `workflow_run`
+            # trigger, so an event-driven rescuer cannot fire when CodeQL is the
+            # last check to settle -- the common case under saturation, since it
+            # is also the slowest.
             #
-            # No loop risk: "PR gate" is not among pr-gate-rerun.yml's trigger
-            # workflows, so a re-run cannot re-trigger the rescuer.
+            # No loop risk: this sweep has no `workflow_run` trigger of its own
+            # (`schedule` / manual `workflow_dispatch` only), so a re-run cannot
+            # re-trigger it.
             RUN=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&event=pull_request&per_page=100" \
                     --jq '[.workflow_runs[] | select(.name == "PR gate")] | sort_by(.created_at) | last' 2>/dev/null)
             RUN_ID=$(printf '%s' "${RUN:-}" | jq -r '.id // empty' 2>/dev/null)

--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -400,16 +400,23 @@ jobs:
               #
               # L'intention d'acceptance 5 -- ne pas blanchir une vraie
               # interruption -- tient toujours, parce que le sweep ne merge
-              # rien : il RELANCE le gate, qui re-lit l'etat live et conclura
-              # FAIL si un constituant est reellement rouge. Le verdict reste
-              # rendu par le gate, jamais par le sweep. Cout d'un faux positif
-              # d'eligibilite : une minute de runner. Cout du faux negatif
-              # actuel : une PR BLOCKED pour toujours, puisque le gate
-              # `cancelled` ne peut pas devenir SUCCESS tout seul.
+              # rien : il relaie ce qui re-rendera le verdict, et le gate
+              # re-lit l'etat live et conclura FAIL si un constituant est
+              # reellement rouge. Le verdict reste rendu par le gate, jamais
+              # par le sweep. Cout d'un faux positif d'eligibilite : une
+              # minute de runner. Cout du faux negatif actuel : une PR
+              # BLOCKED pour toujours, puisque le gate `cancelled` ne peut
+              # pas devenir SUCCESS tout seul.
               #
               # Exemption d'une SEULE conclusion, jamais une liste blanche de
               # bloquants : `startup_failure`, `stale` et toute conclusion
               # future inconnue continuent d'exclure.
+              #
+              # Divergence DELIBEREMENT maintenue d'avec CONCLUSION_BAD
+              # (pr_gate.py, ou `cancelled` faut) : le gate JUGE les
+              # conclusions -- un `cancelled` requis n'est pas un verdict ;
+              # le sweep REPARE les causes -- il relaie le constituant
+              # annule (#15775), pas l'agregateur qui le re-lirait identique.
               OTHERS_NOT_BLOCKING = GREEN | {"cancelled"}
               red_others = [(k, c) for k, c in others
                             if (c.get("conclusion") or "")
@@ -419,6 +426,27 @@ jobs:
                       f"{k[1]}[run {k[0]}]={c.get('conclusion')}"
                       for k, c in red_others])
                   continue
+
+              # #15775 -- quand l'eligibilite ne tient qu'a l'exemption
+              # `cancelled`, la cause reparable est le CONSTITUANT annule,
+              # pas l'agregateur : relancer le gate re-lit un constituant
+              # qui n'a pas bouge et re-rend le meme FAIL (mesure du
+              # 2026-09-12 sur #15452 et #15748 : six re-lancements de gate
+              # sans effet, deux re-lancements de constituant conclusifs).
+              # La ligne emet alors les run ids des constituants annules en
+              # 5e champ ; l'action relaie ces runs, et la PASSE SUIVANTE
+              # de ce sweep relaie le gate sur un constituant re-render (le
+              # re-agregateur event-driven pr-gate-rerun.yml est retire
+              # depuis #11860 : c'est bien ce sweep qui scelle). Une jambe
+              # annulee sans details_url resolvable n'emet rien -- repli
+              # conservateur sur le gate, jamais plus permissif.
+              rerun_ids = []
+              for _k, c in others:
+                  if (c.get("conclusion") or "") != "cancelled":
+                      continue
+                  m = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
+                  if m:
+                      rerun_ids.append(m.group(1))
 
               # Tier: 0 = mature (verdict older than the dwell floor -> the
               # re-run converts to a merge), 1 = immature (the re-run can only
@@ -439,8 +467,13 @@ jobs:
                   rank = 0 if verdict_age_s >= DWELL_FLOOR_S else 1
               except ValueError:
                   rank = 1
+              # 5e champ conditionnel (#15775) : run ids des constituants
+              # `cancelled` a relancer, separes par des virgules. Absent
+              # quand il n'y en a pas (ou aucun resolvable) : la ligne reste
+              # au format historique 4 champs, l'action relaie le gate.
+              tail = f" {','.join(rerun_ids)}" if rerun_ids else ""
               print(f'{p["number"]} {p["sha"]} '
-                    f'{str(p.get("fork", False)).lower()} {rank}')
+                    f'{str(p.get("fork", False)).lower()} {rank}{tail}')
           PY
 
           # OLDEST FIRST, and the cap is the whole reason it matters.
@@ -482,7 +515,7 @@ jobs:
 
           m=0
           i=0
-          while read -r NUM SHA FORK RANK; do
+          while read -r NUM SHA FORK RANK TARGET; do
             [ -z "${NUM:-}" ] && continue
             # Capped rows of one tier must not stop the loop: the sort puts
             # mature first, so `continue` walks on into the immature block.
@@ -490,6 +523,30 @@ jobs:
               continue
             fi
             if [ "${RANK:-1}" != "0" ] && [ "$i" -ge "$MAX_IMMATURE" ]; then
+              continue
+            fi
+            # #15775 -- 5e champ porteur de run ids de constituants
+            # `cancelled` : la cause du rouge est le CONSTITUANT, on relaie
+            # SES runs et PAS le gate. Relancer le gate relirait un
+            # constituant inchangé et re-renderait le même FAIL (mesuré
+            # 2026-09-12 : six re-lancements de gate sans effet sur
+            # #15452/#15748) ; la PASSE SUIVANTE de ce sweep relaie le gate
+            # sur le constituant re-render et scelle le verdict -- le
+            # re-agregateur event-driven est retire depuis #11860, aucun
+            # `workflow_run` actif n'ecoute ces runs, et ce sweep est
+            # schedule-only : la relance ne peut pas se re-declencher.
+            TARGET="${TARGET:--}"
+            if [ "$TARGET" != "-" ]; then
+              for RID in $(printf '%s' "$TARGET" | tr ',' ' '); do
+                if [ "${DRY_RUN:-false}" = "true" ]; then
+                  echo "[stale-sweep] (dry-run) would re-run constituent run $RID for #$NUM ($SHA)"
+                else
+                  echo "[stale-sweep] re-running constituent run $RID for #$NUM ($SHA) -- next pass re-lays the gate"
+                  gh run rerun "$RID" --repo "$REPO" \
+                    || echo "[stale-sweep] constituent re-run refused for #$NUM (non-fatal)"
+                fi
+              done
+              if [ "${RANK:-1}" = "0" ]; then m=$((m + 1)); else i=$((i + 1)); fi
               continue
             fi
             # Re-run the ORIGINAL run rather than POSTing a fresh verdict.

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -435,3 +435,86 @@ def test_workflow_pins_tier_sort_and_per_tier_caps():
     # Le cap d'un tier ne doit pas arreter la boucle : les immatures ranges
     # derriere doivent rester servis (continue, pas break).
     assert "break" not in re.sub(r"#.*", "", run.split("MAX_MATURE=12")[1].split("done <")[0])
+
+
+# --- #15775 : la classe `cancelled`-constituant -- le sweep relaie la CAUSE ---
+
+# Mesure du 2026-09-12 : le sweep exemptait `cancelled` cote constituants mais
+# relaissait ensuite le GATE, qui relisait un constituant inchangé et re-renderait
+# le même FAIL -- la reparation re-selectionnait ce qu'elle ne pouvait pas
+# reparer (#15452, #15748 : six re-lancements de gate sans effet). Le selecteur
+# emet désormais les run ids des constituants annules en 5e champ CONDITIONNEL :
+# absent, la ligne reste au format historique 4 champs et l'action relaie le
+# gate (comportement d'origine, y compris pour test 108 dont la jambe annulee
+# n'a pas de details_url resolvable).
+
+CPU_CANCELLED_555 = ("Scripts Tests (CPU)", "completed", "cancelled",
+                     "2026-01-01T10:05:00Z", 555123)
+GUARD_CANCELLED_666 = ("Always-on guards", "completed", "cancelled",
+                       "2026-01-01T10:06:00Z", 556987)
+
+
+def test_cancelled_constituent_emits_rerun_target(tmp_path):
+    """Acceptance 1 (#15775) -- le test de falsification : constituant
+    `cancelled` (resolvable) + gate rouge + reste vert -> la ligne candidate
+    porte le run id du CONSTITUANT en 5e champ. Echoue sur le RED d'avant (la
+    ligne n'avait que 4 champs) : c'est ce qui distinguait la nouvelle action
+    de l'ancienne relance de gate."""
+    out = _run_selector(tmp_path, [_pr(125, [GATE_FAIL, OTHER_GREEN, CPU_CANCELLED_555])])
+    assert out.strip() == "125 deadbeef false 0 555123"
+
+
+def test_two_cancelled_constituants_emit_both_ids(tmp_path):
+    """Plusieurs constituants annules -> tous leurs run ids, dans l'ordre de
+    premiere apparition (celui du pliage), separes par des virgules."""
+    out = _run_selector(
+        tmp_path,
+        [_pr(126, [GATE_FAIL, CPU_CANCELLED_555, GUARD_CANCELLED_666])],
+    )
+    assert out.strip() == "126 deadbeef false 0 555123,556987"
+
+
+def test_cancelled_constituant_unresolvable_keeps_gate_rerun(tmp_path):
+    """Une jambe annulee SANS details_url resolvable n'emet rien : repli
+    conservateur sur le format 4 champs (relance de gate, l'etat d'avant).
+    Jamais plus permissif -- meme philosophie que le repli wfmap."""
+    cancelled_norun = ("Hermes review", "completed", "cancelled", "2026-01-01T11:00:00Z")
+    out = _run_selector(tmp_path, [_pr(127, [GATE_FAIL, cancelled_norun])])
+    assert out.strip() == "127 deadbeef false 0"
+
+
+def test_superseded_cancelled_emits_no_target(tmp_path):
+    """Un `cancelled` SUPSEDE par un vert plus recent de la meme cle de pliage
+    n'est pas une cause vivante : aucun 5e champ. Relancer un run annule
+    ecrase par un verdict plus recent serait une reparation fantome."""
+    cancelled_old = ("Hermes review", "completed", "cancelled",
+                     "2026-01-01T09:00:00Z", 777)
+    green_new = ("Hermes review", "completed", "success",
+                 "2026-01-01T11:00:00Z", 888)
+    # workflows map les DEUX run ids vers le meme workflow : c'est le cas
+    # reel de supersession (deux runs d'un meme workflow). Sans elle, le
+    # repli par run id les garde en cles DISTINCTES et la jambe annulee
+    # reste vivante -- la relancer serait alors correct.
+    out = _run_selector(tmp_path, [_pr(
+        128, [GATE_FAIL, cancelled_old, green_new], workflows={777: 12, 888: 12})])
+    assert out.strip() == "128 deadbeef false 0"
+
+
+def test_workflow_pins_constituent_rerun_branch():
+    """Garde structurelle : le workflow CONSOMME le 5e champ. Sans ce pin, le
+    selecteur pourrait emettre des cibles que l'action ignorerait -- la boucle
+    relancerait le gate sur une ligne a 5 champs en la tronquant, revenant au
+    defaut #15775 sans qu'aucun test du selecteur ne rougisse."""
+    with open(WORKFLOW, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    run = str(next(
+        step.get("run", "") for step in doc["jobs"]["sweep"]["steps"]
+        if "MAX_MATURE" in str(step.get("run", ""))
+    ))
+    assert "while read -r NUM SHA FORK RANK TARGET; do" in run
+    assert 'TARGET="${TARGET:--}"' in run
+    # La branche constituant relaie les ids du 5e champ et ne touche pas au
+    # gate (pas de lookup "PR gate" dans cette branche).
+    branch = run.split('TARGET="${TARGET:--}"', 1)[1].split("fi", 1)[0]
+    assert "gh run rerun" in branch
+    assert "PR gate" not in branch


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15784

## Summary

#15775 : le sweep exemptait `cancelled` côté constituants (éligibilité) mais relançait ensuite le **gate** — qui relisait un constituant inchangé et re-renderait le même FAIL. La réparation re-sélectionnait ce qu'elle ne pouvait pas réparer (mesure du 2026-09-12 : six re-lancements de gate sans effet sur #15452 et #15748, deux re-lancements de **constituant** conclusifs). Le sweep relaie désormais la **cause** : quand l'éligibilité d'une PR ne tient qu'à l'exemption `cancelled`, la ligne candidate porte les run ids des constituants annulés en 5e champ, et l'action relaie **ces runs** au lieu du gate.

## Mécanisme (réparation en 2 passes)

1. **Cette passe** : le sweep relaie le(s) run(s) du/des constituant(s) `cancelled` (`gh run rerun <run_id>`, même mécanisme in-place que pour le gate). Le constituant ré-exécute et rend une nouvelle conclusion.
2. **La passe suivante** : le sweep relaie le gate, qui lit alors le constituant re-render et scelle le verdict (SUCCESS si le constituant est vert).

**Correction de cadrage vs le corps de l'issue** : #15775 écrit « laisse `pr-gate-rerun.yml` (workflow_run) re-agréger » — ce chemin event-driven est **retiré depuis #11860** (le fichier n'est plus qu'un harnais `workflow_dispatch` manuel ; aucun `workflow_run` actif n'écoute ces runs, vérifié sur les 6 workflows qui mentionnent le trigger). C'est donc bien la passe suivante de CE sweep qui scelle — même mécanisme que la classe stale-gate existante, une passe de latence en plus.

## Le diff (2 fichiers, +165/−22)

| Fichier | Changement |
|---|---|
| `pr-gate-stale-sweep.yml` | Sélecteur : détection des jambes `cancelled` résolvables (run id extrait du `details_url`, même repli conservateur que wfmap — jambe non résolvable = pas de 5e champ) + émission **conditionnelle** du 5e champ. Action : branche constituant (rerun des ids, `DRY_RUN` honoré, refus non-fatal) avant le chemin gate inchangé. |
| `scripts/tests/test_pr_gate_sweep_select.py` | +5 tests (#15775) dont 3 de falsification et 1 pin structurel. |

Le format de ligne reste **historique 4 champs** quand il n'y a pas de constituant annulé résolvable : toutes les assertions exactes préexistantes (tests 101-110, 11808, 122-124) passent sans modification — le comportement d'origine est littéralement inchangé hors la nouvelle classe.

## Preuves d'exécution

```
$ python -m pytest scripts/tests/test_pr_gate_sweep_select.py scripts/tests/test_pr_gate_sweep_timing.py -q
31 passed
$ python -m pytest scripts/tests/test_check_pr_perimeter.py test_check_scheduler_liveness.py \
    test_check_self_hosted_runner_policy.py test_check_stale_guard_reds.py \
    test_heartbeat_sweep_emit.py test_merge_dwell.py test_pr_gate_rerun_noop_guard.py -q
339 passed
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate-stale-sweep.yml'))"
OK (6 steps)
```

**Rouge d'abord, prouvé** : **3** tests de falsification échouent sur le workflow d'origine restauré (backup/restore `cp`, jamais `git checkout --`) — `test_cancelled_constituent_emits_rerun_target`, `test_two_cancelled_constituants_emit_both_ids`, `test_workflow_pins_constituent_rerun_branch` — et passent sur le fix. Mesuré : `3 failed, 28 passed` sur la base, `31 passed` sur le fix.

## Acceptance de l'issue, point par point

| Case à cocher #15775 | Livré par |
|---|---|
| Le sweep relaie le **constituant** `cancelled` au lieu du gate | Branche constituant de la boucle d'action ; le lookup gate n'est même pas exécuté pour cette classe (pin `test_workflow_pins_constituent_rerun_branch` : `"PR gate" not in branch`) |
| Test épingle : constituant `cancelled` + reste vert → rerun de constituant, pas de gate | `test_cancelled_constituant_emits_rerun_target` (falsification, rouge sur HEAD) + pin de consommation du 5e champ par le workflow |
| Contrôle négatif : constituant `failure` → comportement inchangé | `test_other_cancelled_plus_failure_still_abstains` (exclusion, préexistant) + `test_gate_failure_others_green_candidate` (ligne 4 champs exacte = pas de cible) ; + nouveau `test_superseded_cancelled_emits_no_target` (jambe annulée supersédée par un vert = pas de relance fantôme) |
| Prémisse de `OTHERS_NOT_BLOCKING` corrigée ou documentée | Divergence délibérée d'avec `CONCLUSION_BAD` écrite AU MÊME ENDROIT (le gate JUGE les conclusions, le sweep REPARE les causes) + renvoi #15775 dans le bloc d'intention |

## Sûreté

- **Pas de cascade** : aucun listener `workflow_run` actif (retrait #11860) ; le sweep est schedule-only, donc une relance de constituant ne peut pas re-déclencher le sweep.
- **Pas de greenwash** : `cancelled` reste hors de `GREEN` (pin `test_selector_has_cancelled_in_red_not_green`) ; un `startup_failure`/`stale` continue d'exclure.
- **Refus non-fatal** : un rerun refusé n'interrompt pas la boucle (même contrat que le chemin gate).
- Le plafond `ict-tests.yml` source des `cancelled` reste traité séparément (#15761) — cette PR ferme la boucle, ne tarit pas la source.

## Suite de revue (Hermes, head `a5c35004`)

Deux écarts relevés par la revue, tous deux mesurés puis traités — le fix lui-même est inchangé (la revue le confirme explicitement).

| Point | Mesure | Traitement |
|---|---|---|
| Le corps sous-compte le rouge-avant (« 2 tests de falsification ») | workflow d'origine restauré + tests du head : **3 failed, 28 passed** ; le 3e est `test_two_cancelled_constituants_emit_both_ids` (le sélecteur est embarqué dans le YAML restauré) | liste corrigée à **3**, mesure chiffrée dans la section « Preuves d'exécution » |
| L'en-tête de `pr-gate-stale-sweep.yml` affirme encore que `pr-gate-rerun.yml` re-agrège via `workflow_run` (l.11-13, l.56-57) | vérifié firsthand : `pr-gate-rerun.yml` porte « RETIRED event-driven path (#11860). This workflow NO LONGER triggers on `workflow_run` » | en-tête passé au passé + marqueur RETIRED #11860 — commit `bed670b8bc` |

Troisième occurrence, non nommée par la revue mais de la même classe : le commentaire de la boucle d'action (« Same remedy as pr-gate-rerun.yml (#11546); this sweep is its complement » + non-bouclage ancré sur les triggers de rerun.yml) contredisait le bloc ajouté par cette PR 25 lignes plus haut (l.535 : « le re-agregateur event-driven est retire depuis #11860 »). Corrigé dans le même commit : « complement » → REPLACEMENT schedule-mutualisé, non-bouclage re-ancré sur les déclencheurs réels du sweep (`schedule` / `workflow_dispatch`, aucun `workflow_run`).

**Commentaires seuls** : `git diff -U0 | grep -vE '^[+-]\s*#'` ne rend aucune ligne — 0 ligne fonctionnelle touchée. YAML OK (6 étapes), `31 passed`.

Closes #15775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

