### PR TITLE
ci(lean,#14337): migrate lean-conway.yml target-coverage to coursia-lean pool (tranche 2)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -262,13 +262,18 @@ jobs:
   # that keeps its own copy of the list detects everyone's drift but its own.
   target-coverage:
     name: conway target-coverage
-    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
-    # auto-hebergee. Le `if:` ci-dessous est la garde anti-fork exigee par
-    # scripts/ci/check_self_hosted_runner_policy.py ; un `runs-on` STATIQUE la
-    # rend auditable (une expression dynamique leve DYNAMIC_RUNS_ON).
-    # Les PRs de fork sautent le job -- pr_gate.py compte `skipped` comme OK.
-    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
-    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    # Routage #14337 tranche 2 (decision ai-01 2026-09-04, migration narrow
+    # heritage G-VAR-1 Tell c.531-L2 strict) : bascule `coursia-linux` vers
+    # `coursia-lean` pour beneficier du cache Mathlib chaud (image
+    # Dockerfile.lean = elan + leanprover/lean4:v4.32.1 baked in, .lake/packages
+    # garde au chaud dans le volume _work par slot). Pattern PR #15303 tranche
+    # 1 sur lean-social-choice.yml (po-2024 c.1020). Le `if:` ci-dessous est la
+    # garde anti-fork exigee par scripts/ci/check_self_hosted_runner_policy.py ;
+    # un `runs-on` STATIQUE la rend auditable (une expression dynamique leve
+    # DYNAMIC_RUNS_ON). Les PRs de fork sautent le job -- pr_gate.py compte
+    # `skipped` comme OK. Allowlist deja presente (ligne 128 du policy script,
+    # tranche 3c #14283). Retour arriere = remettre `coursia-linux` + push.
+    runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
     if: (github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository) && always()
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #15828

## Contexte

Issue #14337 `[EPIC] Knot Theory Lean — pools de runners spécialisés par labels (cache Mathlib chaud)` ouvre la voie d'une migration du CI Lean depuis l'image Linux généraliste (`coursia-linux`) vers un pool dédié `coursia-lean` (image `Dockerfile.lean` = elan + `leanprover/lean4:v4.32.1` baked in, `.lake/packages` gardé au chaud dans le volume `_work` par slot). La motivation est purement incrémentale : un cache Mathlib chaud évite de re-télécharger + re-compiler les 200+ modules Mathlib à chaque run sur la branche par défaut.

**Tranche 1** a été livrée par po-2024 c.1020 via **PR #15303** (OPEN) : migration du job `build` de `lean-social-choice.yml` vers `coursia-lean`, +15/-1 sur 2 fichiers (workflow + script policy allowlist). **Tranche 2** (cette PR) applique le même pattern à `lean-conway.yml` qui, malgré la présence du label `coursia-lean` dans l'image bake, **n'a jamais été migrée** — vérification first-hand : `grep -L coursia-lean .github/workflows/lean-*.yml` rend 28 fichiers, dont `lean-conway.yml`.

## Cause RACINE first-hand (Tell c.1356 ★★★ preflight ×37ᵉ)

Mesure first-hand c.508 :

```
$ grep -n "runs-on:" .github/workflows/lean-conway.yml
271:    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]

$ grep -n "coursia-lean" .github/workflows/lean-conway.yml
# (aucun match)
```

La migration de tranche 1 a été scopée strictement à `lean-social-choice.yml` (cf body PR #15303). La tranche 2a #14667 a introduit les composite actions `.github/actions/lean-{axiom,build}/action.yml` mais **n'a pas appliqué la bascule** `coursia-linux` → `coursia-lean` sur `lean-conway.yml` — qui continue à utiliser le job `target-coverage` non-reusable et `runs-on: coursia-linux`.

## Pré-conditions (Tell c.518 L898 collision guard ×6ᵉ)

- `lean-conway.yml` **est déjà dans l'allowlist** `LINUX_RUNNER_LABELS_BYPASS` du script `scripts/ci/check_self_hosted_runner_policy.py` (ligne 128, ajoutée tranche 3c #14283). **Aucune modification du script policy requise** — le seul changement est sur le workflow lui-même.
- `lean-conway.yml` est un workflow **non-reusable** (pas de `workflow_call`). Vérif first-hand : `grep -L workflow_call .github/workflows/lean-conway.yml` = match. Conforme à la note de PR #15303 : seuls les workflows non-reusables peuvent router vers `coursia-lean` (`lean-build.yml` et `lean-axiom.yml` restent ubuntu-latest car `workflow_call` les expose aux forks, Tell c.REUSABLE_SELF_HOSTED refuse).
- Aucune PR OPEN en collision sur `lean-conway.yml` : `gh pr list --state open --search "lean-conway.yml in:path"` rend seulement #15706 qui ne touche pas ce fichier (vérif first-hand : fichiers modifiés = `[lean-axiom.yml, lean-build.yml, lean-knot.yml, lean-planning.yml, lean-social-choice.yml]`, lean-conway.yml absent).
- Claim posée c.508 sur issue #14337 (issuecomment-5648283366) avec clause `paths:` restreinte.

## Fix (Tell c.531-L2 narrow héritage G-VAR-1 strict)

Un seul fichier, une seule ligne substantive change : `runs-on: coursia-linux` → `runs-on: coursia-lean`. Le commentaire narratif est mis à jour pour documenter le routage et son retour arrière.

```diff
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -262,13 +262,18 @@ jobs:
   target-coverage:
     name: conway target-coverage
-    # Routage #14283 tranche 3 (decision ai-01 2026-09-02) : jambe Linux
-    # auto-hebergee. ...
-    runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    # Routage #14337 tranche 2 (decision ai-01 2026-09-04, migration narrow
+    # heritage G-VAR-1 Tell c.531-L2 strict) : bascule `coursia-linux` vers
+    # `coursia-lean` pour beneficier du cache Mathlib chaud ...
+    runs-on: [self-hosted, coursia-ephemeral, coursia-lean]
```

Pattern strictement identique à PR #15303. Aucune modification de `scripts/ci/check_self_hosted_runner_policy.py` (allowlist déjà conforme).

## Vérification first-hand

| Test | Résultat |
|---|---|
| `python scripts/ci/check_self_hosted_runner_policy.py` | `[self-hosted-policy] workflows=159 jobs=202 self_hosted=131` + `OK -- all self-hosted jobs satisfy isolation policy` ✓ |
| `grep -L workflow_call .github/workflows/lean-conway.yml` | match ✓ (non-reusable, éligible) |
| `gh pr list --state open --search "lean-conway.yml in:path"` | seulement #15706 qui ne touche pas lean-conway.yml ✓ (Tell c.518 L898) |
| `grep -n coursia-lean .github/workflows/lean-conway.yml` (post-fix) | `runs-on: [self-hosted, coursia-ephemeral, coursia-lean]` ✓ |
| `git diff --stat` | 1 fichier modifié, +12/-7 ✓ (Tell c.531-L2 strict) |

## Conformité tells

- **Tell c.518 L898 ★★★ collision guard ×6ᵉ** : vérif first-hand avant claim (`gh pr list`), vérification absence de collision sur `lean-conway.yml` (seul #15706 OPEN, ne touche pas le fichier).
- **Tell c.531-L2 ★★ narrow héritage G-VAR-1 strict** : 1 fichier, scope strict borné, tranche extraite d'un EPIC #14337 multi-tranches. Tell c.831-L10 ★★★ mi-livraison multi-tranches ×2 reconnue (tranche 1 po-2024 + tranche 2 cette PR).
- **Tell c.1356 ★★★ preflight ×37ᵉ** : mesures first-hand `runs-on:` actuel + `coursia-lean` absent + allowlist présente + workflows non-reusables.
- **Tell c.1069 strict honnêteté référentielle ×37ᵉ** : PR #15303 lue intégralement (2 fichiers +15/-1, body mentionnant `REUSABLE_SELF_HOSTED`), PR #14667 lue (composite actions introduites sans bascule appliquée), Tell c.531-L2 narrow héritage pattern strictement reproduit.
- **Tell c.466 ★★ fondateur TENSION conditionnelle** : pré-condition = PR sous DWELL strict (n/a, narrow héritage n'est pas DWELL).
- **Tell c.480 ★★★ patience ≠ aveuglément attendre préciser MÉCANISME** : 4 vérifications first-hand distinctes avant édition.
- **Tell c.1502 strict 0 merge/close d'autrui** : PR LIVRÉE au coord (ai-01), je ne la merge pas.
- **Tell c.677-L4 ★★ dissipation body HORS worktree** : body généré dans scratchpad `c508_pr14337_tranche2_body.md`, JAMAIS dans le worktree.
- **Tell c.647 strict INLINE body DM** : PR ouverte via `gh pr create --body-file`.
- **Tell c.984 ★★★ ★★ fondateur main a bougé** : cycle démarre après FF `9d42c7653` (PR #15609 MERGED).
- **Tell c.1102 ★★★★★ anti-stonewall sustained ×33ᵉ**.
- **Tell c.1107-L3 ★ auto-invalidée c.506 + Tell c.1107-L2 ★★ INTERDIT ai-01 c.506** : aucune idée de self-merge.

## Hors scope de cette PR

- Les 27 autres workflows lean-* non encore migrés : chacun mérite sa propre PR (1 workflow = 1 tranche narrow héritage G-VAR-1 strict). Candidates naturelles après mesure first-hand : `lean-knot.yml`, `lean-galois.yml`, `lean-grothendieck.yml` (les plus touchés par le cache Mathlib).
- La résolution du warning `target-coverage` self-hosted `#15698` (#15706 OPEN) : orthogonal, géré par po-2024 sur sa propre tranche.

## Diff

```
 .github/workflows/lean-conway.yml | 19 ++++++++++++-------
 1 file changed, 12 insertions(+), 7 deletions(-)
```

## Test

```bash
python scripts/ci/check_self_hosted_runner_policy.py
# [self-hosted-policy] workflows=159 jobs=202 self_hosted=131
# [self-hosted-policy] OK -- all self-hosted jobs satisfy isolation policy.
```
