### PR TITLE
fix(guard,#15309): les invariants prev: s'évaluent sur le body seul (4e axe)

### DIFF
--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -425,7 +425,10 @@ def check(
     Pure function so unit tests pin each branch without going through the
     CLI. ``commits`` is the list of commit message strings on the branch
     (the workflow fetches them via ``gh pr view --json commits``); each is
-    scanned independently so the verdict can name which commit offended.
+    scanned independently so the verdict can name which commit offended --
+    **for close-keywords only**. Les invariants ``prev:`` lisent le body
+    seul (#15309 4e axe : le message de commit n'est pas une surface
+    declarative, et le corriger exige une reecriture d'historique).
 
     ``current_pr`` is the number of the PR carrying the tag -- required to
     evaluate PREV-SELF (invariant 1). ``prev_targets`` is the JSON the
@@ -443,31 +446,25 @@ def check(
         for h in gt.find_prev_close_keywords(msg):
             hits_commits.append({"commit_index": i, **h})
 
-    # (b) invalid `prev:` PR reference (#13475 invariants 1-3).
+    # (b) invalid `prev:` PR reference (#13475 invariants 1-3) -- body ONLY.
+    # #15309 4e axe : un message de commit n'est pas une surface declarative
+    # -- variation-protocol.md §1 place la declaration dans le [CLAIMED] et
+    # le body de PR. Un `prev:` errone dans un commit ne se repare par aucun
+    # geste que le protocole autorise par defaut : il faut reecrire
+    # l'historique, que git-workflow.md presente comme le dernier recours.
+    # Un garde n'exige pas, pour etre satisfait, un geste que la regle
+    # voisine decourage. La surface commits garde son role pour les
+    # close-keywords ci-dessus : la, la surface EST le mecanisme (#10093).
     hits_prev_invalid: list[dict] = []
-    # PREV-SELF -- body + every commit. The current_pr is constant across
-    # all locations; a self-reference in a commit message is the same defect
-    # as one in the body, and we name the slot so the failure is debuggable.
+    # PREV-SELF -- body seul.
     hits_prev_invalid.extend(
         {"location": "body", "kind": "prev-self", "prev_pr": h["prev_pr"]}
         for h in find_prev_self_references(body, current_pr)
     )
-    for i, msg in enumerate(commits or []):
-        hits_prev_invalid.extend(
-            {"location": f"commits[{i}]", "kind": "prev-self",
-             "prev_pr": h["prev_pr"]}
-            for h in find_prev_self_references(msg, current_pr)
-        )
-    # PREV-ABANDONED + PREV-NOT-PR -- body + every commit. Each location
-    # gets its own target list because the body and each commit carry
-    # independent `prev:` clauses; aggregating them would mix concerns.
+    # PREV-ABANDONED + PREV-NOT-PR -- body seul.
     body_targets = find_prev_target_pr_numbers(body)
     hits_prev_invalid.extend(validate_prev_targets(
         body_targets, prev_targets, location="body"))
-    for i, msg in enumerate(commits or []):
-        commit_targets = find_prev_target_pr_numbers(msg)
-        hits_prev_invalid.extend(validate_prev_targets(
-            commit_targets, prev_targets, location=f"commits[{i}]"))
 
     if not hits_body and not hits_commits and not hits_prev_invalid:
         return {"guard_pass": True,

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -150,9 +150,18 @@ def test_prev_self_reference_blocks():
                for h in v["hits"]["prev_invalid"])
 
 
-def test_prev_self_in_commit_message_blocks():
-    # The #10093 precedent says commit messages are in scope (squash-merge
-    # publishes them). A PREV-SELF in a commit must be flagged the same way.
+def test_prev_self_in_commit_message_does_not_block():
+    # INVERSE depuis #15309 (4e axe, arbitrage ai-01 2026-09-12T03:36Z) : les
+    # invariants `prev:` s'evaluent sur le BODY SEUL, la surface declarative
+    # du §1 de variation-protocol.md. Le precedent #10093 (squash-merge
+    # publie les messages de commit) reste valable pour les CLOSE-KEYWORDS --
+    # la, la surface est le mecanisme -- mais pas pour `prev:` : corriger un
+    # `prev:` de commit exige une reecriture d'historique, le geste que
+    # git-workflow.md presente comme dernier recours. Un garde n'exige pas,
+    # pour etre satisfait, un geste que la regle voisine decourage.
+    # Ce test etait l'assertion inverse (commits[1] prev-self bloquant)
+    # avant #15309 ; il epingle desormais la non-remontee de la surface
+    # commits, et le maintien du blocage cote body.
     commits = [
         "feat: normal commit",
         "Grain: MED/refactor -- prev: MED/refactor #13473",
@@ -166,7 +175,7 @@ def test_prev_self_in_commit_message_blocks():
     assert v["guard_pass"] is False
     kinds_by_loc = {(h["location"], h["kind"]) for h in v["hits"]["prev_invalid"]}
     assert ("body", "prev-self") in kinds_by_loc
-    assert ("commits[1]", "prev-self") in kinds_by_loc
+    assert not any(loc.startswith("commits[") for loc, _ in kinds_by_loc)
 
 
 def test_prev_self_abstains_when_current_pr_unknown():
@@ -851,26 +860,66 @@ def test_multiline_backticked_citation_in_commit_passes_full_guard():
     assert v["guard_pass"] is True
     assert v["hits"]["prev_invalid"] == []
 
-    # TEETH CONTROL: the SAME wrapped clause WITHOUT backticks is a bare
-    # `prev:` declaration in a commit -- it must still block (the regex
-    # matches across the soft line break via ``\\s*``). This is what makes
-    # the two tests above fail on the pre-#14700 regex (`` `[^`\\n]*` ``):
-    # back then the L5 half ``#14592`` escaped the mask and this exact
-    # block fired. If the mask ever regresses, the pair above goes red
-    # while this one stays red-but-expected -- remove it and the suite
-    # loses its proof that the pass was earned.
-    commit_bare_wrapped = (
-        "fix(guard): stray declaration\n"
+    # TEETH CONTROL, deplace sur la surface BODY par #15309 (4e axe,
+    # arbitrage ai-01 2026-09-12T03:36Z) : la meme clause nue SANS
+    # backticks, dans le BODY cette fois, doit toujours bloquer -- la
+    # surface ou les invariants `prev:` s'evaluent desormais. Avant
+    # #15309, ce controle etait joue sur ``commits[0]`` ; la prescription
+    # a retire la surface commits des invariants prev: (corriger un
+    # message de commit exige une reecriture d'historique), donc la
+    # preuve que le vert est MERITE par le masque se joue maintenant
+    # cote body : si le masque regressait (regex `` `[^`\\n]*` `` de
+    # pre-#14700), le ``#14592`` fuiterait du code span et ce bloc
+    # rougirait.
+    body_with_bare_wrapped = (
+        "Grain: LIGHT/refactor -- lane myia-po-2026:CoursIA "
+        "-- prev: LIGHT/refactor #13826\n"
         "\n"
         "1. text with prev: MED/training\n"
         "#14592 outside any backticks.\n"
     )
-    v = vpg.check(CLEAN_PREV_BODY, [commit_bare_wrapped],
+    v = vpg.check(body_with_bare_wrapped, [],
                   current_pr=14703, prev_targets=targets)
     assert v["guard_pass"] is False
     assert any(h["kind"] == "prev-abandoned" and h["prev_pr"] == 14592
-               and h["location"] == "commits[0]"
+               and h["location"] == "body"
                for h in v["hits"]["prev_invalid"])
+
+
+def test_stale_commit_prev_cannot_veto_a_valid_body_15303():
+    # #15309 4e axe -- le controle positif d'ai-01, rejoue : au head
+    # ``1c2f8b7af9`` de #15303, ``--body-file`` seul rend guard_pass=True
+    # (prev: DEEP/lean #15082, PR MERGED) et l'ajout de ``--commits-file``
+    # rendait guard_pass=False sur ``commits[0]``, qui porte une
+    # declaration ANTERIEURE pointant #15288 (une ISSUE). La correction
+    # dans la surface declarative (le body) doit SUFFIRE : un message de
+    # commit n'est pas une surface declarative, et la lane ne peut pas
+    # l'editer sans reecrire l'historique.
+    targets = {
+        "15082": {"kind": "pr", "state": "MERGED", "merged": True},
+        "15288": {"kind": "issue"},
+    }
+    body = ("Grain: DEEP/lean -- lane myia-po-2024:CoursIA-2 "
+            "-- prev: DEEP/lean #15082")
+    stale_commit = (
+        "feat(lean): premiere tranche\n"
+        "\n"
+        "Grain: CONTENU/lean -- lane myia-po-2024:CoursIA-2 "
+        "-- prev: MED/lean #15288\n"
+    )
+    v = vpg.check(body, [stale_commit], current_pr=15303,
+                  prev_targets=targets)
+    assert v["guard_pass"] is True
+    assert v["hits"]["prev_invalid"] == []
+    # Controle negatif de la prescription : la meme declaration dans le
+    # BODY rougit toujours -- c'est exactement ce que #13475 voulait
+    # attraper, et le retrait de la surface commits ne l'atteint pas.
+    v2 = vpg.check(body.replace("#15082", "#15288"), [],
+                   current_pr=15303, prev_targets=targets)
+    assert v2["guard_pass"] is False
+    assert any(h["kind"] == "prev-not-pr" and h["prev_pr"] == 15288
+               and h["location"] == "body"
+               for h in v2["hits"]["prev_invalid"])
 
 
 # --- #14550, second defect: a silent fail-open is an unearned attestation ----


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA — prev: MED/notebook-lean #15626

See #15309 — **4e axe**, mesuré et prescrit par ai-01 le 2026-09-12T03:36Z ; la prescription est exécutée telle quelle, y compris ses deux contrôles. Claim : [commentaire d'issue](https://github.com/jsboige/CoursIA/issues/15309#issuecomment-5647786558) (18:17Z, avec `paths:`).

## Le défaut (la mesure d'ai-01, qui bloquait #15303)

Au head `1c2f8b7af9` de #15303, l'invocation complète du garde rendait :

```
--body-file seul                -> guard_pass: true,  prev_targets_accepted: [15082]
--body-file + --commits-file    -> guard_pass: false, prev-not-pr -> [15288] sur commits[0]
```

Le **body** était correct (`prev: DEEP/lean #15082`, PR MERGED de la même lane) ; ce qui rougissait était `commits[0]`, qui porte une déclaration **antérieure** pointant #15288 (une issue). La lane a corrigé sa déclaration là où le protocole lui demande de l'écrire (§1 de `variation-protocol.md` : le `[CLAIMED]` et le body de PR) — et le garde continuait de lire l'ancienne sur une surface qu'elle ne peut plus atteindre sans `--amend` + `--force-with-lease`, le geste que `git-workflow.md` présente comme dernier recours.

## Le changement (mécanique, borné)

`check()` distingue ses surfaces par invariant :

- invariants `prev:` (`prev-self`, `prev-abandoned`, `prev-not-pr`, `prev-not-merged`) → **body seul** ;
- close-keywords → **body + commits, inchangé** — là, la surface *est* le mécanisme (#10093 : GitHub ferme réellement une issue depuis un message de commit).

Concrètement : la boucle `for i, msg in enumerate(commits or [])` cesse d'alimenter `hits_prev_invalid` (deux occurrences : PREV-SELF et PREV-ABANDONED/PREV-NOT-PR). La boucle close-keywords ne bouge pas. Diff : 2 fichiers, +80/−34.

## Preuves

- **Contrôle positif, rejoué sur les données réelles de #15303** (body + commits[0] récupérés via l'API au head courant, cibles passées en `--prev-targets-file` — la résolution `gh` étant momentanément limitée en quota) :

```
$ python scripts/ci/variation_prev_guard.py --body-file b15303.txt \
    --commits-file c15303.json --current-pr 15303 --prev-targets-file t15303.json
{"guard_pass": true, "reason": "no prev: defect (close-keyword or invalid ref)",
 "hits": {"body": [], "commits": [], "prev_invalid": []},
 "prev_targets_accepted": [15082]}
```

  #15303 passe **sans que son historique soit réécrit** — c'est le contrôle positif nommé par la prescription. Avant le fix, cette invocation exacte rendait `prev-not-pr -> [15288]` sur `commits[0]` (mesure d'ai-01).

- **Contrôle négatif** (nouveau test `test_stale_commit_prev_cannot_veto_a_valid_body_15303`) : le même `#15288` déclaré **dans le body** rougit toujours (`prev-not-pr`, location `body`) — c'est ce que #13475 voulait attraper, et le retrait de la surface commits ne l'atteint pas.
- **Suite** : `51 passed` (50 avant + 1 nouveau ; 2 tests réécrits en sens inverse et ancrés sur l'arbitrage : `test_prev_self_in_commit_message_*` et le teeth control #14700, déplacé sur la surface body où il garde sa fonction de preuve — le vert du masque reste gagné, démontré désormais côté body).
- Les tests de close-keywords sur commits sont inchangés et passent (la surface commits garde son rôle pour (a)).

## Ce que ce grain n'est pas

- Pas un retrait du scan des commits : il porte les close-keywords (#10093).
- Pas une couverture élargie de la zone silencieuse : la déclaration **déclarative** reste intégralement vérifiée ; seule la lecture d'une surface non déclarative cesse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
