### PR TITLE
ci(slides,#15835): run slidev build on the PR that touches a deck

### DIFF
--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -83,8 +83,19 @@ on:
     # The `paths` filter is not cosmetic: it is the scope guarantee (acceptance
     # 3). A PR outside slides/ never wakes this job at all, and the job never
     # holds a self-hosted slot to prove it had nothing to do.
+    #
+    # The SECOND entry is not part of that scope, it is a consequence of the
+    # job POSING A LABEL. #8822, enforced blocking by label-paths-guard.yml
+    # ("Label-poser workflows self-cover"): a label-poser that is paths-filtered
+    # without covering its own file can never re-run once the matching paths
+    # leave the diff -- so it can never REMOVE the label it added, and the label
+    # outlives the defect it names. Measured: without this line the guard names
+    # this very file. A workflow-only PR therefore fires this job and gets the
+    # "no deck impacted" exit 0 -- cheap, and the price of a label that can be
+    # taken back.
     paths:
       - 'slides/**'
+      - '.github/workflows/slides-build-advisory.yml'
   schedule:
     # Nocturnal sweep -- post-merge main verification.
     # Tranche 1 #12817 : sortir les advisory lourds de pull_request

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -6,13 +6,24 @@ name: Slides Build Advisory
 # caught only by a human running the build locally, which nobody did. This workflow
 # makes a deck that does not construct VISIBLE on the PR that touches it.
 #
-# ADVISORY, never blocking (issue #8817 acceptance 5): the job ALWAYS exits 0 on a
-# build failure. The actionable payload is the `slides-build-failed` LABEL, NEVER
-# the green conclusion of the job (which is green by construction). A reviewer who
-# reads only "exit 0" as "the slides build" has read the wrong signal -- the same
-# trap that let a non-conforming PR through in #8797, and that #8816 codified for
-# the exercises convention. The job prints its denominator precisely so this
-# confusion is impossible.
+# TWO LEGS, TWO VERDICTS (#15835).
+#
+# The PR leg BLOCKS: a deck that does not construct is a broken deliverable, not
+# an observation, so the job exits 1 and the check-run goes RED on the very PR
+# that introduced it. The nocturne leg stays ADVISORY (issue #8817 acceptance 5):
+# under `schedule` there is no PR to signal and no merge to gate, exit 0 is the
+# only sane conclusion, and the payload is the build output itself.
+#
+# Why a SCOPE change and not a pendulum. "Advisory, never blocking" was written
+# for a gate whose only consumer was a human reading a label at night. On a PR
+# the same finding has a different consumer -- the merge gate -- and a label is
+# not a signal that gate reads. So #8817's contract is preserved verbatim where
+# it was written (the nocturne) and given teeth only where it was silent (the
+# PR). A reviewer who reads "exit 0" as "the slides build" still reads the wrong
+# signal on the nocturne leg, where the LABEL remains the payload -- the trap
+# that let a non-conforming PR through in #8797, and that #8816 codified for the
+# exercises convention. The job prints its denominator precisely so this
+# confusion is impossible on either leg.
 #
 # Per-PR scope (acceptance 1): builds ONLY the decks impacted by the PR -- either
 # the deck whose directory changed, or ALL decks when shared slides infra changed
@@ -48,15 +59,43 @@ name: Slides Build Advisory
 # builds the decks impacted by the last-24h window of main; the label side is
 # PR-only and skipped at night -- the nocturne payload is the build output.
 #
-# Promoting to a blocking gate is a separate decision, to revisit only once the
-# advisory has run green-and-stable across enough slide PRs to trust it.
+# #15835 re-arms that trigger, so the #12817 trap is live again and is answered
+# head-on: the job carries the UNIVERSAL same-repo guard
+# (`head.repo.full_name == null || == github.repository`). It is TRUE under
+# schedule/workflow_dispatch (the field is null) and still FALSE for a fork PR.
+# The DIRECT form would extinguish the nocturne exactly as #12817 measured --
+# scripts/ci/check_self_hosted_runner_policy.py accepts both forms, and only one
+# of them keeps the organ alive. That asymmetry is the reason this paragraph is
+# spelled out instead of left to the guard's default.
+#
+# Promoting the NOCTURNE to blocking remains a separate decision, unchanged.
 
 on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+    # #15835 -- the build was cron-only, so a PR could break a deck and stay
+    # green end to end. #15808 wrote it down: "slidev build NOT RUN this cycle
+    # ... the repo CI will replay it (to be confirmed)". The "to be confirmed"
+    # was the honest part, and the answer was NO -- nothing replayed it. The
+    # worker assumed a net that did not exist; that is what a CI is for.
+    #
+    # The `paths` filter is not cosmetic: it is the scope guarantee (acceptance
+    # 3). A PR outside slides/ never wakes this job at all, and the job never
+    # holds a self-hosted slot to prove it had nothing to do.
+    paths:
+      - 'slides/**'
   schedule:
     # Nocturnal sweep -- post-merge main verification.
     # Tranche 1 #12817 : sortir les advisory lourds de pull_request
     # (clone 2.22 Go par run). Stratification user 2026-08-23 :
     # "les jobs lourds devraient être payés une fois par fournée".
+    #
+    # #15835 nuance cette stratification plutot que de la retourner : le cout
+    # qu'elle visait est celui du CLONE paye a chaque PR. Le job PR ne paye que
+    # les decks du diff (portee ci-dessus) et le cache lockfile, soit la part
+    # fixe du cout -- le nocturne garde le balayage complet, une fois par
+    # fournee. La stratification tient ; c'est son perimetre qui se precise.
     - cron: '20 03 * * *'
   workflow_dispatch: {}
 permissions:
@@ -69,18 +108,33 @@ concurrency:
 
 jobs:
   slides-build-advisory:
-    name: "Slidev build advisory (label, non-blocking)"
+    name: "Slidev build (PR blocking, nocturne advisory)"
     # Routage #14283 tranche 4 (ai-01 2026-09-02) : balayage cron pur-Python.
-    # Declencheur `schedule` uniquement -- il ne tourne que sur la branche par
-    # defaut, donc aucun code de fork ne peut l'atteindre et aucune garde
-    # same-repo n'est requise (cf en-tete de check_self_hosted_runner_policy.py).
-    # Retour arriere = remettre `runs-on: ubuntu-latest` + retrait de l'allowlist.
+    # #15835 ajoute le declencheur pull_request : le profil change (le job
+    # n'est plus cron-only), donc la garde same-repo redevient EXIGEE par
+    # scripts/ci/check_self_hosted_runner_policy.py -- c'est le `if:`
+    # ci-dessous, et c'est la forme UNIVERSELLE (le commentaire d'en-tete
+    # explique pourquoi la forme directe eteindrait le nocturne, #12817).
+    # `runs-on` reste STATIQUE : une expression dynamique leverait
+    # DYNAMIC_RUNS_ON. Retour arriere = remettre `runs-on: ubuntu-latest`
+    # + retrait de l'allowlist + retrait du declencheur pull_request.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
+    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
+    # Newly blocking on the PR leg, so it must not be able to hang one: the
+    # worst case is a cold `npm ci` (~12 min, #15835 body) plus one build per
+    # touched deck. 30 min bounds that without ratcheting the normal path.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
         with:
+          # #15835 -- the PR leg diffs `base.sha...head.sha`, so it must check
+          # out and build the PR's OWN head, not the merge ref (the merge ref
+          # would silently build main's version of the deck merged in). Under
+          # schedule there is no PR and `github.sha` is main's HEAD, which is
+          # exactly what the nocturne window resolves against.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           # Need base..head history for `git diff` of changed slides.
           fetch-depth: 0
           filter: blob:none
@@ -122,6 +176,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          # #15835 point 3. The `node_modules` cache below already skips `npm ci`
+          # entirely on a hit; this one caches the npm DOWNLOAD cache, which is
+          # what the miss pays -- and a miss is the normal case on the first PR
+          # that moves the lockfile. `cache-dependency-path` is not optional
+          # here: the lockfile lives in slides/, not at the repo root, so the
+          # default lookup would find nothing and cache nothing, silently.
+          cache: npm
+          cache-dependency-path: slides/package-lock.json
 
       - name: Cache slides node_modules
         id: cache-nm
@@ -185,6 +247,26 @@ jobs:
           for d in slides/*/; do
             [ -d "$d" ] || continue
             base="$(basename "$d")"
+
+            # NAMED fixture exclusion. `slides/_composition-control/` is the
+            # committed positive-control deck of slides-composition-advisory
+            # (#15545) -- a FIXTURE, not a course deck. That organ excludes it
+            # in three places (find `-not -path`, `grep -v`, CTRL_DIR); this one
+            # excluded it nowhere, so the file committed on 2026-09-11 made the
+            # symmetric check below fire on EVERY run: measured red nocturne
+            # 2026-09-12T07:58Z (M=17 N=19, ZERO_TARGET_DIRS=1), with the build
+            # loop never reaching a single deck -- the organ reporting its own
+            # confusion, loudly and correctly, and building nothing.
+            #
+            # Excluded BY NAME on purpose. A blanket `_*` rule reads tidier and
+            # would reopen exactly the hole the symmetric check exists to close:
+            # renaming 01-introduction to _introduction would go silent instead
+            # of loud, which is the #8807 incident one notch down. A new fixture
+            # must be named here -- deliberately, in a diff a reviewer reads.
+            if [ "$base" = "_composition-control" ]; then
+              continue
+            fi
+
             if ! printf '%s' "$base" | grep -qE '^(S)?[0-9]'; then
               # SYMMETRIC of trap 1 (ai-01 #8821 review blocage 2): a dir that
               # does NOT match the convention but DOES carry a deck file is
@@ -294,19 +376,24 @@ jobs:
             fi
           done
 
-          # ---- Label signaling (advisory: exit 0 regardless). ----
+          # ---- Verdict. PR leg: RED. Nocturne leg: advisory + label (#15835). ----
           if [ "$FAILURES" -gt 0 ]; then
-            if [ "$NOCTURNE" -eq 1 ]; then
-              echo "::warning::$FAILURES deck(s) impacted by the last-24h window failed to build. Failed:$FAILED_LIST"
-            else
-              echo "::notice::$FAILURES impacted deck(s) failed to build. See the '$LABEL' label. Failed:$FAILED_LIST"
-            fi
             gh label create "$LABEL" \
               --description "A Slidev deck impacted by this PR does not construct (#8807)" \
               --color "D93F0B" --force 2>/dev/null || true
-            [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
-          else
-            echo "All ${#TOUCHED[@]} impacted deck(s) build cleanly."
-            [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::$FAILURES deck(s) impacted by the last-24h window failed to build. Failed:$FAILED_LIST"
+              exit 0
+            fi
+            # Acceptance 1 of #15835 asks for a RED check-run, and the label is
+            # NOT one: `gh pr edit` succeeding colours nothing. Only the exit
+            # code reddens the check -- so it is the LAST statement, placed
+            # after the annotation and the label, so the failing decks are
+            # named in the log before the job dies.
+            echo "::error::$FAILURES deck(s) touched by this PR failed to build. Failed:$FAILED_LIST"
+            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+            exit 1
           fi
+          echo "All ${#TOUCHED[@]} impacted deck(s) build cleanly."
+          [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
           exit 0


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: LIGHT/notebook-python #15680

## Quoi

**Aucune PR touchant `slides/**` ne faisait tourner `slidev build`.** Le seul workflow slides câblé sur `pull_request` mesurait la **composition** (bandes vides, `gap_max`) ; celui qui construit ne tournait qu'au cron. Une PR pouvait donc casser un deck et rester verte de bout en bout — #15808 l'avait écrit noir sur blanc (« the repo CI will replay it (**to be confirmed**) »), et la réponse était non.

**Livré :** une jambe `pull_request` filtrée sur `paths: ['slides/**']` sur le workflow de build **existant**, qui construit réellement les decks du diff et **rougit** quand l'un ne construit pas.

## Les quatre points de l'issue, dans l'ordre

| Point | Ce qui a été fait |
|---|---|
| 1 — portée | Seuls les decks dont un fichier a changé sont construits ; **tous** quand l'infra partagée bouge (`theme-ia101`, `package.json`, `package-lock.json`). |
| 2 — bloquant ? | **Bloquant sur la jambe PR** : `exit 1` → check-run rouge. Le nocturne reste advisory (sous `schedule` il n'y a ni PR à gater ni merge à signaler, et la charge utile est la sortie de build). |
| 3 — cache | `actions/setup-node` avec `cache: npm` + `cache-dependency-path: slides/package-lock.json` (sans le second, la recherche par défaut ne trouve rien à la racine — échec silencieux). |
| 4 — réutiliser | **Un seul chemin de build** : pas de second workflow. Une variable (`NOCTURNE`) décide du verdict, la boucle de build est la même. |

## Statut des critères d'acceptation — 3 sur 3, tous mesurés sur la CI réelle

| # | Critère | Statut |
|---|---|---|
| 1 | Une PR cassant un deck produit un check-run **rouge** | **PROUVÉ** — run `34719821219`, `failure` |
| 2 | Une PR `slides/**` saine reste verte, en quelques minutes | **PROUVÉ** — run `34719843460`, `success`, build en ~17 s |
| 3 | Une PR hors `slides/**` ne déclenche pas le job | **PROUVÉ** |

**Acceptation 3, mesurée sur cette PR même.** Avant le second commit, #15846 ne touchait que `.github/workflows/` : `gh pr checks 15846 --json name,state` → **16 checks, 0 job Slidev**. Le filtre `paths` fait bien son travail ; le job ne consomme pas de slot self-hosted pour prouver qu'il n'a rien à faire.

**Acceptation 1 — PROUVÉE sur la CI réelle.** La PR jetable **#15847** porte `slides/99-positive-control/slides.md` avec **deux défauts fatals indépendants** (frontmatter YAML invalide + erreur de syntaxe JavaScript dans `script setup`). Verdict, run **`34719821219`**, `completed` / **`failure`** :

```
Deck dirs tracked (M): 18
===== BUILDING 1 impacted deck(s) =====
##[warning]BUILD FAILED: 99-positive-control/slides.md
##[error]1 deck(s) touched by this PR failed to build. Failed:
  - 99-positive-control/slides.md
```

Trois choses s'y lisent d'un coup :

- **1 seul deck construit** pour 18 découverts — la portée sur le diff fait son travail, on ne paie pas 18 builds par PR.
- **`##[error]` puis `failure`** — la jambe PR rougit réellement. Le gate a été **vu rouge** : il est mesuré, pas supposé.
- **La méta-vérification de découverte ne s'est pas déclenchée** (`M=18`, aucun `ZERO_TARGET_DIRS`) — l'exclusion nommée du fixture tient sur la CI, pas seulement dans ma simulation locale.

**Ce contrôle a exercé mon câblage, pas celui de `main`.** La branche de contrôle porte son propre commit (`d16792488`, basé sur `77575efeb`) et le workflow qu'elle exécute a le blob **`ce35ddee`** — **identique octet pour octet** à celui de mon commit `c2bb05e3a`. Le workflow de `main` est `c631a7a9` : `schedule` + `dispatch` seulement, aucune jambe PR. Le contrôle est donc valide. Différence assumée : la branche de contrôle porte la **v1** (sans la ligne d'auto-couverture #8822 du commit 2) — cette ligne ne peut pas changer le comportement de build, elle ne fait qu'autoriser le job à re-tourner sur son propre fichier.

**Acceptation 2 — PROUVÉE.** La PR jetable **#15848** porte un deck **sain** (`slides/98-positive-control-sound/slides.md`). Verdict, run **`34719843460`**, `completed` / **`success`** (runner `myia-ai-01-wsl-6`, labels `self-hosted,coursia-ephemeral,coursia-linux`) :

```
Deck dirs tracked (M): 18
===== BUILDING 1 impacted deck(s) =====
All 1 impacted deck(s) build cleanly.
```

Deux points de plus, mesurés :

- **Le cache paie.** Le run à froid (#15847) a passé plusieurs minutes en `Install Slidev deps` + build ; ici l'étape de build va de `21:33:19` à `21:33:36`, soit **≈ 17 s**, avec le job complet démarré à `21:32:28`. C'est ce qui rend la jambe PR tenable sur chaque PR `slides/**`.
- **`ZERO_TARGET_DIRS=0`.** La méta-vérification de découverte passe avec le fixture exclu — le nocturne rouge du 2026-09-12 est bien refermé, pas contourné.

Les deux PR de contrôle sont **additives** (aucun deck de cours touché), marquées `[DO NOT MERGE]`, et fermées avec leur branche. Le pool self-hosted est chargé : c'est de la **file, pas une panne** — mesuré en lisant `runner_name`/`labels` des jobs `in_progress`, pas le compteur `/actions/runners`, qui rend `50x offline` **pendant** que ces jobs tournent (le runner qui exécutait ce job se déclarait lui-même `offline busy=false`).

Les trois critères de l'issue sont donc mesurés, dont les deux que l'issue désignait comme non facultatifs.

## La garde same-repo n'est pas stylistique — elle est porteuse

Le job passe sur un runner **self-hosted** et gagne un déclencheur `pull_request`, donc `check_self_hosted_runner_policy.py` exige la garde anti-fork au niveau job. J'ai posé la forme **universelle** :

```
github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
```

La forme **directe** (`... == github.repository`) est **fausse sous `schedule`** — le champ vaut `null` — donc le job serait **SKIPPED** et le nocturne **éteint** : littéralement la régression #12817 tranche 2, que l'en-tête de ce fichier documente déjà.

**Mesure (copie mutée, pas le fichier)** : le scanner **accepte les deux formes** (`rc=0`) ; il ne rougit que sur la garde **absente** (`VIOLATION SAME_REPO_GUARD`, `rc=1`). **L'organe est aveugle au piège #12817** — rien d'autre que la prose ne le ferme. C'est pourquoi le paragraphe est écrit dans le fichier.

## Deux défauts trouvés en route (hors périmètre initial, dans le périmètre du sujet)

**1. La découverte était déjà rouge sur `main`.** En rejouant l'étape localement :

```
::error::'slides/_composition-control/' carries a deck file ... but does NOT match the NN/SN convention
Deck dirs tracked (M): 17     Build targets discovered (N): 19
::error::1 deck dir(s) yielded zero build targets -- discovery incomplete.
```

`slides/_composition-control/` est le **fixture** de contrôle positif de `slides-composition-advisory` (#15545, #15561 mergée le 2026-09-11). Cet organe-là l'exclut **en trois endroits** ; celui-ci ne l'excluait nulle part. Conséquence : **nocturne rouge le 2026-09-12T07:58Z**, et depuis le 11/09 la boucle de build **n'atteint aucun deck**. C'est le préalable de mon sujet — sans ce correctif, **toute PR slides serait rouge** pour une cause préexistante. Corrigé par exclusion **nommée** : une règle `_*` générique serait plus lisible et **rouvrirait le trou** que la vérification symétrique ferme (renommer `01-introduction` en `_introduction` deviendrait silencieux au lieu de bruyant).

**2. Le poseur de label ne s'auto-couvrait pas.** `label-paths-guard.yml` (« Label-poser workflows self-cover », **bloquant**) l'a attrapé avant la CI : le job pose `slides-build-failed`, donc il **doit** couvrir son propre fichier (#8822) — sinon, une fois les chemins sortis du diff, il ne peut plus re-tourner, donc plus **retirer** son label, et le label survit au défaut qu'il nomme. Mesure : sans la ligne, `Non-self-covered (VIOLATION): 1` nommant ce fichier ; avec, `0`. Conséquence assumée : une PR touchant *seulement* ce workflow déclenche le job et prend la sortie « no deck impacted » en `exit 0` — le prix d'un label retirable, que les cinq autres poseurs auto-couverts du dépôt paient aussi.

## Preuves

| Vérification | Résultat |
|---|---|
| `scripts/ci/check_self_hosted_runner_policy.py --check` | **159 workflows OK** |
| `scripts/tests/test_check_self_hosted_runner_policy.py` | **58/58** |
| `scripts/check_workflow_label_paths.py` | violation **1 → 0** (`PASS`) |
| `scripts/tests/test_check_workflow_label_paths.py` | **18/18** |
| `scripts/ci/check_unique_check_run_names.py --check` | aucun doublon |
| `variation_tag_required.py` / `variation_prev_guard.py --resolve-targets` | `required_pass: true` (MED/guard) / `guard_pass: true`, `prev_targets_accepted: [15680]` |
| Contrôle négatif garde same-repo (copie mutée) | garde retirée → `VIOLATION SAME_REPO_GUARD rc=1` ; **forme directe → `OK rc=0`** (l'angle mort) |
| Étape extraite, rejouée sur 3 diffs simulés | deck cassé → `::error::` + **exit 1** ; deck sain → « build cleanly » + **exit 0** ; aucun deck → **exit 0** |
| **Contrôle positif sur la CI réelle** (PR #15847, run `34719821219`) | deck cassé → `##[error]` + run **`failure`** ; **1** deck construit sur 18 découverts |
| **Contrôle négatif sur la CI réelle** (PR #15848, run `34719843460`) | deck sain → `All 1 impacted deck(s) build cleanly.` + run **`success`** ; build **≈ 17 s** (cache chaud) ; `ZERO_TARGET_DIRS=0` |
| Blob workflow de la branche de contrôle vs le mien | `ce35ddee` = `ce35ddee` (identique) ; `main` = `c631a7a9` (≠) |
| `bash -n` sur l'étape extraite | propre |

## Périmètre

1 fichier : `.github/workflows/slides-build-advisory.yml`. La PR #15846 ne touche **pas** `slides/` ni le catalogue. Les deux PR de contrôle (#15847, #15848) sont **jetables** et ne font pas partie du livrable.

Closes #15835. See #15808. See #13224. See #12817. See #15545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- refresh-adj: 2026-09-13T14:34:29Z -->
