### PR TITLE
fix(ci,#15766): comparer les liens casses a la base, pas au fichier fige

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -6,6 +6,13 @@ name: Docs Link Check
 # toute la lane). Ce fichier garde `workflow_dispatch` pour le re-run manuel
 # sur `main` apres une panne CI (#9858). Les `paths:` d'origine vivent dans
 # `scripts/ci/fast_lane_registry.py` (TRANCHE1).
+#
+# Les deux voies n'excusent PAS les liens casses de la meme facon (#15766) :
+# la garde de PR compare a sa base (`--base {base_ref}`), ou un lien deja
+# casse n'est pas la regression de la branche ; ce dispatch, qui n'a pas de
+# base a comparer, s'en remet seul au fichier de reference fige. C'est
+# volontaire : `--baseline` n'est appele par aucune automatisation, donc ce
+# fichier ne doit rien excuser de plus que ce qu'il contient deja.
 
 on:
   workflow_dispatch:

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -8,21 +8,31 @@ exist.
 Also detects orphan .md files in docs/ (not referenced by any scanned file).
 
 Usage:
-    python scripts/check_docs_links.py               # Full scan
-    python scripts/check_docs_links.py --baseline     # Write baseline report
-    python scripts/check_docs_links.py --check        # Check against baseline
-    python scripts/check_docs_links.py --quiet        # Minimal output (for CI)
-    python scripts/check_docs_links.py --orphans      # Also report orphan docs
+    python scripts/check_docs_links.py                        # Full scan
+    python scripts/check_docs_links.py --baseline             # Write baseline report
+    python scripts/check_docs_links.py --check                # Check against baseline
+    python scripts/check_docs_links.py --check --base origin/main
+    python scripts/check_docs_links.py --quiet                # Minimal output (for CI)
+    python scripts/check_docs_links.py --orphans              # Also report orphan docs
+
+``--check`` accepts two independent excuses for a broken link. The frozen
+``baseline_docs_links.json`` covers paths with no comparison revision (manual
+dispatch, plain full scan). ``--base REF`` additionally excuses a link that was
+ALREADY broken at REF: without it, a single broken link on ``main`` reddens
+``check-links`` on every open PR until someone regenerates the baseline, which
+nothing does (#15766).
 
 Exit codes:
-    0 = all links valid (or only pre-existing broken links in baseline mode)
+    0 = all links valid (or only excused broken links)
     1 = new broken links found (regression)
     2 = error during execution
 """
 
 import argparse
 import json
+import posixpath
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -170,17 +180,16 @@ def find_scan_files() -> list[Path]:
     return files
 
 
-def scan_file(filepath: Path) -> list[LinkRef]:
-    """Extract all relative links from a markdown file.
+def scan_content(content: str, rel_source: str) -> list[LinkRef]:
+    """Extract all relative links from markdown ``content``.
+
+    ``rel_source`` is the repo-relative posix path the content comes from: link
+    targets resolve against its directory, so the same routine serves both the
+    working tree and a ``git show`` read of an arbitrary revision.
 
     Skips links inside fenced code blocks (```...```).
     """
     refs = []
-    try:
-        content = filepath.read_text(encoding="utf-8")
-    except (UnicodeDecodeError, PermissionError, OSError):
-        return refs
-
     in_code_block = False
     for line_num, line in enumerate(content.splitlines(), 1):
         stripped = line.strip()
@@ -199,10 +208,6 @@ def scan_file(filepath: Path) -> list[LinkRef]:
             text = match.group(1)
             target = match.group(2)
             if _is_valid_target(target):
-                try:
-                    rel_source = str(filepath.relative_to(REPO_ROOT)).replace("\\", "/")
-                except ValueError:
-                    rel_source = str(filepath)
                 refs.append(LinkRef(
                     source=rel_source,
                     target=target,
@@ -210,6 +215,19 @@ def scan_file(filepath: Path) -> list[LinkRef]:
                     text=text,
                 ))
     return refs
+
+
+def scan_file(filepath: Path) -> list[LinkRef]:
+    """Extract all relative links from a markdown file on disk."""
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, PermissionError, OSError):
+        return []
+    try:
+        rel_source = filepath.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel_source = str(filepath)
+    return scan_content(content, rel_source)
 
 
 def _is_quarto_render_target(html_path: Path, root: Path) -> bool:
@@ -261,6 +279,113 @@ def check_link(target: str, source_path: Path, root: Path = REPO_ROOT) -> bool:
     return resolved.suffix.lower() == ".html" and _is_quarto_render_target(
         resolved, root
     )
+
+
+def _git_show(rev: str, rel_path: str) -> str | None:
+    """Content of ``rel_path`` at ``rev``, or None when it is not readable.
+
+    The return code is inspected BEFORE the stdout is used: a partial clone can
+    exit non-zero and still emit a body, which would then be scanned as if it
+    were the file (#15387).
+    """
+    proc = subprocess.run(
+        ["git", "show", f"{rev}:{rel_path}"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _git_tree_files(rev: str) -> set[str] | None:
+    """Every blob path (repo-relative posix) at ``rev``, or None if unreachable.
+
+    None is the caller's signal that the comparison revision could not be read;
+    the caller then falls back to the frozen baseline rather than inventing
+    regressions it cannot substantiate.
+    """
+    proc = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", rev],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    if proc.returncode != 0:
+        return None
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def _tree_dirs(files: set[str]) -> set[str]:
+    """Directories implied by a file listing (git stores no empty directory)."""
+    dirs: set[str] = set()
+    for name in files:
+        parts = name.split("/")
+        for i in range(1, len(parts)):
+            dirs.add("/".join(parts[:i]))
+    return dirs
+
+
+def _link_exists_in_tree(target: str, source_rel: str, files: set[str],
+                         dirs: set[str], quarto_yml: str | None) -> bool:
+    """Existence oracle over a git tree listing, mirroring ``check_link``."""
+    try:
+        decoded = unquote(target)
+    except (ValueError, TypeError):
+        return False
+
+    rel = posixpath.normpath(posixpath.join(posixpath.dirname(source_rel), decoded))
+    if rel.startswith(("/", "..")):
+        return False  # escapes the repo, as in check_link
+    if any(rel == sm or rel.startswith(sm + "/") for sm in SUBMODULE_PATHS):
+        return True
+    if rel in files or rel.rstrip("/") in dirs:
+        return True
+    # Quarto-generated pages are absent from the source tree by design: valid
+    # only when the sibling notebook exists and project.render lists it.
+    if rel.endswith(".html") and quarto_yml is not None:
+        notebook = rel[:-5] + ".ipynb"
+        return notebook in files and f'"{notebook}"' in quarto_yml
+    return False
+
+
+def preexisting_broken(broken_refs: list[LinkRef], rev: str) -> set[tuple[str, str]] | None:
+    """Among ``broken_refs``, those already broken at ``rev``.
+
+    Only the sources carrying a broken link at HEAD are read at ``rev``: the
+    question is never "what was broken there" but "was THIS link already
+    broken", so the base revision is consulted source by source instead of
+    being scanned wholesale.
+
+    A link counts as pre-existing only when the source existed at ``rev``,
+    carried the same target, and that target was already absent there. A target
+    deleted by the branch, or a link the branch introduced, stays a regression.
+
+    Returns None when ``rev`` cannot be read.
+    """
+    if not broken_refs:
+        return set()
+    tree = _git_tree_files(rev)
+    if tree is None:
+        return None
+    dirs = _tree_dirs(tree)
+    quarto_yml = _git_show(rev, "_quarto.yml")
+
+    wanted: dict[str, set[str]] = {}
+    for ref in broken_refs:
+        wanted.setdefault(ref.source, set()).add(ref.target)
+
+    preexisting: set[tuple[str, str]] = set()
+    for source, targets in wanted.items():
+        if source not in tree:
+            continue  # created by this branch: nothing pre-existed
+        content = _git_show(rev, source)
+        if content is None:
+            continue
+        base_targets = {r.target for r in scan_content(content, source)}
+        for target in targets:
+            if target in base_targets and not _link_exists_in_tree(
+                target, source, tree, dirs, quarto_yml
+            ):
+                preexisting.add((source, target))
+    return preexisting
 
 
 def find_orphan_docs(scanned_files: list[Path], all_refs: list[LinkRef]) -> list[str]:
@@ -344,17 +469,22 @@ def load_baseline(path: Path = BASELINE_PATH) -> dict | None:
         return None
 
 
-def check_regression(result: ScanResult, baseline: dict) -> list[LinkRef]:
-    """Find broken links that are NOT in the baseline (new regressions)."""
+def check_regression(result: ScanResult, baseline: dict,
+                     preexisting: set[tuple[str, str]] | None = None) -> list[LinkRef]:
+    """Find broken links that are NOT already excused (new regressions).
+
+    Two independent excuses apply. The frozen ``baseline`` covers the
+    non-PR paths (dispatch, plain full scan) where no comparison revision is
+    available. ``preexisting`` — computed against the branch's base revision —
+    covers the PR path: a link already broken before the branch is not this
+    branch's regression, and would otherwise redden every open PR at once
+    (#15766).
+    """
     baseline_targets = {
         (b["source"], b["target"]) for b in baseline.get("broken_links", [])
     }
-    new_broken = []
-    for ref in result.broken:
-        key = (ref.source, ref.target)
-        if key not in baseline_targets:
-            new_broken.append(ref)
-    return new_broken
+    excused = baseline_targets | (preexisting or set())
+    return [ref for ref in result.broken if (ref.source, ref.target) not in excused]
 
 
 def format_report(result: ScanResult, show_orphans: bool = False) -> str:
@@ -386,6 +516,9 @@ def main():
                         help="Write current state as baseline")
     parser.add_argument("--check", action="store_true",
                         help="Check for regressions against baseline")
+    parser.add_argument("--base", metavar="REF", default=None,
+                        help="With --check: a broken link already broken at REF "
+                             "(e.g. origin/main) is not a regression")
     parser.add_argument("--orphans", action="store_true",
                         help="Also report orphan docs")
     parser.add_argument("--quiet", action="store_true",
@@ -403,30 +536,38 @@ def main():
             return
 
         if args.check:
+            preexisting = None
+            if args.base:
+                preexisting = preexisting_broken(result.broken, args.base)
+                if preexisting is None and not args.quiet:
+                    print(f"WARNING: {args.base!r} is not readable, comparing against the "
+                          f"frozen baseline only.", file=sys.stderr)
+
             baseline = load_baseline()
-            if baseline is None:
+            if baseline is None and preexisting is None:
                 if not args.quiet:
                     print("No baseline found. Run with --baseline first.")
-                # If no baseline, any broken link is a regression
+                # Nothing can excuse a broken link: every one is a regression
                 if result.broken:
                     if not args.quiet:
                         print(format_report(result))
                     sys.exit(1)
                 sys.exit(0)
 
-            new_broken = check_regression(result, baseline)
+            new_broken = check_regression(result, baseline or {}, preexisting)
             if new_broken:
                 if not args.quiet:
                     print(f"REGRESSION: {len(new_broken)} new broken link(s):")
                     for ref in new_broken:
                         print(f"  {ref.source}:{ref.line} -> {ref.target}")
-                    print(f"\nBaseline had {len(baseline.get('broken_links', []))} known broken.")
+                    print(f"\nExcused: {len((baseline or {}).get('broken_links', []))} from baseline"
+                          f" + {len(preexisting or ())} already broken at {args.base or '(no base)'}.")
                 sys.exit(1)
-            else:
-                if not args.quiet:
-                    print(f"OK: No new broken links. "
-                          f"({len(result.broken)} pre-existing, {result.total_links} total)")
-                sys.exit(0)
+
+            if not args.quiet:
+                print(f"OK: No new broken links. "
+                      f"({len(result.broken)} pre-existing, {result.total_links} total)")
+            sys.exit(0)
 
         # Default: full scan
         if not args.quiet:

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -417,9 +417,17 @@ PILOT: list[Guard] = [
 # couvre deja tout ce que ces trois gardes demandent.
 # ---------------------------------------------------------------------------
 TRANCHE1: list[Guard] = [
-    # Forme 1 : scan global simple, sans base. Source : docs-link-check.yml
-    # (job `check-links`). Le nom du garde est le nom du JOB, pas celui du
-    # workflow -- c'est lui que le rollup affichait.
+    # Forme 1 : scan global. Source : docs-link-check.yml (job `check-links`).
+    # Le nom du garde est le nom du JOB, pas celui du workflow -- c'est lui que
+    # le rollup affichait.
+    #
+    # `--base {base_ref}` (#15766) : le baseline fige est a `broken_links: []`
+    # et rien ne le regenere, donc un seul lien casse sur `main` rendait ce
+    # garde rouge sur TOUTE PR ouverte (`check-links` + `Always-on guards` +
+    # `PR gate`), quel que soit le contenu de la PR. Comparer a la base rend
+    # l'excuse exacte : un lien deja casse avant la branche n'est pas la
+    # regression de la branche. Le baseline fige reste la voie des executions
+    # hors PR (dispatch, scan complet), ou aucune base n'est disponible.
     Guard(
         name="check-links",
         source="docs-link-check.yml",
@@ -428,9 +436,11 @@ TRANCHE1: list[Guard] = [
             ".claude/rules/**", "docs/**", "**/README.md",
             "scripts/check_docs_links.py",
         ],
-        argv=["python", "scripts/check_docs_links.py", "--check"],
+        argv=["python", "scripts/check_docs_links.py", "--check",
+              "--base", "{base_ref}"],
         blocking=True,
         absorbed=True,
+        needs_base=True,
     ),
     # Forme 2 : scan globs, bloque sur la convention zero-pad des series
     # DECLAREES (#11840/#12586, portee explicite #15489 defaut 5). Source :

--- a/scripts/tests/test_check_docs_links.py
+++ b/scripts/tests/test_check_docs_links.py
@@ -9,6 +9,7 @@ Validates all acceptance criteria from issue #2453:
 """
 
 import json
+import subprocess
 import textwrap
 from pathlib import Path
 
@@ -18,6 +19,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import check_docs_links
 from check_docs_links import (
     BASELINE_PATH,
     LinkRef,
@@ -28,11 +30,15 @@ from check_docs_links import (
     find_scan_files,
     format_report,
     load_baseline,
+    preexisting_broken,
     run_scan,
+    scan_content,
     scan_file,
     write_baseline,
     _is_valid_target,
+    _link_exists_in_tree,
     _should_skip,
+    _tree_dirs,
     REPO_ROOT,
 )
 
@@ -405,6 +411,149 @@ class TestRegressionDetection:
         result = ScanResult(broken=[])  # All fixed now
         new_broken = check_regression(result, baseline)
         assert len(new_broken) == 0
+
+
+class TestPreexistingExcuse:
+    """--check accepts links already broken at the comparison revision (#15766)."""
+
+    def test_preexisting_link_is_not_a_regression(self):
+        result = ScanResult(broken=[
+            LinkRef(source="README.md", target="docs/gone.md", line=3, text="gone"),
+        ])
+        new_broken = check_regression(
+            result, {}, preexisting={("README.md", "docs/gone.md")})
+        assert new_broken == []
+
+    def test_unrelated_preexisting_does_not_mask_a_new_link(self):
+        result = ScanResult(broken=[
+            LinkRef(source="README.md", target="docs/gone.md", line=3, text="gone"),
+            LinkRef(source="CLAUDE.md", target="docs/fresh.md", line=9, text="fresh"),
+        ])
+        new_broken = check_regression(
+            result, {}, preexisting={("README.md", "docs/gone.md")})
+        assert [r.target for r in new_broken] == ["docs/fresh.md"]
+
+    def test_baseline_and_preexisting_both_excuse(self):
+        baseline = {"broken_links": [
+            {"source": "README.md", "target": "docs/old.md", "line": 1, "text": "old"},
+        ]}
+        result = ScanResult(broken=[
+            LinkRef(source="README.md", target="docs/old.md", line=1, text="old"),
+            LinkRef(source="PARCOURS.md", target="docs/gone.md", line=2, text="gone"),
+        ])
+        new_broken = check_regression(
+            result, baseline, preexisting={("PARCOURS.md", "docs/gone.md")})
+        assert new_broken == []
+
+    def test_no_preexisting_keeps_legacy_semantics(self):
+        """Omitting the comparison revision behaves exactly as before."""
+        result = ScanResult(broken=[
+            LinkRef(source="README.md", target="docs/gone.md", line=3, text="gone"),
+        ])
+        assert len(check_regression(result, {})) == 1
+
+
+class TestLinkExistsInTree:
+    """The git-tree existence oracle mirrors check_link on a file listing."""
+
+    FILES = {"docs/a.md", "docs/sub/b.md", "README.md"}
+
+    def test_existing_file(self):
+        assert _link_exists_in_tree("./a.md", "docs/a.md", self.FILES,
+                                    _tree_dirs(self.FILES), None)
+
+    def test_missing_file(self):
+        assert not _link_exists_in_tree("./nope.md", "docs/a.md", self.FILES,
+                                        _tree_dirs(self.FILES), None)
+
+    def test_parent_traversal_inside_repo(self):
+        assert _link_exists_in_tree("../README.md", "docs/a.md", self.FILES,
+                                    _tree_dirs(self.FILES), None)
+
+    def test_directory_target(self):
+        assert _link_exists_in_tree("./sub/", "docs/a.md", self.FILES,
+                                    _tree_dirs(self.FILES), None)
+
+    def test_escaping_the_repo_is_broken(self):
+        assert not _link_exists_in_tree("../../outside.md", "docs/a.md", self.FILES,
+                                        _tree_dirs(self.FILES), None)
+
+    def test_html_needs_listed_notebook(self):
+        files = self.FILES | {"docs/nb.ipynb"}
+        dirs = _tree_dirs(files)
+        assert not _link_exists_in_tree("./nb.html", "docs/a.md", files, dirs, "")
+        assert _link_exists_in_tree("./nb.html", "docs/a.md", files, dirs,
+                                    '"docs/nb.ipynb"')
+
+    def test_submodule_path_is_valid(self, monkeypatch):
+        monkeypatch.setattr(check_docs_links, "SUBMODULE_PATHS", {"vendor/lib"})
+        assert _link_exists_in_tree("vendor/lib/x.py", "README.md", self.FILES,
+                                    _tree_dirs(self.FILES), None)
+
+
+class TestPreexistingBrokenAgainstRealGit:
+    """End-to-end: only links already broken at the base revision are excused."""
+
+    @staticmethod
+    def _git(root: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+            cwd=root, check=True, capture_output=True,
+        )
+
+    def _fixture(self, tmp_path: Path, monkeypatch) -> Path:
+        root = tmp_path / "repo"
+        (root / "docs").mkdir(parents=True)
+        self._git(root, "init", "-q")
+        # Base revision: one link whose target is already missing, one that works.
+        (root / "docs" / "present.md").write_text("# present\n", encoding="utf-8")
+        (root / "docs" / "a.md").write_text(
+            "[gone](./missing.md)\n[ok](./present.md)\n", encoding="utf-8")
+        self._git(root, "add", "-A")
+        self._git(root, "commit", "-q", "-m", "base")
+        # Head revision: unchanged a.md, plus a new file carrying a new broken link.
+        (root / "docs" / "b.md").write_text("[newgone](../nope.md)\n", encoding="utf-8")
+        self._git(root, "add", "-A")
+        self._git(root, "commit", "-q", "-m", "head")
+        monkeypatch.setattr(check_docs_links, "REPO_ROOT", root)
+        return root
+
+    def test_only_already_broken_links_are_excused(self, tmp_path, monkeypatch):
+        self._fixture(tmp_path, monkeypatch)
+        refs = [
+            LinkRef(source="docs/a.md", target="./missing.md", line=1, text="gone"),
+            LinkRef(source="docs/a.md", target="./present.md", line=2, text="ok"),
+            LinkRef(source="docs/b.md", target="../nope.md", line=1, text="newgone"),
+        ]
+        excused = preexisting_broken(refs, "HEAD~1")
+
+        assert excused == {("docs/a.md", "./missing.md")}
+        # The link whose target existed at base is a real regression now, and the
+        # file added by this branch has nothing to excuse it.
+        remaining = check_regression(ScanResult(broken=refs), {}, excused)
+        assert sorted(r.target for r in remaining) == ["../nope.md", "./present.md"]
+
+    def test_unreadable_revision_returns_none(self, tmp_path, monkeypatch):
+        self._fixture(tmp_path, monkeypatch)
+        refs = [LinkRef(source="docs/a.md", target="./missing.md", line=1, text="x")]
+        assert preexisting_broken(refs, "no-such-rev-15766") is None
+
+    def test_no_broken_refs_short_circuits(self, tmp_path, monkeypatch):
+        """Nothing broken at HEAD means no revision needs to be read at all."""
+        monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+        assert preexisting_broken([], "no-such-rev-15766") == set()
+
+    def test_scan_content_matches_scan_file(self, tmp_path, monkeypatch):
+        """The extracted scanner keeps the on-disk behaviour byte for byte."""
+        f = tmp_path / "x.md"
+        body = "# t\n\n[ok](./y.md)\n\n```\n[skip](./z.md)\n```\n"
+        f.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(check_docs_links, "REPO_ROOT", tmp_path)
+        from_file = scan_file(f)
+        from_content = scan_content(body, "x.md")
+        assert [(r.source, r.target, r.line) for r in from_file] == \
+               [(r.source, r.target, r.line) for r in from_content]
+        assert [r.target for r in from_content] == ["./y.md"]
 
 
 class TestSelfCheck:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15795

## Le defaut

`scripts/check_docs_links.py --check` n'excusait un lien casse que s'il figurait dans `scripts/tests/baseline_docs_links.json` — un fichier fige a `broken_links: []`. Or `--baseline`, le seul mode qui l'ecrit, **n'est appele par aucune automatisation** (ni workflow, ni cron, ni script). Consequence mesuree : un seul lien casse sur `main`, meme introduit par une PR **mergee**, est rapporte comme « REGRESSION » sur **toute PR ouverte**, et rougit trois checks d'un coup — `check-links`, `Always-on guards` (`Organes bloquants en echec : fastlane`) et `PR gate`.

Le rouge est vrai mais **mal attribue** : il ne dit rien sur la PR qu'il annote.

## La voie choisie, et pourquoi

L'issue proposait deux voies. C'est la **voie 1** (comparer a la base) qui est livree : elle supprime la **classe** de defaut, pas seulement l'instance, et elle est deja la forme des autres ratchets du depot (« Output-failure ratchet base vs PR », « Translation hot-drift base vs PR »).

La voie 2 (rafraichir la reference sur `main` par un cron) est **ecartee explicitement** : passer `broken_links` de 0 a 1 *cache* le lien casse au lieu de le reparer, piege que l'issue nomme elle-meme. Sans compter qu'un cron sur `main` ne rendrait toujours pas le verdict dependant de la PR.

## Ce que fait le correctif

- **`--check --base <ref>`** : lit l'arbre de la base (`git ls-tree -r`) et l'excuse les liens **deja casses la-bas**.
- Un lien n'est excuse que si les trois conditions tiennent : la source **existait** a la base, elle **portait la meme cible**, et cette cible **y manquait deja**. Donc restent detectees — et c'est le controle positif — un lien **ajoute** par la branche, et une cible que la branche **supprime** (le lien existait et resolvait a la base).
- **`scan_file` scinde** en `scan_content(content, rel_source)` + enveloppe : le meme scanner sert l'arbre de travail et un `git show <ref>:<path>`. Aucune duplication de la logique de scan (blocs de code, spans inline, `_is_valid_target`).
- L'oracle d'existence sur l'arbre `git` **mirroir de `check_link`** : traversal hors depot, sous-modules, cibles `html` generees par Quarto (notebook frere + `project.render`).
- Le **fichier fige garde son role** sur les voies ou aucune base n'est disponible (dispatch manuel, scan complet). Les deux excuses sont independantes et se cumulent.
- **Garde de voie rapide** `check-links` : passage a `--base {base_ref}` avec `needs_base=True`, la convention des gardes base-vs-head du depot. Le commentaire de `docs-link-check.yml` documente desormais l'ecart voulu entre les deux voies.

Le code de retour de `git` est inspecte **avant** de lire stdout : un clone partiel peut sortir non-zero en emettant un corps partiel, qui serait scanne comme s'il etait le fichier (#15387).

## Preuves

Instance vivante de l'issue — lien `MyIA.AI.Notebooks/IIT/ICT-Series/README.md:214 -> ICT-22b-CausalInterventionEngine.ipynb` (ajoute par #15752 MERGED, cible vivant dans la PR ouverte #15609), arbre `origin/main` propre :

```
$ python scripts/check_docs_links.py --check
REGRESSION: 1 new broken link(s):
  MyIA.AI.Notebooks/IIT/ICT-Series/README.md:214 -> ICT-22b-CausalInterventionEngine.ipynb
$ echo $?
1

$ python scripts/check_docs_links.py --check --base origin/main
OK: No new broken links. (1 pre-existing, 6845 total)
$ echo $?
0
```

Acceptance 2 — controle positif, un lien **neuf** injecte dans un fichier scanne :

```
$ python scripts/check_docs_links.py --check --base origin/main
REGRESSION: 1 new broken link(s):
  docs/reference/common-commands.md:84 -> ./NOPE-missing-target-15766.md

Excused: 0 from baseline + 1 already broken at origin/main.
$ echo $?
1
```

Acceptance 1 et 2 satisfaites. Acceptance 3 (le lien README lui-meme redevient valide) **n'est pas livree ici** : elle releve de #15609, et l'issue la decrit comme l'autre moitie — c'est pourquoi cette PR dit `See` et non `Closes`.

## Tests

`scripts/tests/test_check_docs_links.py` : **66 passent**, dont 9 neufs — excuse par la base, non-masquage d'un lien neuf, cumul baseline+base, semantique inchangee sans base, oracle d'arbre (fichier, traversal interne, traversal hors depot, cible repertoire, html/Quarto liste ou non, sous-module), et un scenario **git reel** en `tmp_path` (depot init + 2 commits) verifiant les trois verdicts d'un coup, plus la revision illisible qui rend `None`.

```
$ python -m pytest scripts/tests/test_check_docs_links.py -q
66 passed

$ python -m pytest scripts/tests/test_check_docs_links.py scripts/tests/test_fast_lane.py scripts/tests/test_fast_lane_merge_base.py -q
141 passed
```

`scripts/tests` est execute par `scripts-tests.yml` (declencheur `scripts/**`), donc ces tests tournent bien en CI.

## Perimetre

4 fichiers, 345 insertions / 38 suppressions : le checker, son test, la garde de voie rapide, et le commentaire du workflow absorbe. Catalogue byte-identique a `main` (non touche). Aucun notebook.

## Residuel, signale et non traite

- Le **lien README lui-meme** reste casse sur `main` jusqu'au merge de #15609. Cette PR rend le garde juste ; elle ne retire pas la cause.
- La **durabilite du fichier fige** : il n'est toujours ecrit par personne. Il ne sert plus que les voies sans base, donc il ne peut plus produire de faux rouge de PR — mais le jour ou un dispatch manuel tombera dessus avec un `main` casse, il dira « REGRESSION ». C'est le comportement voulu (pas de base a comparer), pas une dette a rembourser.

See #15766

🤖 Generated with [Claude Code](https://claude.com/claude-code)
