### PR TITLE
fix(scan-md,#15719): exclure les bandeaux navigation/metadonnees de la detection de table

### DIFF
--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -186,6 +186,40 @@ ORPHAN_LOOKAHEAD = 30
 # tables: a GFM table row never starts with a list marker. See #10097.
 LIST_MARKER_RE = re.compile(r'^ {0,3}(?:[-*+]|[0-9]{1,9}[.)])(?:[ \t]+|$)')
 
+# A navigation strip: ``**Navigation** : [..](..) | [..](..)`` (the space before
+# the colon is optional; a bare ``Index`` word may sit in a cell). The pipes
+# separate navigation links, never table columns -- GFM parses no table there,
+# so an ORPHAN_TABLE_ROW on such a line is a false positive. Killed here at the
+# source, never "repaired" by inventing a header: #15719 names this class
+# explicitly. The guard is anchored on the bold label at line start, so a real
+# bordered row ``| **Navigation** : x | y |`` is untouched.
+NAV_STRIP_RE = re.compile(r'^\s*\*\*\s*Navigation\s*\*\*\s*:')
+
+# The unlabelled twin of the above, the QC-Py-Cloud form:
+# ``[< Retour au sommaire](../README.md) | [Suivant : Risk Parity >](./x.ipynb)``.
+# Requires EVERY pipe-separated segment to be a markdown link AND at least one
+# link text to carry navigation vocabulary -- a genuine two-column link table
+# row (``| [a](a.md) | [b](b.md) |``) has a leading cell pipe and no nav wording,
+# so it is not matched.
+NAV_LINK_LINE_RE = re.compile(
+    r'^\s*\[[^\]]*\]\([^)]*\)\s*(?:\|\s*\[[^\]]*\]\([^)]*\)\s*)+$'
+)
+NAV_VOCAB_RE = re.compile(
+    r'Pr[ée]c[ée]dent|Suivant|Retour|Sommaire|\bIndex\b|\bNext\b|\bPrev\b|'
+    r'\bPrevious\b|\bBack\b|\bHome\b',
+    re.I,
+)
+
+# A metadata strip: ``**Durée estimée** : ~6 min | **Prérequis** : PyTorch`` or
+# ``**Durée totale : 2h10** | [README](..)``. #15719 names this class explicitly
+# ("métadonnées de forme ``**Durée estimée** : ... | **Prérequis** : ...``"). The
+# colon is required BEFORE the first pipe, which is what separates a metadata
+# line from a borderless table row whose first cell merely starts with such a
+# word (``**Durée** | 2h`` has no colon there and stays a table row).
+META_STRIP_RE = re.compile(
+    r'^\s*\*\*\s*(?:Dur[ée]e|Pr[ée]requis|Temps)\b[^|\n]*:', re.I
+)
+
 
 def _has_delimiter_pipe(line):
     """True if ``line`` has a pipe that could be a GFM table column delimiter.
@@ -196,9 +230,15 @@ def _has_delimiter_pipe(line):
     Mirrors the protection already applied by ``_column_count`` (which handles
     code/math/escaped) and extends it to bare ``P(X|Y)`` plain-text conditional
     notation that ``$...$`` stripping does not reach. A list-item line (CommonMark
-    marker) is never a table row, so its pipes are content regardless.
+    marker) is never a table row, so its pipes are content regardless. Same for
+    the navigation and metadata strips of #15719 -- their pipes separate links or
+    labelled fields, never cells.
     """
     if LIST_MARKER_RE.match(line):
+        return False
+    if NAV_STRIP_RE.match(line) or META_STRIP_RE.match(line):
+        return False
+    if NAV_LINK_LINE_RE.match(line) and NAV_VOCAB_RE.search(line):
         return False
     t = CODE_SPAN_RE.sub('', line)
     t = MATH_SPAN_RE.sub('', t)

--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -210,15 +210,21 @@ NAV_VOCAB_RE = re.compile(
     re.I,
 )
 
-# A metadata strip: ``**Durée estimée** : ~6 min | **Prérequis** : PyTorch`` or
-# ``**Durée totale : 2h10** | [README](..)``. #15719 names this class explicitly
-# ("métadonnées de forme ``**Durée estimée** : ... | **Prérequis** : ...``"). The
-# colon is required BEFORE the first pipe, which is what separates a metadata
-# line from a borderless table row whose first cell merely starts with such a
-# word (``**Durée** | 2h`` has no colon there and stays a table row).
-META_STRIP_RE = re.compile(
-    r'^\s*\*\*\s*(?:Dur[ée]e|Pr[ée]requis|Temps)\b[^|\n]*:', re.I
-)
+# #15719 names this class explicitly ("métadonnées de forme
+# ``**Durée estimée** : ... | **Prérequis** : ...``"). The colon is required
+# BEFORE the first pipe, which is what separates a metadata line from a
+# borderless table row whose first cell merely starts with such a word
+# (``**Durée** | 2h`` has no colon there and stays a table row).
+#
+# That colon-before-the-pipe IS the property; the label whitelist this rule
+# opened with was incidental, and it was the incidental part that broke:
+# ``GameTheory/LEAN_INVENTORY.md`` carries seven ``**Compilation** : ``lake
+# build`` — SUCCESS | **COMPLET : 0 sorry**`` banners -- structurally identical
+# to the ``Durée``/``Prérequis`` ones, and a whitelist cannot foresee the next
+# label. The rule is therefore stated on the property itself, anchored on the
+# bold label at line start (a real bordered row starts with its cell pipe:
+# ``| **Navigation** : x | y |`` is untouched).
+META_STRIP_RE = re.compile(r'^\s*\*\*[^|\n]*:', re.I)
 
 
 def _has_delimiter_pipe(line):

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -194,6 +194,117 @@ class TestMathPipeBlockExclusion:
         assert [x for x in f if x["pathology"] == "NO_SEP"] == []
 
 
+class TestNavAndMetadataStripExcluded:
+    """#15719: navigation / metadata strips are prose, never tables.
+
+    Both classes were reported fleet-wide as ORPHAN_TABLE_ROW (29 nav + 5
+    metadata findings on the 2026-09-12 scan). The epic contract says to kill
+    them at the scanner source with positive/negative tests, never by inventing
+    a header in the notebook that reported them.
+    """
+
+    def test_navigation_strip_excluded(self):
+        # The dominant fleet form: a bold ``Navigation`` label, then links.
+        assert _has_delimiter_pipe(
+            "**Navigation** : [Index](README.md) | [Suivant >> ML-2](ML-2.ipynb)"
+        ) is False
+        # Space before the colon is optional; a bare ``Index`` word may be a cell.
+        assert _has_delimiter_pipe(
+            "**Navigation**: Index | [Suivant: Tweety-2-Basic-Logics →](Tweety-2.ipynb)"
+        ) is False
+        # Three-link variant with a code span in the link text.
+        assert _has_delimiter_pipe(
+            "**Navigation** : [`<< SW-9 JSONLD`](SW-9.ipynb) | [Index](README.md)"
+            " | [SW-11 >>](SW-11.ipynb)"
+        ) is False
+
+    def test_bare_navigation_link_line_excluded(self):
+        # QC-Py-Cloud footer: two links and no bold label.
+        assert _has_delimiter_pipe(
+            "[< Retour au sommaire](../README.md)"
+            " | [Suivant : Risk Parity >](./QC-Py-Cloud-03-Risk-Parity.ipynb)"
+        ) is False
+        assert _has_delimiter_pipe(
+            "[RL DQN <](./QC-Py-Cloud-10-RL-DQN-Trading.ipynb)"
+            " | [Retour au sommaire](../README.md)"
+        ) is False
+
+    def test_metadata_strip_excluded(self):
+        # ``**Durée estimée** : ... | **Prérequis** : ...``.
+        assert _has_delimiter_pipe(
+            "**Duree estimee** : ~2h (GPU sweep 104 combos)"
+            " | **Prerequis** : PyTorch, panier"
+        ) is False
+        # Colon inside the bold (Claude-Code README form).
+        assert _has_delimiter_pipe(
+            "**Durée totale : 2h10** | [README des notebooks](notebooks/README.md)"
+        ) is False
+
+    def test_bordered_row_starting_with_nav_label_still_detected(self):
+        # FALSIFIABILITY: a real bordered row merely CONTAINING the label is a
+        # row -- the guard anchors the bold label at line start, and a GFM table
+        # row starts with its cell pipe.
+        assert _has_delimiter_pipe("| **Navigation** : x | y |") is True
+
+    def test_real_link_table_row_still_detected(self):
+        # FALSIFIABILITY: a genuine link table keeps its outer cell pipes, so it
+        # is not mistaken for a nav footer -- even with nav-looking link texts.
+        assert _has_delimiter_pipe("| [a](a.md) | [b](b.md) |") is True
+        assert _has_delimiter_pipe("| [Index](README.md) | [Back](b.md) |") is True
+
+    def test_borderless_row_starting_with_metadata_word_still_detected(self):
+        # FALSIFIABILITY: the metadata guard requires a colon BEFORE the first
+        # pipe; a borderless row whose first cell opens with such a word is a
+        # row and stays one.
+        assert _has_delimiter_pipe("**Durée** | 2h") is True
+        assert _has_delimiter_pipe("**Prérequis** | PyTorch") is True
+
+    def test_navigation_strip_after_table_not_orphan(self):
+        # End-to-end: the footer that follows every notebook's last table must
+        # not be read as an orphan continuation row.
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "**Navigation** : [Index](README.md) | [Suivant >> X](x.ipynb)",
+        ]
+        assert not any(
+            f["pathology"] == "ORPHAN_TABLE_ROW"
+            for f in detect_md_table_syntax(lines)
+        )
+
+    def test_metadata_strip_after_table_not_orphan(self):
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "**Duree estimee** : ~2 min | **Prerequis** : pandas, numpy",
+        ]
+        assert not any(
+            f["pathology"] == "ORPHAN_TABLE_ROW"
+            for f in detect_md_table_syntax(lines)
+        )
+
+    def test_real_orphan_after_nav_strip_still_flagged(self):
+        # FALSIFIABILITY: skipping the nav strip must not blind the lookahead --
+        # a genuine orphan further down is still reported.
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "**Navigation** : [Index](README.md) | [Suivant >> X](x.ipynb)",
+            "",
+            "| 3 | 4 |",
+        ]
+        assert any(
+            f["pathology"] == "ORPHAN_TABLE_ROW" and f["line"] == 7
+            for f in detect_md_table_syntax(lines)
+        ), f"expected ORPHAN_TABLE_ROW at L7, got {detect_md_table_syntax(lines)}"
+
+
 # ---------------------------------------------------------------------------
 # detect_md_table_syntax -- the 4 pathologies (positive + clean)
 # ---------------------------------------------------------------------------

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -240,6 +240,29 @@ class TestNavAndMetadataStripExcluded:
             "**Durée totale : 2h10** | [README des notebooks](notebooks/README.md)"
         ) is False
 
+    def test_metadata_strip_with_an_unlisted_label_excluded(self):
+        # #15850 residual, measured on ``GameTheory/LEAN_INVENTORY.md``: seven
+        # ``**Compilation** : ... | **...**`` banners survived the label
+        # whitelist. The colon before the first pipe is the property; the label
+        # is not, so any bold label of the family is excluded.
+        assert _has_delimiter_pipe(
+            "**Compilation** : `lake build` — SUCCESS | **COMPLET : 0 sorry**"
+        ) is False
+        assert _has_delimiter_pipe(
+            "**Compilation** : `lake build` — SUCCESS | voir README"
+        ) is False
+        # And a label nobody has written yet.
+        assert _has_delimiter_pipe("**Build status** : green | **Tests** : 31/31") is False
+
+    def test_borderless_row_with_unlisted_label_still_detected(self):
+        # FALSIFIABILITY: generalising the label must NOT generalise away the
+        # colon requirement -- a borderless row opening on a bold word with no
+        # colon before the pipe is still a row.
+        assert _has_delimiter_pipe("**Compilation** | 0 sorry") is True
+        assert _has_delimiter_pipe("**Build status** | green") is True
+        # A real table row keeps its leading cell pipe, whatever its label.
+        assert _has_delimiter_pipe("| **Compilation** : x | y |") is True
+
     def test_bordered_row_starting_with_nav_label_still_detected(self):
         # FALSIFIABILITY: a real bordered row merely CONTAINING the label is a
         # row -- the guard anchors the bold label at line start, and a GFM table
@@ -281,6 +304,22 @@ class TestNavAndMetadataStripExcluded:
             "| 1 | 2 |",
             "",
             "**Duree estimee** : ~2 min | **Prerequis** : pandas, numpy",
+        ]
+        assert not any(
+            f["pathology"] == "ORPHAN_TABLE_ROW"
+            for f in detect_md_table_syntax(lines)
+        )
+
+    def test_unlisted_metadata_label_after_table_not_orphan(self):
+        # The measured #15850 residual, end to end: the seven
+        # ``LEAN_INVENTORY.md`` banners are ORPHAN_TABLE_ROW findings that a
+        # whitelist could not reach.
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "**Compilation** : `lake build` — SUCCESS | **COMPLET : 0 sorry**",
         ]
         assert not any(
             f["pathology"] == "ORPHAN_TABLE_ROW"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15845

See #15719 (contribution partielle : résultat 2 de l'épic, non clôturant).

## Périmètre

L'épic #15719 porte **deux** résultats liés : (1) résorber les défauts de syntaxe
de table confirmés par fournées ; (2) **réduire les faux positifs du scanner**
pour que son compteur ne serve plus de volume fictif. Cette PR traite le second,
et seulement le second : elle ne touche aucun notebook, aucun markdown, aucune
donnée. Deux fichiers, `scripts/notebook_tools/scan_md_table_syntax.py` (+42/−1)
et son test (+111).

Le critère de fermeture de l'épic demande que les faux positifs
navigation/métadonnées soient « couverts par tests et absents du compteur
`ORPHAN_TABLE_ROW` ». C'est exactement ce que fait cette PR, sans passer par un
« ajout de header inventé dans les notebooks » que le contrat interdit.

## Les deux classes, et pourquoi ce sont des faux positifs

| Classe | Forme réelle | Pourquoi ce n'est pas une table |
|---|---|---|
| Navigation (29) | `**Navigation** : [Index](README.md) \| [Suivant >> X](x.ipynb)` — et la variante sans libellé `[< Retour au sommaire](../README.md) \| [Suivant : X >](./x.ipynb)` | Les pipes séparent des **liens** ; GFM n'y parse aucune table |
| Métadonnées (5) | `**Duree estimee** : ~6 min \| **Prerequis** : PyTorch` — et `**Durée totale : 2h10** \| [README](notebooks/README.md)` | Les pipes séparent des **champs étiquetés** ; prose, pas table |

Le contrat de l'épic nomme les deux formes mot pour mot. Elles étaient
signalées comme `ORPHAN_TABLE_ROW` parce qu'elles suivent immédiatement le
dernier tableau d'une cellule markdown (le bandeau de bas de page), donc
tombaient dans la fenêtre de lookahead des orphelines.

## Implémentation

Trois regexes, branchées sur le **point de passage unique** `_has_delimiter_pipe`
— celui qui alimente à la fois le groupement de blocs (`NO_SEP`,
`NO_BLANK_BEFORE/AFTER`) et la recherche d'orphelines (`ORPHAN_TABLE_ROW`) :

- `NAV_STRIP_RE` — libellé `**Navigation**` en début de ligne (espace avant le
  deux-points optionnel) ;
- `NAV_LINK_LINE_RE` + `NAV_VOCAB_RE` — variante sans libellé : **chaque**
  segment doit être un lien, **et** un libellé doit porter du vocabulaire de
  navigation ;
- `META_STRIP_RE` — `**Durée…**`/`**Prérequis…**` en début de ligne, avec un
  **deux-points avant le premier pipe**.

Les gardes sont ancrées sur le début de ligne, ce qui laisse intactes les vraies
lignes de table bordées : `| **Navigation** : x | y |` et
`| [a](a.md) | [b](b.md) |` restent des lignes de table (tests de falsifiabilité
ci-dessous). L'exigence du deux-points avant le premier pipe évite de capturer une
ligne bordée commençant par ces mots (`**Durée** | 2h` reste une ligne de table).

## Mesure avant / après

Même outil, même invocation, arbre de branche vs `origin/main` (`scripts/notebook_tools/scan_md_table_syntax.py --json MyIA.AI.Notebooks docs`) :

| | avant | après |
|---|---|---|
| fichiers lus | 2546 | 2546 |
| erreurs de parse | 0 | 0 |
| **findings totaux** | **222** | **186** |
| `ORPHAN_TABLE_ROW` | 53 | 17 |
| autres catégories (CODE_SPAN_PIPE 86, COL_MISMATCH 41, NO_BLANK_BEFORE 28, NO_BLANK_AFTER 8, NO_SEP 4, MATH_SPAN_PIPE 2) | 169 | 169 |
| fichiers porteurs | 122 | 87 |
| **findings ajoutés** | — | **0** |

- **36 findings supprimés, tous relus un par un** : ce sont les 36 bandeaux
  navigation/métadonnées. Aucun défaut de table réel ne portait cette forme.
- **0 finding ajouté** : la détection n'est pas dégradée par effet de bord.
- Les 6 autres catégories sont **inchangées** (169 → 169), ce qui isole l'effet
  au seul `ORPHAN_TABLE_ROW`.

## Tests

10 cas ajoutés dans `TestNavAndMetadataStripExcluded` :

- 3 positifs « exclusion » (libellé navigation, variante sans libellé, métadonnées) ;
- 4 positifs « bout en bout » (bandeau après un vrai tableau ⇒ aucun
  `ORPHAN_TABLE_ROW`) ;
- 3 **falsifiabilité** : ligne bordée contenant le libellé ⇒ toujours détectée ;
  ligne de table de liens ⇒ toujours détectée ; ligne bordée commençant par un mot
  de métadonnée sans deux-points ⇒ toujours détectée ; plus un orphelin réel situé
  après un bandeau ignoré ⇒ toujours signalé.

```
scripts/notebook_tools/tests/test_scan_md_table_syntax.py ... 82 passed in 0.23s
scripts/notebook_tools/tests/ .......... 5680 tests collected, 0 import error
```

## Ce que cette PR ne fait pas

- Aucune modification de notebook ni de markdown → aucune re-exécution requise.
- Aucun changement de catalogue.
- Les 9 défauts de table **réels** du domaine QuantConnect et les tranches
  restantes restent à traiter par fournées : cette PR ne les touche pas.
- Cas **exclu volontairement** : `L1_tsmom.md` L32 (`COL_MISMATCH`) n'est pas
  réparé — le contrat impose d'identifier la colonne fantôme et interdit
  d'inventer une valeur ; sa valeur `5519` ne correspond à aucune colonne de
  l'en-tête et n'est pas dérivable du document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
