### PR TITLE
fix(vibe-coding,#15672): blocs copiables Linux du chemin canonique alignés + test hermétique

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -49,13 +49,14 @@ claude --version
 #### Linux / WSL
 
 ```bash
-# Installation via script
-curl -fsSL https://install.claude.com | sh
+# Installation via le script officiel (binaire natif, Node.js non requis)
+curl -fsSL https://claude.ai/install.sh | bash
 
-# Ajouter au PATH (si necessaire)
-echo 'export PATH="$HOME/.claude/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
+# Si "claude --version" reste introuvable apres avoir rouvert le terminal :
+# echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
+
+Le binaire natif vit sous `~/.local/bin` (cf. encadré ci-dessus) et les installations natives se mettent à jour automatiquement en arrière-plan. Source consultée le 2026-09-12 : [code.claude.com/docs/en/quickstart](https://code.claude.com/docs/en/quickstart).
 
 **Verification :**
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/helpers/test_claude_cli.py
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/helpers/test_claude_cli.py
@@ -77,8 +77,33 @@ def test_verify_installation_false_when_not_in_path(monkeypatch):
 
 
 def test_verify_installation_true_when_in_path(monkeypatch):
+    # Hermetic: mock BOTH layers -- shutil.which resolves the binary AND
+    # subprocess.run answers -- so the verdict never depends on a real CLI
+    # installed on the host running the suite (#15672).
     monkeypatch.setattr(claude_cli.shutil, "which", lambda cmd: "/usr/local/bin/claude")
+
+    class _FakeOk:
+        returncode = 0
+        stdout = "1.0.100 (Claude Code)\n"
+        stderr = ""
+
+    monkeypatch.setattr(claude_cli.subprocess, "run", lambda *a, **k: _FakeOk())
     assert claude_cli.verify_installation() is True
+
+
+def test_verify_installation_false_when_run_fails(monkeypatch):
+    # Falsification companion: same PATH hit, failing '--version' run.
+    # Proves the True verdict above depends on execution, not on
+    # shutil.which alone.
+    monkeypatch.setattr(claude_cli.shutil, "which", lambda cmd: "/usr/local/bin/claude")
+
+    class _FakeFail:
+        returncode = 127
+        stdout = ""
+        stderr = "command failed"
+
+    monkeypatch.setattr(claude_cli.subprocess, "run", lambda *a, **k: _FakeFail())
+    assert claude_cli.verify_installation() is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/guard #15836

# fix(vibe-coding,#15672): blocs copiables Linux du chemin canonique alignés + test hermétique

Closes #15672

Les deux défauts de l'issue, mesurés à l'instant sur `origin/main` (`9d42c76532`), sont corrigés dans cette PR :

## 1. Les blocs copiables contredisaient le paragraphe canonique du même document

`INSTALLATION-CLAUDE-CODE.md` portait deux affirmations incompatibles à 40 lignes d'écart : l'encadré canonique L14 (« le binaire vit sous `~/.local/bin` », source quickstart 2026-09-09) contre le bloc copiable Linux (`install.claude.com | sh` + `export PATH="$HOME/.claude/bin:$PATH"` — chemin de l'ère npm). Un étudiant Linux/WSL suivant le chemin canonique le jour de la séance ajoutait une entrée PATH inutile pointant vers un répertoire qui ne contient plus le binaire natif.

**Correctif** — le bloc copiable Linux/WSL est aligné sur la source officielle, **re-consultée le jour de la PR** (2026-09-12, [code.claude.com/docs/en/quickstart](https://code.claude.com/docs/en/quickstart)) :

- `curl -fsSL https://install.claude.com | sh` → `curl -fsSL https://claude.ai/install.sh | bash` (commande officielle du jour, onglet « Native Install (Recommended) »).
- L'export PATH pointe désormais sur `~/.local/bin` — le chemin réel du binaire natif, cohérent avec L14 — et devient un repli commenté (« si `claude --version` reste introuvable après avoir rouvert le terminal »), car l'installateur gère le PATH.
- Prose ajoutée sous le bloc : binaire sous `~/.local/bin`, mises à jour automatiques natives en arrière-plan, source + date de consultation (même discipline de sourçage que L14).

## 2. Le test compagnon échouait par exécution (non-hermétique)

`test_verify_installation_true_when_in_path` ne mockait que `shutil.which` : `installation_status()` enchaine sur un appel `subprocess.run` réel vers `/usr/local/bin/claude --version`, qui lève `FileNotFoundError` sur toute machine sans binaire à ce chemin exact → verdict « non-executable » → `verify_installation()` rend False → le test échoue, en contradiction avec le docstring de sa propre suite (« deterministic, no real claude CLI invocation »).

**Preuve rouge (origin/main, exécution réelle ce cycle)** :

```
test_claude_cli.py::test_verify_installation_true_when_in_path
E   assert False is True
======================== 1 failed, 29 passed in 1.87s =========================
```

**Correctif** — le test mocke désormais **les deux couches** : `shutil.which` résout le binaire ET `subprocess.run` répond (rc=0, version) — le verdict ne dépend plus d'une CLI réellement installée sur l'hôte qui exécute la suite. Ajout d'un **companion de falsification** : même hit PATH, `--version` en échec (rc=127) → `verify_installation()` rend False — preuve que le verdict True dépend bien de l'exécution, pas du seul `shutil.which`.

**Preuve verte (post-fix)** :

```
test_claude_cli.py ...............................                       [100%]
============================= 31 passed in 0.52s ==============================
```

(30 tests avant + 1 nouveau ; les 29 adjacents inchangés par le fix restent verts.)

## Perimetre

2 fichiers : `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md` (+6/−5), `notebooks/helpers/test_claude_cli.py` (+25/−0). Catalogue byte-identique à main. Pas de recouvrement avec #15656 (section OpenRouter L97+, hors zone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
