### PR TITLE
docs(genai,#15290): residuel H06 — README Environment/Audio alignés sur COMFYUI_API_TOKEN

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
@@ -38,7 +38,7 @@ Ce module configure l'environnement technique avant toute exploration GenAI. Les
 |--------|--------|
 | Python | 3.10+ avec dépendances (`pip install -r requirements.txt`) |
 | Docker Desktop | v29.5+ recommandé pour les notebooks GPU |
-| Clés API | `.env` dans `GenAI/` : `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `COMFYUI_BEARER_TOKEN` |
+| Clés API | `.env` dans `GenAI/` : `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `COMFYUI_API_TOKEN` |
 | GPU | Optionnel pour ce module, requis pour les sous-domaines Image/Audio/Video |
 
 ## FAQ
@@ -52,7 +52,8 @@ Le notebook [00-1-Environment-Setup](00-1-Environment-Setup.ipynb) configure les
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
 OPENROUTER_API_KEY=sk-or-v1-...
-COMFYUI_BEARER_TOKEN=...
+COMFYUI_API_TOKEN=...
+# COMFYUI_AUTH_TOKEN est un alias synchronisé : même valeur que COMFYUI_API_TOKEN.
 ```
 
 Points fréquents :

--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -284,8 +284,8 @@ docker ps | grep -E "whisper|kokoro|musicgen"
 # Redémarrer un service spécifique
 cd docker-configurations && docker compose restart whisper-api kokoro-tts
 
-# Vérifier le bearer token (drift bcrypt)
-cat GenAI/.env | grep COMFYUI_BEARER_TOKEN
+# Vérifier le bearer token (drift bcrypt) — COMFYUI_API_TOKEN (principal), COMFYUI_AUTH_TOKEN (alias)
+grep -E '^(COMFYUI_API_TOKEN|COMFYUI_AUTH_TOKEN)=' GenAI/.env
 ```
 
 Les notebooks ont une **graceful degradation** : sans token, ils basculent vers les APIs cloud (OpenAI TTS/Whisper).


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2024:CoursIA — prev: LIGHT/docs #15735

See #15290

## Résiduel H06 non suivi : deux README prescrivent encore `COMFYUI_BEARER_TOKEN`

Le fix merge #15307 (decision canonique : `COMFYUI_API_TOKEN` clee maitresse, `COMFYUI_AUTH_TOKEN` alias synchronise) a aligne le README Image, et #15673 / PR #15730 suivent le README racine. Mais l'enumeration des residus de #15307 **omet deux sites vivants**, mesures firsthand sur `origin/main` = `8e3d077e02` :

| Fichier | Site | Defaut |
|---|---|---|
| `00-GenAI-Environment/README.md` | L41 (table prerequis) + L55 (bloc FAQ `.env`) | Le **guide d'installation** — la premiere chose qu'un etudiant ouvre — prescrit la variable morte. Le template FAQ montre `COMFYUI_BEARER_TOKEN=...` |
| `Audio/README.md` | L288 (depannage) | Le meme grep-de-reassurance que le defaut P0 d'origine : `cat GenAI/.env \| grep COMFYUI_BEARER_TOKEN` rend le vide, indiscernable d'un secret non configure |

Pourquoi l'audit initial les a rates : sa mesure portait sur `*.py` et `*.ipynb` (code), pas sur l'ensemble des README de la serie.

## Changements

Application mecanique de la decision deja tranchee par #15307, meme motif que le README Image :

- Table L41 : `COMFYUI_BEARER_TOKEN` -> `COMFYUI_API_TOKEN`
- Bloc FAQ L55 : `COMFYUI_API_TOKEN=...` + ligne documentant l'alias synchronise (mirroir de `Image/README.md:173`)
- Audio L287-288 : le grep passe a `grep -E '^(COMFYUI_API_TOKEN\|COMFYUI_AUTH_TOKEN)='` (mirroir de `Image/README.md:267-268`)

2 fichiers, +5/-4. Aucune valeur de secret.

## Validation

- `grep -c COMFYUI_BEARER_TOKEN` sur les 2 fichiers : **0 / 0**
- `python scripts/check_docs_links.py` : scanned 702 files, 6845 links — aucune regression introduite (l'unique lien casse rendu est preexistant, hors diff, voir ci-dessous)
- `git diff --check` : OK

## Decouvert hors scope (signale, non fixe ici)

`check_docs_links.py` rend un lien casse preexistant : `MyIA.AI.Notebooks/IIT/ICT-Series/README.md:214 -> ICT-22b-CausalInterventionEngine.ipynb` (introuvable). Aucun rapport avec ce diff — a traiter en grain separe.

## Residuel restant (inchange, liste exacte dans #15307)

Le lecteur fallback legacy du notebook Video 03-3 et les mentions `.claude/` restent hors de ce grain, comme #15307 les a laisses : lecteur tolerant, pas prescription etudiante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
