### PR TITLE
fix(ci,#15758): pr_gate_missing — verdict bot atteignable pour toute orthographe du login

### DIFF
--- a/scripts/pr_gate_missing.py
+++ b/scripts/pr_gate_missing.py
@@ -79,7 +79,14 @@ LABEL_CONFLICT_DESC = ("PR gate absent: PR en conflit avec main, aucun run "
 # required by main's branch protection. Renaming here silently detaches the
 # detector (same invariant as pr-gate.yml: keep the string stable).
 GATE_NAME = "PR gate"
-BOT_LOGIN = "app/github-actions"
+# The bot's login spelling depends on the API that measured it: REST reads
+# `.user.login` -> "github-actions[bot]" (what list_open_prs emits), GraphQL
+# returns "app/github-actions", and the bare app slug shows up on some
+# endpoints. Comparing to ONE spelling made `bot_missing` unreachable for
+# every other one (#15758) -- same families as
+# guard_comment_upsert.GUARD_BOT_LOGINS and pick_idle_grain.AUTOMATION_AUTHORS.
+BOT_LOGINS = frozenset({"github-actions[bot]", "app/github-actions",
+                        "github-actions"})
 
 # Marker framing the advisory comment, so re-runs can find and update it.
 COMMENT_MARKER_START = "<!-- PR-GATE-MISSING:START -->"
@@ -146,7 +153,8 @@ REMEDIATION_UNKNOWN = (
 )
 
 REMEDIATION_BOT = (
-    "PR ouverte par le bot (`app/github-actions`) sans `PR gate` dans son "
+    "PR ouverte par le bot d'automatisation (`github-actions[bot]` en REST, "
+    "`app/github-actions` en GraphQL) sans `PR gate` dans son "
     "rollup : cas **structurel** (issue #10928). Un push fait avec "
     "`GITHUB_TOKEN` ne cree pas de nouveau workflow run (regle anti-recursion "
     "GitHub), donc le contexte requis ne sera jamais rapporte par un push du "
@@ -196,7 +204,7 @@ def classify(pr: dict) -> tuple[str, str]:
         return ("draft", f"#{number} draft PR, non mergeable")
     if GATE_NAME in rollup_names(pr):
         return ("has_gate", f"#{number} PR gate present (conclusion: {len(rollup_names(pr))} checks)")
-    if pr.get("author_login") == BOT_LOGIN:
+    if pr.get("author_login") in BOT_LOGINS:
         return ("bot_missing", f"#{number} bot PR, no PR gate (structural)")
     return ("missing", f"#{number} PR gate absent du rollup")
 
@@ -224,7 +232,9 @@ def prescribe(pr: dict) -> tuple[str, str]:
         retarget  -> un ``base_ref_changed`` postérieur au dernier run
                      ``pull_request`` : remede = commit vide a arbre identique
         skip_ci   -> token ``[skip ci]`` dans le sujet de tete (cause #10898)
-        bot       -> PR ``app/github-actions`` (cause #10558)
+        bot       -> PR du bot d'automatisation, toute orthographe
+                     (``github-actions[bot]`` REST / ``app/github-actions``
+                     GraphQL ; cause #10558)
         unknown   -> aucune des quatre : nommer les mesures, ne rien prescrire
 
     Returns:
@@ -240,8 +250,9 @@ def prescribe(pr: dict) -> tuple[str, str]:
                 f"base_ref_changed={changed}, dernier run PR gate={last or 'aucun'}")
     if "[skip ci]" in head_subject(pr):
         return ("skip_ci", f"sujet de tete porte le token [skip ci] : {head_subject(pr)[:72]!r}")
-    if pr.get("author_login") == BOT_LOGIN:
-        return ("bot", "auteur app/github-actions -- push GITHUB_TOKEN sans run")
+    if pr.get("author_login") in BOT_LOGINS:
+        return ("bot",
+                f"auteur {pr.get('author_login')} (bot) -- push GITHUB_TOKEN sans run")
     return ("unknown",
             f"mergeable_state={ms}, pas de base_ref_changed, sujet sans [skip ci], "
             f"auteur {pr.get('author_login')}")

--- a/scripts/tests/test_pr_gate_missing.py
+++ b/scripts/tests/test_pr_gate_missing.py
@@ -326,6 +326,50 @@ def test_classify_input_is_the_only_shape():
     assert classify(row)[0] == "has_gate"
 
 
+# ---------------------------------------------------------------------------
+# (#15758) le login du bot depend de l'API qui le mesure
+#
+# Le collecteur lit REST `.user.login` -> `github-actions[bot]` ; GraphQL
+# renvoie `app/github-actions` ; le slug nu `github-actions` apparait selon
+# l'endpoint. Comparer a UNE seule orthographe rendait `bot_missing`
+# inatteignable avec la forme meme du producteur (convention partagee avec
+# guard_comment_upsert.GUARD_BOT_LOGINS et pick_idle_grain.AUTOMATION_AUTHORS).
+# Chaque orthographe passe par `classify_input()` -- la fabrique reelle --
+# jamais par un dict construit a la main avec les cles du consommateur.
+# ---------------------------------------------------------------------------
+
+
+def test_bot_verdict_reachable_for_every_measured_spelling():
+    # Critere 1 : quelle que soit l'orthographe mesuree, la PR bot est
+    # `bot_missing` / cause `bot` -- pas `missing`/`unknown`.
+    for spelling in ("github-actions[bot]", "app/github-actions",
+                     "github-actions"):
+        row = classify_input(10558, "main", False, spelling,
+                             _codeql_only_rollup())
+        verdict, why = classify(row)
+        assert verdict == "bot_missing", "%s: %s" % (spelling, why)
+        cause, detail = prescribe(row)
+        assert cause == "bot", spelling
+        assert spelling in detail  # la valeur lue, pas une orthographe supposee
+
+
+def test_human_pr_not_absorbed_by_bot_predicate():
+    # Critere 2 : le predicat bot ne s'attrape pas les auteurs humains.
+    row = classify_input(10902, "main", False, "jsboige", _codeql_only_rollup())
+    verdict, why = classify(row)
+    assert verdict == "missing", why
+    assert prescribe(row)[0] == "unknown"
+
+
+def test_bot_with_gate_still_has_gate_any_spelling():
+    # Critere 4 : elargir le predicat bot ne derobe pas `has_gate`.
+    rollup = _codeql_only_rollup() + [{"name": GATE_NAME, "conclusion": "SUCCESS"}]
+    for spelling in ("github-actions[bot]", "app/github-actions",
+                     "github-actions"):
+        row = classify_input(10558, "main", False, spelling, rollup)
+        assert classify(row)[0] == "has_gate", spelling
+
+
 def test_label_descriptions_within_github_limit():
     # GitHub refuse une description de plus de 100 caracteres. Mesure #15621 :
     # 108 / 121 / 145 -- `gh label create` echouait, l'echec etait avale, et les


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #15824

# fix(ci,#15758): pr_gate_missing — verdict bot atteignable pour toute orthographe du login

Closes #15758

## Defaut

`BOT_LOGIN = "app/github-actions"` (orthographe GraphQL) etait compare en egalite stricte (`author_login == BOT_LOGIN`) aux deux sites de decision — `classify()` (verdict `bot_missing`) et `prescribe()` (cause `bot`). Or le collecteur `list_open_prs` lit REST `.user.login` et emet `github-actions[bot]` : le verdict bot etait donc **inatteignable avec la forme meme du producteur** — une PR bot sans gate serait classee `missing` (« investigation manuelle ») au lieu du cas structurel. Defaut latent (aucune PR bot ouverte aujourd'hui : `bot_missing: 0` par vacuite), famille #15621 (producteur/consommateur).

## Fix

- `BOT_LOGINS = frozenset({"github-actions[bot]", "app/github-actions", "github-actions"})` — les trois orthographes mesurees selon l'API, meme convention que `guard_comment_upsert.GUARD_BOT_LOGINS` et `pick_idle_grain.AUTOMATION_AUTHORS`.
- Les deux predicats passent au test d'appartenance `in BOT_LOGINS`.
- Le detail de `prescribe` nomme la valeur MESUREE (`auteur {login} (bot)`) au lieu d'une orthographe supposee (#14477) ; `REMEDIATION_BOT` et la docstring de `prescribe` documentent les orthographes REST/GraphQL.

## Tests (critere 3 : epingler la forme du PRODUCTEUR)

Nouvelle section #15758 dans `scripts/tests/test_pr_gate_missing.py` — chaque orthographe passe par `classify_input()` (la fabrique reelle, celle du collecteur), jamais par un dict construit a la main avec les cles du consommateur :

- `test_bot_verdict_reachable_for_every_measured_spelling` — critere 1 : les 3 orthographes -> `bot_missing` + cause `bot`, le login mesure cite dans le detail.
- `test_human_pr_not_absorbed_by_bot_predicate` — critere 2 : `jsboige` reste `missing` / cause `unknown`.
- `test_bot_with_gate_still_has_gate_any_spelling` — critere 4 : le predicat elargi ne derobe pas `has_gate`.

**Preuve red/green** : sur le code d'`origin/main`, le premier test ROUGIT avec `assert 'missing' == 'bot_missing'` (l'orthographe REST `github-actions[bot]` tombe dans `missing`) ; apres fix : **32/32 passed** (`pytest scripts/tests/test_pr_gate_missing.py -q`, Python 3.13.3).

Les 29 tests existants (verdicts `missing`/`draft`/`excluded_base`/`has_gate`, causes `conflict`/`retarget`/`skip_ci`/`bot`/`unknown`, collecteur #15621, labels, gh write) restent verts **sans modification** — critere 4.

## Perimetre

2 fichiers : `scripts/pr_gate_missing.py` (+17/-6), `scripts/tests/test_pr_gate_missing.py` (+44). Catalogue byte-identique a main (aucun fichier catalogue touche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
