### PR TITLE
fix(ci,#15825): pr_gate — un crash publie quand même un titre (tranche 1)

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -1566,5 +1566,58 @@ def _maybe_post_check_run(args, code: int, message: str) -> None:
     )
 
 
+def _crash_fallback_publish(exc: BaseException) -> None:
+    """(#15825) A crashed gate still owes its check-run a non-empty title.
+
+    Measured 2026-09-12: 9 of 43 `PR gate` failures in the open population
+    render ``output.title = null`` -- an organ that goes red without a
+    motive. The emission tail publishes the verdict, but an unhandled
+    exception anywhere under it used to bypass publication entirely: the
+    auto check-run concluded ``failure`` carrying nothing. This fallback
+    PATCHes the crash motive from environment-derived parameters (main()
+    may have died before parsing anything), and never raises: a publication
+    failure must not mask the original crash.
+    """
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if not repo or not run_id:
+        return
+    try:
+        publish_check_run_output(
+            repo, run_id, DEFAULT_SELF_NAME, 1,
+            f"FAIL -- pr_gate internal error: {type(exc).__name__}: {exc}",
+        )
+    except Exception as pub_exc:
+        print(
+            f"[pr-gate] WARN -- crash fallback not published: {pub_exc!r}",
+            flush=True,
+        )
+
+
+def _entry(argv: "Iterable[str] | None" = None) -> int:
+    """Mute-failure guard (#15825 criterion 1): impossible by construction.
+
+    Any conclusion that is not ``success`` must carry a non-empty
+    ``output.title`` -- including the crash path. main()'s GateError paths
+    already fall through to the single emission tail; this wrapper closes
+    the remaining hole (a non-GateError exception) by publishing a fallback
+    title, printing the same ``[pr-gate] FAIL`` + ``::error::`` motif, and
+    exiting nonzero. Verdict semantics unchanged: an unreadable state is a
+    failure, never a pass (rule 1).
+    """
+    try:
+        return main(argv)
+    except Exception as exc:
+        _crash_fallback_publish(exc)
+        print(f"[pr-gate] FAIL -- internal error: {exc!r}", flush=True)
+        print(
+            f"::error::[pr-gate] internal error: "
+            f"{_workflow_command_escape(repr(exc))}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_entry())

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -161,6 +161,7 @@ import re
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
 from typing import Iterable, Sequence
 
@@ -1577,6 +1578,12 @@ def _crash_fallback_publish(exc: BaseException) -> None:
     PATCHes the crash motive from environment-derived parameters (main()
     may have died before parsing anything), and never raises: a publication
     failure must not mask the original crash.
+
+    ``run_attempt`` is propagated for the same reason the normal path passes
+    it: a re-run leaves the superseded attempts' jobs in the same run, and
+    without the filter the selector resolves the crash motive onto the
+    SUPERSEDED check-run -- leaving the current attempt carrying
+    ``output.title = null``, the very defect #15825 removes.
     """
     repo = os.environ.get("GITHUB_REPOSITORY", "")
     run_id = os.environ.get("GITHUB_RUN_ID", "")
@@ -1586,6 +1593,7 @@ def _crash_fallback_publish(exc: BaseException) -> None:
         publish_check_run_output(
             repo, run_id, DEFAULT_SELF_NAME, 1,
             f"FAIL -- pr_gate internal error: {type(exc).__name__}: {exc}",
+            run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT"),
         )
     except Exception as pub_exc:
         print(
@@ -1608,6 +1616,9 @@ def _entry(argv: "Iterable[str] | None" = None) -> int:
     try:
         return main(argv)
     except Exception as exc:
+        # `repr(exc)` alone loses the causal frame -- the check-run title has
+        # to stay one line, but the log is where the crash is diagnosable.
+        traceback.print_exc()
         _crash_fallback_publish(exc)
         print(f"[pr-gate] FAIL -- internal error: {exc!r}", flush=True)
         print(

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -245,6 +245,58 @@ def test_crash_fallback_publish_failure_does_not_mask_the_crash(
     assert "crash fallback not published" in out.out
 
 
+def test_crash_fallback_propagates_the_current_run_attempt(
+    monkeypatch, capsys
+):
+    """Le repli de crash doit viser le check-run de la tentative COURANTE.
+
+    Mesure de l'adjudant (head `1c7f57119a`) : sur un `run_attempt=2` qui
+    porte encore les jobs des tentatives 1 et 2, la voie normale filtre par
+    `GITHUB_RUN_ATTEMPT` mais le repli ne le transmettait pas -- il resolvait
+    alors le titre de crash sur le check-run SUPERSEDE de la tentative 1, et
+    la tentative courante gardait `output.title = null` : le defaut meme que
+    #15825 elimine, sur le chemin qui doit justement le couvrir.
+    """
+    def crash(*_args, **_kwargs):
+        raise ValueError("boom au run_attempt 2")
+
+    seen = {}
+
+    def fake_publish(repo, run_id, job_name, code, message,
+                     advisory=(), run_attempt=None, **_k):
+        seen["run_attempt"] = run_attempt
+        return True
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+    monkeypatch.setenv("GITHUB_RUN_ID", "34608518559")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+    monkeypatch.setattr(pr_gate, "wait_and_decide", crash)
+    monkeypatch.setattr(pr_gate, "publish_check_run_output", fake_publish)
+    assert pr_gate._entry(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    assert seen["run_attempt"] == "2", (
+        "sans la tentative courante, le repli PATCH le check-run supersede et "
+        "le defaut #15825 survit sur le run_attempt > 1"
+    )
+    capsys.readouterr()
+
+
+def test_crash_fallback_preserves_the_traceback(monkeypatch, capsys):
+    """Le titre du check-run tient sur une ligne, donc le repli ne garde que
+    `repr(exc)` ; la trame causale doit rester lisible dans le log."""
+    def crash(*_args, **_kwargs):
+        raise ValueError("cause racine a diagnostiquer")
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(pr_gate, "wait_and_decide", crash)
+    monkeypatch.setattr(pr_gate, "publish_check_run_output",
+                        lambda *_a, **_k: True)
+    assert pr_gate._entry(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    captured = capsys.readouterr()
+    assert "Traceback (most recent call last)" in captured.err
+    assert "cause racine a diagnostiquer" in captured.err
+
+
 def test_completed_without_conclusion_is_pending_not_pass():
     """`status=completed, conclusion=null` is a transient GitHub state."""
     pending, bad, ok, _adv = pr_gate.classify([run("Odd", None)])

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -160,6 +160,91 @@ def test_posted_check_run_message_is_not_escaped(monkeypatch):
     )
 
 
+# --- #15825 -- toute conclusion non-success porte un titre non vide -----------
+#
+# Mesure 2026-09-12 : 9 echecs `PR gate` sur 43 rendent output.title = null.
+# Deux classes : (a) le snapshot de script fige par le rerun d'un event
+# payload stale -- le head de #15440 est derriere main de 175 commits, ses
+# 8 tentatives rejouent l'ancien script depourvu de publication (classe
+# irreparable cote gate, d'ou le repli lecteur, critere 2 de l'issue) ;
+# (b) le crash non rattrape dans le script ACTUEL : une exception hors
+# GateError sous main() court-circuitait la queue d'emission. Ces tests
+# epinglent (b) : le contrat est « toute conclusion non-success porte un
+# titre non vide » (critere 3).
+
+
+def test_crashed_gate_publishes_nonempty_title(monkeypatch, capsys):
+    """Critere 1 : un crash sous main() publie quand meme un titre."""
+    def crash(*_args, **_kwargs):
+        raise ValueError("pollution du rollup par un dict inattendu")
+
+    seen = {}
+
+    def fake_publish(repo, run_id, job_name, code, message, *_a, **_k):
+        seen.update(repo=repo, run_id=run_id, job_name=job_name, code=code,
+                    title=message.splitlines()[0] if message else "")
+        return True
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+    monkeypatch.setenv("GITHUB_RUN_ID", "34608518559")
+    monkeypatch.setattr(pr_gate, "wait_and_decide", crash)
+    monkeypatch.setattr(pr_gate, "publish_check_run_output", fake_publish)
+    assert pr_gate._entry(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    assert seen["code"] == 1
+    assert seen["title"], "un titre vide est exactement le defaut #15825"
+    assert "internal error" in seen["title"]
+    assert "ValueError" in seen["title"]
+    assert seen["job_name"] == pr_gate.DEFAULT_SELF_NAME
+    out = capsys.readouterr()
+    assert "[pr-gate] FAIL -- internal error" in out.out
+    assert "::error::" in out.err
+
+
+def test_crashed_gate_without_publish_context_still_fails_one(
+    monkeypatch, capsys
+):
+    """Hors Actions (ni GITHUB_REPOSITORY ni GITHUB_RUN_ID) : la publication
+    n'est pas possible, mais l'exit code 1 et le motif FAIL restent -- un
+    contexte de publication absent ne doit jamais transformer un crash en
+    silence (ou pire, en 0)."""
+    def crash(*_args, **_kwargs):
+        raise ValueError("boom local")
+
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.setattr(pr_gate, "wait_and_decide", crash)
+
+    def must_not_publish(*_a, **_k):
+        raise AssertionError("ne doit pas publier sans contexte Actions")
+
+    monkeypatch.setattr(pr_gate, "publish_check_run_output", must_not_publish)
+    assert pr_gate._entry(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    out = capsys.readouterr()
+    assert "[pr-gate] FAIL -- internal error" in out.out
+
+
+def test_crash_fallback_publish_failure_does_not_mask_the_crash(
+    monkeypatch, capsys
+):
+    """La publication de repli ne doit JAMAIS masquer le crash d'origine :
+    si le PATCH plante aussi, le motif FAIL interne reste emis et l'exit
+    reste 1."""
+    def crash(*_args, **_kwargs):
+        raise ValueError("crash d'origine")
+
+    def exploding_publish(*_a, **_k):
+        raise RuntimeError("PATCH explose aussi")
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "jsboige/CoursIA")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setattr(pr_gate, "wait_and_decide", crash)
+    monkeypatch.setattr(pr_gate, "publish_check_run_output", exploding_publish)
+    assert pr_gate._entry(["--repo", "o/r", "--sha", "deadbeef"]) == 1
+    out = capsys.readouterr()
+    assert "[pr-gate] FAIL -- internal error" in out.out
+    assert "crash fallback not published" in out.out
+
+
 def test_completed_without_conclusion_is_pending_not_pass():
     """`status=completed, conclusion=null` is a transient GitHub state."""
     pending, bad, ok, _adv = pr_gate.classify([run("Odd", None)])


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #15828

# fix(ci,#15825): pr_gate — un crash publie quand même un titre (tranche 1 : critères 1+3)

See #15825

## Forensique d'abord (ce que la mesure a départagé)

L'issue mesure **9/43 échecs `PR gate` avec `output.title = null`** et cite le run `34608518559` de #15440 (8 tentatives × ~23 s, log explicite, API muette). Trois chemins silencieux possibles dans `publish_check_run_output` (chacun imprime un WARN). **Le log du run ne contient AUCUN des trois WARN** — la fonction n'a jamais rendu `False` en warnant. Le mécanisme de publication (#15725) était mergé à **11:24Z**, le run muet a tourné à **17:06Z**… mais `compare/6516fc5abf...62286af5d1` (head de #15440) rend **`diverged, behind_by=175`** : le head ne contient pas #15725, et un rerun rejoue l'event payload figé — **les 8 tentatives exécutent l'ancien script, sans publication, pour toujours**. C'est la classe stale-snapshot (famille #15771/#15693) : irréparable côté gate, seul le **repli lecteur** (critère 2, tranche suivante) peut la diagnostiquer.

## Ce que cette PR ferme : le trou du script ACTUEL (critère 1 + 3)

Post-#15725, tous les verdicts passent par la queue d'émission unique (`GateError` rattrapé l.1413 → publication l.1479). **Le trou restant : une exception hors `GateError` n'importe où sous `main()`** court-circuite la queue — le check-run auto conclut `failure` avec `Process completed with exit code 1` et `output.title = null`. C'est exactement « conclusion posée sans payload output », citée par l'issue.

- **`_entry()`** : wrapper de `__main__` — `main()` qui crash publie quand même un titre de repli, imprime le motif `[pr-gate] FAIL -- internal error: <Type>: <msg>` + l'annotation `::error::` (même motif d'émission), exit 1. Sémantique de verdict inchangée (règle 1 : un état illisible est un échec, jamais un vert).
- **`_crash_fallback_publish()`** : PATCH le motif de crash depuis `GITHUB_REPOSITORY`/`GITHUB_RUN_ID` (main() peut être mort avant tout parsing) ; **ne raise jamais** — une publication qui plante n'éclipse pas le crash d'origine (WARN dédié).

Un `conclusion: failure` sans `output.title` devient **impossible par construction** sur les chemins du script vivant : toute sortie non-`success` passe soit par la queue d'émission, soit par le repli de crash.

## Tests (critère 3 : contrat « toute conclusion non-success porte un titre non vide »)

5 nouveaux tests dans `scripts/tests/test_pr_gate.py` (section #15825, documentant les deux classes mesurées) :

- `test_crashed_gate_publishes_nonempty_title` — un `ValueError` injecté sous `main()` via `wait_and_decide` : `_entry` rend 1, la publication de repli porte un titre non vide (`internal error`, `ValueError` nommés), motif FAIL + annotation émis.
- `test_crashed_gate_without_publish_context_still_fails_one` — hors Actions (pas de contexte env) : pas de publication, mais exit 1 + motif FAIL — jamais un silence.
- `test_crash_fallback_publish_failure_does_not_mask_the_crash` — le PATCH de repli qui explose n'éclipse pas le crash d'origine.
- `test_crash_fallback_propagates_the_current_run_attempt` — le repli transmet la tentative COURANTE (finding de l'ADJOINT).
- `test_crash_fallback_preserves_the_traceback` — la trame causale reste lisible dans le log.

**Preuve red/green** : sur le code d'`origin/main`, les 3 tests ROUISSENT (`_entry` inexistant = le crash traverse tout) ; après fix : **110/110 passed** (`pytest scripts/tests/test_pr_gate.py -q`, 105 existants inchangés et verts, Python 3.13.3).

## Perimetre et residuel

2 fichiers : `scripts/pr_gate.py` (+65/-1), `scripts/tests/test_pr_gate.py` (+137). Catalogue byte-identique à main.

**Tranche 2 restante (critère 2 de l'issue)** — non couverte ici, claim #15825 laissé actif : un `output.title` nul traité comme un défaut du gate par les lecteurs (sweep / `pick_idle_grain.py`), repli minimal = reporter la dernière ligne `[pr-gate]` du log du run. C'est la seule couverture possible de la classe stale-snapshot mesurée (9/43), puisque ces runs exécutent un script figé qu'aucun fix rétroactif ne peut atteindre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Suite de revue (ADJOINT préflight sur `1c7f57119a`)

**Finding traité — la tentative courante n'était pas transmise au repli.** La voie normale passe `GITHUB_RUN_ATTEMPT` à `publish_check_run_output` pour sélectionner le check-run vivant ; `_crash_fallback_publish` ne le passait pas. Sur un `run_attempt=2` portant encore les jobs des tentatives 1 et 2, le sélecteur résolvait donc le titre de crash sur le check-run **supersédé** de la tentative 1 : la tentative courante gardait `output.title = null` — le défaut même de #15825, sur le chemin censé le couvrir, et précisément sur le cas forensique de l'issue (`run_attempt=8`).

Correctif borné appliqué : `run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT")` dans l'appel du repli. **Rider** appliqué aussi : `traceback.print_exc()` dans le catch de `_entry` — le titre du check-run doit rester mono-ligne, mais `repr(exc)` seul perdait la trame causale.

**Rouge d'abord, prouvé** (2 mutations reversées, backup/restore `cp`) :

```
pre-fix   : 2 failed, 108 deselected
restaure  : 2 passed, 108 deselected
```

**Décompte périmé corrigé.** Le corps annonçait `+61/-1` et `+78` ; mesure `gh pr view --json files` au head `734851691a` : `+65/-1` et `+137` (le chiffre d'origine était faux dès avant cette passe — réel `+54/-1` et `+85` — et la présente passe l'a déplacé). Catalogue toujours byte-identique à main.
