### PR TITLE
fix(semanticweb,#14817): neutraliser le stub IsValidJsonLd de SW-9 C#

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
@@ -121,7 +121,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -131,10 +130,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -149,7 +145,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -161,13 +156,11 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '33116.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '48836.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -211,13 +204,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -230,7 +221,7 @@
     {
      "data": {
       "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>dotNetRDF, 3.5.2</span></li></ul></div></div>"
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>dotNetRDF</span></li></ul></div><div></div></div>"
       ]
      },
      "metadata": {},
@@ -2438,13 +2429,13 @@
     "\n",
     "**Objectif** : Testez le parser avec un JSON-LD volontairement casse (par exemple, `@context` invalide, ou un triplet incoherent). Le parser doit lever une exception descriptive.\n",
     "\n",
-    "**Sortie attendue** :\n",
+    "**Sortie attendue** (une fois l'exercice complete) :\n",
     "```\n",
     "JSON-LD valide (cas correct): True\n",
-    "JSON-LD valide (cas casse): True  -- ou False selon le parser\n",
+    "JSON-LD valide (cas casse): False\n",
     "```\n",
     "\n",
-    "**Note** : la sortie observee pour ce notebook montre `True` pour les deux cas, ce qui suggere que le parser dotNetRDF est tolerant (ou que les cas casses ne sont pas assez severes).\n",
+    "**Sortie du stub non complete** : tant que `IsValidJsonLd` n'est pas implemente, la cellule emet le marqueur `Exercice a completer : IsValidJsonLd` puis `False` pour **les deux** cas -- y compris le JSON-LD correct. Ces deux `False` sont la valeur neutre du stub (`return false;` sous `# TODO etudiant`) : ils ne renseignent ni sur la tolerance de dotNetRDF ni sur la validite des documents, et ne doivent pas etre lus comme un verdict du parser.\n",
     "\n",
     "**Difficulte** : moyenne.\n",
     "\n",
@@ -2478,9 +2469,16 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : IsValidJsonLd\r\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "JSON-LD valide (cas correct): True"
+       "JSON-LD valide (cas correct): False"
       ]
      },
      "metadata": {},
@@ -2489,7 +2487,7 @@
     {
      "data": {
       "text/plain": [
-       "JSON-LD valide (cas casse): True"
+       "JSON-LD valide (cas casse): False"
       ]
      },
      "metadata": {},
@@ -2504,8 +2502,12 @@
     "public static bool IsValidJsonLd(string json)\n",
     "{\n",
     "    // TODO etudiant : retournez vrai si parsable, faux sinon\n",
-    "    return true;\n",
+    "    return false;\n",
     "}\n",
+    "// Stub non complete : `false` est une valeur neutre (indiscernable de \"pas fait\"),\n",
+    "// pas un verdict du parser -- les deux lignes ci-dessous ne renseignent donc pas\n",
+    "// sur la tolerance de dotNetRDF ni sur la validite des deux documents.\n",
+    "Console.WriteLine(\"Exercice a completer : IsValidJsonLd\");\n",
     "Show(\"JSON-LD valide (cas correct)\", IsValidJsonLd(\"{\\\"@id\\\":\\\"http://x.org/a\\\",\\\"@type\\\":\\\"http://x.org/T\\\",\\\"http://x.org/name\\\":\\\"foo\\\"}\"));\n",
     "Show(\"JSON-LD valide (cas casse)\", IsValidJsonLd(\"{ce n'est pas du json}\"));\n"
    ]
@@ -2526,18 +2528,19 @@
    "source": [
     "### Lecture de l'exercice 3 (stub) (ancre sur code[10])\n",
     "\n",
-    "La sortie verbatim de code[10] montre les resultats du test :\n",
+    "La sortie verbatim de code[10] montre le marqueur du stub, puis les deux verdicts :\n",
     "```\n",
-    "JSON-LD valide (cas correct): True\n",
-    "JSON-LD valide (cas casse): True\n",
+    "Exercice a completer : IsValidJsonLd\n",
+    "JSON-LD valide (cas correct): False\n",
+    "JSON-LD valide (cas casse): False\n",
     "```\n",
     "\n",
-    "Le parser dotNetRDF est plutot tolerant : meme le cas casse retourne `True` (probablement parce que le cas casse n'est pas assez severe).\n",
+    "Ces deux `False` sont la **valeur neutre du stub** (`return false;` sous `# TODO etudiant`), pas un resultat du parser : la fonction n'appelle encore ni `LoadJsonLd` ni `try/catch`. La sortie ne dit donc **rien** de la tolerance de dotNetRDF -- elle dit seulement que l'exercice n'est pas fait, et le `False` affiche sur le cas correct est precisement le signe que rien n'est encore implemente. Apres completion, l'attendu est `True` pour le cas correct et `False` pour le cas casse.\n",
     "\n",
-    "**Pour implementer cet exercice plus strictement** :\n",
-    "1. Creer un document JSON-LD clairement invalide (par exemple, `@context` avec un term mal forme).\n",
-    "2. Utiliser un wrapper qui catch `RdfParseException` et leve une exception explicite.\n",
-    "3. Logger le contexte de l'erreur (line, column, etc.).\n",
+    "**Pour implementer cet exercice** :\n",
+    "1. Encapsuler l'appel de parsing (`LoadJsonLd` / `JsonLdParser.Load`) dans un `try/catch`.\n",
+    "2. Retourner `false` dans le `catch` (`RdfParseException` ou `JsonReaderException`) et `true` apres un `Load` reussi.\n",
+    "3. Logger le contexte de l'erreur (line, column, etc.) pour un diagnostic utile.\n",
     "\n",
     "**Code attendu** :\n",
     "```csharp\n",
@@ -2561,7 +2564,7 @@
     "Console.WriteLine($\"Cas casse: {ValidateJsonLd(invalidJson)}\");\n",
     "```\n",
     "\n",
-    "**Note de portee** : pour une validation stricte, preferer SHACL shapes (cf. SW-8) qui permettent de definir des regles structurelles (Cardinality, Datatype, Pattern)."
+    "**Note de portee** : pour une validation stricte, preferer SHACL shapes (cf. SW-8) qui permettent de definir des regles structurelles (Cardinality, Datatype, Pattern).\n"
    ]
   },
   {
@@ -2596,18 +2599,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 6.268952,
-   "end_time": "2026-09-07T22:46:33.701457+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "SW-9-CSharp-JSONLD.ipynb",
-   "output_path": "SW-9-CSharp-JSONLD.ipynb",
-   "parameters": {},
-   "start_time": "2026-09-07T22:46:27.432505+00:00",
-   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelName": "csharp"

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld/0009-2026-09-12-myia-po-2025-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld/0009-2026-09-12-myia-po-2025-CoursIA.yaml
@@ -1,0 +1,6 @@
+date: '2026-09-12'
+by: myia-po-2025:CoursIA
+python_sha: da3142efa2d665de3f50baf1c96b0f33f3eceeda
+csharp_sha: df70143332491ece1c9f89b859824257dd4a3a25
+content_python_sha: 988c346b165ddef55e1cd0e7a5f55655d4403abb7fef9fc3dbf359387f2b5f1d
+content_csharp_sha: 69a4ce7ebed2b0f7d7f62bd4d5e4e3104fccabcc072265671303b07828af7869


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python #15797

## Résumé

Corrige le résidu C# SW-9 de la classe #14817 sans résoudre l’exercice étudiant : `IsValidJsonLd` retournait `true` en dur, si bien que la sortie commitée présentait le JSON-LD correct **et** le JSON volontairement cassé comme valides alors que le parser n’était jamais appelé.

- remplace l’affirmation `return true;` par la valeur neutre `return false;` requise par la forme booléenne C# ;
- imprime `Exercice a completer : IsValidJsonLd` avant les deux verdicts ;
- corrige l’énoncé et la lecture pour ne plus attribuer `True / True` à une tolérance de dotNetRDF ;
- conserve le `TODO` et l’indice `try/catch` autour de `LoadJsonLd` / `JsonLdParser.Load` ;
- ré-exécute intégralement le notebook avec .NET Interactive, puis retire uniquement les bannières `probeAddresses` avec l’outil canonique ;
- régénère l’attestation twin en dernier commit.

See #14817

## Sortie réelle après exécution

```text
Exercice a completer : IsValidJsonLd
JSON-LD valide (cas correct): False
JSON-LD valide (cas casse): False
```

Le couple `False / False` est explicitement présenté comme le résultat neutre du stub non complété. Il ne constitue un verdict ni sur la validité des deux entrées ni sur la tolérance du parser. Après implémentation par l’étudiant, l’attendu documenté reste `True` pour le JSON-LD correct et `False` pour le cas cassé.

## Preuve d’exécution — EXEC_PROVED

Commande canonique utilisée :

```text
python scripts/notebook_tools/exec_dotnet_persist.py MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb 300
python scripts/notebook_tools/strip_probe_banner.py --apply MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
```

Résultat vérifié sur le HEAD publié :

- 34 cellules au total, nombre inchangé ;
- 11 cellules `.net-csharp` ;
- `execution_count` exactement `1..11` ;
- 0 sortie `error` ;
- 0 occurrence `probeAddresses` ;
- `validate_pr_notebooks.py origin/main <notebook>` : **1/1 PASS**, 11 cellules contrôlées ;
- blob notebook : `df70143332491ece1c9f89b859824257dd4a3a25`.

## Contrôles C.1 / C.2 / C.3 et anti-régression

- `detect_stub_truth_returns.py --self-check` : **16/16 PASS** ;
- scan du notebook cible : **0 stub fautif** ;
- `count_exercises.py` : **5 exercices**, seuil minimal 3 satisfait ;
- sortie-failure ratchet : **1 notebook changé, 0 régression** ;
- output-collapse ratchet : **0 finding** ;
- source/output ratchet : **0 cellule stale** ;
- execution-count ratchet : **CLEAN -> CLEAN**, 0 régression ;
- papermill ratchet : **BLOCK_REMOVED**, 0 régression ;
- `git diff --check origin/main..HEAD` : PASS ;
- catalogues générés : byte-identiques à `origin/main`.

## Attestation twin

L’attestation a été produite par `check_twin_parity.py --update --pair "SW-9 JSON-LD" --by "myia-po-2025:CoursIA"` après l’exécution et le strip autorisé, puis commitée séparément et en dernier.

- `python_sha` inchangé : `da3142efa2d665de3f50baf1c96b0f33f3eceeda` ;
- `csharp_sha` attesté : `df70143332491ece1c9f89b859824257dd4a3a25` ;
- contrôle par paire : `[OK] SW-9 JSON-LD`, `base=OK`, `head=OK`, `INTRO=0` ;
- trois dérives globales (`Probas-16`, `SW-2`, `SW-7`) sont préexistantes (`DRIFT-PRE`) et hors périmètre.

## Diagnostic dérive

**Cause : (b) affirmation antérieure fabriquée par le stub.** Le parser n’était jamais invoqué : `return true;` produisait honnêtement l’output `True / True`, mais cet output était ensuite interprété à tort comme une observation de dotNetRDF.

**Verdict : CAUSE_FIXED.** La valeur affirmative disparaît, le marqueur précède les verdicts et la prose distingue désormais explicitement le résultat neutre du stub d’un résultat du parser. L’exercice reste volontairement non résolu et C.1-safe.

## Périmètre

Deux fichiers seulement :

1. `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb` ;
2. `scripts/notebook_tools/twin_pairs.d/sw-9-json-ld/0009-2026-09-12-myia-po-2025-CoursIA.yaml`.

Deux commits ordonnés : notebook exécuté d’abord, attestation twin ensuite et en dernier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
