### PR TITLE
fix(ci,#15825): sweep — repli lecteur pour les gates muets (tranche 2)

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -112,6 +112,12 @@ permissions:
   actions: write       # re-run the ORIGINAL `PR gate` run (see the note below)
   pull-requests: write # gate-absent step below: labels via `gh pr edit` (#14477)
   issues: write        # ... and remediation comments via `gh pr comment`
+  # #15825 tranche 2: the mute-leg repair PATCHes the last `[pr-gate]` log
+  # line onto the check-run's `output` -- same mechanism, same permission, as
+  # pr-gate.yml's own publication (#15693). The job's GITHUB_TOKEN is an
+  # installation token; a PAT would be refused ("You must authenticate via a
+  # GitHub App", measured 2026-09-12).
+  checks: write
 
 concurrency:
   # One sweep at a time, and never cancel a running one: a sweep that is killed
@@ -208,6 +214,11 @@ jobs:
           #     what #15375 exists to stop.
           MAX_MATURE=12
           MAX_IMMATURE=4
+          # #15825: mute-leg repairs are a log fetch + one PATCH each, no
+          # runner slot held (unlike a re-run, which parks a coursia-waiter
+          # for the gate's full poll). 12 matches MAX_MATURE -- the mute
+          # class measured 9 legs on 2026-09-12, so one sweep drains it.
+          MAX_MUTE=12
 
           # Collected over REST, one small call per PR, NOT one bulk GraphQL
           # query. `gh pr list --limit 60 --json statusCheckRollup` returns
@@ -225,6 +236,7 @@ jobs:
             || { echo "[stale-sweep] PR listing failed (upstream) -- skip this sweep"; exit 0; }
 
           : > /tmp/runs.jsonl
+          : > /tmp/mute.txt
           while read -r NUM SHA FORK; do
             [ -z "${NUM:-}" ] && continue
             # details_url (.../actions/runs/{run_id}/job/{job_id}) is collected
@@ -233,8 +245,11 @@ jobs:
             # (workflow_id, name) instead of per name -- three workflows emit a
             # job named "Ratchet (base vs PR)" and a name-only fold merges their
             # verdicts (#11808).
+            # `title` (#15825): the collected output.title, "" when the
+            # check-run concluded without one -- the mute-leg signal the
+            # selector routes to the repair stream instead of a re-run.
             BODY=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
-                     --jq '[.check_runs[] | {name, status, conclusion, started_at, details_url}]' 2>/dev/null) || continue
+                     --jq '[.check_runs[] | {name, status, conclusion, started_at, details_url, title: (.output.title // "")}]' 2>/dev/null) || continue
             # Carte run_id -> workflow_id. UN seul appel de plus par PR (pas par
             # run) : la liste des runs du SHA porte deja `workflow_id`. C'est ce
             # qui permet de replier les runs JUMEAUX d'un MEME workflow sans
@@ -365,6 +380,44 @@ jobs:
                   # "Flag PRs whose PR gate never ran" step of this same
                   # sweep (#14477) -- re-aggregation has nothing to re-run.
                   continue
+
+              # (#15825) Mute gate leg: a RED conclusion carrying no
+              # output.title -- an organ that goes red without a motive
+              # (measured 2026-09-12: 9 of 43 gate failures in the open
+              # population). The re-run this sweep exists for is INERT on
+              # that class: it replays the SAME stale event payload, whose
+              # checkout predates the publication machinery (#15725), so
+              # the re-executed script renders the same mute red forever.
+              # Measured: run 34608518559 on #15440, 8 attempts x ~23 s,
+              # each identical, while the log carried the verdict from the
+              # first attempt. A mute leg is therefore NOT a re-run
+              # candidate -- it goes to the repair stream (last [pr-gate]
+              # log line PATCHed into output.title), never spending a
+              # waiter slot. The absent-key default is deliberate: data
+              # collected before #15825 has no `title` key at all and is
+              # never classified mute.
+              def _mute(c):
+                  return ((c.get("conclusion") or "") in RED
+                          and "title" in c and not c["title"].strip())
+
+              mute = [c for c in gate_legs if _mute(c)]
+              if mute:
+                  newest_mute = max(mute, key=lambda c: c.get("started_at") or "")
+                  m = re.search(r"/runs/(\d+)/job/(\d+)",
+                                newest_mute.get("details_url") or "")
+                  if m:
+                      with open(os.environ.get("SWEEP_MUTE_FILE", "/tmp/mute.txt"),
+                                "a", encoding="utf-8") as fh:
+                          fh.write(f'{p["number"]} {p["sha"]} '
+                                   f'{m.group(2)} {m.group(1)}\n')
+                  print(f'[stale-sweep] #{p["number"]}: MUTE gate leg '
+                        f'(red, output.title vide)'
+                        + (f' -- reparation depuis le log du run {m.group(1)}'
+                           if m else ' -- details_url illisible, ni re-run ni reparation')
+                        + ' (re-run inert sur snapshot stale, #15825)',
+                        file=sys.stderr)
+                  continue
+
               if not any((c.get("conclusion") or "") in RED for c in gate_legs):
                   continue
 
@@ -470,6 +523,55 @@ jobs:
           # number the secondary -- mature candidates first (their re-run
           # converts to a merge), oldest verdicts first within each tier.
           sort -s -k4,4n -k1,1n -o /tmp/candidates.txt /tmp/candidates.txt
+
+          # --- #15825 : repair of mute gate legs (red, no output.title) -----
+          #
+          # The repair does NOT clear the red -- only a real fix on the branch
+          # (update-branch, new push, new gate on a fresh checkout) can. It
+          # NAMES the cause: the last [pr-gate] line of the run's log, which
+          # has carried the verdict since the first attempt while the API
+          # rendered nothing. After this, any reader -- lane, coordinator,
+          # pick_idle_grain -- sees the motive on the check-run itself.
+          #
+          # PATCH in place (job id == check-run id, measured in
+          # pr_gate.own_job_id): same mechanism as pr_gate.py's own
+          # publication, same App-authenticated token, never a POSTed twin
+          # (a twin lands in a foreign suite and the AND keeps the PR
+          # blocked, #11519).
+          MUTE_N=0
+          MUTE_TOTAL=$(wc -l < /tmp/mute.txt | tr -d ' ')
+          while read -r NUM SHA JOB_ID RUN_ID; do
+            [ -z "${NUM:-}" ] && continue
+            if [ "$MUTE_N" -ge "$MAX_MUTE" ]; then
+              echo "[stale-sweep] mute cap reached ($MAX_MUTE) -- the rest next sweep"
+              break
+            fi
+            LINE=$(gh run view "$RUN_ID" --repo "$REPO" --log 2>/dev/null \
+                     | grep '\[pr-gate\]' | tail -1 | sed 's/.*\[pr-gate\] //') || true
+            if [ -z "${LINE:-}" ] && [ "${DRY_RUN:-false}" != "true" ]; then
+              LINE="(aucune ligne [pr-gate] dans le log du run $RUN_ID -- defaut du gate lui-meme, #15825)"
+            fi
+            if [ "${DRY_RUN:-false}" = "true" ]; then
+              echo "[stale-sweep] (dry-run) would repair #$NUM mute leg from run $RUN_ID: ${LINE:-<log illisible>}"
+              MUTE_N=$((MUTE_N + 1))
+              continue
+            fi
+            if [ -z "${LINE:-}" ]; then
+              echo "[stale-sweep] #$NUM: log du run $RUN_ID illisible -- leg mute gardee pour le prochain sweep"
+              continue
+            fi
+            # Summary sur UNE ligne physique : une ligne vide litterale dans
+            # un block scalaire YAML termine le bloc (le parseur le prouve).
+            if gh api --method PATCH "repos/$REPO/check-runs/$JOB_ID" \
+                 -f "output[title]=PR gate: ${LINE:0:222}" \
+                 -f "output[summary]=${LINE} -- titre rapporte depuis le log du run $RUN_ID par le sweep (#15825 : check-run conclu sans output, re-run inert sur snapshot stale, la cause etait dans le log depuis la premiere tentative)"; then
+              echo "[stale-sweep] #$NUM: mute gate leg -- titre repare depuis le log: $LINE"
+              MUTE_N=$((MUTE_N + 1))
+            else
+              echo "[stale-sweep] #$NUM: PATCH de reparation echoue -- leg gardee pour le prochain sweep"
+            fi
+          done < /tmp/mute.txt
+          echo "[stale-sweep] mute gate legs: $MUTE_TOTAL found, $MUTE_N repaired"
 
           COUNT=$(wc -l < /tmp/candidates.txt | tr -d ' ')
           MATURE_N=$(awk '$4 == "0"' /tmp/candidates.txt | wc -l | tr -d ' ')

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -83,7 +83,8 @@ def _run_selector_both(tmp_path, rows):
     fixture.write_text(
         "".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8"
     )
-    env = dict(os.environ, SWEEP_RUNS_FILE=str(fixture))
+    env = dict(os.environ, SWEEP_RUNS_FILE=str(fixture),
+               SWEEP_MUTE_FILE=str(tmp_path / "mute.txt"))
     out = subprocess.run(
         ["python", "-c", SELECTOR],
         capture_output=True, text=True, encoding="utf-8", env=env, cwd=tmp_path,
@@ -99,6 +100,12 @@ def _pr(number, checks, sha="deadbeef", fork=False, workflows=None):
     replie alors sous la cle sentinel ``unattributed`` (comportement des
     donnees collectees avant #11808). Avec un run_id, la fixture porte le
     details_url REST (.../actions/runs/{run_id}/job/...).
+
+    Le 6e element est le ``output.title`` collecte (#15825) : absent, la
+    fixture decrit la forme PRE-collection du champ et la leg n'est jamais
+    classee muette ; les fixtures muettes le portent a "" explicitement --
+    la forme exacte que le collecteur emet pour un check-run conclu sans
+    output.
     """
     rows = []
     for ch in checks:
@@ -109,6 +116,8 @@ def _pr(number, checks, sha="deadbeef", fork=False, workflows=None):
                 "https://github.com/jsboige/CoursIA/actions/runs/"
                 f"{ch[4]}/job/96158568958"
             )
+        if len(ch) > 5:
+            row["title"] = ch[5]
         rows.append(row)
     row_out = {"number": number, "sha": sha, "fork": fork, "checks": rows}
     if workflows:
@@ -122,6 +131,11 @@ GATE_FAIL = ("PR gate", "completed", "failure", "2026-01-01T10:00:00Z")
 OTHER_GREEN = ("Hermes review", "completed", "success", "2026-01-01T10:05:00Z")
 OTHER_RED = ("Hermes review", "completed", "failure", "2026-01-01T10:05:00Z")
 OTHER_QUEUED = ("Hermes review", "queued", None, "2026-01-01T10:05:00Z")
+# (#15825) legs portant le titre collecte : muet (rouge, titre vide) vs
+# eloquent (rouge, titre porte) -- la mesure 2026-09-12 : 9 muets sur 43.
+GATE_MUTE = ("PR gate", "completed", "failure", "2026-01-01T10:00:00Z", 111, "")
+GATE_FAIL_TITLED = ("PR gate", "completed", "failure", "2026-01-01T10:00:00Z",
+                    111, "FAIL -- failing checks: Proof integrity (knot_lean)")
 
 
 def test_gate_cancelled_alone_is_candidate(tmp_path):
@@ -154,6 +168,72 @@ def test_gate_failure_others_green_candidate(tmp_path):
     reste candidat."""
     out = _run_selector(tmp_path, [_pr(104, [GATE_FAIL, OTHER_GREEN])])
     assert out.strip() == "104 deadbeef false 0"
+
+
+# --- #15825 : legs muettes (rouge, output.title vide) -> reparation, pas re-run
+#
+# Mesure 2026-09-12 : 9 echecs `PR gate` sur 43 rendent output.title = null.
+# Classe stale-snapshot : le rerun rejoue l'event payload fige, dont le
+# checkout PREDATE la machinerie de publication (#15725) -- le script
+# re-execute est l'ancien, sans publication. Preuve : run 34608518559 sur
+# #15440, 8 tentatives x ~23 s, identiques, pendant que le log portait le
+# verdict depuis la premiere. Ces tests epinglent le routage : jamais un
+# candidat re-run (inert et brule un slot waiter), toujours le flux de
+# reparation (job_id + run_id pour le PATCH du titre depuis le log).
+
+
+def _run_selector_with_mute(tmp_path, rows):
+    """Exec le selecteur livree et rend (stdout, lignes du flux muet)."""
+    out = _run_selector_both(tmp_path, rows)
+    mute_file = tmp_path / "mute.txt"
+    lines = (mute_file.read_text(encoding="utf-8").splitlines()
+             if mute_file.exists() else [])
+    return out.stdout, lines
+
+
+def test_mute_gate_leg_routed_to_repair_not_rerun(tmp_path):
+    """#15825 critere 2 : un gate rouge SANS output.title va au flux de
+    reparation -- stdout VIDE (aucun candidat re-run)."""
+    stdout, mute_lines = _run_selector_with_mute(
+        tmp_path, [_pr(101, [GATE_MUTE, OTHER_GREEN])])
+    assert stdout.strip() == ""
+    assert mute_lines == ["101 deadbeef 96158568958 111"]
+
+
+def test_titled_red_gate_still_rerun_candidate(tmp_path):
+    """Contre-falsification : le meme rouge AVEC titre reste un candidat
+    re-run -- le predicat muet ne doit pas absorber les gates eloquents."""
+    out = _run_selector(tmp_path, [_pr(105, [GATE_FAIL_TITLED, OTHER_GREEN])])
+    assert out.strip() == "105 deadbeef false 0"
+
+
+def test_mute_gate_leg_with_other_red_still_routed_to_repair(tmp_path):
+    """La reparation muette est inconditionnelle : nommer la cause vaut meme
+    si un autre check est rouge (c'est un diagnostic, pas un deblocage)."""
+    stdout, mute_lines = _run_selector_with_mute(
+        tmp_path, [_pr(106, [GATE_MUTE, OTHER_RED])])
+    assert stdout.strip() == ""
+    assert mute_lines == ["106 deadbeef 96158568958 111"]
+
+
+def test_mute_leg_without_details_url_diagnosed_not_crashed(tmp_path):
+    """Leg muette sans details_url (verdict POSTe, aucun run derriere) :
+    diag nomme, ni candidat ni reparation -- le selecteur ne crashe pas."""
+    leg = ("PR gate", "completed", "failure", "2026-01-01T10:00:00Z", None, "")
+    stdout, mute_lines = _run_selector_with_mute(
+        tmp_path, [_pr(107, [leg, OTHER_GREEN])])
+    assert stdout.strip() == ""
+    assert mute_lines == []
+
+
+def test_titleless_success_leg_is_never_mute(tmp_path):
+    """Un SUCCESS sans titre n'est jamais muet (rien a diagnostiquer) ni
+    candidat (pas rouge) : PR saine, le sweep la traverse."""
+    leg = ("PR gate", "completed", "success", "2026-01-01T10:00:00Z", 111, "")
+    stdout, mute_lines = _run_selector_with_mute(
+        tmp_path, [_pr(108, [leg, OTHER_GREEN])])
+    assert stdout.strip() == ""
+    assert mute_lines == []
 
 
 def test_no_gate_leg_skipped(tmp_path):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/guard #15830

# fix(ci,#15825): sweep — repli lecteur pour les gates muets (tranche 2 : critère 2)

See #15825

Avec la tranche 1 (#15830, critères 1+3), cette PR couvre le dernier critère : **un `output.title` nul est traité comme un défaut du gate, jamais comme une absence d'information** — et la cause que le log porte depuis la première tentative devient lisible sur le check-run lui-même.

**Ordre de merge — `Closes` volontairement absent.** Les critères 1+3 vivent dans #15830, qui n'est pas sur `main`. Si #15836 atterrissait d'abord, `Closes #15825` ferait fermer l'issue **avant** que le fallback producteur soit sur `main`. L'ordre requis est donc #15830 puis #15836 ; la fermeture de l'issue appartient alors au coordinateur, pas au mot-clé.

## Ce qui change dans le sweep (`pr-gate-stale-sweep.yml`)

**1. Collecte du signal.** Le jq du collecteur ajoute `title: (.output.title // "")` — la forme exacte du producteur, chaîne toujours présente, vide exactement quand le check-run a conclu sans output.

**2. Routage : réparation, plus jamais de re-run.** Le sélecteur classe une leg `PR gate` muette (conclusion rouge + titre vide) et l'envoie vers un flux de réparation (`/tmp/mute.txt` : numéro, SHA, job_id, run_id extraits du `details_url`), **sans** l'émettre comme candidate re-run :

- Le re-run est **inert par construction** sur la classe stale-snapshot (mesurée tranche 1 : head de #15440 derrière main de 175 commits, l'event payload figé fait re-exécuter l'ancien script sans publication — 8 tentatives × ~23 s, identiques). Chaque re-run brûlait un slot coursia-waiter pour re-rendre le même rouge muet.
- La réparation est **inconditionnelle** (un autre check rouge n'y change rien) : nommer la cause est un diagnostic, pas un déblocage.
- Absence de clé `title` (données pré-#15825) = jamais muette — compat des formes antérieures.

**3. La réparation.** Nouveau bloc après le tri des candidats, avant l'early-exit « nothing to do » : `gh run view $RUN_ID --log` → dernière ligne `[pr-gate]` → **PATCH en place** (`repos/$REPO/check-runs/$JOB_ID`, job id == check-run id, mesuré dans `pr_gate.own_job_id`) de `output[title]`/`output[summary]` avec provenance. Jamais de twin POSTé (suite étrangère, AND, #11519). Token du job = installation token (App auth — un PAT serait refusé, mesuré 2026-09-12). Log illisible → titre de repli nommant le défaut du gate lui-même ; cap `MAX_MUTE=12` (une log-fetch + un PATCH, zéro slot runner) ; `dry_run` respecté ; permission `checks: write` ajoutée.

## Réserve bornée — le gain anti-re-run n'est pas durable dans tous les cas

Mesure de l'adjoint sur la population live des 9 legs `PR gate` muettes : après simulation du titre réparé, **2 des 9** — les cas à 22 et 13 tentatives — redeviennent candidates au sweep suivant, faute de constituant rouge encore visible. Rien ne persiste la provenance de la réparation dans le prédicat du sélecteur.

Formulation exacte du gain, sans l'absolutiser : **ce sweep-ci** n'émet plus la leg muette comme candidate re-run, et le diagnostic devient lisible sur le check-run. Le mécanisme ne garantit **pas** qu'une leg muette disparaisse durablement de la population des candidates. Un refus du PATCH reste fail-soft et ne fabrique pas de vert.

## Critère 2 — couverture des trois lecteurs nommés par l'issue

| Lecteur | Couverture |
|---|---|
| **Le sweep** | Livrée ici : détection + diagnostic nommé sur stderr + réparation du titre, la leg muette étant routée vers la réparation au lieu du re-run (gain borné ci-dessus). |
| **Un lecteur humain** | Couvert par la réparation : le titre (cause telle que le log la nomme) est visible sur le check-run ≤ 1 h après détection. |
| **`pick_idle_grain.py`** | **Vacant par construction** : le picker ne lit pas `output.title` — son canal de cause pour les agrégateurs est les annotations (`fetch_check_organs`, l.1377), canal que même l'ancien script émettait (le log de 34608518559 porte `##[error][pr-gate] FAIL -- failing checks: Proof integrity (knot_lean)`). Il n'existe donc pas de code lisant un titre nul à corriger ; après réparation, le titre est de toute façon non nul pour tout lecteur. |

## Tests

5 tests nouveaux dans `scripts/tests/test_pr_gate_sweep_select.py` (le sélecteur livré est exécuté VERBATIM depuis le YAML, seam `SWEEP_RUNS_FILE`/`SWEEP_MUTE_FILE`) :

- `test_mute_gate_leg_routed_to_repair_not_rerun` — stdout vide, ligne de réparation `num sha job_id run_id` exacte.
- `test_titled_red_gate_still_rerun_candidate` — **falsification** : le même rouge AVEC titre reste candidat re-run.
- `test_mute_gate_leg_with_other_red_still_routed_to_repair` — diagnostic inconditionnel.
- `test_mute_leg_without_details_url_diagnosed_not_crashed` — verdict POSTé sans run : diag, ni candidat ni réparation, pas de crash.
- `test_titleless_success_leg_is_never_mute` — un SUCCESS sans titre n'est jamais muet.

**Preuve red/green** : sur le workflow d'`origin/main`, 3 tests ROUISSENT — la leg muette y est émise en candidat re-run (`107 deadbeef false 0`), exactement le comportement que l'issue condamne ; les 2 contrôles de falsification restent verts des deux côtés. Après fix : **28/28** + **64/64** sur les suites adjacentes qui contraignent ce workflow (`test_pr_gate_sweep_timing.py`, `test_pr_gate_rerun_noop_guard.py`, `test_check_self_hosted_runner_policy.py`), Python 3.13.

## Limite vérifiable seulement en production

Le PATCH cible le check-run d'un autre workflow run. Le couple endpoint/champs et l'ownership GitHub Actions sont cohérents, mais aucun chemin existant du dépôt ne prouve encore ce PATCH cross-run. Un refus resterait fail-soft.

## Perimetre

2 fichiers : `.github/workflows/pr-gate-stale-sweep.yml` (+117/-1), `scripts/tests/test_pr_gate_sweep_select.py` (+95/-2). Catalogue byte-identique à main. Tranche 1 = #15830 (critères 1+3, script `pr_gate.py`) — pas de recouvrement de fichiers, aucune pile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

