### PR TITLE
fix(ci,#15697): les gardes lisent le corps de PR à l'exécution, pas dans le payload

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -197,7 +197,7 @@ jobs:
       # dernier run restait affiche sur un corps qui n'existe plus --
       # 72 h sur #15303, 15 h sur #15587, les deux sans faute de lane.
       # Une seule lecture en tete de job, exportee dans PR_BODY : les
-      # quatre sites ecrivant /tmp/pr_body.txt sont inchanges.
+      # neuf sites ecrivant /tmp/pr_body.txt sont inchanges.
       # Repli : appel API vide/echoue -> payload de l'evenement (photo-
       # graphie au declenchement). Jamais bloquant sur une panne de
       # lecture. `// empty` : un corps null rendrait le literal "null".

--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -129,7 +129,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_BODY: ${{ github.event.pull_request.body }}
+      # PR_BODY n'est plus fixe ici : lue en LIVE par l'etape de bootstrap
+      # "#15697" ci-dessous (un env de job STATIQUE primerait sur le
+      # GITHUB_ENV exporte par cette etape, lui coupant la parole).
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
@@ -185,6 +187,38 @@ jobs:
       # un _quarto.yml invalide.
       - name: "Installer dependances detecteurs (pyyaml, Pillow)"
         run: pip install --quiet pyyaml Pillow
+
+      # -----------------------------------------------------------------
+      # BODY LIVE (#15697) : les organes qui lisent le corps (tag Grain:,
+      # prev:, [CLAIMED], mots-cles de fermeture) le lisent A L'EXECUTION,
+      # pas dans le payload de l'evenement. Le corps d'une PR se modifie
+      # SANS commit, et un amendement par github-actions (GITHUB_TOKEN)
+      # n'emet AUCUN evenement (anti-recursion documentee) : le verdict du
+      # dernier run restait affiche sur un corps qui n'existe plus --
+      # 72 h sur #15303, 15 h sur #15587, les deux sans faute de lane.
+      # Une seule lecture en tete de job, exportee dans PR_BODY : les
+      # quatre sites ecrivant /tmp/pr_body.txt sont inchanges.
+      # Repli : appel API vide/echoue -> payload de l'evenement (photo-
+      # graphie au declenchement). Jamais bloquant sur une panne de
+      # lecture. `// empty` : un corps null rendrait le literal "null".
+      # -----------------------------------------------------------------
+      - name: "Body live : lecture API a l'execution (#15697)"
+        env:
+          PAYLOAD_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          LIVE=""
+          if [ -n "${PR_NUMBER:-}" ]; then
+            LIVE=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.body // empty' 2>/dev/null || true)
+          fi
+          if [ -n "$LIVE" ]; then
+            echo "[body-live] corps courant lu via API : ${#LIVE} chars (#15697)"
+            BODY="$LIVE"
+          else
+            echo "::warning::[body-live] lecture API vide/echouee -- repli sur le payload de l'evenement (photographie)"
+            BODY="${PAYLOAD_BODY:-}"
+          fi
+          delim="BODY_LIVE_EOF_$$"
+          printf 'PR_BODY<<%s\n%s\n%s\n' "$delim" "$BODY" "$delim" >> "$GITHUB_ENV"
 
       # -----------------------------------------------------------------
       # ORGANES ADVISORY (sortent toujours en 0 ; labels et commentaires

--- a/scripts/tests/test_always_on_guards_live_body.py
+++ b/scripts/tests/test_always_on_guards_live_body.py
@@ -29,6 +29,12 @@ WORKFLOW = os.path.join(
     REPO_ROOT, ".github", "workflows", "always-on-guards.yml"
 )
 
+# Sites ecrivant le litteral canonique dans always-on-guards.yml (job unique
+# `always-on-guards`, 20 etapes, consommateurs aux indices 5-7 et 9-14).
+# Valeur IDENTIQUE a la base de #15697 : c'est l'invariant que le corps
+# revendique (« point unique de changement, les sites sont inchanges »).
+PR_BODY_WRITE_SITES = 9
+
 
 def _doc():
     with open(WORKFLOW, encoding="utf-8") as f:
@@ -80,13 +86,15 @@ def test_bootstrap_null_guard_and_fallback():
 
 
 def test_consumer_sites_unchanged():
-    """Les organes restent inchanges : quatre sites ecrivent /tmp/pr_body.txt
-    depuis ``${PR_BODY:-}`` -- le point unique de changement tient."""
+    """Les organes restent inchanges : NEUF sites ecrivent /tmp/pr_body.txt
+    depuis ``${PR_BODY:-}`` -- le point unique de changement tient. Le pin
+    est EXACT, pas un plancher : c'est l'invariant que le corps revendique,
+    et un ``>= N`` laisserait passer la suppression de sites consommateurs."""
     run_all = "\n".join(
         str(s.get("run", "")) for s in _steps(_doc())
     )
-    assert run_all.count("pr_body.txt") >= 4
-    assert 'printf \'%s\' "${PR_BODY:-}" > /tmp/pr_body.txt' in run_all
+    literal = 'printf \'%s\' "${PR_BODY:-}" > /tmp/pr_body.txt'
+    assert run_all.count(literal) == PR_BODY_WRITE_SITES
 
 
 FAKE_GH = textwrap.dedent(

--- a/scripts/tests/test_always_on_guards_live_body.py
+++ b/scripts/tests/test_always_on_guards_live_body.py
@@ -1,0 +1,194 @@
+"""#15697 -- les organes du corps de PR lisent le corps A L'EXECUTION.
+
+Le defaut mesure : ``always-on-guards.yml`` fixait ``PR_BODY`` depuis
+``github.event.pull_request.body`` -- une photographie au moment du
+declenchement. Un corps amende SANS commit (typiquement par un organe sous
+``github-actions``, dont les evenements sont avales par l'anti-recursion)
+laissait le verdict du dernier run affiche sur un corps qui n'existe plus :
+72 h sur #15303, 15 h sur #15587.
+
+Le correctif : une etape de bootstrap lit le corps COURANT par l'API et
+l'exporte dans ``PR_BODY`` via ``GITHUB_ENV`` ; repli sur le payload si
+l'appel echoue. Ce fichier pince la structure ET execute le bloc livree
+avec un ``gh`` factice (acceptance 1 + controle negatif de repli).
+"""
+
+import os
+import re
+import stat
+import subprocess
+import textwrap
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+)
+WORKFLOW = os.path.join(
+    REPO_ROOT, ".github", "workflows", "always-on-guards.yml"
+)
+
+
+def _doc():
+    with open(WORKFLOW, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _steps(doc):
+    return doc["jobs"]["always-on-guards"]["steps"]
+
+
+def _bootstrap(steps):
+    return next(
+        (s for s in steps if "#15697" in s.get("name", "")), None
+    )
+
+
+def test_job_env_no_longer_pins_payload_body():
+    """L'env de job ne fixe PLUS PR_BODY : un env statique primerait sur le
+    GITHUB_ENV exporte par le bootstrap (precedence job-env > GITHUB_ENV),
+    lui coupant la parole -- le defaut masque en pleine vue."""
+    env = _doc()["jobs"]["always-on-guards"]["env"]
+    assert "PR_BODY" not in env
+
+
+def test_bootstrap_step_exists_before_first_consumer():
+    """Le bootstrap existe et precede le premier organe qui consomme le corps
+    -- un bootstrap place apres un consommateur jugerait la photographie."""
+    steps = _steps(_doc())
+    boot = _bootstrap(steps)
+    assert boot is not None, "etape body-live #15697 absente"
+    boot_idx = steps.index(boot)
+    consumers = [
+        i for i, s in enumerate(steps)
+        if "pr_body.txt" in str(s.get("run", ""))
+    ]
+    assert consumers, "aucun consommateur de /tmp/pr_body.txt ?!"
+    assert boot_idx < min(consumers)
+
+
+def test_bootstrap_null_guard_and_fallback():
+    """Le jq porte le null-guard (``// empty`` : un corps null rendrait le
+    literal \"null\"), et le repli payload existe -- la lecture fraiche ne
+    doit pouvoir bloquer aucune PR sur une panne d'API."""
+    boot = _bootstrap(_steps(_doc()))
+    run = boot["run"]
+    assert "// empty" in run
+    assert "PAYLOAD_BODY" in boot["env"]
+    assert "PAYLOAD_BODY" in run
+
+
+def test_consumer_sites_unchanged():
+    """Les organes restent inchanges : quatre sites ecrivent /tmp/pr_body.txt
+    depuis ``${PR_BODY:-}`` -- le point unique de changement tient."""
+    run_all = "\n".join(
+        str(s.get("run", "")) for s in _steps(_doc())
+    )
+    assert run_all.count("pr_body.txt") >= 4
+    assert 'printf \'%s\' "${PR_BODY:-}" > /tmp/pr_body.txt' in run_all
+
+
+FAKE_GH = textwrap.dedent(
+    """
+    #!/usr/bin/env bash
+    # gh factice : la sous-commande api rend le corps fixe par GH_FAKE_BODY,
+    # ou echoue (exit 1) si GH_FAKE_FAIL=1. Le jq est en $3, l'expression
+    # en $4 : gh api <url> --jq <expr>.
+    if [ "${GH_FAKE_FAIL:-}" = "1" ]; then exit 1; fi
+    if [ "$1" = "api" ] && [ "$3" = "--jq" ]; then
+      printf '%s' "${GH_FAKE_BODY:-}"
+      exit 0
+    fi
+    exit 64
+    """
+)
+
+
+def _bash_exe():
+    """Sur Linux/CI : ``bash``. Sur Windows : le bash de Git for Windows --
+    le ``bash.exe`` de System32 est le lanceur WSL, qui ne lit PAS les
+    chemins Windows (``C:/...`` -> ``No such file or directory``)."""
+    if os.name != "nt":
+        return "bash"
+    pf = os.environ.get("ProgramFiles", r"C:\Program Files")
+    for cand in (
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+    ):
+        if os.path.exists(cand):
+            return cand
+    pytest.skip("Git Bash introuvable -- le bash System32 (WSL) ne lit pas les chemins Windows")
+
+
+def _run_bootstrap(tmp_path, fake_body, fail=False):
+    """Extrait le bloc `run:` du bootstrap et l'execute avec le gh factice."""
+    boot = _bootstrap(_steps(_doc()))
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(FAKE_GH, encoding="utf-8")
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+    envfile = tmp_path / "github_env"
+    script = tmp_path / "boot.sh"
+    script.write_text(boot["run"], encoding="utf-8")
+    env = dict(
+        os.environ,
+        GITHUB_ENV=str(envfile),
+        GH_REPO="jsboige/CoursIA",
+        PR_NUMBER="15587",
+        PAYLOAD_BODY="Grain: PAYLOAD/photographie",
+        GH_FAKE_BODY=fake_body,
+    )
+    if fail:
+        env["GH_FAKE_FAIL"] = "1"
+    # bash (Git Bash / runner Linux) n'accepte ni les separateurs Windows ni
+    # un PATH mixte : un PATH ':'-sepague d'entrees ';'-separees est
+    # re-parse par MSYS et le bin/ du gh factice se perd -- le gh REEL
+    # repond alors (mesure : le test a lu le vrai corps de #15587 au lieu
+    # du fixture). On convertit TOUT le PATH en entrees POSIX ':'-separees.
+    path_entries = [
+        p.replace("\\", "/")
+        for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p
+    ]
+    env["PATH"] = ":".join(
+        [str(bindir).replace("\\", "/")] + path_entries
+    )
+    out = subprocess.run(
+        [_bash_exe(), str(script).replace("\\", "/")],
+        capture_output=True, text=True, encoding="utf-8", env=env,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout, envfile.read_text(encoding="utf-8")
+
+
+def test_bootstrap_writes_live_body(tmp_path):
+    """Acceptance 1, execution reelle du bloc livre : l'API rend le corps
+    courant -> PR_BODY vaut le corps LIVE, pas le payload."""
+    live = "Grain: LIVE/lu-a-l-execution -- corrige sans commit"
+    stdout, genv = _run_bootstrap(tmp_path, live)
+    assert "photographie" not in genv
+    m = re.search(r"PR_BODY<<(\S+)\n(.*?)\n\1\n", genv, re.S)
+    assert m, f"export GITHUB_ENV mal forme :\n{genv}"
+    assert m.group(2) == live
+
+
+def test_bootstrap_falls_back_to_payload_on_api_failure(tmp_path):
+    """Controle negatif : API injoignable -> repli sur le payload, jamais de
+    verdict vert par absence de corps (la lecture fraiche n'est pas une
+    dispense)."""
+    stdout, genv = _run_bootstrap(tmp_path, "", fail=True)
+    m = re.search(r"PR_BODY<<(\S+)\n(.*?)\n\1\n", genv, re.S)
+    assert m, f"export GITHUB_ENV mal forme :\n{genv}"
+    assert m.group(2) == "Grain: PAYLOAD/photographie"
+    assert "::warning::" in stdout
+
+
+def test_bootstrap_multiline_body_survives_heredoc(tmp_path):
+    """Un corps multiline (le cas reel : sections, tableaux) traverse
+    l'export GITHUB_ENV sans troncature ni pollution du delimiteur."""
+    live = "Grain: MED/tooling\n\n## Summary\n\n| a | b |\n|---|---|\n| 1 | 2 |"
+    _, genv = _run_bootstrap(tmp_path, live)
+    m = re.search(r"PR_BODY<<(\S+)\n(.*?)\n\1\n", genv, re.S)
+    assert m and m.group(2) == live


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15785

## Summary

#15697 (acceptance révisée du commentaire de correction) : les organes d'`always-on-guards.yml` qui lisent le corps de PR (tag `Grain:`, `prev:`, `[CLAIMED]`, mots-clés de fermeture) le lisaient depuis `github.event.pull_request.body` — une **photographie** au moment du déclenchement. Un corps amendé **sans commit** (typiquement par un organe sous `github-actions`, dont les événements sont avalés par l'anti-récursion) laissait le verdict du dernier run affiché sur un corps qui n'existe plus : **72 h sur #15303, 15 h sur #15587**, les deux sans faute de lane. Le correctif : une étape de bootstrap lit le corps **courant** par l'API en tête de job et l'exporte dans `PR_BODY` via `GITHUB_ENV` — point unique de changement, les neuf sites `/tmp/pr_body.txt` sont inchangés.

## Le diff (2 fichiers, +237/−1 : workflow +35/−1, tests +202)

| Élément | Rôle |
|---|---|
| Bootstrap « Body live (#15697) » (20e étape, avant le premier organe) | `gh api repos/$GH_REPO/pulls/$PR_NUMBER --jq '.body // empty'` → export `PR_BODY` dans `GITHUB_ENV` (heredoc délimiteur PID-unique, corps multiline OK). **Repli** : appel vide/échoué → payload de l'événement + `::warning::` — une panne de lecture ne bloque jamais une PR. `// empty` : un corps null rendrait le littéral `"null"`. |
| Retrait de `PR_BODY` de l'env de job | Un env de job **statique** primerait sur le `GITHUB_ENV` exporté par le bootstrap (précédence job-env > GITHUB_ENV) — le défaut masqué en pleine vue, épinglé par test. |
| `scripts/tests/test_always_on_guards_live_body.py` | 7 tests : 4 pins structurels + 3 exécutant **le bloc livré** avec un `gh` factice (acceptance 1 + contrôle négatif de repli + heredoc multiline). |

## Preuves d'exécution

```
$ python -m pytest scripts/tests/test_always_on_guards_live_body.py -q
7 passed
$ python -m pytest scripts/tests/test_audit_workflow_paths_filters.py test_bash_e_rc_capture.py \
    test_check_pr_perimeter.py test_emit_dead_scope_warnings.py \
    test_guard_comment_upsert.py test_hot_subset_ratchet_wiring.py -q
256 passed        (baseline des pins existants sur ce workflow : intacte)
```

**Rouge d'abord, prouvé** : 6/7 tests échouent sur le workflow HEAD (restauration temporaire, backup/restore `cp`).

Le test comportemental exécute le bloc `run:` **tel que livré** (extraction depuis l'arbre YAML, convention du fichier de test du stale-sweep), avec un `gh` factice — hermétique. Deux pièges Windows mesurés pendant le développement, documentés dans le fichier de test : le `bash.exe` de System32 est le lanceur WSL (ne lit pas les chemins Windows) → résolution explicite de Git Bash ; un PATH mixte `:`/`;` est re-parse par MSYS et perd le bin factice → conversion intégrale en entrées POSIX (le gh réel avait répondu à la place du factice — lecture du vrai corps de #15587, involontaire mais confirmant le diagnostic au passage).

## Acceptance révisée de #15697, point par point

| # | Demande | Livré |
|---|---|---|
| 1 | Les organes lisant le corps le lisent **à l'exécution**, pas depuis `github.event.pull_request.body` | Bootstrap API → `PR_BODY` ; le pin `test_job_env_no_longer_pins_payload_body` interdit le retour de l'env statique |
| 2 | Contrôle positif : corps amendé après un run rouge → verdict recalculé au run suivant **sans commit** | **Post-merge, gesture documenté** : un run `pull_request` exécute la version du workflow **portée par la branche de la PR** (leçon variation-tag-guard/#11718) — #15587 doit d'abord re-baser pour porter ce fix, puis l'édition de corps sous compte de lane (correction n°2 de l'issue, gesture d'une seconde, sans reset DWELL) émet l'événement frais qui recalcule. La validation de ce grain = la PR suivante qui amende son corps sur une branche à jour. |
| 3 | Contrôle négatif : une PR réellement sans tag reste rouge | Organes inchangés (pin : les **9** sites d'écriture du littéral canonique sont identiques à la base) ; le repli payload nourrit les organes en cas de panne de lecture — `test_bootstrap_falls_back_to_payload_on_api_failure` |
| 4 | Le plafond de débit du sweep couvre les re-runs **ensuite** (point de déclenchement), pas avant | Hors scope de ce grain tel que rédigé par l'issue elle-même — rien de livré ici ne déclenche de runs supplémentaires |
| 5 | Noter comment un lecteur distingue le frais du périmé parmi les check-runs homonymes | Trois marques : (a) le run frais commence son log par `[body-live] corps courant lu via API : N chars (#15697)` — absent des runs pré-fix ; (b) `started_at` du check-run **postérieur** à `updated_at` du corps ; (c) un run en repli porte le `::warning::` payload — à lire comme photographie |

Closes #15697

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Suite de revue (Hermes, head `68c08333`)

Les trois points sont mesures puis traites — le fix lui-meme est inchange.

| Point | Mesure | Traitement |
|---|---|---|
| « les quatre sites » (commentaire workflow l.200 + docstring du test) | **9** sites d'ecriture du litteral canonique, au head **et** a la base (consommateurs aux indices 5-7 et 9-14 d'un job de 20 etapes) | « quatre » -> « **neuf** » aux deux endroits |
| Ventilation : « workflow **+36**/-1 » | `git diff --numstat` base..head **au moment de la revue** : **35**/1 (workflow) + **194**/0 (tests) = **229** | corrige en « **+35**/-1 » ; apres le commit de reparation `44130e3c16` le head est **35**/1 + **202**/0 = **237** (le chiffre 194/229 est la mesure d'avant ce commit) |
| `test_consumer_sites_unchanged` : `count("pr_body.txt") >= 4` (reel : 20) | l'invariant revendique etait laisse ouvert | pin **EXACT** : `count(litteral) == PR_BODY_WRITE_SITES` (=9) |

Controle negatif du pin durci, joue pour prouver la causalite :

```
head            : count=9  | >=4 -> True  | ==9 -> True
apres -5 sites  : count=4  | >=4 -> True  | ==9 -> False   <- l'ancien garde laissait passer
```

Le chiffre « quatre » est donc faux **des deux cotes** de la comparaison, comme le note la revue ; et le nouveau pin ferme la porte que le plancher laissait ouverte. Seul le workflow porte un commentaire modifie (aucun effet fonctionnel).

## Etat CI : le rouge courant n'est pas ce diff (mesure)

`Scripts Tests (CPU)` n'a pas **echoue** : il a ete **annule par son propre `timeout-minutes: 20`** (run 34722001777 / job 103629507460). L'etape « Run tests » a tourne 19 min 49 s puis a ete tuee ; le cleanup a termine un `pytest` orphelin. Le log date l'arret : derniere ligne de progression a **84 %**, sur `scripts/lean/tests/test_life_components.py` (22:18:32Z), puis **12 min de silence** jusqu'a l'annulation (22:30:49Z).

Le fichier suivant dans l'ordre de collecte est `scripts/lean/tests/test_life_compose.py` : il n'apparait **jamais** dans le log, donc c'est lui qui n'a pas rendu. Mesure locale (po-2023) : `timeout 60 python -m pytest scripts/lean/tests/test_life_compose.py` rend **rc=124 sur deux essais** — le fichier depasse 60 s a lui seul. Son budget est un **nombre de noeuds** (`DEFAULT_NODE_BUDGET = 200_000`, `life_compose.py:80`), pas une duree : le temps mural varie donc avec la machine et la charge, sans plafond.

Ce diff ne touche ni `scripts/lean/` ni ce fichier — ses 2 fichiers sont `.github/workflows/always-on-guards.yml` et `scripts/tests/test_always_on_guards_live_body.py`, dont les 7 tests tournent en **0,48 s** en local. Le meme job **passait** sur le commit precedent de cette branche (`68c08333`), et d'autres PRs passent dans la meme heure : l'annulation est intermittente, pilotee par la charge du runner.

**Signale, non corrige ici** (un sujet par PR) : le cout de `test_life_compose.py` regarde son proprietaire — plafond mural dans le test, budget de noeuds reduit, ou sortie du job. A noter pour cette PR : `PR gate` herite ce rouge et restera FAIL jusque-la, y compris apres re-run (un re-run re-timeout, il ne reussit pas).


