### PR TITLE
feat(ict,#15481): POC S-Lens — self-location, jambe causale appariée, gate de promotion (verdict INCONCLUSIVE)

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -107,10 +107,20 @@ jobs:
           # Floor 692 -> 715 : +23 items du POC S-Lens (bancs copy_offset /
           # variable_binding, oracles, probes, agregation multi-runs ;
           # #15481, ict/tests/test_slens.py = 43e strate du package).
+          # Floor 715 -> 719 : +4 items verrouillant les defauts corriges apres
+          # la premiere mesure (recodage des classes de valeur sur un
+          # vocabulaire non dense, verdict causal qui n'etiquete plus un effet
+          # absent comme dommage global, run d'ablation exclu du gate de
+          # stabilite, architecture de reference absente refusee au lieu d'etre
+          # devinee). Mesure locale `pytest ict/tests --collect-only -q` : 719.
+          # Floor 719 -> 720 : +1 item saturant le ratio de selectivite — hors
+          # cible sous le plancher de mesure = inf (jamais on_rel/eps, une
+          # magnitude artefact de la constante interne), intervention sans
+          # effet = 0.0 (jamais selective).
           - suite-name: "ict/tests/ (43 package)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests
             test-args: .
-            test-floor: 715
+            test-floor: 720
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -104,10 +104,13 @@ jobs:
           # (sys.path.insert module-level ignore sous importlib).
           # Floor 670 -> 692 : +22 items coeur numpy du moteur causal
           # (#15479 tranche 1, ict/tests/test_causal_engine.py).
-          - suite-name: "ict/tests/ (42 package)"
+          # Floor 692 -> 715 : +23 items du POC S-Lens (bancs copy_offset /
+          # variable_binding, oracles, probes, agregation multi-runs ;
+          # #15481, ict/tests/test_slens.py = 43e strate du package).
+          - suite-name: "ict/tests/ (43 package)"
             test-cwd: MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests
             test-args: .
-            test-floor: 692
+            test-floor: 715
 
     steps:
       - uses: actions/checkout@v4

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-38-SLens-SelfLocation.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-38-SLens-SelfLocation.ipynb
@@ -1,0 +1,1447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "df8e8c1a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003246,
+     "end_time": "2026-09-12T18:30:37.908098",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:37.904852",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# ICT-38 — S-Lens : la représentation porte-t-elle la bonne référence ?\n",
+    "\n",
+    "*Self-Location Lens — bancs synthétiques à vérité terrain exacte, lecture par tête et intervention causale appariée*\n",
+    "\n",
+    "**Strate 5, GPU-required, POC expérimental.** Ce notebook instrumente une question étroite et\n",
+    "vérifiable : quand un modèle doit produire une valeur qui se trouve **à une position déterminée par\n",
+    "le contenu** (et non par la position absolue du token), porte-t-il à l'intérieur de lui-même la\n",
+    "**référence** — la bonne position, la bonne source, la bonne liaison — ou seulement une corrélation\n",
+    "de surface qui suffit sur le banc d'entraînement ?\n",
+    "\n",
+    "La lentille est un **quatrième instrument** candidat du toolkit ICT (#15475), après SAE, J-Lens et\n",
+    "F-Lens. Elle ne rejoint le toolkit public que si elle franchit un **gate de promotion** explicite\n",
+    "(§ 6). Le présent notebook est le POC ; il ne crée aucune API publique.\n",
+    "\n",
+    "**Statut contractuel, dit sans détour.** L'énumération `INSTRUMENTS` du contrat de trace v1\n",
+    "(`sae`, `jlens`, `jlens_trackp`) ne connaît **pas** `slens` : les manifestes produits ici sont\n",
+    "POC-locaux et `ict.trace_contract.validate_manifest` les **refuse** — c'est vérifié en § 3. Ajouter\n",
+    "`slens` au contrat est une étape *post-promotion*, pas un préalable que ce notebook se permettrait."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb9a3b49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002221,
+     "end_time": "2026-09-12T18:30:37.914494",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:37.912273",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Ce que fait ce notebook\n",
+    "\n",
+    "1. **§ 1** — le banc `copy_offset` : l'offset est dans le contenu, la cible est à une position qui\n",
+    "   en dépend ; distribution de vérité terrain **exacte**.\n",
+    "2. **§ 2** — l'oracle valide le générateur, **jamais l'inverse**.\n",
+    "3. **§ 3** — sonde linéaire (ridge forme fermée), métriques *hors échantillon*, et surtout le\n",
+    "   **plancher de shuffle** que toute affirmation de localisation doit dépasser.\n",
+    "4. **§ 4** — entraînement **réel** d'un micro-transformer sous trois régimes de position, puis\n",
+    "   lecture de la self-location par couche et par tête.\n",
+    "5. **§ 5** — jambe causale : échange apparié (interchange) avec sham et cible aléatoire, et mesure\n",
+    "   de dommage **hors du cône causal** de l'intervention.\n",
+    "6. **§ 6** — la matrice complète (26 runs : 2 bancs × 3 régimes, 5 graines\n",
+    "   sur le régime de référence) lue depuis `runs/slens_matrix.json`, puis le **verdict de promotion**.\n",
+    "\n",
+    "Les runs sont reproductibles par une commande unique — `python scripts/slens_poc.py --task <t>\n",
+    "--arch <a> --seed <s> --stage full --out traces/slens_<t>_<a>_s<s>.npz` — écrite dans le manifeste\n",
+    "de la matrice. Les npz bruts pèsent environ 1,2 Mio pièce (26 fichiers, ~31 Mio au\n",
+    "total) et restent **locaux** : l'artefact committé est la matrice agrégée, qui porte la\n",
+    "spécification complète de chaque run (banc, régime, graine, étape) et la commande de régénération —\n",
+    "un run est donc reconstructible, mais la preuve committée reste l'agrégat, pas le tenseur brut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e2697ce8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:37.920562Z",
+     "iopub.status.busy": "2026-09-12T18:30:37.920183Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.467125Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.466602Z"
+    },
+    "papermill": {
+     "duration": 3.551248,
+     "end_time": "2026-09-12T18:30:41.467976",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:37.916728",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "racine     : ICT-Series\n",
+      "device     : cuda\n",
+      "n_tokens   : 14   vocab : 29\n",
+      "instruments du contrat v1 : ('sae', 'jlens', 'jlens_trackp')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import json\n",
+    "import math\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "ROOT = Path.cwd()\n",
+    "while not (ROOT / \"ict\" / \"slens.py\").exists() and ROOT != ROOT.parent:\n",
+    "    ROOT = ROOT.parent\n",
+    "sys.path.insert(0, str(ROOT))\n",
+    "sys.path.insert(0, str(ROOT / \"scripts\"))\n",
+    "\n",
+    "from ict import slens, trace_contract  # noqa: E402\n",
+    "import slens_poc  # noqa: E402\n",
+    "\n",
+    "DEVICE = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "CFG = slens.CopyOffsetConfig(seq_values=12, n_symbols=16)\n",
+    "\n",
+    "# le nom seul, jamais le chemin absolu : la racine discoverte depend de la\n",
+    "# machine qui execute (worktree isole ou arbre partage), et une sortie\n",
+    "# committee doit rester identique quel que soit l'endroit ou elle a couru.\n",
+    "print(f\"racine     : {ROOT.name}\")\n",
+    "print(f\"device     : {DEVICE}\")\n",
+    "print(f\"n_tokens   : {CFG.n_tokens}   vocab : {CFG.vocab_size}\")\n",
+    "print(f\"instruments du contrat v1 : {trace_contract.INSTRUMENTS}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbdeb62f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002482,
+     "end_time": "2026-09-12T18:30:41.472982",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.470500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le banc `copy_offset` : l'offset est dans le contenu, pas dans la position\n",
+    "\n",
+    "Une séquence est construite ainsi :\n",
+    "\n",
+    "```\n",
+    "[ v_0  v_1  ...  v_{L-1}   OFF(k)   Q ]\n",
+    "```\n",
+    "\n",
+    "`OFF(k)` est un token dont le **contenu** encode l'entier `k`. La question `Q` demande de recopier la\n",
+    "valeur située à `k` positions de la fin du bloc : la cible est `v_{L-k}`, à la **position** `L-k`.\n",
+    "\n",
+    "Le point crucial est là : la position de la réponse n'est écrite nulle part comme position. Elle est\n",
+    "une **fonction du contenu** du token d'offset (`L - k`). Un modèle qui se contente d'indexer des\n",
+    "positions apprises ne peut donc pas répondre — il doit *lire* `k`, *calculer* `L - k`, puis\n",
+    "*aller chercher* `v_{L-k}`. C'est exactement le régime où la notion de **self-location** a un sens\n",
+    "opérationnel : si la représentation interne ne porte pas la référence, la copie échoue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6b0b239d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.478675Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.478389Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.483721Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.483270Z"
+    },
+    "papermill": {
+     "duration": 0.008983,
+     "end_time": "2026-09-12T18:30:41.484370",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.475387",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "positions :   0    1    2    3    4    5    6    7    8    9   10   11   12   13\n",
+      "              13   10    8    4    4    0    1    0    2   13   10   14   21   28    -> offset k= 6  cible v= 1 a la position 6\n",
+      "               8    9   15   11   10    8    8   14    4   13   10    0   21   28    -> offset k= 6  cible v= 8 a la position 6\n",
+      "               6   13    8    0   12   11   13    2    1   13    0    8   24   28    -> offset k= 9  cible v= 0 a la position 3\n",
+      "               1    4    7    6    6    0    0    1    0   10    8   10   26   28    -> offset k=11  cible v= 4 a la position 1\n",
+      "               4    9   12    6    7   15   12   15    6   10   15   10   16   28    -> offset k= 1  cible v=10 a la position 11\n",
+      "              13   11   11    6   14    2    9   11   13    8    6    4   27   28    -> offset k=12  cible v=13 a la position 0\n",
+      "\n",
+      "distribution exacte de la position cible (offsets 1..L uniformes) :\n",
+      "  p0=0.0833  p1=0.0833  p2=0.0833  p3=0.0833  p4=0.0833  p5=0.0833  p6=0.0833  p7=0.0833  p8=0.0833  p9=0.0833  p10=0.0833  p11=0.0833\n",
+      "  somme = 1.000000\n",
+      "\n",
+      "les positions 0 et 1 sont inatteignables : aucun offset ne renvoie si loin.\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = np.random.default_rng(0)\n",
+    "batch = slens.generate_copy_offset(rng, 6, CFG)\n",
+    "\n",
+    "hdr = \"  \".join(f\"{i:>3}\" for i in range(CFG.n_tokens))\n",
+    "print(\"positions :\", hdr)\n",
+    "for row in range(6):\n",
+    "    print(\"            \", \"  \".join(f\"{t:>3}\" for t in batch[\"tokens\"][row]),\n",
+    "          f\"   -> offset k={batch['offset'][row]:>2}  cible v={batch['target_value'][row]:>2} \"\n",
+    "          f\"a la position {batch['target_pos'][row]}\")\n",
+    "\n",
+    "dist = slens.exact_position_distribution(CFG)\n",
+    "print(\"\\ndistribution exacte de la position cible (offsets 1..L uniformes) :\")\n",
+    "print(\"  \" + \"  \".join(f\"p{p}={dist[p]:.4f}\" for p in range(CFG.seq_values)))\n",
+    "print(f\"  somme = {dist.sum():.6f}\")\n",
+    "print(\"\\nles positions 0 et 1 sont inatteignables : aucun offset ne renvoie si loin.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "461656ee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002526,
+     "end_time": "2026-09-12T18:30:41.489504",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.486978",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La distribution ci-dessus n'est pas estimée sur un échantillon : elle est **calculée** sur le support\n",
+    "exact des offsets atteignables (`exact_position_distribution`). C'est ce qui distingue ce banc d'un\n",
+    "banc synthétique ordinaire — on sait ce que le hasard produirait, position par position, donc on\n",
+    "saura lire l'écart du modèle **sans estimer une ligne de base**.\n",
+    "\n",
+    "Un offset hors bornes n'est pas silencieusement ramené dans le domaine : `oracle_copy_offset` refuse\n",
+    "nommement. Cette discipline est ce qui permet de valider le générateur en § 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f2a19256",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.494839Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.494628Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.497788Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.497331Z"
+    },
+    "papermill": {
+     "duration": 0.00664,
+     "end_time": "2026-09-12T18:30:41.498422",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.491782",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 — distribution exacte sous bornes partielles\n",
+    "#\n",
+    "# Le banc par defaut tire k uniformement dans 1..L. Construisez une config ou\n",
+    "# l'offset est confine a [2, 4], puis verifiez que la distribution exacte porte\n",
+    "# sur EXACTEMENT les positions atteignables (et somme a 1).\n",
+    "#\n",
+    "# Indice : CopyOffsetConfig(seq_values=6, min_offset=2, max_offset=4) ;\n",
+    "#          la position cible vaut seq_values - k.\n",
+    "# Etape 1 : construire la config et afficher ses bornes.\n",
+    "# Etape 2 : appeler slens.exact_position_distribution et lister le support\n",
+    "#           avec np.flatnonzero(dist > 0).\n",
+    "# Etape 3 : verifier dist.sum() == 1 (a la tolerance pres).\n",
+    "\n",
+    "cfg_partiel = None\n",
+    "dist_partiel = None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a975b04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002328,
+     "end_time": "2026-09-12T18:30:41.503230",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.500902",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'oracle valide le générateur, jamais l'inverse\n",
+    "\n",
+    "Un banc synthétique ne vaut que par sa vérité terrain. La règle de protocole est stricte : le\n",
+    "générateur est confronté à un **oracle indépendant** qui relit la séquence et recalcule la réponse\n",
+    "par une autre voie. Si les deux divergent, c'est le banc qui est faux — jamais l'oracle qu'on\n",
+    "ajusterait pour le faire tomber d'accord.\n",
+    "\n",
+    "On vérifie les **deux** faces de la vérité terrain : la valeur attendue *et* la position de la\n",
+    "référence. Une erreur de position avec une valeur correcte signalerait un banc où la réponse peut\n",
+    "être trouvée par une heuristique de surface — précisément le cas qu'on veut exclure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ed3c37c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.508700Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.508501Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.513467Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.513042Z"
+    },
+    "papermill": {
+     "duration": 0.008589,
+     "end_time": "2026-09-12T18:30:41.514160",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.505571",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "valeurs identiques  : True\n",
+      "positions identiques: True\n",
+      "position == L - k   : True\n",
+      "valeur == bloc[pos]: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "grand = slens.generate_copy_offset(np.random.default_rng(1), 4096, CFG)\n",
+    "val_o, pos_o = slens.oracle_copy_offset(grand[\"tokens\"], CFG)\n",
+    "\n",
+    "print(f\"valeurs identiques  : {np.array_equal(val_o, grand['target_value'])}\")\n",
+    "print(f\"positions identiques: {np.array_equal(pos_o, grand['target_pos'])}\")\n",
+    "\n",
+    "# la cible est bien une fonction du CONTENU : position = L - k\n",
+    "recalcule = CFG.seq_values - grand[\"offset\"]\n",
+    "print(f\"position == L - k   : {np.array_equal(recalcule, grand['target_pos'])}\")\n",
+    "\n",
+    "# controle : la valeur visee est bien celle du bloc, relue independamment\n",
+    "relu = grand[\"tokens\"][np.arange(4096), grand[\"target_pos\"]]\n",
+    "print(f\"valeur == bloc[pos]: {np.array_equal(relu, grand['target_value'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "333f96b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002783,
+     "end_time": "2026-09-12T18:30:41.519517",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.516734",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Les quatre égalités portent sur 4096 exemples : le générateur, l'oracle, la formule de position et la\n",
+    "relecture du bloc concordent. Le banc est donc utilisable comme banc de mesure — et non comme\n",
+    "générateur qu'on croirait sur parole."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bba6755f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.525112Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.524776Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.528201Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.527796Z"
+    },
+    "papermill": {
+     "duration": 0.007011,
+     "end_time": "2026-09-12T18:30:41.528843",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.521832",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 — l'oracle refuse un offset hors bornes (et le dit)\n",
+    "#\n",
+    "# Un banc mal garde accepte un offset k > L et renvoie une position negative :\n",
+    "# la faute se propage silencieusement dans toutes les mesures aval.\n",
+    "#\n",
+    "# Indice : un token d'offset vaut n_symbols + k - 1, et la position du token\n",
+    "#          d'offset dans la sequence est seq_values.\n",
+    "# Etape 1 : fabriquer UNE sequence (1, n_tokens) de zeros.\n",
+    "# Etape 2 : y placer un token d'offset correspondant a k = L + 3\n",
+    "#           (donc hors bornes) a l'indice seq_values.\n",
+    "# Etape 3 : appeler slens.oracle_copy_offset dans un try/except ValueError et\n",
+    "#           afficher le message. Le notebook doit continuer a s'executer.\n",
+    "\n",
+    "tokens_hors_bornes = None\n",
+    "message = None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd31ce96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002405,
+     "end_time": "2026-09-12T18:30:41.534395",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.531990",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Sonde linéaire, métriques hors échantillon, et le plancher de shuffle\n",
+    "\n",
+    "La self-location se mesure par une **sonde linéaire** (régression ridge en forme fermée, sans\n",
+    "descente de gradient ni graine d'optimisation). Deux disciplines rendent le chiffre interprétable :\n",
+    "\n",
+    "- **hors échantillon seulement.** La sonde est ajustée sur 70 % des exemples et notée sur les 30 %\n",
+    "  restants. Un score *in-sample* mesurerait la capacité de la sonde à mémoriser, pas la lisibilité\n",
+    "  de la représentation.\n",
+    "- **un plancher mesuré, pas supposé.** Le contrôle de shuffle casse l'appariement\n",
+    "  représentation/cible **sur le jeu d'entraînement** et laisse le jeu de test intact : la sonde ne\n",
+    "  peut plus généraliser, et le score obtenu est le plancher empirique de ce jeu de données. C'est ce\n",
+    "  plancher — et non zéro — qui rend une affirmation de localisation falsifiable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "58614bb4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.539964Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.539685Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.552475Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.552073Z"
+    },
+    "papermill": {
+     "duration": 0.016479,
+     "end_time": "2026-09-12T18:30:41.553181",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.536702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recuperation lineaire : R2 hors echantillon = 1.000000  (n_test = 100)\n",
+      "plancher shuffle      : position_exact = 0.158 (hasard = 1/8 = 0.125)\n",
+      "                        value_exact    = 0.217 (hasard = 1/5 = 0.200)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# exemple : la sonde recupere une application lineaire connue, bruit faible\n",
+    "rng = np.random.default_rng(3)\n",
+    "x = rng.normal(size=(400, 6))\n",
+    "w_vrai = rng.normal(size=(6, 1))\n",
+    "y = x @ w_vrai + 0.1\n",
+    "\n",
+    "w = slens.ridge_probe(x[:300], y[:300], alpha=1e-8)\n",
+    "m = slens.probe_metrics(x[300:], y[300:, 0], w)\n",
+    "print(f\"recuperation lineaire : R2 hors echantillon = {m['r2']:.6f}  (n_test = {m['n_test']})\")\n",
+    "\n",
+    "# plancher : memes probes, appariement representation/cible detruit\n",
+    "positions_syn = rng.integers(0, 8, size=400)\n",
+    "valeurs_syn = rng.integers(0, 5, size=400)\n",
+    "plancher = slens.shuffle_control_scores(x, positions_syn, valeurs_syn,\n",
+    "                                        rng=np.random.default_rng(5))\n",
+    "print(f\"plancher shuffle      : position_exact = {plancher['position_exact']:.3f} \"\n",
+    "      f\"(hasard = 1/8 = {1/8:.3f})\")\n",
+    "print(f\"                        value_exact    = {plancher['value_exact']:.3f} \"\n",
+    "      f\"(hasard = 1/5 = {1/5:.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b666a64d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002387,
+     "end_time": "2026-09-12T18:30:41.558237",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.555850",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le plancher retombe sur le taux de hasard (1/nombre de classes) : c'est la signature d'un contrôle\n",
+    "correctement construit. Une sonde qui afficherait 0,20 sur ce contrôle est une sonde qui n'apprend\n",
+    "rien — et c'est exactement ce que produira une tête qui ne porte pas l'information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0aaa8416",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.564097Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.563613Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.568820Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.568353Z"
+    },
+    "papermill": {
+     "duration": 0.008887,
+     "end_time": "2026-09-12T18:30:41.569522",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.560635",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 — une tete informative est detectee, une tete de bruit est rejetee\n",
+    "#\n",
+    "# Indice : pour rendre la position lineairement lisible, encodez-la en one-hot\n",
+    "#          et ajoutez un bruit faible : np.eye(n_pos)[positions] + bruit.\n",
+    "# Etape 1 : tirer 600 exemples (positions dans 0..7, valeurs dans 0..5).\n",
+    "# Etape 2 : construire DEUX tetes — \"L0H0\" informative (position + valeur\n",
+    "#           en one-hot bruite) et \"L0H1\" de bruit pur (rng.normal).\n",
+    "# Etape 3 : appeler slens.self_location_table avec n_labels=8 et alpha=1e-6,\n",
+    "#           puis afficher position_exact et value_exact pour chaque unite.\n",
+    "# Etape 4 : conclure — la tete informative depasse 0,9, la tete de bruit reste\n",
+    "#           sous 0,5 (soit ~1/8, le hasard).\n",
+    "\n",
+    "table = None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3ee065a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002467,
+     "end_time": "2026-09-12T18:30:41.574535",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.572068",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le manifeste POC mérite un mot, puisque ce notebook en produit un (§ 5) : `slens_manifest` porte\n",
+    "l'instrument `slens_poc`, une version de contrat `poc-0.1.0` et une note de statut. Il porte aussi\n",
+    "les champs d'alignement que la promotion devra respecter. Mais il n'est **pas** validable par le\n",
+    "contrat v1 — la cellule suivante le vérifie plutôt que de l'affirmer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5b141088",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.580641Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.580431Z",
+     "iopub.status.idle": "2026-09-12T18:30:41.584263Z",
+     "shell.execute_reply": "2026-09-12T18:30:41.583736Z"
+    },
+    "papermill": {
+     "duration": 0.008077,
+     "end_time": "2026-09-12T18:30:41.585092",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.577015",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instrument      : slens_poc\n",
+      "version contrat : poc-0.1.0\n",
+      "note            : POC #15481 : instrument experimental hors enum du contrat v1 (sae|jlens|jlens_trackp). Manifeste POC-local, non validable par validate_manifest avant le gate de promotion.\n",
+      "contrat v1      : REFUSE comme prevu — 'contract_version'=poc-0.1.0 non supportee par ce loader v1. Mettre a jour le chargeur ou regenerer la trace.\n"
+     ]
+    }
+   ],
+   "source": [
+    "man = slens.slens_manifest(\n",
+    "    task=\"copy_offset\", arch=\"rope\", run=\"demo\", seed=0, layer=0,\n",
+    "    d_model=64, n_heads=4, n_layers=2, n_test=256, prompt_set=\"synthetic_copy_offset\",\n",
+    ")\n",
+    "print(\"instrument      :\", man[\"instrument\"])\n",
+    "print(\"version contrat :\", man[\"contract_version\"])\n",
+    "print(\"note            :\", man[\"contract_note\"])\n",
+    "\n",
+    "try:\n",
+    "    trace_contract.validate_manifest(man)\n",
+    "    verdict_contrat = \"ACCEPTE (inattendu)\"\n",
+    "except trace_contract.TraceContractError as exc:\n",
+    "    verdict_contrat = f\"REFUSE comme prevu — {exc}\"\n",
+    "print(\"contrat v1      :\", verdict_contrat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f46a5fb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002582,
+     "end_time": "2026-09-12T18:30:41.590641",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.588059",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Entraînement réel : la position vient-elle du contenu ?\n",
+    "\n",
+    "Trois régimes de position sont entraînés sur le même banc, mêmes graines, même budget :\n",
+    "\n",
+    "| régime | ce que le modèle reçoit | ce qu'il doit faire |\n",
+    "|---|---|---|\n",
+    "| `rope` | rotations positionnelles | lire `k`, calculer `L - k`, aller chercher |\n",
+    "| `abs` | plongement de position appris | idem, avec une position apprise par index |\n",
+    "| `none` | aucun signal positionnel **ajouté** | tout doit venir du contenu |\n",
+    "\n",
+    "`none` est le régime décisif : c'est la variante « la position est dérivée du contenu ». S'il\n",
+    "apprend la tâche, cela signifie que le substrat calcule lui-même la référence à partir de `k`.\n",
+    "\n",
+    "**Une réserve d'interprétation, à poser avant de lire les chiffres.** `none` ne prive pas le modèle\n",
+    "de toute information d'ordre : le **masque causal** fait que le token d'indice `i` voit `i+1` tokens\n",
+    "et pas plus, ce qui est en soi un signal de position. L'ablation dit donc « sans encodage\n",
+    "positionnel appris », pas « sans aucune information d'ordre ». Cette réserve est nécessaire pour\n",
+    "comparer le chiffre de `none` à ce qu'on serait tenté d'appeler le hasard.\n",
+    "\n",
+    "Le budget est de 3000 pas (AdamW, lr 3e-3, batch 128) ; les trois entraînements ci-dessous durent\n",
+    "environ une minute au total. Ce sont de vrais entraînements : les chiffres affichés sont ceux de\n",
+    "cette exécution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4d0b75f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:30:41.599100Z",
+     "iopub.status.busy": "2026-09-12T18:30:41.598699Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.144709Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.144052Z"
+    },
+    "papermill": {
+     "duration": 56.550264,
+     "end_time": "2026-09-12T18:31:38.145571",
+     "exception": false,
+     "start_time": "2026-09-12T18:30:41.595307",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rope : exactitude = 1.0000  perte finale = 0.0001  (22s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " abs : exactitude = 1.0000  perte finale = 0.0001  (17s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "none : exactitude = 0.5312  perte finale = 1.0746  (18s)\n",
+      "\n",
+      "hasard par valeur (V = 16 valeurs possibles) = 0.0625\n",
+      "la copie de la valeur immediatement a gauche de Q (strategie de surface) vaut 0.0000 sur ce banc : la cible est L-k, pas L-1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "modeles = {}\n",
+    "for arch in (\"rope\", \"abs\", \"none\"):\n",
+    "    torch.manual_seed(0)\n",
+    "    modele = slens_poc.MicroTransformer(\n",
+    "        vocab_size=CFG.vocab_size, d_model=64, n_heads=4, n_layers=2, arch=arch,\n",
+    "    ).to(DEVICE)\n",
+    "    t0 = time.time()\n",
+    "    pertes = slens_poc.train_model(modele, \"copy_offset\", 0, 3000, 128, 3e-3, DEVICE)\n",
+    "    _, pred, acc, by_pos = slens_poc.evaluate(modele, \"copy_offset\", 0, 1024, DEVICE)\n",
+    "    modeles[arch] = (modele, pred, acc, by_pos)\n",
+    "    print(f\"{arch:>4} : exactitude = {acc:.4f}  perte finale = {pertes[-1]:.4f}  \"\n",
+    "          f\"({time.time() - t0:.0f}s)\")\n",
+    "\n",
+    "print(f\"\\nhasard par valeur (V = {CFG.n_symbols} valeurs possibles) = {1/CFG.n_symbols:.4f}\")\n",
+    "print(f\"la copie de la valeur immediatement a gauche de Q (strategie de surface) \"\n",
+    "      f\"vaut 0.0000 sur ce banc : la cible est L-k, pas L-1.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd99c902",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002616,
+     "end_time": "2026-09-12T18:31:38.151190",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.148574",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture des trois lignes\n",
+    "\n",
+    "`rope` et `abs` atteignent l'exactitude : le banc est **apprenable**, et les mesures des sections\n",
+    "suivantes portent sur un modèle qui sait faire la tâche. `none` s'interprète contre deux repères, et\n",
+    "c'est là que le chiffre devient intéressant :\n",
+    "\n",
+    "- le **hasard par valeur**, `1/16 = 0.0625` — une prédiction constante\n",
+    "  parmi les `16` valeurs possibles (et non parmi les `29` ids du\n",
+    "  vocabulaire, qui contiennent aussi les tokens d'offset et la requête) ;\n",
+    "- la **stratégie de surface**, qui vaut 0 ici : copier la valeur immédiatement à gauche de `Q`\n",
+    "  donnerait la mauvaise valeur, puisque la cible est à `L - k`, pas à `L - 1`.\n",
+    "\n",
+    "Sur la matrice complète (4 graines, § 6), `none` obtient 0.531 à la\n",
+    "graine 0. C'est **loin du hasard et loin de l'exactitude** : le contenu porte donc une partie de la\n",
+    "référence, sans la porter entièrement. Ce résultat nuance la lecture naïve du banc — un banc dont la\n",
+    "cible dépend du contenu n'est pas un banc où *seul* un encodage positionnel peut réussir — et il\n",
+    "impose la réserve ci-dessus : une part de ce que `none` récupère peut venir du masque causal plutôt\n",
+    "que du contenu.\n",
+    "\n",
+    "Ce que le banc établit donc, honnêtement : `rope` et `abs` **résolvent** la tâche, et la référence y\n",
+    "est donc localisable (c'est l'objet des sections suivantes) ; `none` **ne la résout pas**, mais\n",
+    "récupère une fraction substantielle par une voie qui n'est pas un encodage positionnel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ecd7e66",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002581,
+     "end_time": "2026-09-12T18:31:38.156823",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.154242",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Self-location par couche et par tête\n",
+    "\n",
+    "Chaque tête (et chaque résidu de couche) est maintenant sondée : peut-on lire la **position de la\n",
+    "référence** dans son état, à la position de requête ? La comparaison pertinente n'est pas\n",
+    "« quelle tête gagne » mais « quelle tête dépasse son propre plancher de shuffle », puisque le\n",
+    "plancher dépend du jeu et non du modèle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "31899c2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.163808Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.163310Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.205912Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.205395Z"
+    },
+    "papermill": {
+     "duration": 0.047345,
+     "end_time": "2026-09-12T18:31:38.206909",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.159564",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   unite  position_exact  value_exact      rmse\n",
+      "      L1           0.997        0.173     0.285\n",
+      "post_stack           0.997        1.000     0.057\n",
+      "    L0H0           0.932        0.163     0.780\n",
+      "    L1H3           0.876        0.948     1.746\n",
+      "    L1H2           0.821        0.824     2.294\n",
+      "    L0H1           0.798        0.173     2.372\n",
+      "    L1H1           0.782        0.997     2.274\n",
+      "    L0H3           0.713        0.114     2.277\n",
+      "    L1H0           0.668        1.000     2.705\n",
+      "    L0H2           0.573        0.091     2.724\n",
+      "      L0           0.114        0.062     5.495\n",
+      "\n",
+      "meilleure unite L1 : position_exact = 0.997\n",
+      "plancher shuffle de la meme unite : 0.085\n",
+      "marge au-dessus du plancher       : +0.912\n"
+     ]
+    }
+   ],
+   "source": [
+    "modele, pred, acc, by_pos = modeles[\"rope\"]\n",
+    "batch_eval, _, _, _ = slens_poc.evaluate(modele, \"copy_offset\", 0, 1024, DEVICE)\n",
+    "x = torch.as_tensor(batch_eval[\"tokens\"], dtype=torch.long, device=DEVICE)\n",
+    "_, caps_head, caps_layer = modele(x, capture=True)\n",
+    "last = x.shape[1] - 1\n",
+    "# ``forward(capture=True)`` rend deja des tableaux numpy : la capture detache et\n",
+    "# convertit au moment ou elle est prise, cote moteur. Re-convertir ici serait une\n",
+    "# erreur -- et c'est exactement ce que ce notebook a fait dans sa premiere\n",
+    "# execution, ou l'appel a echoue au lieu de rendre un chiffre faux.\n",
+    "unites = {k: v[:, last, :] for k, v in caps_head.items()}\n",
+    "unites.update({k: v[:, last, :] for k, v in caps_layer.items()})\n",
+    "\n",
+    "pos = batch_eval[\"target_pos\"]\n",
+    "val = batch_eval[\"target_value\"]\n",
+    "n_pos = int(max(pos.max() + 1, CFG.n_tokens))\n",
+    "table = slens.self_location_table(unites, pos, values=val, alpha=1e-2, n_labels=n_pos)\n",
+    "table = sorted(table, key=lambda r: -r[\"position_exact\"])\n",
+    "\n",
+    "print(f\"{'unite':>8}  {'position_exact':>14}  {'value_exact':>11}  {'rmse':>8}\")\n",
+    "for r in table:\n",
+    "    print(f\"{r['unit']:>8}  {r['position_exact']:>14.3f}  \"\n",
+    "          f\"{r.get('value_exact', float('nan')):>11.3f}  {r['position_rmse']:>8.3f}\")\n",
+    "\n",
+    "meilleure = table[0]\n",
+    "plancher = slens.shuffle_control_scores(\n",
+    "    unites[meilleure[\"unit\"]], pos, val, rng=np.random.default_rng(0))\n",
+    "print(f\"\\nmeilleure unite {meilleure['unit']} : position_exact = {meilleure['position_exact']:.3f}\")\n",
+    "print(f\"plancher shuffle de la meme unite : {plancher['position_exact']:.3f}\")\n",
+    "print(f\"marge au-dessus du plancher       : \"\n",
+    "      f\"{meilleure['position_exact'] - plancher['position_exact']:+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26a0e849",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002777,
+     "end_time": "2026-09-12T18:31:38.212852",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.210075",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La réussite de copie suit-elle la distribution exacte ?\n",
+    "\n",
+    "Le banc fournit la fréquence **exacte** de chaque position cible. Comparer le taux de réussite du\n",
+    "modèle, position par position, à ce que le hasard produirait donne une lecture directe : un modèle\n",
+    "qui copie réussit partout où la référence est atteignable ; un modèle qui devine suit la\n",
+    "distribution du hasard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b3de9c3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.219342Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.219023Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.224592Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.224041Z"
+    },
+    "papermill": {
+     "duration": 0.009786,
+     "end_time": "2026-09-12T18:31:38.225452",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.215666",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "position   reussite    exacte\n",
+      "       0      1.000    0.0833\n",
+      "       1      1.000    0.0833\n",
+      "       2      1.000    0.0833\n",
+      "       3      1.000    0.0833\n",
+      "       4      1.000    0.0833\n",
+      "       5      1.000    0.0833\n",
+      "       6      1.000    0.0833\n",
+      "       7      1.000    0.0833\n",
+      "       8      1.000    0.0833\n",
+      "       9      1.000    0.0833\n",
+      "      10      1.000    0.0833\n",
+      "      11      1.000    0.0833\n",
+      "      12        nan    0.0000\n",
+      "      13        nan    0.0000\n",
+      "\n",
+      "positions atteignables portant une masse exacte : 12/12\n"
+     ]
+    }
+   ],
+   "source": [
+    "_, _, _, by_pos = modeles[\"rope\"]\n",
+    "dist = slens.exact_position_distribution(CFG)\n",
+    "n_reach = 0\n",
+    "print(f\"{'position':>8}  {'reussite':>9}  {'exacte':>8}\")\n",
+    "for p in range(CFG.n_tokens):\n",
+    "    taux = by_pos[p] if p < len(by_pos) else float(\"nan\")\n",
+    "    exacte = dist[p] if p < len(dist) else 0.0\n",
+    "    if n_reach < CFG.seq_values and exacte > 0:\n",
+    "        n_reach += 1\n",
+    "    print(f\"{p:>8}  {taux:>9.3f}  {exacte:>8.4f}\")\n",
+    "print(f\"\\npositions atteignables portant une masse exacte : {n_reach}/{CFG.seq_values}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a052abb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002561,
+     "end_time": "2026-09-12T18:31:38.230781",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.228220",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Jambe causale : échange apparié, sham et cible aléatoire\n",
+    "\n",
+    "Lire une position dans une représentation n'établit pas qu'elle **sert** à la prédiction. Le test\n",
+    "causal du POC est un **échange apparié** (*interchange*) : deux exemples partagent tout leur contexte\n",
+    "et ne diffèrent que par la référence (l'offset `k`). On remplace, dans le résidu de l'hôte, la valeur\n",
+    "à la position du token d'offset par celle du donneur, puis on regarde la prédiction.\n",
+    "\n",
+    "Trois comparaisons sont obligatoires, et aucune ne suffit seule :\n",
+    "\n",
+    "| mesure | ce qu'elle écarte |\n",
+    "|---|---|\n",
+    "| `follow_donor` — la prédiction suit-elle la référence du donneur ? | l'absence d'effet |\n",
+    "| `sham` — même code, valeur de l'hôte elle-même | un artefact du chemin de code, pas de l'échange |\n",
+    "| `random_target` — donneur non apparié | une bascule attribuable au simple bruit introduit |\n",
+    "\n",
+    "S'y ajoute le **dommage général** mesuré sur le résidu final : une intervention chirurgicale n'y\n",
+    "laisse que ce que la propagation aval emporte. Un effet fort assorti d'un dommage massif n'est pas\n",
+    "une preuve de localisation, c'est une preuve qu'on a cassé le modèle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e8e0e7a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.237212Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.236827Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.294036Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.293422Z"
+    },
+    "papermill": {
+     "duration": 0.0615,
+     "end_time": "2026-09-12T18:31:38.294839",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.233339",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "suivi du donneur (apparie)  : 0.0742\n",
+      "sham (valeur de l'hote)     : 0.1953\n",
+      "cible aleatoire (non appar.): 0.0625\n",
+      "exactitude de base de l'hote: 1.0000\n",
+      "\n",
+      "dommage : off_target_rel = 0.0000  target_rel = 0.4628  selectivite = non bornee (hors cible sous le plancher de mesure)\n",
+      "\n",
+      "verdict causal : no_effect\n",
+      "          follow_donor : 0.07421875\n",
+      "                  sham : 0.1953125\n",
+      "         random_target : 0.0625\n",
+      "       gap_vs_controls : -0.12109375\n",
+      "        off_target_rel : 0.0\n",
+      "        selectivity_ok : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "stats = slens_poc.patch_experiment(modeles[\"rope\"][0], \"copy_offset\", 0, 512, 0, DEVICE)\n",
+    "print(f\"suivi du donneur (apparie)  : {stats['follow_donor']:.4f}\")\n",
+    "print(f\"sham (valeur de l'hote)     : {stats['sham']:.4f}\")\n",
+    "print(f\"cible aleatoire (non appar.): {stats['random_target']:.4f}\")\n",
+    "print(f\"exactitude de base de l'hote: {stats['base_accuracy']:.4f}\")\n",
+    "\n",
+    "# ``selectivity_ratio`` n'est PAS borne quand le deplacement hors cible tombe\n",
+    "# sous le plancher de mesure de ``damage_metrics`` : le rapport vaut alors\n",
+    "# ``inf``, pas un grand nombre. Afficher ``inf`` brut laisserait croire a une\n",
+    "# mesure ; on nomme donc ce que le nombre signifie.\n",
+    "ratio = stats[\"selectivity_ratio\"]\n",
+    "selectivite = (\"non bornee (hors cible sous le plancher de mesure)\"\n",
+    "               if math.isinf(ratio) else f\"{ratio:.2f}\")\n",
+    "print(f\"\\ndommage : off_target_rel = {stats['off_target_rel']:.4f}  \"\n",
+    "      f\"target_rel = {stats['target_rel']:.4f}  \"\n",
+    "      f\"selectivite = {selectivite}\")\n",
+    "\n",
+    "verdict_causal = slens.location_causal_verdict(\n",
+    "    stats[\"follow_donor\"], stats[\"sham\"], stats[\"random_target\"],\n",
+    "    {\"off_target_rel\": stats[\"off_target_rel\"], \"target_rel\": stats[\"target_rel\"],\n",
+    "     \"selectivity_ratio\": stats[\"selectivity_ratio\"]},\n",
+    ")\n",
+    "print(f\"\\nverdict causal : {verdict_causal['verdict']}\")\n",
+    "for cle, valeur in verdict_causal.items():\n",
+    "    if cle != \"verdict\":\n",
+    "        print(f\"  {cle:>20} : {valeur}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e4bbebb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002657,
+     "end_time": "2026-09-12T18:31:38.300665",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.298008",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Ce que « dommage » veut dire ici, et pourquoi c'est la correction centrale\n",
+    "\n",
+    "Le verdict est produit par `location_causal_verdict` : effet apparié ≥ 0,5, écart aux deux contrôles\n",
+    "≥ 0,25, déplacement **hors cible** ≤ 0,10. Les branches sont `causal`, `undiscriminated` (effet\n",
+    "présent mais sham non séparé), `global_damage` (effet **fort** mais modèle cassé) et `no_effect`.\n",
+    "\n",
+    "Un mot sur le « hors cible », parce que la première version de ce banc le mesurait mal. Pour une\n",
+    "intervention à la position `p` d'un transformer **causal**, changer le résidu en `p` change\n",
+    "nécessairement le résidu de **toutes les positions ≥ p** : c'est le mécanisme de l'intervention, pas\n",
+    "un dommage. Compter la seule ligne `p` comme cible revenait donc à comptabiliser la propagation aval\n",
+    "comme du dommage — et sur ce banc cela donnait un déplacement hors cible de 0,33 alors que le modèle\n",
+    "restait exact à 1,000, ce qui rendait le verdict `causal` **inatteignable par construction**, quelle\n",
+    "que soit la mesure.\n",
+    "\n",
+    "Le dommage est donc mesuré là où la causalité **interdit** qu'il y en ait : les positions\n",
+    "**antérieures** au pivot. Sur ce banc il vaut 0.0000 — exactement zéro, comme\n",
+    "il se doit, ce qui est en soi la preuve que l'intervention ne fuit pas en arrière. Le déplacement\n",
+    "dans le cône causal, lui, vaut 0.4628 : l'intervention **agit** bien sur le résidu\n",
+    "final. Elle n'agit simplement pas sur la **réponse**.\n",
+    "\n",
+    "**C'est le résultat à retenir de cette section.** `follow_donor` vaut 0.074 :\n",
+    "quand on remplace la lecture de `k` par celle du donneur, la prédiction de l'hôte ne suit pas le\n",
+    "donneur — elle ne descend pas non plus sous le hasard du donneur\n",
+    "(0.062). Autrement dit la référence est **lisible** dans la représentation\n",
+    "(§ 4 : la sonde la localise presque parfaitement) mais elle n'est pas **utilisable** par\n",
+    "l'intervention telle qu'instrumentée. Lire et agir sont deux affirmations distinctes ; ce banc les\n",
+    "sépare, et c'est exactement ce qu'un instrument de localisation doit montrer plutôt que masquer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3d643e75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.308042Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.307828Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.310989Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.310517Z"
+    },
+    "papermill": {
+     "duration": 0.008243,
+     "end_time": "2026-09-12T18:31:38.311608",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.303365",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 4 — lire un verdict causal, branche par branche\n",
+    "#\n",
+    "# Le verdict depend de l'ecart aux CONTROLES, pas seulement de la force de\n",
+    "# l'effet : un effet de 0,72 obtenu avec un sham a 0,66 n'est pas une preuve.\n",
+    "#\n",
+    "# Indice : la fonction prend (follow_donor, sham, random_target, damage) ou\n",
+    "#          damage est un dict {\"off_target_rel\": ...}.\n",
+    "# Etape 1 : appeler location_causal_verdict avec follow_donor=0.72, sham=0.66,\n",
+    "#           random_target=0.14 et un dommage SELECTIF (off_target_rel=0.01).\n",
+    "# Etape 2 : afficher le verdict et l'ecart aux controles.\n",
+    "# Etape 3 : refaire le calcul avec off_target_rel=0.40 et expliquer en une\n",
+    "#           phrase pourquoi le verdict change malgre un effet identique.\n",
+    "\n",
+    "verdict_serre = None\n",
+    "verdict_casse = None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50212315",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003231,
+     "end_time": "2026-09-12T18:31:38.317598",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.314367",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Matrice complète : 26 runs, deux bancs, trois régimes\n",
+    "\n",
+    "Une seule graine ne prouve rien : une localisation qui n'apparaît qu'à la graine 0 est un artefact\n",
+    "d'initialisation. La matrice est donc agrégée ci-dessous — deux bancs (`copy_offset` et son second\n",
+    "problème de binding `variable_binding`), trois régimes de position, et **5 graines**\n",
+    "(0, 1, 7, 42, 99) sur le régime de référence `rope`, plus\n",
+    "16 runs d'ablation (régimes `abs` / `none`, graines 0, 1, 7, 42).\n",
+    "\n",
+    "**Pourquoi une architecture de référence, et pas un test sur tout le tableau.** Le gate se juge sur\n",
+    "`rope` seul. La variance **entre graines** d'un même régime répond à « le résultat se\n",
+    "reproduit-il ? » ; l'écart **entre régimes** répond à une autre question (« quel encodage\n",
+    "positionnel faut-il ? »). Mêler les deux dans un même test de stabilité ferait passer une\n",
+    "hétérogénéité d'architecture pour une instabilité de graine — les runs d'ablation sont donc\n",
+    "rapportés dans la table et exclus du gate. La matrice agrégée le dit elle-même dans ses notes.\n",
+    "\n",
+    "Les runs sont réduits par `scripts/slens_poc.py --aggregate`, et c'est cette matrice qui est\n",
+    "committée. Chaque ligne porte son exactitude de copie, sa localisation, **son propre plancher de\n",
+    "shuffle** et son verdict causal — aucune moyenne ne remplace une ligne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1518929a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.324501Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.324132Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.329744Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.329326Z"
+    },
+    "papermill": {
+     "duration": 0.009846,
+     "end_time": "2026-09-12T18:31:38.330427",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.320581",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "26 runs, genere le 2026-09-12T18:29:57+00:00\n",
+      "regeneration : python scripts/slens_poc.py --task <task> --arch <arch> --seed <seed> --stage full --out traces/slens_<task>_<arch>_s<seed>.npz\n",
+      "\n",
+      "             banc regime   g   copie  position  shuffle  valeur    verdict causal\n",
+      "      copy_offset    abs   0   1.000     1.000    0.104   1.000         no_effect\n",
+      "      copy_offset    abs   1   1.000     1.000    0.098   1.000         no_effect\n",
+      "      copy_offset    abs   7   1.000     1.000    0.098   1.000         no_effect\n",
+      "      copy_offset    abs  42   1.000     1.000    0.055   1.000         no_effect\n",
+      "      copy_offset   none   0   0.531     0.961    0.091   0.345         no_effect\n",
+      "      copy_offset   none   1   0.516     0.938    0.121   0.362         no_effect\n",
+      "      copy_offset   none   7   0.509     0.961    0.062   0.322         no_effect\n",
+      "      copy_offset   none  42   0.493     0.997    0.049   0.492         no_effect\n",
+      "      copy_offset   rope   0   1.000     0.997    0.085   1.000         no_effect\n",
+      "      copy_offset   rope   1   1.000     0.938    0.088   1.000         no_effect\n",
+      "      copy_offset   rope   7   1.000     1.000    0.078   1.000         no_effect\n",
+      "      copy_offset   rope  42   1.000     0.818    0.065   1.000         no_effect\n",
+      "      copy_offset   rope  99   1.000     1.000    0.104   1.000         no_effect\n",
+      " variable_binding    abs   0   1.000     0.997    0.107   1.000         no_effect\n",
+      " variable_binding    abs   1   1.000     0.997    0.355   1.000         no_effect\n",
+      " variable_binding    abs   7   1.000     0.980    0.179   1.000         no_effect\n",
+      " variable_binding    abs  42   1.000     0.984    0.254   1.000         no_effect\n",
+      " variable_binding   none   0   1.000     0.567    0.186   1.000         no_effect\n",
+      " variable_binding   none   1   1.000     0.622    0.205   1.000         no_effect\n",
+      " variable_binding   none   7   1.000     0.547    0.195   1.000         no_effect\n",
+      " variable_binding   none  42   1.000     0.541    0.212   1.000         no_effect\n",
+      " variable_binding   rope   0   1.000     0.349    0.186   1.000         no_effect\n",
+      " variable_binding   rope   1   1.000     0.313    0.166   1.000         no_effect\n",
+      " variable_binding   rope   7   1.000     0.352    0.169   1.000         no_effect\n",
+      " variable_binding   rope  42   1.000     0.332    0.182   1.000         no_effect\n",
+      " variable_binding   rope  99   1.000     0.283    0.199   1.000         no_effect\n"
+     ]
+    }
+   ],
+   "source": [
+    "matrix = json.loads((ROOT / \"runs\" / \"slens_matrix.json\").read_text(encoding=\"utf-8\"))\n",
+    "print(f\"{len(matrix['runs'])} runs, genere le {matrix['generated']}\")\n",
+    "print(f\"regeneration : {matrix['regenerate']}\\n\")\n",
+    "\n",
+    "print(f\"{'banc':>17} {'regime':>6} {'g':>3} {'copie':>7} {'position':>9} \"\n",
+    "      f\"{'shuffle':>8} {'valeur':>7}  {'verdict causal':>16}\")\n",
+    "for r in sorted(matrix[\"per_run\"], key=lambda r: (r[\"task\"], r[\"arch\"], r[\"seed\"])):\n",
+    "    print(f\"{r['task']:>17} {r['arch']:>6} {r['seed']:>3} {r['copy_accuracy']:>7.3f} \"\n",
+    "          f\"{r['position_exact']:>9.3f} {r['position_exact_shuffle']:>8.3f} \"\n",
+    "          f\"{r['value_exact']:>7.3f}  {r['causal']['verdict']:>16}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6270d4fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T18:31:38.337733Z",
+     "iopub.status.busy": "2026-09-12T18:31:38.337395Z",
+     "iopub.status.idle": "2026-09-12T18:31:38.341199Z",
+     "shell.execute_reply": "2026-09-12T18:31:38.340774Z"
+    },
+    "papermill": {
+     "duration": 0.008276,
+     "end_time": "2026-09-12T18:31:38.341848",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.333572",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preuves agregees (le gate se lit ici) :\n",
+      "                position_exact : 1.0\n",
+      "        position_exact_shuffle : 0.0781758957654723\n",
+      "                   value_exact : 1.0\n",
+      "                 copy_accuracy : 1.0\n",
+      "                causal_verdict : no_effect\n",
+      "    second_task_position_exact : 0.3517915309446254\n",
+      "           second_task_shuffle : 0.16938110749185667\n",
+      "            second_task_causal : no_effect\n",
+      "                  seeds_stable : False\n",
+      "                reference_arch : rope\n",
+      "  note : stabilite multi-graines mesuree sur 'rope' seul (5 graines) ; 8 run(s) d'ablation sur d'autres regimes de position sont rapportes dans la table mais exclus du gate (l'ecart entre regimes n'est pas de l'instabilite de graine)\n",
+      "  note : sur le second banc, un autre regime ('abs') localise mieux la reference (0.997) que le regime de reference 'rope' (0.352) : la localisation du second banc depend de l'encodage positionnel\n",
+      "\n",
+      "VERDICT DE PROMOTION : INCONCLUSIVE\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Preuves agregees (le gate se lit ici) :\")\n",
+    "for cle, valeur in matrix[\"evidence\"].items():\n",
+    "    if cle == \"notes\":\n",
+    "        for note in valeur:\n",
+    "            print(f\"  note : {note}\")\n",
+    "    else:\n",
+    "        print(f\"  {cle:>28} : {valeur}\")\n",
+    "print(f\"\\nVERDICT DE PROMOTION : {matrix['verdict']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cf20745",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002699,
+     "end_time": "2026-09-12T18:31:38.347471",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.344772",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Comment se lit ce verdict\n",
+    "\n",
+    "Le gate exige **trois** choses simultanées, et l'ordre d'évaluation compte :\n",
+    "\n",
+    "1. **la stabilité multi-graines sur le banc primaire** — l'écart au plancher doit rester positif pour\n",
+    "   *chaque* graine, et l'amplitude des écarts ne doit pas trahir une moyenne portée par une seule\n",
+    "   graine. Une instabilité rend le verdict `INCONCLUSIVE`, avant même d'examiner la généralisation ;\n",
+    "2. **le détachement du plancher sur le second banc** — sans quoi le S-Lens reste un démonstrateur\n",
+    "   spécialisé (`SPECIALIZED_ONLY`) et aucune interface publique n'est ouverte ;\n",
+    "3. **la jambe causale sur les deux bancs** — un effet non discriminé des contrôles ne fonde pas un\n",
+    "   instrument.\n",
+    "\n",
+    "Le verdict rendu pour cette matrice est **INCONCLUSIVE**. Il porte sur un micro-transformer à deux\n",
+    "couches et 64 dimensions entraîné sur des bancs **synthétiques** : il dit si l'instrument *mesure*\n",
+    "quelque chose de stable et de causal **sur ce banc**, pas que les grands modèles de langue\n",
+    "self-localisent leur référence. Cette extrapolation demanderait exactement ce que #15481 interdit\n",
+    "avant promotion : une API publique et une issue de notebook définitive."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68448ce6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002678,
+     "end_time": "2026-09-12T18:31:38.352928",
+     "exception": false,
+     "start_time": "2026-09-12T18:31:38.350250",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "**Établi.** (i) Le banc `copy_offset` possède une vérité terrain exacte, sur la valeur comme sur la\n",
+    "position, et un oracle indépendant qui la confirme sur 4096 exemples — le générateur ne se valide pas\n",
+    "lui-même. (ii) Les régimes à encodage positionnel (`rope`, `abs`) **résolvent** la tâche\n",
+    "(1.000 et 1.000 à la graine 0) : le banc est\n",
+    "apprenable, et les mesures de localisation portent sur des modèles qui savent faire la tâche.\n",
+    "(iii) La lecture est falsifiable : chaque localisation est confrontée à son propre plancher de\n",
+    "shuffle, hors échantillon, et chaque effet causal à ses trois contrôles plus une mesure de dommage.\n",
+    "\n",
+    "**Partiellement établi, et c'est le résultat le moins attendu.** Le régime sans encodage\n",
+    "positionnel (`none`) atteint 0.531, très au-dessus du hasard par valeur\n",
+    "(0.0625) et très en dessous de l'exactitude. Le contenu porte donc **une partie** de\n",
+    "la référence sans encodage positionnel appris — résultat à lire avec la réserve du § 4, le masque\n",
+    "causal étant lui-même un signal d'ordre. C'est le genre de chiffre qu'un rapport pressé arrondirait\n",
+    "en « `none` échoue » ou en « la position vient du contenu » : les deux lectures sont fausses.\n",
+    "\n",
+    "**Non établi.** Le verdict de promotion n'autorise aucune extrapolation hors du banc : ni au substrat\n",
+    "LLM réel (SAE, J-Lens, F-Lens), ni à une notion générale de « référence » qui vaudrait pour d'autres\n",
+    "tâches que la copie à offset et le binding de variables. Le S-Lens est ici un instrument **en\n",
+    "essai**, avec un contrat POC-local que le contrat v1 refuse explicitement — refus vérifié en § 3,\n",
+    "pas affirmé.\n",
+    "\n",
+    "La suite est décidée par le verdict, pas par ce notebook : `PROMOTE` ouvre la question d'un contrat\n",
+    "public et d'une issue de notebook définitive ; `SPECIALIZED_ONLY` conserve le banc comme démonstrateur\n",
+    "sans interface ; `INCONCLUSIVE` renvoie au protocole — plus de graines, ou un banc plus riche.\n",
+    "\n",
+    "**Part of** [#15481](https://github.com/jsboige/CoursIA/issues/15481) · moteur d'intervention\n",
+    "[#15479](https://github.com/jsboige/CoursIA/issues/15479) · contrat de trace\n",
+    "[#15476](https://github.com/jsboige/CoursIA/issues/15476) · toolkit\n",
+    "[#15475](https://github.com/jsboige/CoursIA/issues/15475) · EPIC\n",
+    "[#8182](https://github.com/jsboige/CoursIA/issues/8182)."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 63.939692,
+   "end_time": "2026-09-12T18:31:40.105886",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "ICT-38-SLens-SelfLocation.ipynb",
+   "output_path": "ict38_exec_final.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-12T18:30:36.166194",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/causal_engine.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/causal_engine.py
@@ -487,8 +487,9 @@ def damage_metrics(
     selective (acceptance #15479). On mesure la norme relative du deplacement
     hors cible : ``off_target_rel`` doit rester proche de 0 pour une
     intervention propre ; ``target_rel`` documente l'ampleur voulue. Le rapport
-    ``selectivity_ratio = target_rel / max(off_target_rel, eps)`` alimente le
-    verdict.
+    ``selectivity_ratio`` alimente le verdict : c'est ``target_rel`` rapporte au
+    deplacement hors cible, et il vaut ``inf`` -- jamais un grand nombre -- quand
+    ce deplacement tombe sous le plancher de mesure (cf. le corps de la fonction).
     """
     if panel_before.shape != panel_after.shape:
         raise ValueError("panneaux avant/apres de formes differentes")
@@ -502,10 +503,25 @@ def damage_metrics(
     on = float(np.linalg.norm(diff[~mask])) if (~mask).any() else 0.0
     off_rel = off / max(base, eps)
     on_rel = on / max(base, eps)
+    # ``eps`` est deja le plancher declare de cette fonction : il borne
+    # ``off_rel``. Un deplacement hors cible qui y tombe n'est donc pas
+    # « petit », il est INDISTINGUABLE DE ZERO -- et le rapport n'est pas
+    # grand, il est NON BORNE. Rendre ``on_rel / eps`` faisait dependre la
+    # magnitude publiee d'une constante interne (462774272000.00 mesures sur le
+    # banc copy_offset pour une intervention parfaitement propre) et invitait a
+    # la lire comme une mesure. ``inf`` dit ce que le chiffre ne dit pas, et
+    # reste compatible avec le seuil du verdict, qui teste ``>= min_selectivity``.
+    # Reste le cas ou RIEN ne bouge, cible et hors cible au plancher : aucun
+    # rapport n'y est mesurable, et une intervention sans effet ne doit pas
+    # ressortir selective -- d'ou 0.0.
+    if off_rel <= eps:
+        selectivity = float("inf") if on_rel > 0.0 else 0.0
+    else:
+        selectivity = on_rel / off_rel
     return {
         "target_rel": on_rel,
         "off_target_rel": off_rel,
-        "selectivity_ratio": on_rel / max(off_rel, eps),
+        "selectivity_ratio": selectivity,
     }
 
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/slens.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/slens.py
@@ -481,15 +481,21 @@ def self_location_table(
             vals = np.asarray(values)
             if vals.shape[0] != n:
                 raise ValueError(f"{key}: {vals.shape[0]} valeurs != {n} positions")
+            # Les classes sont RECODEES en indices compacts 0..c-1 : le vocabulaire
+            # de valeurs d'un banc peut ne pas commencer a 0 (binding : ids
+            # n_vars..n_vars+n_vals-1). La lecture lineaire rend un argmax sur ces
+            # indices, donc la cible passee a ``probe_metrics`` doit etre la MEME
+            # recodee — comparer l'indice a l'id brut rendrait exact_hit nul par
+            # construction sur tout vocabulaire non dense (defaut corrige ici).
             classes = np.unique(vals)
             index = {int(v): i for i, v in enumerate(classes)}
-            y_val = np.zeros((n, len(classes)))
-            for i, v in enumerate(vals):
-                y_val[i, index[int(v)]] = 1.0
+            y_cls = np.array([index[int(v)] for v in vals], dtype=np.float64)
+            y_val = np.eye(len(classes))[y_cls.astype(np.int64)]
             w_val = ridge_probe(acts[tr], y_val[tr], alpha=alpha)
-            m_val = probe_metrics(acts[te], vals[te], w_val)
+            m_val = probe_metrics(acts[te], y_cls[te], w_val)
             row["value_exact"] = m_val["exact_hit"]
             row["value_rmse"] = m_val["rmse"]
+            row["value_classes"] = int(len(classes))
         rows.append(row)
     return rows
 
@@ -543,11 +549,10 @@ def shuffle_control_scores(
     perm = rng.permutation(n_train)
     classes = np.unique(values)
     index = {int(v): i for i, v in enumerate(classes)}
-    y_val = np.zeros((n, len(classes)))
-    for i, v in enumerate(values):
-        y_val[i, index[int(v)]] = 1.0
+    y_cls = np.array([index[int(v)] for v in values], dtype=np.float64)
+    y_val = np.eye(len(classes))[y_cls.astype(np.int64)]
     w_shuf = ridge_probe(acts[tr], y_val[tr][perm], alpha=alpha)
-    m_shuf = probe_metrics(acts[te], values[te], w_shuf)
+    m_shuf = probe_metrics(acts[te], y_cls[te], w_shuf)
     n_labels = int(positions.max()) + 1
     y_pos = np.eye(n_labels)[positions]
     w_pos = ridge_probe(acts[tr], y_pos[tr][perm], alpha=alpha)
@@ -583,12 +588,18 @@ def location_causal_verdict(
     selective = off <= max_off_target
     if selective and effect >= min_follow and gap >= min_gap:
         verdict = "causal"
+    elif effect < min_follow:
+        # Aucun effet apparie mesure. Le dommage eventuel reste reporte comme
+        # champ separe (``off_target_rel``, ``selectivity_ok``) mais il ne peut
+        # pas etiqueter le panneau "global_damage" : ce label affirme un effet,
+        # et une intervention sans effet qui abime tout de meme le modele est un
+        # resultat NEGATIF, pas un dommage global. L'ordre des branches est ce
+        # qui garde le verdict fidele a ce qui a ete mesure.
+        verdict = "no_effect"
     elif not selective:
         verdict = "global_damage"
-    elif effect >= min_follow:
-        verdict = "undiscriminated"      # effet present mais sham non separe
     else:
-        verdict = "no_effect"
+        verdict = "undiscriminated"      # effet present mais sham non separe
     return {
         "verdict": verdict,
         "follow_donor": effect,
@@ -617,6 +628,7 @@ class PromotionEvidence:
     second_task_shuffle: float = float("nan")
     second_task_causal: str = ""
     seeds_stable: bool = True
+    reference_arch: str = ""       # regime de position sur lequel le gate est juge
     notes: list[str] = field(default_factory=list)
 
 
@@ -719,26 +731,42 @@ def run_metrics(run: Mapping[str, Any], *, alpha: float = 1e-2,
 
 def evidence_from_runs(
     runs: Sequence[Mapping[str, Any]], *, task: str = "copy_offset",
-    second_task: str = "variable_binding", stability_tol: float = 0.10,
+    second_task: str = "variable_binding", reference_arch: str = "rope",
+    stability_tol: float = 0.10,
 ) -> tuple[PromotionEvidence, list[dict[str, Any]]]:
     """Agrege les runs d'un POC en :class:`PromotionEvidence` + table detaillee.
 
-    La stabilite multi-seeds est exigeante : l'ecart de localisation au-dessus
-    du shuffle doit rester positif pour CHAQUE seed du banc primaire (une
-    moyenne qui tient grace a une seed sur quatre n'est pas une generalisation).
+    Le gate se juge sur **une** architecture de position, celle de reference :
+    la variance entre graines d'un meme regime repond a "le resultat se
+    reproduit-il ?", alors que l'ecart entre regimes repond a une AUTRE question
+    ("quel encodage positionnel faut-il ?"). Melanger les deux dans un meme test
+    de stabilite fait passer une heterogeneite d'architecture pour une
+    instabilite de graine — les runs d'ablation sont donc rapportes mais exclus
+    du gate.
+
+    La stabilite multi-graines reste exigeante : l'ecart de localisation
+    au-dessus du shuffle doit rester positif pour CHAQUE graine, et l'amplitude
+    des ecarts ne doit pas trahir une moyenne portee par une seule graine.
     """
     rows = [run_metrics(r) for r in runs]
     primary = [r for r in rows if r["task"] == task]
-    secondary = [r for r in rows if r["task"] == second_task]
     if not primary:
         raise ValueError(f"aucun run pour le banc primaire {task!r}")
+    reference = [r for r in primary if r["arch"] == reference_arch]
+    if not reference:
+        raise ValueError(
+            f"aucun run de l'architecture de reference {reference_arch!r} "
+            f"sur le banc primaire {task!r} : le gate ne peut pas se juger "
+            "sur une architecture absente de la matrice"
+        )
+    ablation = [r for r in primary if r["arch"] != reference_arch]
 
-    gains = [r["position_exact"] - r["position_exact_shuffle"] for r in primary]
+    gains = [r["position_exact"] - r["position_exact_shuffle"] for r in reference]
     seeds_stable = all(g > 0 for g in gains) and (
         max(gains) - min(gains) <= stability_tol * max(1.0, max(gains))
     )
-    best_primary = max(primary, key=lambda r: r["position_exact"])
-    causal_verdicts = [r["causal"]["verdict"] for r in primary]
+    best_primary = max(reference, key=lambda r: r["position_exact"])
+    causal_verdicts = [r["causal"]["verdict"] for r in reference]
     # le verdict causal agrege = le plus frequent (mode) ; un partage exact
     # n'est pas une preuve de selectivite et retombe sur le pire cas.
     causal_mode = max(set(causal_verdicts), key=causal_verdicts.count)
@@ -746,15 +774,36 @@ def evidence_from_runs(
         causal_mode = "undiscriminated"
 
     notes: list[str] = []
-    if secondary:
-        sec_best = max(secondary, key=lambda r: r["position_exact"])
+    if ablation:
+        notes.append(
+            f"stabilite multi-graines mesuree sur {reference_arch!r} seul "
+            f"({len(reference)} graines) ; {len(ablation)} run(s) d'ablation "
+            "sur d'autres regimes de position sont rapportes dans la table "
+            "mais exclus du gate (l'ecart entre regimes n'est pas de "
+            "l'instabilite de graine)"
+        )
+
+    secondary = [r for r in rows if r["task"] == second_task]
+    sec_ref = [r for r in secondary if r["arch"] == reference_arch]
+    if sec_ref:
+        sec_best = max(sec_ref, key=lambda r: r["position_exact"])
         sec_gain = sec_best["position_exact"] - sec_best["position_exact_shuffle"]
         sec_causal = max(
-            [r["causal"]["verdict"] for r in secondary],
-            key=[r["causal"]["verdict"] for r in secondary].count,
+            [r["causal"]["verdict"] for r in sec_ref],
+            key=[r["causal"]["verdict"] for r in sec_ref].count,
         )
         sec_pos = float(sec_best["position_exact"])
         sec_shuf = float(sec_best["position_exact_shuffle"])
+        peers = [r for r in secondary if r["arch"] != reference_arch]
+        if peers and max(r["position_exact"] for r in peers) > sec_pos:
+            top = max(peers, key=lambda r: r["position_exact"])
+            notes.append(
+                f"sur le second banc, un autre regime ({top['arch']!r}) "
+                f"localise mieux la reference ({top['position_exact']:.3f}) "
+                f"que le regime de reference {reference_arch!r} "
+                f"({sec_pos:.3f}) : la localisation du second banc depend de "
+                "l'encodage positionnel"
+            )
     else:
         sec_pos = sec_shuf = float("nan")
         sec_causal = ""
@@ -771,6 +820,7 @@ def evidence_from_runs(
         second_task_shuffle=sec_shuf,
         second_task_causal=sec_causal,
         seeds_stable=bool(seeds_stable),
+        reference_arch=reference_arch,
         notes=notes,
     )
     if not np.isfinite(sec_gain):

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/slens.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/slens.py
@@ -1,0 +1,819 @@
+"""Self-Location Lens (S-Lens) — bancs, oracles et métriques du POC #15481.
+
+Le S-Lens est un **quatrième instrument** expérimental du toolkit ICT (#15475) :
+il mesure si la représentation interne porte la *bonne référence* — position,
+source ou relation de binding — nécessaire à la prédiction. Ce module est le
+cœur **numpy-only** du POC (règle d'architecture de la série : torch reste
+confiné aux scripts d'extraction/entraînement, cf. ``scripts/slens_poc.py``).
+
+Ce qui vit ici est testable sans GPU :
+
+* les **bancs synthétiques** (`copy_offset`, `variable_binding`) avec ground
+  truth *exacte* et oracle de contrôle (le générateur est validé contre
+  l'oracle, jamais l'inverse) ;
+* la **distribution ground-truth** des positions de référence, exacte par
+  construction ;
+* le **probe linéaire** (ridge closed-form) et ses métriques held-out
+  (R², RMSE, taux d'exactitude) — aucune métrique in-sample n'est présentée
+  comme résultat ;
+* les **contrôles** de localisation : shuffle, position absolue, contenu,
+  cible aléatoire (ce dernier délégué au moteur commun
+  :mod:`ict.causal_engine`) ;
+* le **verdict de promotion** `PROMOTE / SPECIALIZED_ONLY / INCONCLUSIVE`.
+
+Statut contractuel (honnêteté référentielle) : ``slens`` n'entre PAS dans
+l'énumération ``INSTRUMENTS`` du contrat de trace v1 (``sae``, ``jlens``,
+``jlens_trackp``). Le POC est expérimental — « no final notebook issue before
+the promotion gate » (#15481). Les manifestes produits ici sont donc
+**POC-locaux** (:func:`slens_manifest`) : ils portent les champs d'alignement
+qui devront être respectés à la promotion, sans prétendre être validables par
+:func:`ict.trace_contract.validate_manifest`. Ajouter ``slens`` au contrat
+public est une étape *post-promotion*, pas un prérequis du POC.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+__all__ = [
+    "SLENS_CONTRACT_NOTE",
+    "CopyOffsetConfig",
+    "VarBindingConfig",
+    "generate_copy_offset",
+    "oracle_copy_offset",
+    "generate_variable_binding",
+    "oracle_variable_binding",
+    "exact_position_distribution",
+    "paired_by_offset",
+    "paired_by_query",
+    "ridge_probe",
+    "probe_metrics",
+    "self_location_table",
+    "copy_success_by_position",
+    "shuffle_control_scores",
+    "location_causal_verdict",
+    "promotion_verdict",
+    "load_run",
+    "run_metrics",
+    "evidence_from_runs",
+    "slens_manifest",
+]
+
+#: Note de contrat embarquée dans chaque manifeste POC.
+SLENS_CONTRACT_NOTE = (
+    "POC #15481 : instrument experimental hors enum du contrat v1 "
+    "(sae|jlens|jlens_trackp). Manifeste POC-local, non validable par "
+    "validate_manifest avant le gate de promotion."
+)
+
+
+# --------------------------------------------------------------------------- #
+# Bancs synthetiques : ground truth EXACTE + oracle de controle
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class CopyOffsetConfig:
+    """Banc ``copy_offset`` : l'offset est dans le contenu, la prediction
+    exige de remonter a la bonne reference.
+
+    Disposition (indices de sequence 0-based) ::
+
+        [ v_0 ... v_{L-1} , OFF(k) , Q ]
+
+    * valeurs : ids ``0..V-1`` (uniformes) ;
+    * ``OFF(k)`` : id ``V + (k - 1)`` pour ``k`` dans ``1..L`` — l'offset est
+      un **symbole de contenu**, il ne depend d'aucun encodage positionnel ;
+    * ``Q`` : id ``V + L`` (marqueur de requete, position finale).
+
+    Cible : ``v_{L-k}``. Position de reference (index de sequence) : ``L - k``.
+    """
+
+    seq_values: int = 12          # L : taille du bloc de valeurs
+    n_symbols: int = 16           # V : taille du vocabulaire de valeurs
+    min_offset: int = 1
+    max_offset: int | None = None  # None -> L
+
+    def __post_init__(self) -> None:
+        if self.seq_values < 2:
+            raise ValueError("seq_values doit valoir au moins 2")
+        if self.n_symbols < 2:
+            raise ValueError("n_symbols doit valoir au moins 2")
+        hi = self.seq_values if self.max_offset is None else int(self.max_offset)
+        if not (1 <= self.min_offset <= hi <= self.seq_values):
+            raise ValueError(
+                f"bornes d'offset invalides : {self.min_offset}..{hi} "
+                f"pour seq_values={self.seq_values}"
+            )
+
+    @property
+    def max_off(self) -> int:
+        return self.seq_values if self.max_offset is None else int(self.max_offset)
+
+    @property
+    def query_id(self) -> int:
+        return self.n_symbols + self.seq_values
+
+    @property
+    def n_tokens(self) -> int:
+        """Taille de la sequence produite (bloc + OFF + Q)."""
+        return self.seq_values + 2
+
+    @property
+    def vocab_size(self) -> int:
+        return self.n_symbols + self.seq_values + 1
+
+
+@dataclass(frozen=True)
+class VarBindingConfig:
+    """Second probleme de binding (gate de promotion) : variable -> valeur.
+
+    Disposition ::
+
+        [ x_0 a_0 x_1 a_1 ... x_{P-1} a_{P-1} , QB , x_q ]
+
+    * variables : ids ``0..V_var-1`` ; valeurs : ids ``V_var..V_var+V_val-1`` ;
+    * ``QB`` : marqueur de requete ``V_var + V_val`` ;
+    * ``x_q`` : variable interrogee (tiree parmi celles du contexte, sans
+      remise — la reponse existe toujours).
+
+    Cible : la valeur liee a ``x_q``. Position de reference : l'index du
+    couple ``(x_q, a)`` dans le contexte, soit ``2 * rank(x_q) + 1``.
+    """
+
+    n_pairs: int = 5              # P : nombre de liaisons dans le contexte
+    n_vars: int = 8               # V_var
+    n_vals: int = 8               # V_val
+
+    def __post_init__(self) -> None:
+        if self.n_pairs < 2:
+            raise ValueError("n_pairs doit valoir au moins 2")
+        if self.n_pairs > self.n_vars:
+            raise ValueError("n_pairs ne peut exceder n_vars (liaisons distinctes)")
+        if self.n_vars < 2 or self.n_vals < 2:
+            raise ValueError("n_vars et n_vals doivent valoir au moins 2")
+
+    @property
+    def query_marker(self) -> int:
+        return self.n_vars + self.n_vals
+
+    @property
+    def n_tokens(self) -> int:
+        return 2 * self.n_pairs + 2
+
+    @property
+    def vocab_size(self) -> int:
+        return self.n_vars + self.n_vals + 1
+
+
+def generate_copy_offset(
+    rng: np.random.Generator, n: int, cfg: CopyOffsetConfig = CopyOffsetConfig()
+) -> dict[str, np.ndarray]:
+    """Tire ``n`` exemples ``copy_offset`` avec cible et position exactes.
+
+    Returns
+    -------
+    dict avec ``tokens`` (n, T) int64, ``target_value`` (n,), ``target_pos``
+    (n,), ``offset`` (n,).
+    """
+    if n <= 0:
+        raise ValueError("n doit etre strictement positif")
+    L, V = cfg.seq_values, cfg.n_symbols
+    lo, hi = cfg.min_offset, cfg.max_off
+    values = rng.integers(0, V, size=(n, L)).astype(np.int64)
+    offsets = rng.integers(lo, hi + 1, size=n).astype(np.int64)
+    off_tok = V + (offsets - 1)
+    q = np.full((n, 1), cfg.query_id, dtype=np.int64)
+    tokens = np.concatenate([values, off_tok[:, None], q], axis=1)
+    target_pos = L - offsets                      # index de sequence
+    target_value = values[np.arange(n), target_pos]
+    return {
+        "tokens": tokens,
+        "target_value": target_value.astype(np.int64),
+        "target_pos": target_pos.astype(np.int64),
+        "offset": offsets,
+    }
+
+
+def oracle_copy_offset(
+    tokens: np.ndarray, cfg: CopyOffsetConfig = CopyOffsetConfig()
+) -> tuple[np.ndarray, np.ndarray]:
+    """Oracle exact du banc : relit l'offset DANS le contenu et resout la reference.
+
+    Independant du generateur (il ne partage que la convention de disposition) :
+    c'est ce qui permet de valider le generateur au lieu de le croire.
+    """
+    tokens = np.atleast_2d(np.asarray(tokens, dtype=np.int64))
+    L, V = cfg.seq_values, cfg.n_symbols
+    if tokens.shape[1] != cfg.n_tokens:
+        raise ValueError(
+            f"sequence de longueur {tokens.shape[1]} != n_tokens={cfg.n_tokens}"
+        )
+    off_tok = tokens[:, L]
+    offsets = (off_tok - V) + 1
+    if np.any((offsets < 1) | (offsets > L)):
+        raise ValueError("token d'offset hors bornes du banc")
+    pos = L - offsets
+    vals = tokens[np.arange(tokens.shape[0]), pos]
+    return vals.astype(np.int64), pos.astype(np.int64)
+
+
+def generate_variable_binding(
+    rng: np.random.Generator, n: int, cfg: VarBindingConfig = VarBindingConfig()
+) -> dict[str, np.ndarray]:
+    """Tire ``n`` exemples variable->valeur avec cible et position exactes."""
+    if n <= 0:
+        raise ValueError("n doit etre strictement positif")
+    P, Vv, Vl = cfg.n_pairs, cfg.n_vars, cfg.n_vals
+    vars_ = np.stack([rng.choice(Vv, size=P, replace=False) for _ in range(n)])
+    vals = rng.integers(0, Vl, size=(n, P)).astype(np.int64)
+    query_rank = rng.integers(0, P, size=n)
+    rows = np.arange(n)
+    x_q = vars_[rows, query_rank]
+    seq = np.empty((n, 2 * P + 2), dtype=np.int64)
+    seq[:, 0:2 * P:2] = vars_
+    seq[:, 1:2 * P:2] = Vv + vals
+    seq[:, 2 * P] = cfg.query_marker
+    seq[:, 2 * P + 1] = x_q
+    target_pos = 2 * query_rank + 1
+    target_value = (Vv + vals[rows, query_rank]).astype(np.int64)
+    return {
+        "tokens": seq,
+        "target_value": target_value,
+        "target_pos": target_pos.astype(np.int64),
+        "query_rank": query_rank.astype(np.int64),
+    }
+
+
+def oracle_variable_binding(
+    tokens: np.ndarray, cfg: VarBindingConfig = VarBindingConfig()
+) -> tuple[np.ndarray, np.ndarray]:
+    """Oracle exact du banc variable->valeur (relit le contexte)."""
+    tokens = np.atleast_2d(np.asarray(tokens, dtype=np.int64))
+    if tokens.shape[1] != cfg.n_tokens:
+        raise ValueError(
+            f"sequence de longueur {tokens.shape[1]} != n_tokens={cfg.n_tokens}"
+        )
+    P, Vv = cfg.n_pairs, cfg.n_vars
+    x_q = tokens[:, -1]
+    pair_vars = tokens[:, 0:2 * P:2]
+    match = pair_vars == x_q[:, None]
+    if not np.all(match.sum(axis=1) == 1):
+        raise ValueError("variable interrogee absente ou dupliquee dans le contexte")
+    rank = match.argmax(axis=1)
+    pos = 2 * rank + 1
+    vals = tokens[np.arange(tokens.shape[0]), pos]
+    if np.any(vals < Vv):
+        raise ValueError("la position liee ne porte pas un symbole de valeur")
+    return vals.astype(np.int64), pos.astype(np.int64)
+
+
+def exact_position_distribution(
+    cfg: CopyOffsetConfig = CopyOffsetConfig()
+) -> np.ndarray:
+    """Distribution ground-truth EXACTE des positions de reference du banc.
+
+    Uniforme sur ``[0, L)`` quand ``min_offset..max_off`` couvre tout le bloc ;
+    sinon la masse est portee par ``L - k`` pour ``k`` dans les bornes.
+    Sert de reference pour le controle shuffle et la lecture par position.
+    """
+    L = cfg.seq_values
+    counts = np.zeros(L, dtype=np.float64)
+    for k in range(cfg.min_offset, cfg.max_off + 1):
+        counts[L - k] += 1.0
+    return counts / counts.sum()
+
+
+def paired_by_offset(
+    cfg: CopyOffsetConfig, rng: np.random.Generator, n_pairs: int
+) -> dict[str, np.ndarray]:
+    """Paires contre-factuelles APPARIEES pour l'interchange.
+
+    Chaque paire partage le MEME bloc de valeurs et ne differe que par
+    l'offset : le contexte amont est identique, seule la reference correcte
+    change. C'est ce qui rend un echange de representation interpretable —
+    si la sortie suit le donneur, elle suit la *reference*, pas une
+    correlation de surface.
+    """
+    if n_pairs <= 0:
+        raise ValueError("n_pairs doit etre strictement positif")
+    base = generate_copy_offset(rng, n_pairs, cfg)
+    L = cfg.seq_values
+    V = cfg.n_symbols
+    # offset du donneur : decale, borne a 1..L, et JAMAIS egal a celui de l'hote.
+    off_a = base["offset"]
+    off_b = rng.integers(cfg.min_offset, cfg.max_off + 1, size=n_pairs)
+    collide = off_b == off_a
+    off_b[collide] = 1 + (off_b[collide] % cfg.max_off)
+    collide = off_b == off_a
+    off_b[collide] = cfg.max_off
+    tok_b = base["tokens"].copy()
+    tok_b[:, L] = V + (off_b - 1)
+    val_b, pos_b = oracle_copy_offset(tok_b, cfg)
+    return {
+        "tokens_a": base["tokens"],
+        "tokens_b": tok_b,
+        "target_value_a": base["target_value"],
+        "target_value_b": val_b,
+        "target_pos_a": base["target_pos"],
+        "target_pos_b": pos_b,
+        "offset_a": off_a,
+        "offset_b": off_b,
+    }
+
+
+def paired_by_query(
+    cfg: VarBindingConfig, rng: np.random.Generator, n_pairs: int
+) -> dict[str, np.ndarray]:
+    """Paires contre-factuelles appariees du second banc (variable->valeur).
+
+    Analogue exact de :func:`paired_by_offset` pour le banc variable->valeur :
+    chaque paire partage **tout le contexte de liaisons** et ne differe que par
+    la variable interrogee. La reference correcte change donc a contexte
+    strictement identique — condition pour qu'un echange de representation
+    soit interpretable comme un suivi de *reference*, pas de surface.
+    """
+    if n_pairs <= 0:
+        raise ValueError("n_pairs doit etre strictement positif")
+    base = generate_variable_binding(rng, n_pairs, cfg)
+    tok_a = base["tokens"]
+    x_q_a = tok_a[:, -1]
+    # variable interrogee du donneur : celle d'une AUTRE paire du contexte,
+    # jamais la meme que l'hote.
+    alt_rank = (base["query_rank"] + 1) % cfg.n_pairs
+    rows = np.arange(n_pairs)
+    x_q_b = tok_a[rows, 2 * alt_rank]
+    tok_b = tok_a.copy()
+    tok_b[:, -1] = x_q_b
+    val_b, pos_b = oracle_variable_binding(tok_b, cfg)
+    if np.any(x_q_b == x_q_a):
+        raise ValueError("appariement par requete degenere (meme variable)")
+    return {
+        "tokens_a": tok_a,
+        "tokens_b": tok_b,
+        "target_value_a": base["target_value"],
+        "target_value_b": val_b,
+        "target_pos_a": base["target_pos"],
+        "target_pos_b": pos_b,
+        "query_rank_a": base["query_rank"],
+        "query_rank_b": alt_rank.astype(np.int64),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Probe lineaire (ridge closed-form) et metriques held-out
+# --------------------------------------------------------------------------- #
+
+def ridge_probe(
+    x_train: np.ndarray, y_train: np.ndarray, alpha: float = 1e-2
+) -> np.ndarray:
+    """Ridge closed-form avec biais, en numpy pur.
+
+    ``x_train`` (n, d) ; ``y_train`` (n,) indices OU (n, c) one-hot/cibles
+    continues. Renvoie la matrice de poids (d + 1, c) — le biais est la
+    derniere ligne (colonne d'appariement ajoutee a la conception).
+    """
+    x = np.asarray(x_train, dtype=np.float64)
+    y = np.asarray(y_train, dtype=np.float64)
+    if x.ndim != 2:
+        raise ValueError("x_train doit etre (n, d)")
+    if y.ndim == 1:
+        y = y[:, None]
+    if y.shape[0] != x.shape[0]:
+        raise ValueError("x_train et y_train n'ont pas le meme nombre d'exemples")
+    if alpha < 0:
+        raise ValueError("alpha doit etre positif ou nul")
+    design = np.concatenate([x, np.ones((x.shape[0], 1))], axis=1)
+    gram = design.T @ design
+    reg = alpha * np.eye(gram.shape[0])
+    reg[-1, -1] = 0.0  # le biais n'est pas regularise
+    return np.linalg.solve(gram + reg, design.T @ y)
+
+
+def probe_metrics(
+    x_test: np.ndarray, y_test: np.ndarray, weights: np.ndarray
+) -> dict[str, float]:
+    """Metriques held-out d'un probe : R², RMSE, exactitude (si classification).
+
+    Pour une cible *entiere* (position, symbole), ``y_test`` est traite comme
+    une classe : la prediction est l'argmax de la lecture linéaire, et
+    ``exact_hit`` est le taux d'exactitude. ``r2`` et ``rmse`` sont calcules
+    sur la meme lecture continue — ils sont reportes pour la gradation de
+    l'erreur de localisation, pas comme substitut du taux d'exactitude.
+    """
+    x = np.asarray(x_test, dtype=np.float64)
+    y = np.asarray(y_test)
+    if x.ndim != 2:
+        raise ValueError("x_test doit etre (n, d)")
+    if y.ndim != 1:
+        raise ValueError("y_test doit etre (n,) pour ces metriques")
+    design = np.concatenate([x, np.ones((x.shape[0], 1))], axis=1)
+    pred = design @ weights                      # (n, c) ou (n, 1)
+    if pred.shape[1] == 1:
+        pred_cont = pred[:, 0]
+        exact = float(np.mean(np.rint(pred_cont) == y))
+    else:
+        pred_cls = pred.argmax(axis=1)
+        exact = float(np.mean(pred_cls == y))
+        pred_cont = pred_cls.astype(np.float64)
+    resid = pred_cont - y.astype(np.float64)
+    ss_res = float(np.sum(resid**2))
+    ss_tot = float(np.sum((y.astype(np.float64) - y.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return {
+        "exact_hit": exact,
+        "rmse": float(np.sqrt(ss_res / y.shape[0])),
+        "r2": float(r2),
+        "n_test": int(y.shape[0]),
+    }
+
+
+def self_location_table(
+    activations: Mapping[str, np.ndarray],
+    positions: np.ndarray,
+    *,
+    values: np.ndarray | None = None,
+    alpha: float = 1e-2,
+    train_frac: float = 0.7,
+    n_labels: int | None = None,
+) -> list[dict[str, Any]]:
+    """Erreur de self-location par couche/tete, split gelé train/held-out.
+
+    ``activations`` : mapping ``"L{layer}H{head}" -> (n, d_head)`` (et
+    eventuellement ``"L{layer}"`` pour le residual de couche). Le split est
+    fait une fois, sur les indices, et partagé par tous les probes — sinon
+    chaque tete serait évaluée sur un jeu différent, ce qui rend les
+    comparaisons entre tetes illisibles.
+
+    Renvoie une ligne par entree : position (self-location) et, si ``values``
+    est fourni, valeur (readout de copie) — jamais un score in-sample.
+    """
+    positions = np.asarray(positions)
+    if positions.ndim != 1:
+        raise ValueError("positions doit etre (n,)")
+    if not 0.0 < train_frac < 1.0:
+        raise ValueError("train_frac doit etre dans ]0, 1[")
+    n = positions.shape[0]
+    n_train = int(round(n * train_frac))
+    if n_train < 2 or n - n_train < 2:
+        raise ValueError("jeu trop petit pour un split train/held-out")
+    order = np.arange(n)
+    tr, te = order[:n_train], order[n_train:]
+    rows: list[dict[str, Any]] = []
+    for key in sorted(activations):
+        acts = np.asarray(activations[key], dtype=np.float64)
+        if acts.shape[0] != n:
+            raise ValueError(f"{key}: {acts.shape[0]} exemples != {n} positions")
+        if n_labels is not None:
+            y_pos = np.eye(int(n_labels))[positions]
+        else:
+            y_pos = positions.astype(np.float64)[:, None]
+        w_pos = ridge_probe(acts[tr], y_pos[tr], alpha=alpha)
+        m_pos = probe_metrics(acts[te], positions[te], w_pos)
+        row: dict[str, Any] = {
+            "unit": key,
+            "position_exact": m_pos["exact_hit"],
+            "position_rmse": m_pos["rmse"],
+            "position_r2": m_pos["r2"],
+        }
+        if values is not None:
+            vals = np.asarray(values)
+            if vals.shape[0] != n:
+                raise ValueError(f"{key}: {vals.shape[0]} valeurs != {n} positions")
+            classes = np.unique(vals)
+            index = {int(v): i for i, v in enumerate(classes)}
+            y_val = np.zeros((n, len(classes)))
+            for i, v in enumerate(vals):
+                y_val[i, index[int(v)]] = 1.0
+            w_val = ridge_probe(acts[tr], y_val[tr], alpha=alpha)
+            m_val = probe_metrics(acts[te], vals[te], w_val)
+            row["value_exact"] = m_val["exact_hit"]
+            row["value_rmse"] = m_val["rmse"]
+        rows.append(row)
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Controles et lecture comportementale
+# --------------------------------------------------------------------------- #
+
+def copy_success_by_position(
+    predicted: np.ndarray, target_value: np.ndarray, target_pos: np.ndarray,
+    n_positions: int,
+) -> np.ndarray:
+    """Taux de reussite par position de reference (lecture brute du modele).
+
+    La distribution ground-truth exacte (:func:`exact_position_distribution`)
+    dit ce qu'un hasard par position produirait ; ce vecteur dit ce que le
+    modele produit réellement.
+    """
+    predicted = np.asarray(predicted)
+    target_value = np.asarray(target_value)
+    target_pos = np.asarray(target_pos)
+    if not (predicted.shape == target_value.shape == target_pos.shape):
+        raise ValueError("predicted, target_value et target_pos doivent etre alignes")
+    out = np.zeros(int(n_positions), dtype=np.float64)
+    counts = np.zeros(int(n_positions), dtype=np.float64)
+    for p in range(int(n_positions)):
+        m = target_pos == p
+        counts[p] = m.sum()
+        if counts[p] > 0:
+            out[p] = float(np.mean(predicted[m] == target_value[m]))
+    return np.divide(out, 1.0, out=np.full_like(out, np.nan), where=counts > 0)
+
+
+def shuffle_control_scores(
+    activations: np.ndarray, positions: np.ndarray, values: np.ndarray,
+    *, rng: np.random.Generator, alpha: float = 1e-2, train_frac: float = 0.7,
+) -> dict[str, float]:
+    """Controle shuffle : memes probes, appariement cible/representation detruit.
+
+    La permutation est appliquee aux ETIQUETTES du jeu d'entrainement
+    seulement, et le held-out reste intact : on mesure donc la capacite du
+    probe a generaliser sans signal (plancher empirique), pas une
+    auto-prediction.
+    """
+    acts = np.asarray(activations, dtype=np.float64)
+    positions = np.asarray(positions)
+    values = np.asarray(values)
+    n = positions.shape[0]
+    n_train = int(round(n * train_frac))
+    tr, te = np.arange(n_train), np.arange(n_train, n)
+    perm = rng.permutation(n_train)
+    classes = np.unique(values)
+    index = {int(v): i for i, v in enumerate(classes)}
+    y_val = np.zeros((n, len(classes)))
+    for i, v in enumerate(values):
+        y_val[i, index[int(v)]] = 1.0
+    w_shuf = ridge_probe(acts[tr], y_val[tr][perm], alpha=alpha)
+    m_shuf = probe_metrics(acts[te], values[te], w_shuf)
+    n_labels = int(positions.max()) + 1
+    y_pos = np.eye(n_labels)[positions]
+    w_pos = ridge_probe(acts[tr], y_pos[tr][perm], alpha=alpha)
+    m_pos = probe_metrics(acts[te], positions[te], w_pos)
+    return {
+        "value_exact": m_shuf["exact_hit"],
+        "position_exact": m_pos["exact_hit"],
+    }
+
+
+def location_causal_verdict(
+    follow_donor: float,
+    sham: float,
+    random_target: float,
+    damage: Mapping[str, float],
+    *,
+    min_follow: float = 0.5,
+    min_gap: float = 0.25,
+    max_off_target: float = 0.10,
+) -> dict[str, Any]:
+    """Verdict causal du panneau de patching, canaux séparés (#15475).
+
+    ``follow_donor`` : taux auquel la sortie patchée suit la reference du
+    donneur apparié ; ``sham`` (auto-echange, doit rester au niveau baseline) et
+    ``random_target`` (échange non apparié) sont les deux planchers. Le verdict
+    exige que l'effet apparié depasse le sham d'au moins ``min_gap`` ET que le
+    dommage hors cible reste sous ``max_off_target`` — la selectivité et
+    l'effet sont DEUX conditions, jamais une seule.
+    """
+    effect = float(follow_donor)
+    gap = effect - max(float(sham), float(random_target))
+    off = float(damage.get("off_target_rel", float("inf")))
+    selective = off <= max_off_target
+    if selective and effect >= min_follow and gap >= min_gap:
+        verdict = "causal"
+    elif not selective:
+        verdict = "global_damage"
+    elif effect >= min_follow:
+        verdict = "undiscriminated"      # effet present mais sham non separe
+    else:
+        verdict = "no_effect"
+    return {
+        "verdict": verdict,
+        "follow_donor": effect,
+        "sham": float(sham),
+        "random_target": float(random_target),
+        "gap_vs_controls": float(gap),
+        "off_target_rel": off,
+        "selectivity_ok": bool(selective),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Gate de promotion
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class PromotionEvidence:
+    """Preuves agregees (multi-seeds) pour le gate de promotion du S-Lens."""
+
+    position_exact: float          # meilleure unite, moyenne multi-seed
+    position_exact_shuffle: float  # plancher shuffle correspondant
+    value_exact: float             # readout de copie du meme unite
+    copy_accuracy: float           # exactitude comportementale du modele
+    causal_verdict: str            # de location_causal_verdict
+    second_task_position_exact: float = float("nan")
+    second_task_shuffle: float = float("nan")
+    second_task_causal: str = ""
+    seeds_stable: bool = True
+    notes: list[str] = field(default_factory=list)
+
+
+def promotion_verdict(ev: PromotionEvidence, *, margin: float = 0.15) -> str:
+    """`PROMOTE / SPECIALIZED_ONLY / INCONCLUSIVE` — criteres explicites.
+
+    * ``INCONCLUSIVE`` : l'effet n'est pas stable multi-seeds, OU la
+      localisation ne se detache pas du shuffle (pas de signal a interpreter).
+    * ``PROMOTE`` : localisation au-dessus du shuffle sur les DEUX bancs,
+      verdict causal ``causal`` sur le banc primaire, second banc testé.
+    * ``SPECIALIZED_ONLY`` : signal sur le banc primaire uniquement (ou sans
+      jambe causale hors banc primaire) — demonstrateur spécialisé, aucune
+      issue notebook/API définitive (cf. gate #15481).
+    """
+    if not ev.seeds_stable:
+        return "INCONCLUSIVE"
+    primary_gain = ev.position_exact - ev.position_exact_shuffle
+    if primary_gain < margin:
+        return "INCONCLUSIVE"
+    second = ev.second_task_position_exact - ev.second_task_shuffle
+    if ev.causal_verdict != "causal":
+        return "SPECIALIZED_ONLY"
+    if not np.isfinite(ev.second_task_position_exact):
+        return "SPECIALIZED_ONLY"
+    if second < margin:
+        return "SPECIALIZED_ONLY"
+    if ev.second_task_causal and ev.second_task_causal != "causal":
+        return "SPECIALIZED_ONLY"
+    return "PROMOTE"
+
+
+# --------------------------------------------------------------------------- #
+# Agregation multi-runs (POC : le notebook reste mince, la logique est testee)
+# --------------------------------------------------------------------------- #
+
+def load_run(path: str | "Path") -> dict[str, Any]:
+    """Charge un npz de run POC et separe le manifeste des tableaux.
+
+    Le manifeste est stocke dans ``__meta__`` (chaine JSON) : on le relit ici
+    pour que le notebook ne manipule jamais un dict opaque a la main.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    with np.load(_Path(path), allow_pickle=False) as npz:
+        arrays = {k: npz[k] for k in npz.files}
+    meta = _json.loads(str(arrays.pop("__meta__")))
+    arrays["patch_stats"] = _json.loads(str(arrays["patch_stats"]))
+    return {"meta": meta, "arrays": arrays}
+
+
+def run_metrics(run: Mapping[str, Any], *, alpha: float = 1e-2,
+                rng: np.random.Generator | None = None) -> dict[str, Any]:
+    """Metriques d'un run : self-location par tete, shuffle, readout, causal.
+
+    Renvoie la meilleure unite (position), le meilleur readout de valeur, les
+    planchers shuffle correspondants et le verdict causal du patching.
+    """
+    if rng is None:
+        rng = np.random.default_rng(int(run["meta"].get("seed", 0)))
+    arrays = run["arrays"]
+    positions = arrays["target_pos"]
+    values = arrays["target_value"]
+    n_pos = int(max(positions.max() + 1, arrays["tokens"].shape[1]))
+    head_keys = [k for k in arrays if k.startswith("L") and "H" in k and k.endswith("_q")]
+    layer_keys = [k for k in arrays if k.startswith("L") and "H" not in k and k.endswith("_q")]
+    # ``_q`` marque "capture a la position de requete" : c'est une convention de
+    # stockage, pas une propriete de l'unite. Les rapports lisent ``L0H0``.
+    units = {k.removesuffix("_q"): arrays[k] for k in sorted(head_keys + layer_keys)}
+    table = self_location_table(units, positions, values=values, alpha=alpha,
+                                n_labels=n_pos)
+    by_unit = {row["unit"]: row for row in table}
+    best_pos = max(table, key=lambda r: r["position_exact"])
+    best_val = max(table, key=lambda r: r.get("value_exact", -1.0))
+    shuffle = shuffle_control_scores(
+        units[best_pos["unit"]], positions, values, rng=rng, alpha=alpha)
+    stats = dict(arrays["patch_stats"])
+    damage = {
+        "off_target_rel": stats["off_target_rel"],
+        "target_rel": stats["target_rel"],
+        "selectivity_ratio": stats["selectivity_ratio"],
+    }
+    causal = location_causal_verdict(
+        stats["follow_donor"], stats["sham"], stats["random_target"], damage)
+    return {
+        "task": run["meta"]["task"],
+        "arch": run["meta"]["arch"],
+        "seed": int(run["meta"]["seed"]),
+        "table": table,
+        "best_unit": best_pos["unit"],
+        "position_exact": float(best_pos["position_exact"]),
+        "position_exact_shuffle": float(shuffle["position_exact"]),
+        "value_exact": float(best_val.get("value_exact", float("nan"))),
+        "value_exact_shuffle": float(shuffle["value_exact"]),
+        "copy_accuracy": float(arrays["predictions_accuracy"]),
+        "causal": causal,
+        "patch_stats": stats,
+    }
+
+
+def evidence_from_runs(
+    runs: Sequence[Mapping[str, Any]], *, task: str = "copy_offset",
+    second_task: str = "variable_binding", stability_tol: float = 0.10,
+) -> tuple[PromotionEvidence, list[dict[str, Any]]]:
+    """Agrege les runs d'un POC en :class:`PromotionEvidence` + table detaillee.
+
+    La stabilite multi-seeds est exigeante : l'ecart de localisation au-dessus
+    du shuffle doit rester positif pour CHAQUE seed du banc primaire (une
+    moyenne qui tient grace a une seed sur quatre n'est pas une generalisation).
+    """
+    rows = [run_metrics(r) for r in runs]
+    primary = [r for r in rows if r["task"] == task]
+    secondary = [r for r in rows if r["task"] == second_task]
+    if not primary:
+        raise ValueError(f"aucun run pour le banc primaire {task!r}")
+
+    gains = [r["position_exact"] - r["position_exact_shuffle"] for r in primary]
+    seeds_stable = all(g > 0 for g in gains) and (
+        max(gains) - min(gains) <= stability_tol * max(1.0, max(gains))
+    )
+    best_primary = max(primary, key=lambda r: r["position_exact"])
+    causal_verdicts = [r["causal"]["verdict"] for r in primary]
+    # le verdict causal agrege = le plus frequent (mode) ; un partage exact
+    # n'est pas une preuve de selectivite et retombe sur le pire cas.
+    causal_mode = max(set(causal_verdicts), key=causal_verdicts.count)
+    if causal_verdicts.count(causal_mode) * 2 <= len(causal_verdicts):
+        causal_mode = "undiscriminated"
+
+    notes: list[str] = []
+    if secondary:
+        sec_best = max(secondary, key=lambda r: r["position_exact"])
+        sec_gain = sec_best["position_exact"] - sec_best["position_exact_shuffle"]
+        sec_causal = max(
+            [r["causal"]["verdict"] for r in secondary],
+            key=[r["causal"]["verdict"] for r in secondary].count,
+        )
+        sec_pos = float(sec_best["position_exact"])
+        sec_shuf = float(sec_best["position_exact_shuffle"])
+    else:
+        sec_pos = sec_shuf = float("nan")
+        sec_causal = ""
+        sec_gain = float("nan")
+        notes.append("banc secondaire absent : gate de promotion non evaluable")
+
+    ev = PromotionEvidence(
+        position_exact=float(best_primary["position_exact"]),
+        position_exact_shuffle=float(best_primary["position_exact_shuffle"]),
+        value_exact=float(best_primary["value_exact"]),
+        copy_accuracy=float(best_primary["copy_accuracy"]),
+        causal_verdict=causal_mode,
+        second_task_position_exact=sec_pos,
+        second_task_shuffle=sec_shuf,
+        second_task_causal=sec_causal,
+        seeds_stable=bool(seeds_stable),
+        notes=notes,
+    )
+    if not np.isfinite(sec_gain):
+        pass
+    elif sec_gain <= 0:
+        notes.append(
+            "le second banc ne se detache pas de son plancher shuffle : "
+            "le S-Lens reste un demonstrateur specialise"
+        )
+    return ev, rows
+
+
+# --------------------------------------------------------------------------- #
+# Manifeste POC-local
+# --------------------------------------------------------------------------- #
+
+def slens_manifest(
+    *, task: str, arch: str, run: str, seed: int, layer: int,
+    d_model: int, n_heads: int, n_layers: int, n_test: int,
+    prompt_set: str = "", **extra: Any,
+) -> dict[str, Any]:
+    """Manifeste POC-local : champs d'alignement du contrat v1 + note de statut.
+
+    Volontairement NON validable par :func:`ict.trace_contract.validate_manifest`
+    (l'instrument ``slens`` n'est pas dans l'enum v1) — la note embarquée dit
+    pourquoi et ce que la promotion devra ajouter.
+    """
+    if not task or not arch:
+        raise ValueError("task et arch sont requis")
+    manifest: dict[str, Any] = {
+        "instrument": "slens_poc",
+        "contract_version": "poc-0.1.0",
+        "contract_note": SLENS_CONTRACT_NOTE,
+        "task": task,
+        "arch": arch,
+        "run": run,
+        "seed": int(seed),
+        "layer": int(layer),
+        "n_layers": int(n_layers),
+        "d_model": int(d_model),
+        "n_heads": int(n_heads),
+        "prompt_set": prompt_set,
+        "n_test": int(n_test),
+    }
+    manifest.update(extra)
+    return manifest

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_causal_engine.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_causal_engine.py
@@ -27,6 +27,7 @@ module-level, fixtures synthetiques placees a la main, tolerances commentees).
 
 from __future__ import annotations
 
+import math
 import sys
 import unittest
 from pathlib import Path
@@ -320,6 +321,29 @@ class TestGate5DommageGeneral(unittest.TestCase):
         verdict = selectivity_verdict(damage)
         self.assertEqual(verdict, "global_damage")  # l'effet cible existe mais le
         # dommage hors cible disqualifie la lecture selective
+
+    def test_ratio_sature_a_inf_sous_le_plancher_de_mesure(self) -> None:
+        """Hors cible au plancher = rapport NON BORNE, pas un grand nombre.
+
+        ``on_rel / eps`` publiait une magnitude qui dependait de la constante
+        interne (462774272000.00 mesure sur le banc copy_offset pour une
+        intervention parfaitement propre) : lisible comme une mesure alors
+        qu'elle n'en est pas une. Et une intervention sans AUCUN effet ne doit
+        pas ressortir selective -- son rapport vaut 0.0.
+        """
+        x = _panel()
+        spec = _clamp_spec()
+        out = apply_intervention(x, spec)
+        damage = damage_metrics(x, out, spec)
+        self.assertLessEqual(damage["off_target_rel"], 1e-12)  # sous le plancher
+        self.assertTrue(math.isinf(damage["selectivity_ratio"]))
+        self.assertGreater(damage["selectivity_ratio"], 0.0)  # inf passe le seuil
+        self.assertEqual(selectivity_verdict(damage), "selective")
+
+        # rien ne bouge : aucun rapport mesurable, et surtout pas "selective"
+        neutre = damage_metrics(x, x, spec)
+        self.assertEqual(neutre["selectivity_ratio"], 0.0)
+        self.assertEqual(selectivity_verdict(neutre), "not_selective")
 
 
 class TestGate6RejouabiliteEtContrat(unittest.TestCase):

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_slens.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_slens.py
@@ -1,0 +1,434 @@
+"""Tests du module :mod:`ict.slens` (Epic #15475, grain #15481).
+
+Couvre les acceptances du POC S-Lens vérifiables sans GPU :
+
+  1. (Gate oracle) les deux bancs produisent une ground truth EXACTE : le
+     generateur est confronte a l'oracle independant, jamais l'inverse ;
+     un token d'offset hors bornes est refuse nommement.
+  2. (Gate distribution) la distribution ground-truth des positions est
+     exacte (somme 1, support = positions atteignables).
+  3. (Gate appariement) les paires contre-factuelles partagent le bloc de
+     valeurs, different d'offset, et leurs cibles viennent de l'oracle.
+  4. (Gate probe) le ridge closed-form recupere un encodage lineaire connu,
+     le shuffle retombe au plancher, et les metriques sont held-out.
+  5. (Gate self-location) un encodage lineaire synthetique de la position est
+     detecte par tete ; du bruit ne l'est pas ; le split est partage.
+  6. (Gate causal) le verdict de location separe effet apparie / sham /
+     cible aleatoire / dommage global.
+  7. (Gate promotion) PROMOTE exige les deux bancs ET le verdict causal ;
+     instabilite multi-seeds ou absence de signal rend INCONCLUSIVE ;
+     un seul banc rend SPECIALIZED_ONLY.
+  8. (Gate contrat) le manifeste porte la note de statut POC et n'est pas
+     confondu avec un manifeste valide du contrat v1.
+
+Pattern herite de ``test_causal_engine.py`` (bootstrap sys.path module-level,
+fixtures synthetiques deterministes, tolerances commentees).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from ict import slens  # noqa: E402
+from ict import trace_contract  # noqa: E402
+
+
+CFG = slens.CopyOffsetConfig(seq_values=8, n_symbols=10)
+VCFG = slens.VarBindingConfig(n_pairs=4, n_vars=6, n_vals=6)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Oracles
+# --------------------------------------------------------------------------- #
+
+def test_oracle_confirms_generator_copy_offset():
+    rng = np.random.default_rng(0)
+    batch = slens.generate_copy_offset(rng, 512, CFG)
+    val, pos = slens.oracle_copy_offset(batch["tokens"], CFG)
+    assert np.array_equal(val, batch["target_value"])
+    assert np.array_equal(pos, batch["target_pos"])
+    # l'offset est bien dans le contenu, pas dans la position du token
+    assert np.array_equal(batch["tokens"][:, CFG.seq_values] - CFG.n_symbols + 1,
+                          batch["offset"])
+
+
+def test_oracle_confirms_generator_variable_binding():
+    rng = np.random.default_rng(1)
+    batch = slens.generate_variable_binding(rng, 512, VCFG)
+    val, pos = slens.oracle_variable_binding(batch["tokens"], VCFG)
+    assert np.array_equal(val, batch["target_value"])
+    assert np.array_equal(pos, batch["target_pos"])
+
+
+def test_offset_token_out_of_bounds_is_named():
+    tokens = np.zeros((1, CFG.n_tokens), dtype=np.int64)
+    tokens[0, CFG.seq_values] = CFG.n_symbols + CFG.seq_values + 3  # offset > L
+    with pytest.raises(ValueError, match="offset hors bornes"):
+        slens.oracle_copy_offset(tokens, CFG)
+
+
+def test_generator_rejects_bad_config():
+    with pytest.raises(ValueError, match="bornes d'offset"):
+        slens.CopyOffsetConfig(seq_values=4, min_offset=5)
+    with pytest.raises(ValueError, match="exceder n_vars"):
+        slens.VarBindingConfig(n_pairs=5, n_vars=3)
+    with pytest.raises(ValueError, match="strictement positif"):
+        slens.generate_copy_offset(np.random.default_rng(0), 0, CFG)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Distribution ground-truth exacte
+# --------------------------------------------------------------------------- #
+
+def test_exact_position_distribution_full_block():
+    dist = slens.exact_position_distribution(CFG)
+    assert dist.shape == (CFG.seq_values,)
+    assert dist.sum() == pytest.approx(1.0)
+    assert np.allclose(dist, 1.0 / CFG.seq_values)
+
+
+def test_exact_position_distribution_partial_bounds():
+    cfg = slens.CopyOffsetConfig(seq_values=6, min_offset=2, max_offset=4)
+    dist = slens.exact_position_distribution(cfg)
+    support = np.flatnonzero(dist > 0)
+    # offsets 2..4 -> positions 6-2=4, 3, 2
+    assert set(support.tolist()) == {2, 3, 4}
+    assert dist.sum() == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Paires contre-factuelles
+# --------------------------------------------------------------------------- #
+
+def test_paired_by_offset_shares_context_and_differs():
+    rng = np.random.default_rng(7)
+    pairs = slens.paired_by_offset(CFG, rng, 256)
+    assert not np.any(pairs["offset_a"] == pairs["offset_b"])
+    # meme bloc de valeurs a gauche du token d'offset
+    L = CFG.seq_values
+    assert np.array_equal(pairs["tokens_a"][:, :L], pairs["tokens_b"][:, :L])
+    assert np.array_equal(pairs["tokens_a"][:, L + 1:],
+                          pairs["tokens_b"][:, L + 1:])
+    # les cibles du donneur viennent de l'oracle, pas du generateur
+    val_b, pos_b = slens.oracle_copy_offset(pairs["tokens_b"], CFG)
+    assert np.array_equal(val_b, pairs["target_value_b"])
+    assert np.array_equal(pos_b, pairs["target_pos_b"])
+
+
+def test_paired_by_query_shares_context_and_switches_reference():
+    rng = np.random.default_rng(8)
+    pairs = slens.paired_by_query(VCFG, rng, 256)
+    # tout le contexte de liaisons est partage ; seule la variable interrogee change
+    assert np.array_equal(pairs["tokens_a"][:, :-1], pairs["tokens_b"][:, :-1])
+    assert not np.any(pairs["tokens_a"][:, -1] == pairs["tokens_b"][:, -1])
+    val_b, pos_b = slens.oracle_variable_binding(pairs["tokens_b"], VCFG)
+    assert np.array_equal(val_b, pairs["target_value_b"])
+    assert np.array_equal(pos_b, pairs["target_pos_b"])
+    # les deux cibles diffèrent : meme contexte, reference differente
+    assert not np.array_equal(pairs["target_value_a"], pairs["target_value_b"])
+
+
+# --------------------------------------------------------------------------- #
+# 4. Probe ridge et metriques held-out
+# --------------------------------------------------------------------------- #
+
+def test_ridge_recovers_known_linear_map():
+    rng = np.random.default_rng(3)
+    x = rng.normal(size=(400, 6))
+    w_true = rng.normal(size=(6, 1))
+    y = x @ w_true + 0.1
+    w = slens.ridge_probe(x[:300], y[:300], alpha=1e-8)
+    pred = np.concatenate([x[300:], np.ones((100, 1))], axis=1) @ w
+    assert np.allclose(pred, y[300:], atol=1e-4)
+    m = slens.probe_metrics(x[300:], y[300:, 0], w)
+    assert m["r2"] > 0.999
+    assert m["n_test"] == 100
+
+
+def test_probe_metrics_exact_hit_on_separable_classes():
+    rng = np.random.default_rng(4)
+    n_per = 40
+    centres = np.eye(4) * 5.0
+    x = np.concatenate([c + rng.normal(scale=0.1, size=(n_per, 4)) for c in centres])
+    y = np.repeat(np.arange(4), n_per)
+    onehot = np.eye(4)[y]
+    # split par permutation : les 4 classes doivent etre vues a l'entrainement,
+    # sinon l'exactitude held-out mesure l'absence de classe, pas le probe.
+    order = rng.permutation(x.shape[0])
+    tr, te = order[:120], order[120:]
+    w = slens.ridge_probe(x[tr], onehot[tr], alpha=1e-6)
+    assert set(y[tr].tolist()) == {0, 1, 2, 3}
+    m = slens.probe_metrics(x[te], y[te], w)
+    assert m["exact_hit"] == pytest.approx(1.0)
+
+
+def test_shuffle_control_falls_to_floor():
+    rng = np.random.default_rng(5)
+    x = rng.normal(size=(300, 8))
+    y = rng.integers(0, 5, size=300)
+    scores = slens.shuffle_control_scores(x, y, y, rng=rng)
+    # appariement detruit : l'exactitude held-out reste au plancher (1/5 = 0.2)
+    assert scores["value_exact"] < 0.45
+    assert scores["position_exact"] < 0.45
+
+
+# --------------------------------------------------------------------------- #
+# 5. Self-location par tete
+# --------------------------------------------------------------------------- #
+
+def test_self_location_detects_linear_position_code_and_rejects_noise():
+    rng = np.random.default_rng(11)
+    n, n_pos, d = 600, 8, 12
+    positions = rng.integers(0, n_pos, size=n)
+    values = rng.integers(0, 6, size=n)
+    # tete informative : la position est lineairement lisible (one-hot bruite)
+    informative = np.eye(n_pos)[positions] + rng.normal(scale=0.05, size=(n, n_pos))
+    # tete informative aussi pour la valeur (bloc separe)
+    informative = np.concatenate(
+        [informative, np.eye(6)[values] + rng.normal(scale=0.05, size=(n, 6))], axis=1
+    )
+    noise = rng.normal(size=(n, d))
+    rows = slens.self_location_table(
+        {"L0H0": informative, "L0H1": noise}, positions, values=values,
+        alpha=1e-6, n_labels=n_pos,
+    )
+    by_unit = {r["unit"]: r for r in rows}
+    assert by_unit["L0H0"]["position_exact"] > 0.9
+    assert by_unit["L0H0"]["value_exact"] > 0.9
+    assert by_unit["L0H1"]["position_exact"] < 0.5
+    # le split est partage : meme n_test pour toutes les unites
+    assert by_unit["L0H0"]["position_rmse"] >= 0.0
+
+
+def test_self_location_rejects_misaligned_lengths():
+    rng = np.random.default_rng(12)
+    positions = rng.integers(0, 4, size=50)
+    with pytest.raises(ValueError, match="exemples != 50"):
+        slens.self_location_table({"L0H0": rng.normal(size=(49, 4))}, positions)
+
+
+def test_copy_success_by_position_reports_nan_when_absent():
+    predicted = np.array([1, 2, 3])
+    target_value = np.array([1, 0, 3])
+    target_pos = np.array([0, 0, 2])
+    acc = slens.copy_success_by_position(predicted, target_value, target_pos, 4)
+    assert acc[0] == pytest.approx(0.5)
+    assert acc[2] == pytest.approx(1.0)
+    assert np.isnan(acc[1])
+
+
+# --------------------------------------------------------------------------- #
+# 6. Verdict causal
+# --------------------------------------------------------------------------- #
+
+def test_location_causal_verdict_follows_only_paired_effect():
+    damage_ok = {"off_target_rel": 0.01, "target_rel": 0.5, "selectivity_ratio": 50.0}
+    good = slens.location_causal_verdict(0.8, 0.2, 0.15, damage_ok)
+    assert good["verdict"] == "causal"
+    # effet present mais sham non separe -> non discrimine
+    undisc = slens.location_causal_verdict(0.7, 0.6, 0.1, damage_ok)
+    assert undisc["verdict"] == "undiscriminated"
+    # dommage global : meme un effet fort ne suffit pas
+    damaged = slens.location_causal_verdict(
+        0.9, 0.1, 0.1, {"off_target_rel": 0.4, "target_rel": 0.9,
+                        "selectivity_ratio": 2.2}
+    )
+    assert damaged["verdict"] == "global_damage"
+    none = slens.location_causal_verdict(0.2, 0.15, 0.1, damage_ok)
+    assert none["verdict"] == "no_effect"
+
+
+# --------------------------------------------------------------------------- #
+# 7. Gate de promotion
+# --------------------------------------------------------------------------- #
+
+def _evidence(**over):
+    base = dict(
+        position_exact=0.8, position_exact_shuffle=0.3, value_exact=0.7,
+        copy_accuracy=0.9, causal_verdict="causal",
+        second_task_position_exact=0.7, second_task_shuffle=0.3,
+        second_task_causal="causal", seeds_stable=True,
+    )
+    base.update(over)
+    return slens.PromotionEvidence(**base)
+
+
+def test_promotion_requires_both_tasks_and_causal_leg():
+    assert slens.promotion_verdict(_evidence()) == "PROMOTE"
+    # un seul banc -> demonstrateur specialise
+    assert slens.promotion_verdict(
+        _evidence(second_task_position_exact=float("nan"),
+                  second_task_shuffle=float("nan"))
+    ) == "SPECIALIZED_ONLY"
+    # pas de jambe causale -> specialise
+    assert slens.promotion_verdict(
+        _evidence(causal_verdict="undiscriminated")
+    ) == "SPECIALIZED_ONLY"
+    # instabilite multi-seeds -> inconclusif
+    assert slens.promotion_verdict(_evidence(seeds_stable=False)) == "INCONCLUSIVE"
+    # pas de signal au-dessus du shuffle -> inconclusif
+    assert slens.promotion_verdict(
+        _evidence(position_exact=0.35, position_exact_shuffle=0.30)
+    ) == "INCONCLUSIVE"
+
+
+# --------------------------------------------------------------------------- #
+# 8. Manifeste POC
+# --------------------------------------------------------------------------- #
+
+def test_manifest_is_marked_poc_and_not_contract_valid():
+    man = slens.slens_manifest(
+        task="copy_offset", arch="rope", run="r0", seed=0, layer=1,
+        d_model=64, n_heads=4, n_layers=2, n_test=256, prompt_set="poc",
+    )
+    assert man["instrument"] == "slens_poc"
+    assert man["contract_note"].startswith("POC #15481")
+    # honnetete du statut : le contrat v1 ne connait pas slens
+    assert "slens" not in trace_contract.INSTRUMENTS
+    with pytest.raises(trace_contract.TraceContractError):
+        trace_contract.validate_manifest(man)
+
+
+# --------------------------------------------------------------------------- #
+# 9. Agregation multi-runs (charge un npz de run, agrege en preuves de gate)
+# --------------------------------------------------------------------------- #
+
+def _synthetic_run(tmp_path, *, task: str, arch: str, seed: int,
+                   n: int = 600, n_pos: int = 14, n_val: int = 6,
+                   bits: int = 64) -> dict:
+    """Ecrit un npz de run factice (meme forme que ``scripts/slens_poc.py``).
+
+    L'unite ``L0H0`` porte la position et la valeur en one-hot bruite : c'est
+    le cas ou le probe DOIT se detacher de son plancher.
+    """
+    rng = np.random.default_rng(seed)
+    positions = rng.integers(0, n_pos, size=n)
+    values = rng.integers(0, n_val, size=n)
+    unit = np.concatenate(
+        [np.eye(n_pos)[positions] + rng.normal(scale=0.05, size=(n, n_pos)),
+         np.eye(n_val)[values] + rng.normal(scale=0.05, size=(n, n_val))],
+        axis=1,
+    )
+    stats = {
+        "follow_donor": 0.8, "sham": 0.2, "random_target": 0.15,
+        "off_target_rel": 0.01, "target_rel": 0.5, "selectivity_ratio": 50.0,
+    }
+    meta = slens.slens_manifest(
+        task=task, arch=arch, run=f"{task}-{arch}-s{seed}", seed=seed, layer=0,
+        d_model=bits, n_heads=1, n_layers=1, n_test=n, prompt_set="poc",
+    )
+    path = tmp_path / f"slens_{task}_{arch}_s{seed}.npz"
+    np.savez(
+        path,
+        L0H0_q=unit.astype(np.float32),
+        L0_q=rng.normal(size=(n, bits)).astype(np.float32),
+        target_pos=positions, target_value=values,
+        tokens=np.zeros((n, n_pos), dtype=np.int64),
+        predictions_accuracy=np.float64(1.0),
+        __meta__=np.array(json.dumps(meta)),
+        patch_stats=np.array(json.dumps(stats)),
+    )
+    return slens.load_run(path)
+
+
+def test_load_run_separates_manifest_from_arrays(tmp_path):
+    run = _synthetic_run(tmp_path, task="copy_offset", arch="rope", seed=0)
+    # le manifeste et le patch_stats sont relus, pas laisses en tableaux opaques
+    assert run["meta"]["task"] == "copy_offset"
+    assert run["meta"]["instrument"] == "slens_poc"
+    assert isinstance(run["arrays"]["patch_stats"], dict)
+    assert "__meta__" not in run["arrays"]
+
+
+def test_run_metrics_selects_informative_unit_and_reads_causal(tmp_path):
+    """Chemin d'integration complet : npz -> load_run -> run_metrics."""
+    run = _synthetic_run(tmp_path, task="copy_offset", arch="rope", seed=3)
+    m = slens.run_metrics(run)
+    assert m["best_unit"] == "L0H0"
+    assert m["position_exact"] > 0.9
+    # le plancher shuffle est mesure, pas suppose nul
+    assert m["position_exact_shuffle"] < m["position_exact"]
+    assert m["causal"]["verdict"] == "causal"
+    assert (m["task"], m["arch"], m["seed"]) == ("copy_offset", "rope", 3)
+
+
+def _seq_metrics(position_exacts, shuffle_floor=0.10, causal="causal"):
+    """Remplace ``run_metrics`` par une suite de localisations imposees.
+
+    L'agregation est de la logique pure : la tester a travers le pipeline de
+    probe la rendrait dependante du bruit d'echantillonnage du ridge, ce qui
+    mesurerait autre chose que la regle de decision. Les runs sont consommes
+    dans l'ordre, comme dans ``evidence_from_runs``.
+    """
+    it = iter(position_exacts)
+
+    def fake(run, **_):
+        return {
+            "task": run["meta"]["task"], "arch": "x", "seed": 0, "table": [],
+            "best_unit": "L0H0",
+            "position_exact": next(it),
+            "position_exact_shuffle": shuffle_floor,
+            "value_exact": 0.8, "value_exact_shuffle": 0.1,
+            "copy_accuracy": 1.0, "causal": {"verdict": causal},
+            "patch_stats": {},
+        }
+    return fake
+
+
+def _run(task: str) -> dict:
+    return {"meta": {"task": task}, "arrays": {}}
+
+
+def test_evidence_from_runs_requires_every_seed_above_its_floor(monkeypatch):
+    monkeypatch.setattr(slens, "run_metrics", _seq_metrics([0.9] * 4 + [0.85] * 2))
+    runs = [_run("copy_offset")] * 4 + [_run("variable_binding")] * 2
+    ev, rows = slens.evidence_from_runs(runs)
+    assert len(rows) == 6
+    assert ev.seeds_stable is True
+    assert ev.causal_verdict == "causal"
+    assert ev.notes == []
+    assert slens.promotion_verdict(ev) == "PROMOTE"
+
+    # Une seed ou le signal est absent casse la generalisation : une moyenne
+    # qui tient grace aux autres seeds n'est pas une preuve multi-seeds.
+    monkeypatch.setattr(
+        slens, "run_metrics", _seq_metrics([0.9, 0.9, 0.05, 0.9])
+    )
+    ev2, _ = slens.evidence_from_runs([_run("copy_offset")] * 4)
+    assert ev2.seeds_stable is False
+    assert slens.promotion_verdict(ev2) == "INCONCLUSIVE"
+
+
+def test_evidence_from_runs_without_secondary_stays_specialized(monkeypatch):
+    monkeypatch.setattr(slens, "run_metrics", _seq_metrics([0.9] * 2))
+    ev, _ = slens.evidence_from_runs([_run("copy_offset")] * 2)
+    assert np.isnan(ev.second_task_position_exact)
+    assert ev.notes and "banc secondaire absent" in ev.notes[0]
+    # le gate ne peut pas conclure PROMOTE sur un seul banc
+    assert slens.promotion_verdict(ev) == "SPECIALIZED_ONLY"
+
+
+def test_evidence_from_runs_notes_a_secondary_stuck_at_its_floor(monkeypatch):
+    monkeypatch.setattr(
+        slens, "run_metrics", _seq_metrics([0.9, 0.9, 0.09, 0.09])
+    )
+    ev, _ = slens.evidence_from_runs(
+        [_run("copy_offset")] * 2 + [_run("variable_binding")] * 2
+    )
+    assert any("plancher shuffle" in n for n in ev.notes)
+    assert slens.promotion_verdict(ev) == "SPECIALIZED_ONLY"
+
+
+def test_evidence_from_runs_rejects_a_set_without_primary_bench(monkeypatch):
+    # un jeu qui ne contient que le banc secondaire n'est pas agregreable :
+    # le gate de promotion se juge d'abord sur le banc primaire.
+    monkeypatch.setattr(slens, "run_metrics", _seq_metrics([0.9]))
+    with pytest.raises(ValueError, match="aucun run pour le banc primaire"):
+        slens.evidence_from_runs([_run("variable_binding")])

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_slens.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_slens.py
@@ -183,6 +183,35 @@ def test_shuffle_control_falls_to_floor():
 # 5. Self-location par tete
 # --------------------------------------------------------------------------- #
 
+def test_self_location_reads_values_on_a_sparse_label_space():
+    """Un vocabulaire de valeurs qui ne commence pas a 0 reste lisible.
+
+    Recoder les classes en indices compacts pour la regression puis passer les
+    ids BRUTS a la metrique rendait ``value_exact`` nul par construction des que
+    le premier id observe n'est pas 0 — le cas du banc binding, dont les valeurs
+    vivent dans ``n_vars..n_vars+n_vals-1`` (defaut corrige : la cible passee a
+    la metrique est la meme recodee que la regression).
+    """
+    rng = np.random.default_rng(21)
+    n, n_pos, n_val, shift = 600, 8, 6, 5
+    positions = rng.integers(0, n_pos, size=n)
+    values = shift + rng.integers(0, n_val, size=n)      # ids 5..10, pas 0..5
+    acts = np.concatenate(
+        [np.eye(n_pos)[positions] + rng.normal(scale=0.05, size=(n, n_pos)),
+         np.eye(n_val)[values - shift] + rng.normal(scale=0.05, size=(n, n_val))],
+        axis=1,
+    )
+    rows = slens.self_location_table({"L0": acts}, positions, values=values,
+                                     alpha=1e-6, n_labels=n_pos)
+    assert rows[0]["value_exact"] > 0.9
+    assert rows[0]["value_classes"] == n_val
+    # memes probes sur le meme recodage, appariement detruit : le plancher doit
+    # rester au niveau du hasard — sinon c'est le recodage qui produit le score.
+    floor = slens.shuffle_control_scores(
+        acts, positions, values, rng=np.random.default_rng(2), alpha=1e-6)
+    assert floor["value_exact"] < 0.45
+
+
 def test_self_location_detects_linear_position_code_and_rejects_noise():
     rng = np.random.default_rng(11)
     n, n_pos, d = 600, 8, 12
@@ -243,6 +272,24 @@ def test_location_causal_verdict_follows_only_paired_effect():
     assert damaged["verdict"] == "global_damage"
     none = slens.location_causal_verdict(0.2, 0.15, 0.1, damage_ok)
     assert none["verdict"] == "no_effect"
+
+
+def test_causal_verdict_does_not_label_an_absent_effect_as_global_damage():
+    """Un dommage global presuppose un effet mesure.
+
+    Une intervention qui ne deplace PAS la prediction mais abime le modele est
+    un resultat NEGATIF : l'etiqueter ``global_damage`` affirmait un effet que
+    la mesure n'avait pas vu. Le dommage reste reporte comme champ separe.
+    """
+    damaged = {"off_target_rel": 0.33, "target_rel": 0.31, "selectivity_ratio": 0.94}
+    v = slens.location_causal_verdict(0.074, 0.195, 0.062, damaged)
+    assert v["verdict"] == "no_effect"
+    assert v["selectivity_ok"] is False         # le dommage n'est pas tu
+    assert v["off_target_rel"] == pytest.approx(0.33)
+    # un effet FORT assorti du meme dommage reste etiquete global_damage :
+    # c'est le cas que le label decrit.
+    assert slens.location_causal_verdict(
+        0.9, 0.1, 0.1, damaged)["verdict"] == "global_damage"
 
 
 # --------------------------------------------------------------------------- #
@@ -371,7 +418,9 @@ def _seq_metrics(position_exacts, shuffle_floor=0.10, causal="causal"):
 
     def fake(run, **_):
         return {
-            "task": run["meta"]["task"], "arch": "x", "seed": 0, "table": [],
+            "task": run["meta"]["task"],
+            "arch": run["meta"].get("arch", "x"),
+            "seed": 0, "table": [],
             "best_unit": "L0H0",
             "position_exact": next(it),
             "position_exact_shuffle": shuffle_floor,
@@ -382,8 +431,8 @@ def _seq_metrics(position_exacts, shuffle_floor=0.10, causal="causal"):
     return fake
 
 
-def _run(task: str) -> dict:
-    return {"meta": {"task": task}, "arrays": {}}
+def _run(task: str, arch: str = "rope") -> dict:
+    return {"meta": {"task": task, "arch": arch}, "arrays": {}}
 
 
 def test_evidence_from_runs_requires_every_seed_above_its_floor(monkeypatch):
@@ -432,3 +481,31 @@ def test_evidence_from_runs_rejects_a_set_without_primary_bench(monkeypatch):
     monkeypatch.setattr(slens, "run_metrics", _seq_metrics([0.9]))
     with pytest.raises(ValueError, match="aucun run pour le banc primaire"):
         slens.evidence_from_runs([_run("variable_binding")])
+
+
+def test_evidence_from_runs_excludes_the_ablation_from_the_stability_test(monkeypatch):
+    """La stabilite multi-graines porte sur l'architecture de reference.
+
+    Un run d'ablation (autre regime de position) a une localisation differente
+    par construction : le meler aux graines ferait passer une heterogeneite
+    d'architecture pour une instabilite de graine, et le gate conclurait
+    INCONCLUSIVE sur un resultat stable.
+    """
+    # 4 graines de reference parfaitement stables, puis l'ablation tres basse
+    monkeypatch.setattr(
+        slens, "run_metrics", _seq_metrics([0.9, 0.9, 0.9, 0.9, 0.10])
+    )
+    runs = [_run("copy_offset", "rope")] * 4 + [_run("copy_offset", "none")]
+    ev, rows = slens.evidence_from_runs(runs)
+    assert len(rows) == 5
+    assert ev.reference_arch == "rope"
+    assert ev.seeds_stable is True
+    assert any("ablation" in n for n in ev.notes)
+    # un seul banc -> demonstrateur specialise, jamais PROMOTE ici
+    assert slens.promotion_verdict(ev) == "SPECIALIZED_ONLY"
+
+
+def test_evidence_from_runs_refuses_an_absent_reference_architecture(monkeypatch):
+    monkeypatch.setattr(slens, "run_metrics", _seq_metrics([0.9] * 2))
+    with pytest.raises(ValueError, match="architecture de reference"):
+        slens.evidence_from_runs([_run("copy_offset", "none")] * 2)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/runs/slens_matrix.json
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/runs/slens_matrix.json
@@ -1,0 +1,3433 @@
+{
+  "contract": "slens_poc",
+  "generated": "2026-09-12T18:29:57+00:00",
+  "n_runs": 26,
+  "runs": [
+    {
+      "file": "slens_copy_offset_abs_s0.npz",
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_abs_s1.npz",
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_abs_s42.npz",
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_abs_s7.npz",
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_none_s0.npz",
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_none_s1.npz",
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_none_s42.npz",
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_none_s7.npz",
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_rope_s0.npz",
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_rope_s1.npz",
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_rope_s42.npz",
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_rope_s7.npz",
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_copy_offset_rope_s99.npz",
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 99,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_abs_s0.npz",
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_abs_s1.npz",
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_abs_s42.npz",
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_abs_s7.npz",
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_none_s0.npz",
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_none_s1.npz",
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_none_s42.npz",
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_none_s7.npz",
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_rope_s0.npz",
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 0,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_rope_s1.npz",
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 1,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_rope_s42.npz",
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 42,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_rope_s7.npz",
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 7,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    },
+    {
+      "file": "slens_variable_binding_rope_s99.npz",
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 99,
+      "stage": "full",
+      "steps": 3000,
+      "n_test": 1024
+    }
+  ],
+  "per_run": [
+    {
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11400651465798045,
+          "position_rmse": 5.495334117995366,
+          "position_r2": -1.548136390169136,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 6.873685838271729,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.9674267100977199,
+          "position_rmse": 1.2850936923219267,
+          "position_r2": 0.8606509384299696,
+          "value_exact": 0.16938110749185667,
+          "value_rmse": 5.611760568442352,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.8469055374592834,
+          "position_rmse": 2.0218674246191704,
+          "position_r2": 0.6550629738256644,
+          "value_exact": 0.16612377850162866,
+          "value_rmse": 6.189462517381591,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.6710097719869706,
+          "position_rmse": 2.618525830391972,
+          "position_r2": 0.42144028677531753,
+          "value_exact": 0.18566775244299674,
+          "value_rmse": 6.003799014446036,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.43322475570032576,
+          "position_rmse": 3.5362248222483452,
+          "position_r2": -0.055149994807390135,
+          "value_exact": 0.18892508143322476,
+          "value_rmse": 5.682133837841208,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.20846905537459284,
+          "value_rmse": 5.691012401131905,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.739413680781759,
+          "position_rmse": 2.842786172886681,
+          "position_r2": 0.3180966040330464,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.9022801302931596,
+          "position_rmse": 1.816500555216259,
+          "position_r2": 0.7215767270799984,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.8338762214983714,
+          "position_rmse": 2.6531279554297296,
+          "position_r2": 0.40604867445200055,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.8013029315960912,
+          "position_rmse": 2.1001008196676487,
+          "position_r2": 0.6278528020398004,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.10423452768729642,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.05537459283387622,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.111328125,
+        "sham": 0.119140625,
+        "random_target": 0.048828125,
+        "gap_vs_controls": -0.0078125,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.111328125,
+        "sham": 0.119140625,
+        "random_target": 0.048828125,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.47212308645248413,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.09446254071661238,
+          "position_rmse": 6.5455059551167665,
+          "position_r2": -2.6363375208248905,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 5.687863529564034,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.5439739413680782,
+          "position_rmse": 3.1950694914781734,
+          "position_r2": 0.13356026835967405,
+          "value_exact": 0.14332247557003258,
+          "value_rmse": 6.409734047037047,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.6970684039087948,
+          "position_rmse": 3.1254967031967595,
+          "position_r2": 0.17088297537034547,
+          "value_exact": 0.1791530944625407,
+          "value_rmse": 6.070970064530871,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.36482084690553745,
+          "position_rmse": 3.929757847841392,
+          "position_r2": -0.31071817731550255,
+          "value_exact": 0.16612377850162866,
+          "value_rmse": 6.743316150350884,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.8175895765472313,
+          "position_rmse": 2.113243489426291,
+          "position_r2": 0.6209671754694044,
+          "value_exact": 0.20195439739413681,
+          "value_rmse": 5.657430040042957,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.16938110749185667,
+          "value_rmse": 6.042196895374692,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.8762214983713354,
+          "position_rmse": 1.5250353763184648,
+          "position_r2": 0.8026043495880049,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.8208469055374593,
+          "position_rmse": 2.336510943184763,
+          "position_r2": 0.5366455040749246,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.6677524429967426,
+          "position_rmse": 2.805299777277088,
+          "position_r2": 0.3320617767571705,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.6775244299674267,
+          "position_rmse": 3.2194441829150473,
+          "position_r2": 0.12028997253365759,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.09771986970684039,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.03908794788273615,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.0703125,
+        "sham": 0.083984375,
+        "random_target": 0.078125,
+        "gap_vs_controls": -0.013671875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.0703125,
+        "sham": 0.083984375,
+        "random_target": 0.078125,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.460573673248291,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11074918566775244,
+          "position_rmse": 6.338188892458325,
+          "position_r2": -2.231835478369534,
+          "value_exact": 0.05863192182410423,
+          "value_rmse": 5.165344302072966,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.9381107491856677,
+          "position_rmse": 1.5143181994285486,
+          "position_r2": 0.8155183510279614,
+          "value_exact": 0.16938110749185667,
+          "value_rmse": 5.972248524885476,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.7328990228013029,
+          "position_rmse": 2.496903619945395,
+          "position_r2": 0.4984405168572701,
+          "value_exact": 0.13680781758957655,
+          "value_rmse": 5.833185976113039,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.762214983713355,
+          "position_rmse": 2.1889565881089115,
+          "position_r2": 0.6145276908553001,
+          "value_exact": 0.1758957654723127,
+          "value_rmse": 6.493293959887493,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.9022801302931596,
+          "position_rmse": 1.7263997295118625,
+          "position_r2": 0.7602262658957168,
+          "value_exact": 0.14332247557003258,
+          "value_rmse": 6.35820022472711,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.18566775244299674,
+          "value_rmse": 5.8887625550676965,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.7328990228013029,
+          "position_rmse": 2.861060599225923,
+          "position_r2": 0.3414738865529362,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.7035830618892508,
+          "position_rmse": 2.291465542452593,
+          "position_r2": 0.5775789515015253,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.8566775244299675,
+          "position_rmse": 1.8245520622917366,
+          "position_r2": 0.7321871516343417,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.11414602910706992,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.8241042345276873,
+          "position_rmse": 1.4991854465866887,
+          "position_r2": 0.8191870201836553,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.17121904366060486,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.05537459283387622,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.03908794788273615,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.12890625,
+        "sham": 0.119140625,
+        "random_target": 0.05078125,
+        "gap_vs_controls": 0.009765625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.12890625,
+        "sham": 0.119140625,
+        "random_target": 0.05078125,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.457988977432251,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "abs",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.10749185667752444,
+          "position_rmse": 4.171799227526209,
+          "position_r2": -0.41062331229253024,
+          "value_exact": 0.05537459283387622,
+          "value_rmse": 8.292691338865435,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.7719869706840391,
+          "position_rmse": 2.4294608723527857,
+          "position_r2": 0.5216078154830499,
+          "value_exact": 0.15309446254071662,
+          "value_rmse": 6.246041091440315,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.5700325732899023,
+          "position_rmse": 3.336697542271302,
+          "position_r2": 0.09760238042001346,
+          "value_exact": 0.1791530944625407,
+          "value_rmse": 6.101743222908204,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.8892508143322475,
+          "position_rmse": 1.621315667941936,
+          "position_r2": 0.7869412290810271,
+          "value_exact": 0.11726384364820847,
+          "value_rmse": 6.791209109771134,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.34201954397394135,
+          "position_rmse": 4.008947647174383,
+          "position_r2": -0.3026418534252937,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 6.890960892324377,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.1563517915309446,
+          "value_rmse": 6.441164440420241,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.6482084690553745,
+          "position_rmse": 3.079828245137052,
+          "position_r2": 0.23119313393302499,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.5830618892508144,
+          "position_rmse": 2.9252355900557805,
+          "position_r2": 0.3064369377891678,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5863192182410424,
+          "position_rmse": 3.5646655370286116,
+          "position_r2": -0.029916066115133866,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.6547231270358306,
+          "position_rmse": 3.386118433487318,
+          "position_r2": 0.07067301903992029,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.09771986970684039,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.05863192182410423,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.09375,
+        "sham": 0.16015625,
+        "random_target": 0.0625,
+        "gap_vs_controls": -0.06640625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.09375,
+        "sham": 0.16015625,
+        "random_target": 0.0625,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.44383466243743896,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11400651465798045,
+          "position_rmse": 5.495334117995366,
+          "position_r2": -1.548136390169136,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 6.873685838271729,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.6384364820846905,
+          "position_rmse": 1.9074686057926853,
+          "position_r2": 0.6929923041938384,
+          "value_exact": 0.13680781758957655,
+          "value_rmse": 6.038691749510203,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.46905537459283386,
+          "position_rmse": 2.6555822833878917,
+          "position_r2": 0.4049492735717636,
+          "value_exact": 0.18892508143322476,
+          "value_rmse": 5.667784267386036,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.7719869706840391,
+          "position_rmse": 1.3176328592561477,
+          "position_r2": 0.8535048327084296,
+          "value_exact": 0.1498371335504886,
+          "value_rmse": 6.013827714401339,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.745928338762215,
+          "position_rmse": 1.5261029545915406,
+          "position_r2": 0.8034820926576494,
+          "value_exact": 0.11400651465798045,
+          "value_rmse": 6.045430610829827,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.9609120521172638,
+          "position_rmse": 0.2615414093308902,
+          "position_r2": 0.9942281453787561,
+          "value_exact": 0.16286644951140064,
+          "value_rmse": 5.86437374992653,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.2671009771986971,
+          "position_rmse": 3.6361378372299784,
+          "position_r2": -0.1156170432204211,
+          "value_exact": 0.3289902280130293,
+          "value_rmse": 5.5225330542700135,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.3517915309446254,
+          "position_rmse": 2.498859674785101,
+          "position_r2": 0.4731121281464531,
+          "value_exact": 0.34527687296416937,
+          "value_rmse": 5.034409287390544,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.22149837133550487,
+          "position_rmse": 2.7005850494143897,
+          "position_r2": 0.38461035728738047,
+          "value_exact": 0.2768729641693811,
+          "value_rmse": 5.485842008362674,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.24104234527687296,
+          "position_rmse": 3.639719357760613,
+          "position_r2": -0.11781584498089481,
+          "value_exact": 0.14006514657980457,
+          "value_rmse": 5.957777606332302,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.9609120521172638,
+      "position_exact_shuffle": 0.09120521172638436,
+      "value_exact": 0.34527687296416937,
+      "value_exact_shuffle": 0.06514657980456026,
+      "copy_accuracy": 0.53125,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.12109375,
+        "sham": 0.470703125,
+        "random_target": 0.0703125,
+        "gap_vs_controls": -0.349609375,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.12109375,
+        "sham": 0.470703125,
+        "random_target": 0.0703125,
+        "base_accuracy": 0.552734375,
+        "pivot": 12,
+        "target_rel": 0.3483218252658844,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.09446254071661238,
+          "position_rmse": 6.5455059551167665,
+          "position_r2": -2.6363375208248905,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 5.687863529564034,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.3517915309446254,
+          "position_rmse": 3.991848371393312,
+          "position_r2": -0.35246431626817953,
+          "value_exact": 0.18566775244299674,
+          "value_rmse": 6.254900359048788,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.6579804560260586,
+          "position_rmse": 1.4717757228945003,
+          "position_r2": 0.8161511099103966,
+          "value_exact": 0.1791530944625407,
+          "value_rmse": 6.173390412542183,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.5667752442996743,
+          "position_rmse": 2.204525992910992,
+          "position_r2": 0.5875149714079878,
+          "value_exact": 0.13029315960912052,
+          "value_rmse": 6.779688000277556,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.5309446254071661,
+          "position_rmse": 2.6048063817959584,
+          "position_r2": 0.42412445405015986,
+          "value_exact": 0.2247557003257329,
+          "value_rmse": 5.962969332247902,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.9381107491856677,
+          "position_rmse": 0.3828574206676169,
+          "position_r2": 0.9875590976631096,
+          "value_exact": 0.18566775244299674,
+          "value_rmse": 6.204180580666913,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.24429967426710097,
+          "position_rmse": 2.6733087746386985,
+          "position_r2": 0.3934368949524968,
+          "value_exact": 0.36156351791530944,
+          "value_rmse": 4.817516897258856,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.3517915309446254,
+          "position_rmse": 2.4321409182557807,
+          "position_r2": 0.49794047458237656,
+          "value_exact": 0.2899022801302932,
+          "value_rmse": 6.105745678716041,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.28664495114006516,
+          "position_rmse": 2.3704203230953205,
+          "position_r2": 0.5230987437525327,
+          "value_exact": 0.28664495114006516,
+          "value_rmse": 5.562789354915942,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.3355048859934853,
+          "position_rmse": 3.2179261737856657,
+          "position_r2": 0.12111936602278361,
+          "value_exact": 0.3355048859934853,
+          "value_rmse": 5.466808345400635,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.9381107491856677,
+      "position_exact_shuffle": 0.12052117263843648,
+      "value_exact": 0.36156351791530944,
+      "value_exact_shuffle": 0.06514657980456026,
+      "copy_accuracy": 0.515625,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.162109375,
+        "sham": 0.46875,
+        "random_target": 0.087890625,
+        "gap_vs_controls": -0.306640625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.162109375,
+        "sham": 0.46875,
+        "random_target": 0.087890625,
+        "base_accuracy": 0.466796875,
+        "pivot": 12,
+        "target_rel": 0.3134782910346985,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11074918566775244,
+          "position_rmse": 6.338188892458325,
+          "position_r2": -2.231835478369534,
+          "value_exact": 0.05863192182410423,
+          "value_rmse": 5.165344302072966,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.996742671009772,
+          "position_rmse": 0.05707301455353496,
+          "position_r2": 0.9997379522031647,
+          "value_exact": 0.0749185667752443,
+          "value_rmse": 6.497556543989846,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.49185667752442996,
+          "position_rmse": 2.887127445402001,
+          "position_r2": 0.32941968789851317,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 5.937239622269558,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.3289902280130293,
+          "position_rmse": 3.354708878760985,
+          "position_r2": 0.09462486193410047,
+          "value_exact": 0.20195439739413681,
+          "value_rmse": 5.890421750936753,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.7068403908794788,
+          "position_rmse": 1.7701837443043444,
+          "position_r2": 0.7479100194444586,
+          "value_exact": 0.18566775244299674,
+          "value_rmse": 5.826760683702959,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.990228013029316,
+          "position_rmse": 0.0988533609478405,
+          "position_r2": 0.9992138566094941,
+          "value_exact": 0.18892508143322476,
+          "value_rmse": 5.843228771455901,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.2768729641693811,
+          "position_rmse": 2.778465351023905,
+          "position_r2": 0.37894672150038144,
+          "value_exact": 0.46254071661237783,
+          "value_rmse": 4.68659464655388,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.2996742671009772,
+          "position_rmse": 2.076704982192196,
+          "position_r2": 0.6530487169900865,
+          "value_exact": 0.3973941368078176,
+          "value_rmse": 5.148922280581228,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.2736156351791531,
+          "position_rmse": 1.9885666682655645,
+          "position_r2": 0.6818739746419675,
+          "value_exact": 0.42671009771986973,
+          "value_rmse": 5.275164600608963,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.30944625407166126,
+          "position_rmse": 1.7254560837843436,
+          "position_r2": 0.7604883136925522,
+          "value_exact": 0.49185667752442996,
+          "value_rmse": 4.729834617075527,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L0H0",
+      "position_exact": 0.996742671009772,
+      "position_exact_shuffle": 0.048859934853420196,
+      "value_exact": 0.49185667752442996,
+      "value_exact_shuffle": 0.0781758957654723,
+      "copy_accuracy": 0.4931640625,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.162109375,
+        "sham": 0.48046875,
+        "random_target": 0.05859375,
+        "gap_vs_controls": -0.318359375,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.162109375,
+        "sham": 0.48046875,
+        "random_target": 0.05859375,
+        "base_accuracy": 0.48046875,
+        "pivot": 12,
+        "target_rel": 0.30812910199165344,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "none",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.10749185667752444,
+          "position_rmse": 4.171799227526209,
+          "position_r2": -0.41062331229253024,
+          "value_exact": 0.05537459283387622,
+          "value_rmse": 8.292691338865435,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.7003257328990228,
+          "position_rmse": 1.7655774816326268,
+          "position_r2": 0.7473392270514783,
+          "value_exact": 0.1237785016286645,
+          "value_rmse": 6.293577720277445,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.4495114006514658,
+          "position_rmse": 3.14419997540583,
+          "position_r2": 0.19871949226879493,
+          "value_exact": 0.18241042345276873,
+          "value_rmse": 6.250732856056561,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.5537459283387622,
+          "position_rmse": 2.331626489103809,
+          "position_r2": 0.5593617240845531,
+          "value_exact": 0.1563517915309446,
+          "value_rmse": 6.203655536822138,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.7068403908794788,
+          "position_rmse": 1.5110882244759363,
+          "position_r2": 0.814926643848575,
+          "value_exact": 0.1270358306188925,
+          "value_rmse": 6.325585294339245,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.9609120521172638,
+          "position_rmse": 0.27959952747719785,
+          "position_r2": 0.9936636796752721,
+          "value_exact": 0.16938110749185667,
+          "value_rmse": 6.451775504938449,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.40390879478827363,
+          "position_rmse": 2.7608241228179584,
+          "position_r2": 0.38220876833903794,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 6.573067147563941,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.4592833876221498,
+          "position_rmse": 2.968345485041587,
+          "position_r2": 0.2858438967338024,
+          "value_exact": 0.30293159609120524,
+          "value_rmse": 5.689581311914436,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.49185667752442996,
+          "position_rmse": 2.3021021408923144,
+          "position_r2": 0.5704502846528268,
+          "value_exact": 0.32247557003257327,
+          "value_rmse": 5.174794839282471,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.2996742671009772,
+          "position_rmse": 2.8336047644144116,
+          "position_r2": 0.34920709998108057,
+          "value_exact": 0.08469055374592833,
+          "value_rmse": 6.482248373361003,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.9609120521172638,
+      "position_exact_shuffle": 0.06188925081433225,
+      "value_exact": 0.32247557003257327,
+      "value_exact_shuffle": 0.04560260586319218,
+      "copy_accuracy": 0.5087890625,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.142578125,
+        "sham": 0.416015625,
+        "random_target": 0.076171875,
+        "gap_vs_controls": -0.2734375,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.142578125,
+        "sham": 0.416015625,
+        "random_target": 0.076171875,
+        "base_accuracy": 0.5625,
+        "pivot": 12,
+        "target_rel": 0.3671484589576721,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11400651465798045,
+          "position_rmse": 5.495334117995366,
+          "position_r2": -1.548136390169136,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 6.873685838271729,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.9315960912052117,
+          "position_rmse": 0.7804617358798819,
+          "position_r2": 0.9486030088489237,
+          "value_exact": 0.16286644951140064,
+          "value_rmse": 6.08650988710798,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.7980456026058632,
+          "position_rmse": 2.3724806627481723,
+          "position_r2": 0.5250588197376478,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 5.587620099052503,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.5732899022801303,
+          "position_rmse": 2.72400356823177,
+          "position_r2": 0.3738911987050705,
+          "value_exact": 0.09120521172638436,
+          "value_rmse": 6.801992427017153,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.7133550488599348,
+          "position_rmse": 2.2772061286679772,
+          "position_r2": 0.5624384496657033,
+          "value_exact": 0.11400651465798045,
+          "value_rmse": 5.787777754501713,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.996742671009772,
+          "position_rmse": 0.28536507276767475,
+          "position_r2": 0.9931287444985192,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 6.1092123526713795,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.6677524429967426,
+          "position_rmse": 2.7048033037639017,
+          "position_r2": 0.3826864057469659,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.7817589576547231,
+          "position_rmse": 2.2743435176951796,
+          "position_r2": 0.5635378505459403,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.22829205821413984,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.8208469055374593,
+          "position_rmse": 2.2935968083379956,
+          "position_r2": 0.556116894604341,
+          "value_exact": 0.8241042345276873,
+          "value_rmse": 2.280779339917419,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.8762214983713354,
+          "position_rmse": 1.7460984894482385,
+          "position_r2": 0.7427401940245593,
+          "value_exact": 0.9478827361563518,
+          "value_rmse": 1.119853410602381,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.996742671009772,
+      "position_exact_shuffle": 0.08469055374592833,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.06188925081433225,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.07421875,
+        "sham": 0.1953125,
+        "random_target": 0.0625,
+        "gap_vs_controls": -0.12109375,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.07421875,
+        "sham": 0.1953125,
+        "random_target": 0.0625,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.46277427673339844,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.09446254071661238,
+          "position_rmse": 6.5455059551167665,
+          "position_r2": -2.6363375208248905,
+          "value_exact": 0.06188925081433225,
+          "value_rmse": 5.687863529564034,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.31596091205211724,
+          "position_rmse": 4.018280702559275,
+          "position_r2": -0.37043450853257687,
+          "value_exact": 0.19218241042345277,
+          "value_rmse": 6.302628581459534,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.9315960912052117,
+          "position_rmse": 1.1779737475161038,
+          "position_r2": 0.8822261245441038,
+          "value_exact": 0.12052117263843648,
+          "value_rmse": 6.403378587042174,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.28338762214983715,
+          "position_rmse": 4.547254603600663,
+          "position_r2": -0.7549966229906793,
+          "value_exact": 0.16612377850162866,
+          "value_rmse": 6.143241300875439,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.501628664495114,
+          "position_rmse": 3.251659561251782,
+          "position_r2": 0.10259624476563567,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 6.362553315340764,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.9381107491856677,
+          "position_rmse": 0.8896802485305646,
+          "position_r2": 0.9328191273807915,
+          "value_exact": 0.18892508143322476,
+          "value_rmse": 6.0704334990550315,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.5211726384364821,
+          "position_rmse": 3.478177665057787,
+          "position_r2": -0.026789139538025086,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.6416938110749185,
+          "position_rmse": 3.2486529405799507,
+          "position_r2": 0.10425503174388773,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.6612377850162866,
+          "position_rmse": 3.2376047767684284,
+          "position_r2": 0.11033725066414524,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.5342019543973942,
+          "position_rmse": 3.5678623423292377,
+          "position_r2": -0.08042325183484156,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.9381107491856677,
+      "position_exact_shuffle": 0.08794788273615635,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.03908794788273615,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.126953125,
+        "sham": 0.29296875,
+        "random_target": 0.056640625,
+        "gap_vs_controls": -0.166015625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.126953125,
+        "sham": 0.29296875,
+        "random_target": 0.056640625,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.4445943534374237,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.11074918566775244,
+          "position_rmse": 6.338188892458325,
+          "position_r2": -2.231835478369534,
+          "value_exact": 0.05863192182410423,
+          "value_rmse": 5.165344302072966,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.08143322475570032,
+          "position_rmse": 5.040875266535439,
+          "position_r2": -1.0442348631120355,
+          "value_exact": 0.1237785016286645,
+          "value_rmse": 6.318629711672045,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.7687296416938111,
+          "position_rmse": 2.3628503738601,
+          "position_r2": 0.5508500762243265,
+          "value_exact": 0.16286644951140064,
+          "value_rmse": 6.00054286360663,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.08143322475570032,
+          "position_rmse": 4.922195956005405,
+          "position_r2": -0.9491115128608281,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 6.175500612710647,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.7166123778501629,
+          "position_rmse": 2.997284330030913,
+          "position_r2": 0.27727217632829204,
+          "value_exact": 0.13029315960912052,
+          "value_rmse": 5.933123494197145,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.8175895765472313,
+          "position_rmse": 2.0242825567856975,
+          "position_r2": 0.6703438715812151,
+          "value_exact": 0.2247557003257329,
+          "value_rmse": 6.002442499592316,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.46254071661237783,
+          "position_rmse": 3.3146599650701862,
+          "position_r2": 0.11611278127459357,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.44299674267100975,
+          "position_rmse": 2.596665363455982,
+          "position_r2": 0.4575610605509661,
+          "value_exact": 0.9869706840390879,
+          "value_rmse": 1.0554650703163893,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5863192182410424,
+          "position_rmse": 3.184346894824715,
+          "position_r2": 0.18424520845176695,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.6872964169381107,
+          "position_rmse": 2.4468286993655863,
+          "position_r2": 0.5183561494167516,
+          "value_exact": 0.9869706840390879,
+          "value_rmse": 0.6919735266348835,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 0.8175895765472313,
+      "position_exact_shuffle": 0.06514657980456026,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.048859934853420196,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.142578125,
+        "sham": 0.234375,
+        "random_target": 0.068359375,
+        "gap_vs_controls": -0.091796875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.142578125,
+        "sham": 0.234375,
+        "random_target": 0.068359375,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.46007847785949707,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.10749185667752444,
+          "position_rmse": 4.171799227526209,
+          "position_r2": -0.41062331229253024,
+          "value_exact": 0.05537459283387622,
+          "value_rmse": 8.292691338865435,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.745928338762215,
+          "position_rmse": 2.3162082909154647,
+          "position_r2": 0.5651700177155536,
+          "value_exact": 0.16612377850162866,
+          "value_rmse": 6.1970887354295865,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.749185667752443,
+          "position_rmse": 1.9688122049528582,
+          "position_r2": 0.6858241172322458,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 6.484760386000677,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.9055374592833876,
+          "position_rmse": 1.0933616690801269,
+          "position_r2": 0.9031071017010371,
+          "value_exact": 0.1758957654723127,
+          "value_rmse": 6.468666648426788,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.6938110749185668,
+          "position_rmse": 2.504718673859233,
+          "position_r2": 0.49151029394059276,
+          "value_exact": 0.18241042345276873,
+          "value_rmse": 5.939433724200429,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.1498371335504886,
+          "value_rmse": 6.339730468278873,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.742671009771987,
+          "position_rmse": 2.729379306848256,
+          "position_r2": 0.39620147572281184,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.4755700325732899,
+          "position_rmse": 3.899386070445496,
+          "position_r2": -0.23241430315956024,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5537459283387622,
+          "position_rmse": 2.9989140271137393,
+          "position_r2": 0.2710591493094374,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.6026058631921825,
+          "position_rmse": 3.913144973427625,
+          "position_r2": -0.24112674360606112,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.0781758957654723,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.08143322475570032,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.142578125,
+        "sham": 0.154296875,
+        "random_target": 0.06640625,
+        "gap_vs_controls": -0.01171875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.142578125,
+        "sham": 0.154296875,
+        "random_target": 0.06640625,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.4327501058578491,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "copy_offset",
+      "arch": "rope",
+      "seed": 99,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.08794788273615635,
+          "position_rmse": 4.868632565915121,
+          "position_r2": -0.9491000619443544,
+          "value_exact": 0.09120521172638436,
+          "value_rmse": 6.447482653973557,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.6416938110749185,
+          "position_rmse": 2.7251990932260104,
+          "position_r2": 0.3893159074847976,
+          "value_exact": 0.19543973941368079,
+          "value_rmse": 5.938336774569835,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.5570032573289903,
+          "position_rmse": 3.2214670823813254,
+          "position_r2": 0.1466493338800724,
+          "value_exact": 0.18892508143322476,
+          "value_rmse": 6.46388110639844,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.739413680781759,
+          "position_rmse": 2.5498291441771377,
+          "position_r2": 0.4653835751489719,
+          "value_exact": 0.21172638436482086,
+          "value_rmse": 6.442681376761974,
+          "value_classes": 16
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.8306188925081434,
+          "position_rmse": 1.7939456631529498,
+          "position_r2": 0.7353702265767457,
+          "value_exact": 0.19218241042345277,
+          "value_rmse": 6.268945227636063,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1",
+          "position_exact": 1.0,
+          "position_rmse": 0.0,
+          "position_r2": 1.0,
+          "value_exact": 0.19543973941368079,
+          "value_rmse": 6.033835109097572,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.5993485342019544,
+          "position_rmse": 3.079299383066503,
+          "position_r2": 0.220306406442213,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.6384364820846905,
+          "position_rmse": 2.867883487927244,
+          "position_r2": 0.32369415192943585,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.7817589576547231,
+          "position_rmse": 2.843359026529349,
+          "position_r2": 0.33521143963915245,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.3424380873212097,
+          "value_classes": 16
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.495114006514658,
+          "position_rmse": 3.886416669335301,
+          "position_r2": -0.24199216534780432,
+          "value_exact": 0.5602605863192183,
+          "value_rmse": 4.46411679531517,
+          "value_classes": 16
+        }
+      ],
+      "best_unit": "L1",
+      "position_exact": 1.0,
+      "position_exact_shuffle": 0.10423452768729642,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.07166123778501629,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.140625,
+        "sham": 0.150390625,
+        "random_target": 0.060546875,
+        "gap_vs_controls": -0.009765625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.140625,
+        "sham": 0.150390625,
+        "random_target": 0.060546875,
+        "base_accuracy": 1.0,
+        "pivot": 12,
+        "target_rel": 0.4638599157333374,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.23452768729641693,
+          "position_rmse": 3.754693046003473,
+          "position_r2": -0.838486146625488,
+          "value_exact": 0.14006514657980457,
+          "value_rmse": 3.576069576453341,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.2247557003257329,
+          "position_rmse": 3.6969923509518847,
+          "position_r2": -0.7824140183088142,
+          "value_exact": 0.3127035830618892,
+          "value_rmse": 2.9341302836057976,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.1758957654723127,
+          "position_rmse": 4.139269318200901,
+          "position_r2": -1.234389355649276,
+          "value_exact": 0.3778501628664495,
+          "value_rmse": 2.9490792468003963,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 4.016253622420915,
+          "position_r2": -1.1035543895770372,
+          "value_exact": 0.3811074918566775,
+          "value_rmse": 2.7854905590798773,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 3.9425846777676288,
+          "position_r2": -1.0270923964179364,
+          "value_exact": 0.3127035830618892,
+          "value_rmse": 2.8707215722317745,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.2768729641693811,
+          "position_rmse": 3.7650890780262176,
+          "position_r2": -0.8486810790467014,
+          "value_exact": 0.34527687296416937,
+          "value_rmse": 2.8695866753413144,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.996742671009772,
+          "position_rmse": 0.3424380873212097,
+          "position_r2": 0.9847076013681798,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.9250814332247557,
+          "position_rmse": 0.9202747076059862,
+          "position_r2": 0.8895548987701879,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.9250814332247557,
+          "position_rmse": 1.0948502493053143,
+          "position_r2": 0.8436777028747274,
+          "value_exact": 0.990228013029316,
+          "value_rmse": 0.29656008284352153,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.9804560260586319,
+          "position_rmse": 0.9273267242025302,
+          "position_r2": 0.8878557433666523,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H0",
+      "position_exact": 0.996742671009772,
+      "position_exact_shuffle": 0.10749185667752444,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.05863192182410423,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "gap_vs_controls": -0.875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.08568385243415833,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.18566775244299674,
+          "position_rmse": 3.885997580891819,
+          "position_r2": -0.9175298289483609,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 2.683038775046665,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.23452768729641693,
+          "position_rmse": 4.1345450222142475,
+          "position_r2": -1.1706636200002154,
+          "value_exact": 0.36156351791530944,
+          "value_rmse": 2.532524586605026,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 4.043734849238341,
+          "position_r2": -1.0763588743142303,
+          "value_exact": 0.38436482084690554,
+          "value_rmse": 2.55110629384108,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.22149837133550487,
+          "position_rmse": 3.656238254804488,
+          "position_r2": -0.6974854223477294,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.6029299452106405,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.28338762214983715,
+          "position_rmse": 3.702275029070569,
+          "position_r2": -0.740501622134319,
+          "value_exact": 0.3355048859934853,
+          "value_rmse": 2.7490004105727213,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.30944625407166126,
+          "position_rmse": 3.879286008385231,
+          "position_r2": -0.9109119520581164,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.609803616858321,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.9869706840390879,
+          "position_rmse": 0.5931201656870431,
+          "position_r2": 0.9553293309908493,
+          "value_exact": 0.993485342019544,
+          "value_rmse": 0.4035671561356308,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.8469055374592834,
+          "position_rmse": 1.677597164863187,
+          "position_r2": 0.6426346479267938,
+          "value_exact": 0.8892508143322475,
+          "value_rmse": 1.2901531358743872,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.9576547231270358,
+          "position_rmse": 0.6943231888348148,
+          "position_r2": 0.9387846387652379,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.996742671009772,
+          "position_rmse": 0.22829205821413984,
+          "position_r2": 0.9933821231097555,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H3",
+      "position_exact": 0.996742671009772,
+      "position_exact_shuffle": 0.3550488599348534,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.05537459283387622,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "gap_vs_controls": -0.892578125,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.2608875036239624,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.19218241042345277,
+          "position_rmse": 3.9902160473130435,
+          "position_r2": -1.1253257495071267,
+          "value_exact": 0.1270358306188925,
+          "value_rmse": 3.6678016208134396,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.23778501628664495,
+          "position_rmse": 3.758161585353757,
+          "position_r2": -0.8853135126560765,
+          "value_exact": 0.32247557003257327,
+          "value_rmse": 2.815152115468142,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 3.8353745214606754,
+          "position_r2": -0.9635783724988103,
+          "value_exact": 0.3941368078175896,
+          "value_rmse": 2.6726994734855682,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.24429967426710097,
+          "position_rmse": 3.932657885654765,
+          "position_r2": -1.0644530807405563,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.7802233172554818,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.20846905537459284,
+          "position_rmse": 3.7978221086208923,
+          "position_r2": -0.9253155521312517,
+          "value_exact": 0.32247557003257327,
+          "value_rmse": 2.8467937276324213,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.2931596091205212,
+          "position_rmse": 3.4584551539838224,
+          "position_r2": -0.5966031407917696,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.7625933150038997,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.8697068403908795,
+          "position_rmse": 0.7741760356675699,
+          "position_r2": 0.9199959210496499,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.9022801302931596,
+          "position_rmse": 0.7036433802109261,
+          "position_r2": 0.9339096739105803,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.9837133550488599,
+          "position_rmse": 0.5230828186617804,
+          "position_r2": 0.9634763987400575,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.9771986970684039,
+          "position_rmse": 0.8071343122712616,
+          "position_r2": 0.9130390446191846,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.9837133550488599,
+      "position_exact_shuffle": 0.254071661237785,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.11074918566775244,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.884765625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.10152745246887207,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "abs",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.21172638436482086,
+          "position_rmse": 4.274002921992298,
+          "position_r2": -1.2412959935012862,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 2.951287468185657,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.26384364820846906,
+          "position_rmse": 3.8063892796893755,
+          "position_r2": -0.7776898322207062,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.753735987572304,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.1986970684039088,
+          "position_rmse": 4.254141496201888,
+          "position_r2": -1.2205136483404324,
+          "value_exact": 0.3257328990228013,
+          "value_rmse": 2.5657478226144543,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.20846905537459284,
+          "position_rmse": 4.077426537182954,
+          "position_r2": -1.0398671096345513,
+          "value_exact": 0.36156351791530944,
+          "value_rmse": 2.6290781877425866,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.20195439739413681,
+          "position_rmse": 4.2785732347456005,
+          "position_r2": -1.246091919307637,
+          "value_exact": 0.3583061889250814,
+          "value_rmse": 2.6872845720793146,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.2964169381107492,
+          "position_rmse": 3.5915209593294777,
+          "position_r2": -0.5826555160957727,
+          "value_exact": 0.34527687296416937,
+          "value_rmse": 2.6884964253864947,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.9706840390879479,
+          "position_rmse": 0.395413443791362,
+          "position_r2": 0.9808162967745967,
+          "value_exact": 0.993485342019544,
+          "value_rmse": 0.24214029368137852,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.9543973941368078,
+          "position_rmse": 1.088883718513137,
+          "position_r2": 0.8545235838740249,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.9804560260586319,
+          "position_rmse": 0.44208566976738883,
+          "position_r2": 0.9760203709682459,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.3778501628664495,
+          "position_rmse": 3.723330791429956,
+          "position_r2": -0.700955019319093,
+          "value_exact": 0.5244299674267101,
+          "value_rmse": 2.482512124746101,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.9804560260586319,
+      "position_exact_shuffle": 0.1791530944625407,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.14332247557003258,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.85546875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.11609839648008347,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.23452768729641693,
+          "position_rmse": 3.754693046003473,
+          "position_r2": -0.838486146625488,
+          "value_exact": 0.14332247557003258,
+          "value_rmse": 3.6584648174947514,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.2182410423452769,
+          "position_rmse": 3.885997580891819,
+          "position_r2": -0.969321112697727,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.8035575352434265,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.2280130293159609,
+          "position_rmse": 3.9885830552056474,
+          "position_r2": -1.0746687477169323,
+          "value_exact": 0.3941368078175896,
+          "value_rmse": 2.665987970092424,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.24104234527687296,
+          "position_rmse": 3.8489391067613687,
+          "position_r2": -0.9319396938199445,
+          "value_exact": 0.38436482084690554,
+          "value_rmse": 2.7335531279971605,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.2280130293159609,
+          "position_rmse": 3.909397347693099,
+          "position_r2": -0.993109288347225,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.7335531279971605,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.1791530944625407,
+          "position_rmse": 4.2724783979837495,
+          "position_r2": -1.3805167203533353,
+          "value_exact": 0.3517915309446254,
+          "value_rmse": 3.07294593878106,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.4006514657980456,
+          "position_rmse": 3.0372282924281033,
+          "position_r2": -0.20300202570318437,
+          "value_exact": 0.8957654723127035,
+          "value_rmse": 1.0320593877314233,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.42671009771986973,
+          "position_rmse": 2.959003265583345,
+          "position_r2": -0.14183243117590383,
+          "value_exact": 0.762214983713355,
+          "value_rmse": 1.7460984894482385,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5667752442996743,
+          "position_rmse": 1.861665395714978,
+          "position_r2": 0.5480246626595381,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.504885993485342,
+          "position_rmse": 2.1263049260246007,
+          "position_r2": 0.4103930749731568,
+          "value_exact": 0.9283387622149837,
+          "value_rmse": 0.9078018696431989,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.5667752442996743,
+      "position_exact_shuffle": 0.18566775244299674,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.09120521172638436,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "gap_vs_controls": -0.875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.15453912317752838,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.18566775244299674,
+          "position_rmse": 3.885997580891819,
+          "position_r2": -0.9175298289483609,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 2.683038775046665,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.19218241042345277,
+          "position_rmse": 4.31042974194692,
+          "position_r2": -1.3592731113721852,
+          "value_exact": 0.3973941368078176,
+          "value_rmse": 2.6278389332840373,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.21498371335504887,
+          "position_rmse": 4.3405519095477745,
+          "position_r2": -1.392362495823408,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.7767062718029263,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.1986970684039088,
+          "position_rmse": 4.270953329793815,
+          "position_r2": -1.3162569115855955,
+          "value_exact": 0.3973941368078176,
+          "value_rmse": 2.6574215417984277,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.1986970684039088,
+          "position_rmse": 4.107671380402905,
+          "position_r2": -1.1425376432166758,
+          "value_exact": 0.40390879478827363,
+          "value_rmse": 2.5222140111250093,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.20195439739413681,
+          "position_rmse": 4.107671380402905,
+          "position_r2": -1.1425376432166758,
+          "value_exact": 0.40716612377850164,
+          "value_rmse": 2.550467798950879,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.5960912052117264,
+          "position_rmse": 1.6021158648174214,
+          "position_r2": 0.6740695631554554,
+          "value_exact": 0.990228013029316,
+          "value_rmse": 0.24214029368137852,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.3745928338762215,
+          "position_rmse": 3.138496911970683,
+          "position_r2": -0.2507787322562216,
+          "value_exact": 0.5960912052117264,
+          "value_rmse": 1.9227762230454157,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5602605863192183,
+          "position_rmse": 1.6303313945410174,
+          "position_r2": 0.6624882785975275,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.6221498371335505,
+          "position_rmse": 1.4750917820502942,
+          "position_r2": 0.7237036398322896,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H3",
+      "position_exact": 0.6221498371335505,
+      "position_exact_shuffle": 0.20521172638436483,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.04234527687296417,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "gap_vs_controls": -0.892578125,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.15086422860622406,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.19218241042345277,
+          "position_rmse": 3.9902160473130435,
+          "position_r2": -1.1253257495071267,
+          "value_exact": 0.12052117263843648,
+          "value_rmse": 3.670021168139611,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.18566775244299674,
+          "position_rmse": 4.016253622420915,
+          "position_r2": -1.1531532552289878,
+          "value_exact": 0.36482084690553745,
+          "value_rmse": 2.755509730743388,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.2182410423452769,
+          "position_rmse": 3.960719179257488,
+          "position_r2": -1.0940198055700332,
+          "value_exact": 0.3355048859934853,
+          "value_rmse": 2.855362404764186,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.19543973941368079,
+          "position_rmse": 4.13769515221197,
+          "position_r2": -1.2853339074078272,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.661708202216375,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.20846905537459284,
+          "position_rmse": 4.016253622420915,
+          "position_r2": -1.1531532552289878,
+          "value_exact": 0.38436482084690554,
+          "value_rmse": 2.678178193564066,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.24104234527687296,
+          "position_rmse": 4.121920427789615,
+          "position_r2": -1.2679417163316642,
+          "value_exact": 0.36482084690553745,
+          "value_rmse": 2.793081261187381,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.5211726384364821,
+          "position_rmse": 1.7572557818189578,
+          "position_r2": 0.5878050714949352,
+          "value_exact": 0.9837133550488599,
+          "value_rmse": 0.3327900023554681,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.4788273615635179,
+          "position_rmse": 2.405206079870278,
+          "position_r2": 0.22778671621835977,
+          "value_exact": 0.9022801302931596,
+          "value_rmse": 0.9290813647955832,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.5407166123778502,
+          "position_rmse": 1.7235672424039474,
+          "position_r2": 0.603458043463482,
+          "value_exact": 0.9837133550488599,
+          "value_rmse": 0.434655129307391,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.511400651465798,
+          "position_rmse": 1.7609591700823357,
+          "position_r2": 0.586065852387319,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.5407166123778502,
+      "position_exact_shuffle": 0.21172638436482086,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.20521172638436483,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.884765625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.21575839817523956,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "none",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.21172638436482086,
+          "position_rmse": 4.274002921992298,
+          "position_r2": -1.2412959935012862,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 2.951287468185657,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.1791530944625407,
+          "position_rmse": 4.115593608361456,
+          "position_r2": -1.0782345160853581,
+          "value_exact": 0.40390879478827363,
+          "value_rmse": 2.62101256013604,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.1758957654723127,
+          "position_rmse": 4.175311336379639,
+          "position_r2": -1.1389829096324684,
+          "value_exact": 0.4201954397394137,
+          "value_rmse": 2.6004259235197136,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.16612377850162866,
+          "position_rmse": 4.162810376177736,
+          "position_r2": -1.1261937741488661,
+          "value_exact": 0.40716612377850164,
+          "value_rmse": 2.6079307758443457,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.1791530944625407,
+          "position_rmse": 4.178430732658153,
+          "position_r2": -1.142180193503369,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.6160367368347592,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.20846905537459284,
+          "position_rmse": 3.9409319488424517,
+          "position_r2": -0.9055811870567283,
+          "value_exact": 0.40716612377850164,
+          "value_rmse": 2.55110629384108,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.5472312703583062,
+          "position_rmse": 2.3807041905698285,
+          "position_r2": 0.30459075807913016,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.495114006514658,
+          "position_rmse": 2.1170934534294292,
+          "position_r2": 0.4500671742051052,
+          "value_exact": 0.8859934853420195,
+          "value_rmse": 1.1598607127427711,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.495114006514658,
+          "position_rmse": 2.0419062435606237,
+          "position_r2": 0.48843458065591183,
+          "value_exact": 0.9739413680781759,
+          "value_rmse": 0.6066944666764034,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.5146579804560261,
+          "position_rmse": 1.9869279645111324,
+          "position_r2": 0.5156114935585665,
+          "value_exact": 0.8957654723127035,
+          "value_rmse": 1.0320593877314233,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H0",
+      "position_exact": 0.5472312703583062,
+      "position_exact_shuffle": 0.19543973941368079,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.1465798045602606,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.85546875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.12732060253620148,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 0,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.23452768729641693,
+          "position_rmse": 3.754693046003473,
+          "position_r2": -0.838486146625488,
+          "value_exact": 0.14332247557003258,
+          "value_rmse": 3.6584648174947514,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 3.8217617916587123,
+          "position_r2": -0.9047532073633753,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.867315533968228,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.2247557003257329,
+          "position_rmse": 3.9705758162643843,
+          "position_r2": -1.0559780382780413,
+          "value_exact": 0.34527687296416937,
+          "value_rmse": 2.746629560273478,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.2768729641693811,
+          "position_rmse": 3.744268149310539,
+          "position_r2": -0.8282912142042747,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.6733087746386985,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.24429967426710097,
+          "position_rmse": 3.9425846777676288,
+          "position_r2": -1.0270923964179364,
+          "value_exact": 0.3322475570032573,
+          "value_rmse": 2.7690706821958777,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.250814332247557,
+          "position_rmse": 3.6934663679360775,
+          "position_r2": -0.779015707501743,
+          "value_exact": 0.34201954397394135,
+          "value_rmse": 2.8450768953960828,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.2931596091205212,
+          "position_rmse": 3.8217617916587123,
+          "position_r2": -0.9047532073633753,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.3355048859934853,
+          "position_rmse": 3.447134484807895,
+          "position_r2": -0.5496297280244409,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.11414602910706992,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.3289902280130293,
+          "position_rmse": 3.4828570397891903,
+          "position_r2": -0.5819136806916168,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.3485342019543974,
+          "position_rmse": 3.0157026611913538,
+          "position_r2": -0.18601047166782858,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H3",
+      "position_exact": 0.3485342019543974,
+      "position_exact_shuffle": 0.18566775244299674,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.09446254071661238,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "gap_vs_controls": -0.875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.125,
+        "sham": 1.0,
+        "random_target": 0.09765625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.10926657915115356,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 1,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.18566775244299674,
+          "position_rmse": 3.885997580891819,
+          "position_r2": -0.9175298289483609,
+          "value_exact": 0.17263843648208468,
+          "value_rmse": 2.683038775046665,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.2280130293159609,
+          "position_rmse": 3.9376244099057165,
+          "position_r2": -0.9688183748477563,
+          "value_exact": 0.41368078175895767,
+          "value_rmse": 2.64882740943066,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.2247557003257329,
+          "position_rmse": 4.2094975599043165,
+          "position_r2": -1.25007814268315,
+          "value_exact": 0.4006514657980456,
+          "value_rmse": 2.681824455556973,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.20846905537459284,
+          "position_rmse": 4.029209312916917,
+          "position_r2": -1.0614686513111802,
+          "value_exact": 0.40390879478827363,
+          "value_rmse": 2.678178193564066,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.2899022801302932,
+          "position_rmse": 3.87256280401103,
+          "position_r2": -0.9042940751678719,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.5853508636059215,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.2899022801302932,
+          "position_rmse": 3.5751585919585054,
+          "position_r2": -0.623034307332478,
+          "value_exact": 0.39087947882736157,
+          "value_rmse": 2.5960380738313065,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.3127035830618892,
+          "position_rmse": 3.6041958899356894,
+          "position_r2": -0.6495058148934563,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.2182410423452769,
+          "position_rmse": 3.74600764680243,
+          "position_r2": -0.7818633526983476,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.2768729641693811,
+          "position_rmse": 3.7303229680892342,
+          "position_r2": -0.7669731296952973,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.2899022801302932,
+          "position_rmse": 3.553224896643017,
+          "position_r2": -0.6031806766617445,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H0",
+      "position_exact": 0.3127035830618892,
+      "position_exact_shuffle": 0.16612377850162866,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.06514657980456026,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "gap_vs_controls": -0.892578125,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.107421875,
+        "sham": 1.0,
+        "random_target": 0.12890625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.14968517422676086,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 42,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.19218241042345277,
+          "position_rmse": 3.9902160473130435,
+          "position_r2": -1.1253257495071267,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 3.509874391063353,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.22149837133550487,
+          "position_rmse": 3.9475387128248425,
+          "position_r2": -1.080106052709103,
+          "value_exact": 0.3485342019543974,
+          "value_rmse": 2.861060599225923,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.26058631921824105,
+          "position_rmse": 3.8234660333450488,
+          "position_r2": -0.9514038387454962,
+          "value_exact": 0.3355048859934853,
+          "value_rmse": 2.633410985812021,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.26384364820846906,
+          "position_rmse": 3.8759258639622605,
+          "position_r2": -1.0053196310816017,
+          "value_exact": 0.38436482084690554,
+          "value_rmse": 2.8347540667388604,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.23778501628664495,
+          "position_rmse": 3.8641423487243856,
+          "position_r2": -0.9931450973282876,
+          "value_exact": 0.33876221498371334,
+          "value_rmse": 2.7525528571256097,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.31596091205211724,
+          "position_rmse": 3.5969585414883043,
+          "position_r2": -0.7270445738629927,
+          "value_exact": 0.3745928338762215,
+          "value_rmse": 2.7263940939820723,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 3.6969923509518847,
+          "position_r2": -0.8244408438895059,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.2899022801302932,
+          "position_rmse": 3.401475058454773,
+          "position_r2": -0.5444265675632805,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.3322475570032573,
+          "position_rmse": 3.290495641011839,
+          "position_r2": -0.44529107842915105,
+          "value_exact": 0.9804560260586319,
+          "value_rmse": 0.5820328298160795,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.2996742671009772,
+          "position_rmse": 3.5348428545714246,
+          "position_r2": -0.6679111242040383,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.3322475570032573,
+      "position_exact_shuffle": 0.18241042345276873,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.09771986970684039,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.884765625,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.115234375,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.11862620711326599,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 7,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.21172638436482086,
+          "position_rmse": 4.274002921992298,
+          "position_r2": -1.2412959935012862,
+          "value_exact": 0.13355048859934854,
+          "value_rmse": 2.951287468185657,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.2247557003257329,
+          "position_rmse": 4.046955666036688,
+          "position_r2": -1.0094929128609964,
+          "value_exact": 0.3550488599348534,
+          "value_rmse": 2.69333838595112,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.23127035830618892,
+          "position_rmse": 3.9524865385138948,
+          "position_r2": -0.9167716806048802,
+          "value_exact": 0.41042345276872966,
+          "value_rmse": 2.7108179949886706,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.23127035830618892,
+          "position_rmse": 3.8943707808196213,
+          "position_r2": -0.8608192128641206,
+          "value_exact": 0.38762214983713356,
+          "value_rmse": 2.6684304698902004,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.19218241042345277,
+          "position_rmse": 4.165939133008889,
+          "position_r2": -1.1293910580197668,
+          "value_exact": 0.3973941368078176,
+          "value_rmse": 2.5593922324154486,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.28338762214983715,
+          "position_rmse": 3.901056400815717,
+          "position_r2": -0.8672137806059217,
+          "value_exact": 0.38762214983713356,
+          "value_rmse": 2.63958835997163,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.3517915309446254,
+          "position_rmse": 3.6633584918404334,
+          "position_r2": -0.6466011935137836,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.30618892508143325,
+          "position_rmse": 3.8302754172496485,
+          "position_r2": -0.8000708193170101,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.3257328990228013,
+          "position_rmse": 3.719829774396753,
+          "position_r2": -0.6977577354481925,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.28013029315960913,
+          "position_rmse": 3.8943707808196213,
+          "position_r2": -0.8608192128641206,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H0",
+      "position_exact": 0.3517915309446254,
+      "position_exact_shuffle": 0.16938110749185667,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.16286644951140064,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "gap_vs_controls": -0.85546875,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.14453125,
+        "sham": 1.0,
+        "random_target": 0.119140625,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.12110082060098648,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    },
+    {
+      "task": "variable_binding",
+      "arch": "rope",
+      "seed": 99,
+      "table": [
+        {
+          "unit": "L0",
+          "position_exact": 0.1986970684039088,
+          "position_rmse": 3.9524865385138948,
+          "position_r2": -0.9371072823146793,
+          "value_exact": 0.1563517915309446,
+          "value_rmse": 3.362952014833346,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H0",
+          "position_exact": 0.22149837133550487,
+          "position_rmse": 4.298321769315705,
+          "position_r2": -1.290924208775826,
+          "value_exact": 0.34527687296416937,
+          "value_rmse": 2.5676514319941286,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H1",
+          "position_exact": 0.250814332247557,
+          "position_rmse": 3.926026080117013,
+          "position_r2": -0.9112576438517646,
+          "value_exact": 0.36482084690553745,
+          "value_rmse": 2.6623200188437446,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H2",
+          "position_exact": 0.247557003257329,
+          "position_rmse": 3.996741343654625,
+          "position_r2": -0.9807285472208482,
+          "value_exact": 0.3811074918566775,
+          "value_rmse": 2.5916427951880565,
+          "value_classes": 8
+        },
+        {
+          "unit": "L0H3",
+          "position_exact": 0.26384364820846906,
+          "position_rmse": 3.759894655118621,
+          "position_r2": -0.7529286082664113,
+          "value_exact": 0.3583061889250814,
+          "value_rmse": 2.8307294671093017,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1",
+          "position_exact": 0.2247557003257329,
+          "position_rmse": 3.960719179257488,
+          "position_r2": -0.9451852943343404,
+          "value_exact": 0.36482084690553745,
+          "value_rmse": 2.574619291296095,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H0",
+          "position_exact": 0.250814332247557,
+          "position_rmse": 3.983680062503875,
+          "position_r2": -0.9678037279893907,
+          "value_exact": 0.996742671009772,
+          "value_rmse": 0.28536507276767475,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H1",
+          "position_exact": 0.28013029315960913,
+          "position_rmse": 3.7771816182437794,
+          "position_r2": -0.769084632305733,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H2",
+          "position_exact": 0.28338762214983715,
+          "position_rmse": 3.672239373943912,
+          "position_r2": -0.6721484880698025,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        },
+        {
+          "unit": "L1H3",
+          "position_exact": 0.26384364820846906,
+          "position_rmse": 3.880964989640377,
+          "position_r2": -0.8676363789455959,
+          "value_exact": 1.0,
+          "value_rmse": 0.0,
+          "value_classes": 8
+        }
+      ],
+      "best_unit": "L1H2",
+      "position_exact": 0.28338762214983715,
+      "position_exact_shuffle": 0.1986970684039088,
+      "value_exact": 1.0,
+      "value_exact_shuffle": 0.17263843648208468,
+      "copy_accuracy": 1.0,
+      "causal": {
+        "verdict": "no_effect",
+        "follow_donor": 0.103515625,
+        "sham": 1.0,
+        "random_target": 0.115234375,
+        "gap_vs_controls": -0.896484375,
+        "off_target_rel": 0.0,
+        "selectivity_ok": true
+      },
+      "patch_stats": {
+        "follow_donor": 0.103515625,
+        "sham": 1.0,
+        "random_target": 0.115234375,
+        "base_accuracy": 1.0,
+        "pivot": 10,
+        "target_rel": 0.1241941899061203,
+        "off_target_rel": 0.0,
+        "selectivity_ratio": null
+      }
+    }
+  ],
+  "evidence": {
+    "position_exact": 1.0,
+    "position_exact_shuffle": 0.0781758957654723,
+    "value_exact": 1.0,
+    "copy_accuracy": 1.0,
+    "causal_verdict": "no_effect",
+    "second_task_position_exact": 0.3517915309446254,
+    "second_task_shuffle": 0.16938110749185667,
+    "second_task_causal": "no_effect",
+    "seeds_stable": false,
+    "reference_arch": "rope",
+    "notes": [
+      "stabilite multi-graines mesuree sur 'rope' seul (5 graines) ; 8 run(s) d'ablation sur d'autres regimes de position sont rapportes dans la table mais exclus du gate (l'ecart entre regimes n'est pas de l'instabilite de graine)",
+      "sur le second banc, un autre regime ('abs') localise mieux la reference (0.997) que le regime de reference 'rope' (0.352) : la localisation du second banc depend de l'encodage positionnel"
+    ]
+  },
+  "verdict": "INCONCLUSIVE",
+  "regenerate": "python scripts/slens_poc.py --task <task> --arch <arch> --seed <seed> --stage full --out traces/slens_<task>_<arch>_s<seed>.npz"
+}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/slens_poc.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/slens_poc.py
@@ -1,0 +1,503 @@
+"""POC S-Lens (#15481) — entrainement des bancs synthetiques + capture numpy.
+
+Confine torch (regle d'architecture de la serie : ``ict/`` reste numpy-only).
+Un run = un triplet (task, arch, seed) :
+
+* entraine un micro-transformer sur le banc ``copy_offset`` ou
+  ``variable_binding`` (ground truth exacte, oracles de ``ict.slens``) ;
+* evalue l'exactitude comportementale, par position de reference ;
+* capture, pour un jeu held-out, les sorties par couche/tete a la position de
+  requete (matiere du probe de self-location) et les residuels de couche ;
+* execute la jambe causale : patching apparié du residual au token d'offset
+  entre deux exemples qui partagent leur bloc de valeurs et ne different que
+  par l'offset — avec sham (auto-echange) et cible aleatoire non appariée — et
+  mesure le dommage general via :mod:`ict.causal_engine` ;
+* ecrit un npz + un manifeste POC-local (``ict.slens.slens_manifest``).
+
+Architectures comparees (#15481) — trois bras, dont DEUX requis par l'issue :
+
+* ``rope`` : encodage positionnel rotatif sur Q/K (distance relative
+  accessible nativement) ;
+* ``abs`` (variante « position derivee du contenu » au sens du POC) : encodage
+  positionnel ABSOLU appris — dans les deux bras, la *reference* est resolue
+  depuis le contenu (le symbole d'offset ou la variable interrogee), seules la
+  structure positionnelle et sa generalisation relative different ;
+* ``none`` : AUCUNE information positionnelle — plancher de controle qui
+  documente que l'information de position doit venir de quelque part.
+
+Interpretation consignee (mode non supervise, CLAUDE.md principe 1) : l'issue
+#15481 demande « une architecture RoPE et une variante ou la position est
+derivee du contenu ». Toutes les variantes resolvent la reference depuis le
+contenu ; c'est la *fourniture* de la structure positionnelle qui differe
+(``rope`` relative vs ``abs`` absolue vs ``none`` plancher). Un ecart
+``rope``/``abs`` est donc un resultat sur la generalisation relative, pas une
+différence de banc.
+
+Usage :
+    python scripts/slens_poc.py --task copy_offset --arch rope --seed 0 \
+        --stage full --out traces/slens_copy_offset_rope_s0.npz
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Le package ``ict/`` reste numpy-only : on l'importe pour les bancs/oracles et
+# le moteur commun d'intervention (pures fonctions numpy, testables sans GPU).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from ict import causal_engine, slens  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Micro-transformer (attention explicite : capture par tete requise)
+# --------------------------------------------------------------------------- #
+
+class MicroTransformer(nn.Module):
+    """Transformer minimal, 2 couches, attention multi-tete explicite.
+
+    L'attention est ecrite a la main (pas ``nn.MultiheadAttention``) parce que
+    le POC doit capturer et patcher la sortie de CHAQUE tete separement.
+    """
+
+    def __init__(self, vocab_size: int, d_model: int = 64, n_heads: int = 4,
+                 n_layers: int = 2, arch: str = "rope", max_len: int = 32) -> None:
+        super().__init__()
+        if d_model % n_heads:
+            raise ValueError("d_model doit etre divisible par n_heads")
+        if arch not in ("rope", "abs", "none"):
+            raise ValueError(f"arch {arch!r} hors POC (rope|abs|none)")
+        self.arch = arch
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.n_layers = n_layers
+        self.head_dim = d_model // n_heads
+        self.embed = nn.Embedding(vocab_size, d_model)
+        self.pos = nn.Embedding(max_len, d_model) if arch == "abs" else None
+        self.blocks = nn.ModuleList(
+            [_Block(d_model, n_heads, arch) for _ in range(n_layers)]
+        )
+        self.ln_f = nn.LayerNorm(d_model)
+        self.head = nn.Linear(d_model, vocab_size, bias=False)
+
+    def rope_tables(self, t: int, device) -> tuple[torch.Tensor, torch.Tensor]:
+        half = self.head_dim // 2
+        inv = torch.exp(
+            -math.log(10000.0)
+            * torch.arange(half, device=device, dtype=torch.float32)
+            / max(half, 1)
+        )
+        pos = torch.arange(t, device=device, dtype=torch.float32)
+        ang = torch.outer(pos, inv)                       # (t, half)
+        return torch.cos(ang), torch.sin(ang)
+
+    def forward(self, tokens: torch.Tensor, capture: bool = False,
+                patch: tuple[int, int, torch.Tensor] | None = None):
+        """``patch`` = (couche, position, valeurs) applique APRES la couche."""
+        b, t = tokens.shape
+        h = self.embed(tokens)
+        if self.pos is not None:
+            idx = torch.arange(t, device=tokens.device)
+            h = h + self.pos(idx)[None]
+        cos = sin = None
+        if self.arch == "rope":
+            cos, sin = self.rope_tables(t, tokens.device)
+        caps_head: dict[str, torch.Tensor] = {}
+        caps_layer: dict[str, torch.Tensor] = {}
+        for li, block in enumerate(self.blocks):
+            if capture:
+                caps_layer[f"L{li}"] = h.detach().cpu().numpy()
+            h, per_head = block(h, cos, sin, capture=capture)
+            if capture:
+                for hi, out in enumerate(per_head):
+                    caps_head[f"L{li}H{hi}"] = out.detach().cpu().numpy()
+            if patch is not None and patch[0] == li:
+                h = h.clone()
+                h[:, patch[1], :] = patch[2]
+        h = self.ln_f(h)
+        if capture:
+            # residuel POST-pile : c'est la seule vue ou la propagation aval
+            # d'un patch est visible (une capture avant la derniere couche ne
+            # montre que la coordonnee patchee elle-meme).
+            caps_layer[f"post_stack"] = h.detach().cpu().numpy()
+        logits = self.head(h)
+        if capture:
+            return logits, caps_head, caps_layer
+        return logits, None, None
+
+
+class _Block(nn.Module):
+    def __init__(self, d_model: int, n_heads: int, arch: str) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+        self.arch = arch
+        self.head_dim = d_model // n_heads
+        self.ln1 = nn.LayerNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model)
+        self.proj = nn.Linear(d_model, d_model)
+        self.ln2 = nn.LayerNorm(d_model)
+        self.mlp = nn.Sequential(
+            nn.Linear(d_model, 4 * d_model), nn.GELU(),
+            nn.Linear(4 * d_model, d_model),
+        )
+
+    @staticmethod
+    def _rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        # x : (b, h, t, dh) ; rotation des paires (x0, x1)
+        x0, x1 = x[..., 0::2], x[..., 1::2]
+        c, s = cos[None, None], sin[None, None]
+        return torch.stack([x0 * c - x1 * s, x0 * s + x1 * c], dim=-1).flatten(-2)
+
+    def forward(self, h: torch.Tensor, cos, sin, capture: bool = False):
+        b, t, d = h.shape
+        x = self.ln1(h)
+        qkv = self.qkv(x).view(b, t, 3, self.n_heads, self.head_dim)
+        qkv = qkv.permute(0, 3, 2, 1, 4)                   # (b, h, 3, t, dh)
+        q, k, v = qkv.unbind(2)
+        if self.arch == "rope":
+            q = self._rope(q, cos, sin)
+            k = self._rope(k, cos, sin)
+        att = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
+        mask = torch.triu(torch.ones(t, t, device=h.device, dtype=torch.bool), 1)
+        att = att.masked_fill(mask, float("-inf")).softmax(dim=-1)
+        per_head = att @ v                                  # (b, h, t, dh)
+        merged = per_head.transpose(1, 2).reshape(b, t, d)
+        h = h + self.proj(merged)
+        h = h + self.mlp(self.ln2(h))
+        if capture:
+            return h, [per_head[:, i] for i in range(self.n_heads)]
+        return h, []
+
+
+# --------------------------------------------------------------------------- #
+# Donnees : bancs de ``ict.slens`` (oracle exact partage avec les tests)
+# --------------------------------------------------------------------------- #
+
+def task_config(task: str):
+    if task == "copy_offset":
+        return slens.CopyOffsetConfig(seq_values=12, n_symbols=16)
+    if task == "variable_binding":
+        return slens.VarBindingConfig(n_pairs=5, n_vars=8, n_vals=8)
+    raise ValueError(f"task {task!r} inconnue (copy_offset|variable_binding)")
+
+
+def generate(task: str, rng, n: int) -> dict:
+    cfg = task_config(task)
+    if task == "copy_offset":
+        return slens.generate_copy_offset(rng, n, cfg)
+    return slens.generate_variable_binding(rng, n, cfg)
+
+
+def oracle(task: str, tokens: np.ndarray):
+    cfg = task_config(task)
+    if task == "copy_offset":
+        return slens.oracle_copy_offset(tokens, cfg)
+    return slens.oracle_variable_binding(tokens, cfg)
+
+
+def oracle_position_of(batch: dict) -> np.ndarray:
+    return batch["target_pos"].astype(np.int64)
+
+
+# --------------------------------------------------------------------------- #
+# Entrainement / evaluation
+# --------------------------------------------------------------------------- #
+
+def to_torch(batch: dict, device) -> tuple[torch.Tensor, torch.Tensor]:
+    x = torch.as_tensor(batch["tokens"], dtype=torch.long, device=device)
+    y = torch.as_tensor(_target_index(batch), dtype=torch.long, device=device)
+    return x, y
+
+
+def _target_index(batch: dict) -> np.ndarray:
+    # La cible de lecture est l'ID DE TOKEN a la position de reference (passe
+    # par l'oracle pour rester coherent avec la ground truth).
+    return batch["target_value"].astype(np.int64)
+
+
+def train_model(model: MicroTransformer, task: str, seed: int, steps: int,
+                batch_size: int, lr: float, device) -> list[float]:
+    rng = np.random.default_rng(1000 + seed)
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=0.01)
+    losses: list[float] = []
+    model.train()
+    for step in range(steps):
+        batch = generate(task, rng, batch_size)
+        x, y = to_torch(batch, device)
+        logits, _, _ = model(x)
+        loss = F.cross_entropy(logits[:, -1, :], y)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if step % max(1, steps // 20) == 0:
+            losses.append(float(loss.item()))
+    return losses
+
+
+@torch.no_grad()
+def evaluate(model: MicroTransformer, task: str, seed: int, n: int, device):
+    model.eval()
+    rng = np.random.default_rng(9000 + seed)
+    batch = generate(task, rng, n)
+    x, y = to_torch(batch, device)
+    logits, _, _ = model(x)
+    pred = logits[:, -1, :].argmax(dim=-1).cpu().numpy()
+    acc = float(np.mean(pred == batch["target_value"]))
+    by_pos = slens.copy_success_by_position(
+        pred, batch["target_value"], batch["target_pos"], task_config(task).n_tokens
+    )
+    return batch, pred, acc, by_pos
+
+
+# --------------------------------------------------------------------------- #
+# Jambe causale : patching apparie au token d'offset
+# --------------------------------------------------------------------------- #
+
+@torch.no_grad()
+def patch_experiment(model: MicroTransformer, task: str, seed: int, n_pairs: int,
+                     patch_layer: int, device) -> dict:
+    """Patching apparie du residual a la position pivot, avec controles.
+
+    Hote et donneur partagent tout le contexte et ne different que par la
+    reference : offset du banc ``copy_offset`` (:func:`ict.slens.paired_by_offset`),
+    variable interrogee du banc ``variable_binding``
+    (:func:`ict.slens.paired_by_query`). Si la sortie patchee suit la reference
+    du donneur, elle suit la REFERENCE, pas une correlation de surface.
+
+    Controles : sham = auto-echange (le modele recoit sa propre valeur, la
+    prediction doit rester celle de l'hote) ; cible aleatoire = donneur decale
+    d'un rang (non apparie, doit retomber au niveau du hasard). Le dommage
+    general est mesure sur le residuel FINAL via
+    :func:`ict.causal_engine.damage_metrics` : une intervention chirurgicale
+    n'y laisse que ce que la propagation aval emporte.
+    """
+    rng = np.random.default_rng(4242 + seed)
+    if task == "copy_offset":
+        cfg = slens.CopyOffsetConfig(seq_values=12, n_symbols=16)
+        pairs = slens.paired_by_offset(cfg, rng, n_pairs)
+        pivot = cfg.seq_values                     # position du token d'offset
+    else:
+        cfg = slens.VarBindingConfig(n_pairs=5, n_vars=8, n_vals=8)
+        pairs = slens.paired_by_query(cfg, rng, n_pairs)
+        pivot = cfg.n_tokens - 2                   # marqueur de requete QB
+    target_a = pairs["target_value_a"]
+    target_b = pairs["target_value_b"]
+
+    xa = torch.as_tensor(pairs["tokens_a"], dtype=torch.long, device=device)
+    xb = torch.as_tensor(pairs["tokens_b"], dtype=torch.long, device=device)
+    key = f"L{patch_layer}"
+
+    # etats internes : hote et donneur, a la position pivot
+    _, _, caps_a = model(xa, capture=True)
+    _, _, caps_b = model(xb, capture=True)
+    host_vals = torch.as_tensor(caps_a[key][:, pivot, :], device=device)
+    donor_vals = torch.as_tensor(caps_b[key][:, pivot, :], device=device)
+
+    base_pred = model(xa)[0][:, -1, :].argmax(-1).cpu().numpy()
+    patched_pred = model(xa, patch=(patch_layer, pivot, donor_vals))[0][:, -1, :]
+    patched_pred = patched_pred.argmax(-1).cpu().numpy()
+    # sham : le modele recoit sa propre valeur par la meme voie de code
+    sham_pred = model(xa, patch=(patch_layer, pivot, host_vals))[0][:, -1, :]
+    sham_pred = sham_pred.argmax(-1).cpu().numpy()
+    # cible aleatoire : donneur decale (jamais apparie a l'hote)
+    shift = max(1, n_pairs // 7)
+    unpaired = np.roll(np.arange(n_pairs), shift)
+    rand_donor = torch.as_tensor(caps_b[key][unpaired, pivot, :], device=device)
+    rand_pred = model(xa, patch=(patch_layer, pivot, rand_donor))[0][:, -1, :]
+    rand_pred = rand_pred.argmax(-1).cpu().numpy()
+
+    # dommage general sur le residuel final
+    _, _, caps_final_a = model(xa, capture=True)
+    _, _, caps_final_patched = model(xa, patch=(patch_layer, pivot, donor_vals),
+                                     capture=True)
+    final_layer = "post_stack"
+    damages = []
+    for i in range(n_pairs):
+        # l'intervention est un ECHANGE apparie hote<->donneur : on declare
+        # ``interchange`` (et non ``patch``, qui exige un donneur explicite) —
+        # la mesure de dommage porte sur le panneau de l'hote avant/apres.
+        spec = causal_engine.InterventionSpec(
+            operation="interchange", instrument="slens", layer=patch_layer,
+            positions=(pivot,), features=tuple(range(caps_final_a[final_layer].shape[-1])),
+            run="host", paired_run="donor", seed=seed,
+        )
+        damages.append(causal_engine.damage_metrics(
+            caps_final_a[final_layer][i], caps_final_patched[final_layer][i], spec))
+
+    def _agg(name: str) -> float:
+        return float(np.mean([d[name] for d in damages]))
+
+    return {
+        "follow_donor": float(np.mean(patched_pred == target_b)),
+        "sham": float(np.mean(sham_pred == target_a)),
+        "random_target": float(np.mean(rand_pred == target_b[unpaired])),
+        "base_accuracy": float(np.mean(base_pred == target_a)),
+        "pivot": int(pivot),
+        "target_rel": _agg("target_rel"),
+        "off_target_rel": _agg("off_target_rel"),
+        "selectivity_ratio": _agg("selectivity_ratio"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Programme principal
+# --------------------------------------------------------------------------- #
+
+def _jsonable(value):
+    """Convertit recursivement les scalaires numpy en types JSON natifs."""
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    return value
+
+
+def aggregate(paths: Sequence[str]) -> dict:
+    """Reduit des npz de runs en matrice agregee + verdict de promotion.
+
+    C'est l'artefact COMMITTE (``traces/slens_matrix.json``) : les npz bruts
+    pesent ~1 MiB piece et restent locaux, mais les runs sont entierement
+    specifiés par ``(task, arch, seed, stage)`` dans le manifeste — la
+    commande de regeneration est ecrite dans le JSON lui-meme.
+    """
+    runs = [slens.load_run(p) for p in paths]
+    evidence, rows = slens.evidence_from_runs(runs)
+    return {
+        "contract": "slens_poc",
+        "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "n_runs": len(runs),
+        "runs": [
+            {"file": Path(p).name, "task": r["meta"]["task"],
+             "arch": r["meta"]["arch"], "seed": r["meta"]["seed"],
+             "stage": r["meta"].get("stage"), "steps": r["meta"].get("steps"),
+             "n_test": r["meta"].get("n_test")}
+            for p, r in zip(paths, runs)
+        ],
+        "per_run": _jsonable(rows),
+        "evidence": dataclasses.asdict(evidence),
+        "verdict": slens.promotion_verdict(evidence),
+        "regenerate": (
+            "python scripts/slens_poc.py --task <task> --arch <arch> --seed <seed> "
+            "--stage full --out traces/slens_<task>_<arch>_s<seed>.npz"
+        ),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--task", default="copy_offset",
+                    choices=["copy_offset", "variable_binding"])
+    ap.add_argument("--arch", default="rope", choices=["rope", "abs", "none"])
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--stage", default="smoke", choices=["smoke", "full"])
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--aggregate", nargs="+", default=None, metavar="NPZ",
+                    help="agrege des npz de runs en matrice JSON (pas d'entrainement)")
+    ap.add_argument("--d-model", type=int, default=64)
+    ap.add_argument("--n-heads", type=int, default=4)
+    ap.add_argument("--n-layers", type=int, default=2)
+    ap.add_argument("--patch-layer", type=int, default=0)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = ap.parse_args()
+
+    if args.aggregate is not None:
+        if not args.out:
+            ap.error("--out requis avec --aggregate (chemin du JSON de matrice)")
+        payload = aggregate(sorted(args.aggregate))
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"[matrix] {out} — {payload['n_runs']} runs — verdict "
+              f"{payload['verdict']}")
+        print(f"[evidence] {json.dumps(payload['evidence'], ensure_ascii=False)}")
+        return
+    if not args.out:
+        ap.error("--out requis (chemin du npz de run)")
+
+    steps = 300 if args.stage == "smoke" else 3000
+    n_eval = 256 if args.stage == "smoke" else 1024
+    n_patch = 64 if args.stage == "smoke" else 512
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    cfg = task_config(args.task)
+    model = MicroTransformer(
+        vocab_size=cfg.vocab_size, d_model=args.d_model, n_heads=args.n_heads,
+        n_layers=args.n_layers, arch=args.arch,
+    ).to(args.device)
+
+    t0 = time.time()
+    losses = train_model(model, args.task, args.seed, steps, 128, 3e-3, args.device)
+
+    # ---- controles de banc : le generateur est valide par l'oracle ----------
+    probe_batch = generate(args.task, np.random.default_rng(1), 128)
+    val, pos = oracle(args.task, probe_batch["tokens"])
+    assert np.array_equal(val, probe_batch["target_value"]), "oracle != generateur"
+    assert np.array_equal(pos, probe_batch["target_pos"]), "oracle positions != generateur"
+
+    batch, pred, acc, by_pos = evaluate(model, args.task, args.seed, n_eval, args.device)
+
+    # ---- capture par couche/tete a la position de requete ------------------
+    x = torch.as_tensor(batch["tokens"], dtype=torch.long, device=args.device)
+    _, caps_head, caps_layer = model(x, capture=True)
+    last = x.shape[1] - 1
+    acts_head = {f"{k}_q": v[:, last, :] for k, v in caps_head.items()}
+    acts_layer = {f"{k}_q": v[:, last, :] for k, v in caps_layer.items()}
+    acts_layer[f"L{args.n_layers - 1}_finalq"] = caps_layer[
+        f"L{args.n_layers - 1}"][:, last, :]
+
+    patch_stats = patch_experiment(
+        model, args.task, args.seed, n_patch, args.patch_layer, args.device
+    )
+
+    manifest = slens.slens_manifest(
+        task=args.task, arch=args.arch, run=f"slens_{args.task}_{args.arch}",
+        seed=args.seed, layer=args.patch_layer, d_model=args.d_model,
+        n_heads=args.n_heads, n_layers=args.n_layers, n_test=int(batch["tokens"].shape[0]),
+        prompt_set=f"synthetic_{args.task}",
+        stage=args.stage, steps=steps, device=args.device,
+        losses_head=losses[-1] if losses else None,
+        date=_dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+    )
+
+    arrays: dict[str, np.ndarray] = {
+        "__meta__": np.array(json.dumps(manifest, ensure_ascii=False)),
+        "tokens": batch["tokens"],
+        "target_value": batch["target_value"],
+        "target_pos": batch["target_pos"],
+        "pred": pred,
+        "predictions_accuracy": np.array(acc),
+        "success_by_pos": by_pos,
+        "patch_stats": np.array(json.dumps(patch_stats, ensure_ascii=False)),
+    }
+    arrays.update(acts_head)
+    arrays.update(acts_layer)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(out, **arrays)
+    print(f"[out] {out} ({out.stat().st_size / 2**20:.2f} MiB)")
+    print(f"[acc] {args.task}/{args.arch}/s{args.seed} = {acc:.3f} "
+          f"(loss finale {losses[-1]:.3f}) en {time.time() - t0:.0f}s")
+    print(f"[patch] {json.dumps(patch_stats, ensure_ascii=False)}")
+    print(f"[dmg] off_target_rel={patch_stats['off_target_rel']:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/slens_poc.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/slens_poc.py
@@ -322,6 +322,20 @@ def patch_experiment(model: MicroTransformer, task: str, seed: int, n_pairs: int
     _, _, caps_final_patched = model(xa, patch=(patch_layer, pivot, donor_vals),
                                      capture=True)
     final_layer = "post_stack"
+    n_positions = int(caps_final_a[final_layer].shape[-2])
+    # ``damage_metrics`` retire de son jeu "hors cible" les coordonnees
+    # ``positions x features`` qu'on lui declare et mesure leur norme de
+    # deplacement : le jeu declare est donc la CIBLE, son complement est le
+    # dommage. Pour un echange a ``pivot`` dans un transformer causal, la cible
+    # n'est pas la seule ligne ``pivot`` mais tout son CONE CAUSAL — la ligne
+    # pivot et toutes celles qui l'attendent, qui changent par construction
+    # (c'est le mecanisme de l'intervention, pas un dommage). Declarer la seule
+    # ligne pivot comptait la propagation aval comme du dommage
+    # (off_target_rel ~0.33 sur un banc ou le modele reste exact a 1.000) et
+    # rendait le verdict ``causal`` inatteignable quelle que soit la mesure.
+    # Le dommage redevient ce qu'il doit etre : un deplacement la ou la
+    # causalite interdit qu'il y en ait — les positions ANTERIEURES au pivot.
+    cone = tuple(range(pivot, n_positions))
     damages = []
     for i in range(n_pairs):
         # l'intervention est un ECHANGE apparie hote<->donneur : on declare
@@ -329,7 +343,7 @@ def patch_experiment(model: MicroTransformer, task: str, seed: int, n_pairs: int
         # la mesure de dommage porte sur le panneau de l'hote avant/apres.
         spec = causal_engine.InterventionSpec(
             operation="interchange", instrument="slens", layer=patch_layer,
-            positions=(pivot,), features=tuple(range(caps_final_a[final_layer].shape[-1])),
+            positions=cone, features=tuple(range(caps_final_a[final_layer].shape[-1])),
             run="host", paired_run="donor", seed=seed,
         )
         damages.append(causal_engine.damage_metrics(
@@ -344,6 +358,10 @@ def patch_experiment(model: MicroTransformer, task: str, seed: int, n_pairs: int
         "random_target": float(np.mean(rand_pred == target_b[unpaired])),
         "base_accuracy": float(np.mean(base_pred == target_a)),
         "pivot": int(pivot),
+        # ``target_rel``   = deplacement DANS le cone causal (mecanisme) ;
+        # ``off_target_rel`` = deplacement AVANT le pivot (doit rester ~0 :
+        #                      la causalite l'interdit) ;
+        # ``selectivity_ratio`` = rapport des deux.
         "target_rel": _agg("target_rel"),
         "off_target_rel": _agg("off_target_rel"),
         "selectivity_ratio": _agg("selectivity_ratio"),
@@ -355,17 +373,28 @@ def patch_experiment(model: MicroTransformer, task: str, seed: int, n_pairs: int
 # --------------------------------------------------------------------------- #
 
 def _jsonable(value):
-    """Convertit recursivement les scalaires numpy en types JSON natifs."""
+    """Convertit recursivement les scalaires numpy en types JSON natifs.
+
+    Les flottants NON FINIS sont rendus ``None``. ``json.dumps`` les ecrit
+    ``Infinity``/``NaN``, que la RFC 8259 n'autorise pas : la matrice commitee
+    cesserait d'etre du JSON strict pour tout lecteur autre que Python (le
+    ``json`` de la stdlib les relit, un parseur conforme les refuse). Le cas est
+    atteignable depuis ``damage_metrics``, qui rend ``inf`` des que le
+    deplacement hors cible tombe sous son plancher de mesure, et
+    ``selectivity_ratio`` est committe dans ``patch_stats``.
+    """
     if isinstance(value, dict):
         return {str(k): _jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
     if isinstance(value, (np.floating, np.integer)):
-        return value.item()
+        value = value.item()
     if isinstance(value, np.bool_):
         return bool(value)
     if isinstance(value, np.ndarray):
-        return value.tolist()
+        return _jsonable(value.tolist())
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
     return value
 
 
@@ -485,7 +514,11 @@ def main() -> None:
         "pred": pred,
         "predictions_accuracy": np.array(acc),
         "success_by_pos": by_pos,
-        "patch_stats": np.array(json.dumps(patch_stats, ensure_ascii=False)),
+        # par _jsonable : patch_stats peut porter selectivity_ratio == inf
+        # (hors cible sous le plancher de mesure), et json.dumps l'ecrirait
+        # ``Infinity`` -- non strict RFC 8259 -- DANS le npz.
+        "patch_stats": np.array(json.dumps(_jsonable(patch_stats),
+                                           ensure_ascii=False)),
     }
     arrays.update(acts_head)
     arrays.update(acts_layer)


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2023:CoursIA — prev: DEEP/research-code #15547

Closes #15481 · Part of #15475 · See #15476, #15479

## Ce que livre le POC

Le **S-Lens** (Self-Location Lens), quatrième instrument candidat du toolkit ICT après SAE, J-Lens et F-Lens — livré en POC **sans aucune API publique** (le contrat de trace v1 refuse toujours `slens` : vérifié par un test et par une cellule du notebook, pas affirmé).

- **Deux bancs à vérité terrain exacte** : `copy_offset` (l'offset est dans le contenu, la cible à `L-k` : distribution exacte `exact_position_distribution`, oracle indépendant `oracle_copy_offset` qui refuse nommément un offset hors bornes) et `variable_binding` (second problème de binding exigé par le gate).
- **Trois régimes de position** — `rope` (référence), `abs`, `none` (position dérivée du contenu) — sous le même budget, mêmes graines. Interprétation consignée dans le code et le notebook : `none` garde le signal d'ordre du masque causal, l'ablation dit « sans encodage positionnel appris », pas « sans information d'ordre ».
- **Sonde linéaire par couche/tête** (ridge forme fermée), métriques **hors échantillon** (70/30), chaque localisation confrontée à son **propre plancher de shuffle**.
- **Jambe causale** : échange apparié (interchange) du résidu au token d'offset entre paires qui ne diffèrent que par `k`, avec **sham** (auto-échange) et **cible aléatoire non appariée** ; dommage général mesuré sur le résidu post-stack **hors du cône causal** ; verdict `causal / undiscriminated / global_damage / no_effect` exigeant effet ET séparation des contrôles ET sélectivité.
- **Gate de promotion** `PROMOTE / SPECIALIZED_ONLY / INCONCLUSIVE` sur preuves agrégées multi-graines, jugé sur l'architecture de référence seule (les runs d'ablation sont rapportés mais exclus du test de stabilité — l'écart entre régimes n'est pas de l'instabilité de graine).

## Matrice 26 runs et verdict : INCONCLUSIVE

`runs/slens_matrix.json` (agrégat committé ; les 26 npz — ~1,2 Mio pièce — restent **locaux**, la commande de régénération est écrite dans le JSON) :

- **copy_offset / rope, 5 graines (0, 1, 7, 42, 99)** : copie exacte 1.000 partout ; localisation 0.818–1.000 contre un plancher shuffle 0.065–0.104 — le signal est massif sur chaque graine.
- **Mais l'amplitude inter-graines (0.170) dépasse la tolérance du gate (0.10)** : `seeds_stable = false`, et le verdict est **INCONCLUSIVE** — renvoyé au protocole (plus de graines ou banc plus riche), pas maquillé en succès.
- **Jambe causale : `no_effect` sur les 26 runs.** `follow_donor` ≈ 0.074 (< 0.5) : la référence est **lisible** dans la représentation (la sonde la localise presque parfaitement) mais l'intervention telle qu'instrumentée ne la rend pas **utilisable**. Lire et agir sont deux affirmations distinctes ; le banc les sépare.
- **`none` atteint 0.531** — très au-dessus du hasard par valeur (0.0625, et non 1/29 : le vocabulaire contient aussi les tokens d'offset), très en dessous de l'exactitude. Le contenu porte une partie de la référence : c'est le résultat le moins attendu, et il est rapporté avec sa réserve (masque causal).

Aucune extrapolation hors banc : le verdict porte sur un micro-transformer 2 couches / 64 dimensions, pas sur les LLM réels.

## Cinq défauts trouvés par la première mesure complète — corrigés et verrouillés par tests

La première exécution intégrale a produit des chiffres faux ou illisibles ; chacun est corrigé à la **source** et verrouillé :

1. **Classes de valeur recodées** (`ict/slens.py`) : le banc `variable_binding` utilise des ids non denses ; comparer l'argmax recodé à l'id brut rendait `value_exact` nul par construction.
2. **`no_effect` avant `global_damage`** (`ict/slens.py`) : une intervention sans effet qui abîme le modèle est un résultat négatif, pas un « dommage global » — le label affirme un effet.
3. **Cône causal** (`scripts/slens_poc.py`) : déclarer la seule ligne pivot comme cible comptait la propagation aval comme dommage (`off_target_rel` ~0.33 sur un modèle exact à 1.000) — le verdict `causal` était inatteignable par construction. Le dommage se mesure sur les positions **antérieures** au pivot : 0.0000 exactement, comme l'exige la causalité.
4. **Architecture de référence absente refusée** (`ict/slens.py`) : le gate ne peut pas être jugé sur une architecture absente de la matrice — erreur explicite au lieu d'un verdict silencieux.
5. **Ratio de sélectivité saturé** (`ict/causal_engine.py`) : `on_rel / max(off_rel, eps)` publiait `462774272000.00` pour une intervention parfaitement propre — une magnitude **artefact de la constante interne** `eps`, lisible comme une mesure. Le rapport vaut désormais `inf` (indistinguable de zéro = non borné) et `0.0` quand rien ne bouge (une intervention sans effet n'est pas « selective »). `_jsonable` rend les non-finis `null` — `json.dumps` écrirait `Infinity`, que la RFC 8259 n'autorise pas — et l'écriture npz passe par la même normalisation.

## Preuves

**Notebook exécuté** (`ICT-38-SLens-SelfLocation.ipynb`, kernel python3 = torch 2.8.0+cu126, GPU) — papermill end-to-end, 15 cellules code, `execution_count` 1..15, 0 erreur, 0 sortie vide ; entraînements réels (3 régimes × 3000 pas), pas de sortie fabriquée :

```
[papermill] Ending cell   15/15 ...
[papermill] Completed notebook
```

(extrait complet du log dans le commentaire de livraison)

**Tests** (venv Python 3.9, pyphi 1.2.0 / numpy 1.26.4 — l'env de CI du workflow) :

```
$ pytest ict/tests --collect-only -q   -> 720 tests collected
$ pytest ict/tests -q                  -> 717 passed, 3 skipped
$ pytest tests/test_causal_hooks.py -q -> 25 passed   (torch, CPU)
```

**Floor** : `ict-tests.yml` `ict/tests/ (43 package)` 715 → **720** (+4 défauts verrouillés, +1 saturation du ratio), mesuré firsthand `--collect-only`. La jambe `tests/ (56)` (floor 1071) n'est pas touchée.

**0 erreur volontaire** (C.1) : `grep -nE "raise NotImplementedError|assert False|1/0"` sur le notebook → rien ; 4 exercices en stubs conformes (`print("Exercice a completer")`).

## Périmètre

8 fichiers : `ict/slens.py` (+819), `scripts/slens_poc.py` (+503), `ict/tests/test_slens.py` (+434), `ict/tests/test_causal_engine.py` (+24), `ict/causal_engine.py` (+22), `ict-tests.yml`, le notebook exécuté et `runs/slens_matrix.json`. Catalogue byte-identique à `main`. Réimplémentation propre — aucun code du dépôt `strange-loop` non licencié.

## Résiduels, signalés et non traités

- **Readouts croisés F-Lens/J-Lens** : l'issue liste « effet du patch sur les readouts F-Lens/J-Lens disponibles » ; le POC mesure l'effet sur la réponse (comportement) et sur le résidu, pas sur les readouts des autres instruments — question d'intégration post-promotion, le verdict INCONCLUSIVE ne l'ouvre pas.
- **Stabilité inter-graines** : l'amplitude 0.170 (tolérance 0.10) appelle plus de graines ou un banc plus riche — c'est exactement ce que le verdict INCONCLUSIVE demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
