### PR TITLE
feat(lean,#11703): Lean-16f expose la frontiere CHSH — conway_lean 3/39 -> 1/39 modules noirs

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
@@ -84,8 +84,10 @@
     "3. [L'enonce du theoreme -- ce qu'il dit et ne dit pas](#3)\n",
     "4. [Le port Lean 4 : adossement au code reel](#4)\n",
     "5. [La chaîne de reduction formelle](#5)\n",
-    "6. [Extensibilite : vers d'autres résultats de Conway](#6)\n",
-    "7. [Exercices](#7)\n"
+    "6. [La non-localite quantitative : la frontiere CHSH](#6)\n",
+    "7. [Extensibilite : vers d'autres résultats de Conway](#7)\n",
+    "8. [Exercices](#8)\n",
+    ""
    ]
   },
   {
@@ -1037,6 +1039,237 @@
   },
   {
    "cell_type": "markdown",
+   "id": "chsh-md-intro",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "<a id=\"6\"></a>\n",
+    "## 6. La Non-Localite Quantitative : la Frontiere CHSH\n",
+    "\n",
+    "Le theoreme du libre arbitre s'appuie sur la **non-localite quantique** : la correlation des\n",
+    "particules jumelles (TWIN) ne s'explique par aucune fonction de reponse locale. Sa forme\n",
+    "quantitative canonique est l'inegalite **CHSH** (Clauser, Horne, Shimony, Holt, 1969) : dans tout\n",
+    "modele local classique, le score de correlation est borne par 2 en valeur absolue -- alors que la\n",
+    "mecanique quantique atteint 2*sqrt(2)* (borne de Tsirelson).\n",
+    "\n",
+    "Les deux modules sont compiles par le lac (0 `sorry`) ; cette section rejoue l'enumeration de la\n",
+    "frontiere en Python, puis inventorie les declarations reelles du source Lean.\n",
+    "\n",
+    "Le lac `conway_lean` prouve les deux moities classiques de cette frontiere :\n",
+    "\n",
+    "- `Conway/CHSH.lean` (epic #13106, tranche deterministe) : toute strategie locale **deterministe**\n",
+    "  a un score de valeur absolue **exactement 2** -- `Conway.CHSH.classical_abs_score`, demontre par\n",
+    "  enumeration noyau (`decide`) des 16 assignations, avec sa forme usuelle `classical_bound` ;\n",
+    "- `Conway/CHSHRandomized.lean` (tranche randomisee) : la frontiere tient pour les strategies\n",
+    "  **randomisees** -- toute combinaison convexe de profils garde un score espere borne par 2\n",
+    "  (`Conway.CHSHRandomized.randomized_bound`).\n",
+    "\n",
+    "La borne quantique de Tsirelson reste volontairement ouverte : la formaliser demande des\n",
+    "observables hermitiennes et une norme d'operateur, au-dela du noyau combinatoire de ce pilote\n",
+    "(piste reprise au registre de la section suivante)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "chsh-code-enum",
+   "metadata": {
+    "tags": []
+   },
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "16 profils deterministes (a0 a1 b0 b1) :\n",
+      "  NNNN  score = +2\n",
+      "  NNNP  score = +2\n",
+      "  NNPN  score = -2\n",
+      "  NNPP  score = -2\n",
+      "  NPNN  score = +2\n",
+      "  NPNP  score = -2\n",
+      "  NPPN  score = +2\n",
+      "  NPPP  score = -2\n",
+      "  PNNN  score = -2\n",
+      "  PNNP  score = +2\n",
+      "  PNPN  score = -2\n",
+      "  PNPP  score = +2\n",
+      "  PPNN  score = -2\n",
+      "  PPNP  score = -2\n",
+      "  PPPN  score = +2\n",
+      "  PPPP  score = +2\n",
+      "\n",
+      "Valeurs de |score| observees : [2]\n",
+      "Max |score| = 2  (frontiere classique deterministe)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Miroir numerique de l'enumeration Lean : les 16 profils deterministes.\n",
+    "from itertools import product\n",
+    "\n",
+    "def outcome_value(o):\n",
+    "    # Miroir python de Conway.CHSH.Outcome.value : negative = -1, positive = +1.\n",
+    "    return -1 if o == \"N\" else +1\n",
+    "\n",
+    "def score_chsh(a0, a1, b0, b1):\n",
+    "    # Miroir python de Conway.CHSH.score : a0*b0 + a0*b1 + a1*b0 - a1*b1.\n",
+    "    return a0 * b0 + a0 * b1 + a1 * b0 - a1 * b1\n",
+    "\n",
+    "rows = []\n",
+    "for a0, a1, b0, b1 in product((\"N\", \"P\"), repeat=4):\n",
+    "    s = score_chsh(outcome_value(a0), outcome_value(a1),\n",
+    "                   outcome_value(b0), outcome_value(b1))\n",
+    "    rows.append((f\"{a0}{a1}{b0}{b1}\", s))\n",
+    "\n",
+    "print(\"16 profils deterministes (a0 a1 b0 b1) :\")\n",
+    "for prof, s in rows:\n",
+    "    print(f\"  {prof}  score = {s:+d}\")\n",
+    "abs_scores = sorted({abs(s) for _, s in rows})\n",
+    "print(f\"\\nValeurs de |score| observees : {abs_scores}\")\n",
+    "print(f\"Max |score| = {max(abs_scores)}  (frontiere classique deterministe)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chsh-md-interp-det",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : |score| = 2 partout, et Lean le prouve\n",
+    "\n",
+    "L'enumeration python confirme ce que `Conway.CHSH.classical_abs_score` demontre dans le noyau\n",
+    "Lean : **les 16 strategies deterministes ont toutes un score de valeur absolue exactement 2** --\n",
+    "la frontiere n'est pas une borne atteinte par certaines strategies, c'est la valeur **commune a\n",
+    "toutes**. Le theorem `classical_bound` en est la forme usuelle (|score| <= 2), et\n",
+    "`score_factorization` explique **pourquoi** : le score se reecrit\n",
+    "`a0*(b0+b1) + a1*(b0-b1)`, et pour des reponses binaires (+-1), `b0+b1` et `b0-b1` ne peuvent pas\n",
+    "etre non nuls tous les deux -- un seul des deux termes contribue, de valeur absolue 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "chsh-code-inv",
+   "metadata": {
+    "tags": []
+   },
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CHSH.lean : 88 lignes, 0 occurrence(s) de 'sorry'\n",
+      "  L 33: inductive Outcome\n",
+      "  L 39: def Outcome.value : Outcome → ℤ\n",
+      "  L 44: theorem Outcome.value_sq (outcome : Outcome) : outcome.value ^ 2 = 1 := by\n",
+      "  L 52: def score (a₀ a₁ b₀ b₁ : Outcome) : ℤ :=\n",
+      "  L 58: theorem score_factorization (a₀ a₁ b₀ b₁ : Outcome) :\n",
+      "  L 70: theorem classical_abs_score (a₀ a₁ b₀ b₁ : Outcome) :\n",
+      "  L 75: theorem classical_bound (a₀ a₁ b₀ b₁ : Outcome) :\n",
+      "\n",
+      "CHSHRandomized.lean : 176 lignes, 0 occurrence(s) de 'sorry'\n",
+      "  L 43: abbrev Profile := CHSH.Outcome × CHSH.Outcome × CHSH.Outcome × CHSH.Outcome\n",
+      "  L 53: def Profile.score (p : Profile) : ℤ :=\n",
+      "  L 58: theorem Profile.abs_score (p : Profile) : |Profile.score p| = 2 := by\n",
+      "  L 64: abbrev Strategy := Profile → ℚ\n",
+      "  L 68: def expectedScore (μ : Strategy) : ℚ :=\n",
+      "  L 73: theorem Profile.abs_score_rat (p : Profile) : |(Profile.score p : ℚ)| = 2 := by\n",
+      "  L 82: theorem randomized_bound (μ : Strategy)\n",
+      "  L107: def pPos : Profile := (.positive, .positive, .positive, .positive)\n",
+      "  L111: def pNeg : Profile := (.negative, .negative, .positive, .positive)\n",
+      "  L114: theorem Profile.score_pPos : Profile.score pPos = 2 := by\n",
+      "  L118: theorem Profile.score_pNeg : Profile.score pNeg = -2 := by\n",
+      "  L122: def dirac (p : Profile) : Strategy := fun q => if q = p then (1 : ℚ) else 0\n",
+      "  L126: def balancedMix : Strategy := fun q => if q = pPos ∨ q = pNeg then (1 / 2 : ℚ) else 0\n",
+      "  L129: theorem expectedScore_dirac (p : Profile) : expectedScore (dirac p) = (Profile.score p : ℚ) := by\n",
+      "  L141: lemma expectedScore_add (μ ν : Strategy) :\n",
+      "  L148: lemma expectedScore_mul (k : ℚ) (μ : Strategy) :\n",
+      "  L156: theorem pPos_ne_pNeg : pPos ≠ pNeg := by\n",
+      "  L159: theorem balancedMix_eq : balancedMix = fun q => (1 / 2 : ℚ) * (dirac pPos q + dirac pNeg q) := by\n",
+      "  L167: theorem balancedMix_eq_zero : expectedScore balancedMix = 0 := by\n",
+      "\n",
+      "0 occurrence = la frontiere CHSH est formellement complete (deterministe ET randomisee).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inventaire des declarations REELLES des deux modules CHSH (source de verite, pas une paraphrase).\n",
+    "decl_prefixes = (\"abbrev \", \"def \", \"theorem \", \"lemma \", \"structure \", \"inductive \")\n",
+    "\n",
+    "for fname in [\"CHSH.lean\", \"CHSHRandomized.lean\"]:\n",
+    "    fpath = WIN_LEAN_PROJECT / \"Conway\" / fname\n",
+    "    src_lines = fpath.read_text(encoding=\"utf-8\").splitlines()\n",
+    "    n_sorry = sum(1 for l in src_lines if \"sorry\" in l)\n",
+    "    print(f\"{fname} : {len(src_lines)} lignes, {n_sorry} occurrence(s) de 'sorry'\")\n",
+    "    for i, ln in enumerate(src_lines, 1):\n",
+    "        if ln.startswith(decl_prefixes):\n",
+    "            print(f\"  L{i:>3}: {ln.strip()[:100]}\")\n",
+    "    print()\n",
+    "print(\"0 occurrence = la frontiere CHSH est formellement complete (deterministe ET randomisee).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chsh-md-interp-rand",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : la randomite partagee ne brise pas la frontiere\n",
+    "\n",
+    "`Conway.CHSHRandomized.randomized_bound` etend le resultat aux strategies **randomisees** : une\n",
+    "strategie est une famille de poids rationnels sur les 16 profils (le type `Strategy`), son score\n",
+    "espere `expectedScore` est la combinaison convexe des scores deterministes. La preuve combine\n",
+    "l'inegalite triangulaire (valeur absolue d'une somme <= somme des valeurs absolues) avec le fait\n",
+    "que chaque profil porte |score| = 2 (`Profile.abs_score`) : la convexite des poids\n",
+    "(`h_nonneg`, `h_total`) ramene le tout a une somme de poids fois 2, donc |E[score]| <= 2.\n",
+    "\n",
+    "C'est exactement la structure qui rend le theoreme du libre arbitre **conditionnel** : aucune\n",
+    "theorie locale -- meme randomisee, meme avec randomite partagee -- ne reproduit la correlation\n",
+    "quantique 2*sqrt(2)*. La frontiere ne peut etre franchie qu'en sortant du modele local (reponses\n",
+    "quantiques), ce que FWT capture par ses axiomes SPIN + TWIN + MIN."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chsh-md-exo",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : une strategie randomisee sur la frontiere\n",
+    "\n",
+    "Construisez en python une strategie randomisee (poids sur les 16 profils, somme = 1) dont le\n",
+    "score espere atteint la frontiere |E[score]| = 2, puis verifiez sur quelques exemples que melanger\n",
+    "deux profils de scores opposes rapproche E[score] de 0. Indice : tout profil deterministe convient\n",
+    "pour la frontiere -- la subtilite est le miroir exact d'`expectedScore`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "chsh-code-stub",
+   "metadata": {
+    "tags": []
+   },
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6e917195",
    "metadata": {
     "papermill": {
@@ -1049,8 +1282,8 @@
     "tags": []
    },
    "source": [
-    "<a id=\"6\"></a>\n",
-    "## 6. Extensibilite : Vers d'Autres Résultats de Conway\n",
+    "<a id=\"7\"></a>\n",
+    "## 7. Extensibilite : Vers d'Autres Résultats de Conway\n",
     "\n",
     "Le workspace `conway_lean` est concu comme un **hommage extensible** a l'oeuvre de Conway. Le\n",
     "theoreme de libre arbitre y cotoie d'autres formalisations (Game of Life, Doomsday, Look-and-Say,\n",
@@ -1062,12 +1295,13 @@
     "  `Corollary: the \"strong\" form` de `FreeWillTheorem.lean`).\n",
     "- **Coordonnees R^4 explicites** : remplacer la structure combinatoire abstraite de\n",
     "  `contextMembers` par les 18 vecteurs reels + preuve d'orthogonalite (actuellement implicite).\n",
-    "- **Autres theoremes de contextualite** : Peres-33, carre magique de Mermin-Peres.\n"
+    "- **Autres theoremes de contextualite** : Peres-33, carre magique de Mermin-Peres.\n",
+    ""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "0435f581",
    "metadata": {
     "execution": {
@@ -1109,6 +1343,8 @@
     "    # (nom affiche, module .lean ou None, statut conceptuel)\n",
     "    (\"Kochen-Specker (Cabello 18)\", \"Conway/KochenSpecker.lean\",   \"PROUVE\"),\n",
     "    (\"Free Will Theorem\",           \"Conway/FreeWillTheorem.lean\", \"PROUVE\"),\n",
+    "    (\"CHSH deterministe (|score| = 2)\", \"Conway/CHSH.lean\",            \"PROUVE\"),\n",
+    "    (\"CHSH randomise (|E| <= 2)\",       \"Conway/CHSHRandomized.lean\",   \"PROUVE\"),\n",
     "    (\"Game of Life (B3/S23)\",       \"Conway/Life.lean\",            \"PROUVE\"),\n",
     "    (\"Strong FWT (MIN, 2009)\",      None,                          \"PISTE\"),\n",
     "    (\"Coordonnees R^4 explicites\",  None,                          \"PISTE\"),\n",
@@ -1128,7 +1364,8 @@
     "        mod_disp, sorry_disp = \"(a creer)\", \"-\"\n",
     "    print(f\"{name:<32} | {mod_disp:<28} | {statut:<8} | {sorry_disp}\")\n",
     "print()\n",
-    "print(\"Pour etendre : ajouter une entree ci-dessus + le module .lean dans conway_lean/Conway/.\")\n"
+    "print(\"Pour etendre : ajouter une entree ci-dessus + le module .lean dans conway_lean/Conway/.\")\n",
+    ""
    ]
   },
   {
@@ -1174,12 +1411,13 @@
     "tags": []
    },
    "source": [
-    "<a id=\"7\"></a>\n",
-    "## 7. Exercices\n",
+    "<a id=\"8\"></a>\n",
+    "## 8. Exercices\n",
     "\n",
-    "Trois exercices pour approfondir. Les cellules de code sont des **stubs** a completer : le notebook\n",
+    "Quatre exercices pour approfondir. Les cellules de code sont des **stubs** a completer : le notebook\n",
     "s'execute de bout en bout même sans les resoudre. Comparez vos solutions aux exemples guides des\n",
-    "sections précédentes.\n"
+    "sections précédentes.\n",
+    ""
    ]
   },
   {
@@ -1211,7 +1449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "beebc505",
    "metadata": {
     "execution": {
@@ -1274,7 +1512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "4125d4b5",
    "metadata": {
     "execution": {
@@ -1334,7 +1572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "c73530a8",
    "metadata": {
     "execution": {
@@ -1397,7 +1635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "b099af93",
    "metadata": {
     "execution": {
@@ -1465,6 +1703,8 @@
     "|--------|-------|------|\n",
     "| `KochenSpecker.lean` | 0 | Noyau combinatoire (parite, 18 vecteurs Cabello) |\n",
     "| `FreeWillTheorem.lean` | 0 | Reduction FWT -> KS (SPIN + TWIN + MIN structurel) |\n",
+    "| `CHSH.lean` | 0 | Frontiere CHSH deterministe (\\|score\\| = 2 exactement) |\n",
+    "| `CHSHRandomized.lean` | 0 | Frontiere CHSH randomisee (\\|E[score]\\| <= 2 par convexite) |\n",
     "\n",
     "Chaîne de reduction : `free_will_theorem` -> `fwt_single_particle` -> `kochen_specker` (3 maillons).\n",
     "\n",
@@ -1489,7 +1729,8 @@
     "\n",
     "***\n",
     "\n",
-    "**Navigation** : [<< Lean-16e FRACTRAN](Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb) | [Index](README.md) | [Lean-17a Noeuds >>](Lean-17a-Knots-Conway-Proofs.ipynb)\n"
+    "**Navigation** : [<< Lean-16e FRACTRAN](Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb) | [Index](README.md) | [Lean-17a Noeuds >>](Lean-17a-Knots-Conway-Proofs.ipynb)\n",
+    ""
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16f-Conway-Free-Will-Theorem.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "48e8b04b",
    "metadata": {
-    "papermill": {
-     "duration": 0.003992,
-     "end_time": "2026-06-11T01:38:19.289608",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.285616",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -67,13 +60,6 @@
    "cell_type": "markdown",
    "id": "2a96b075",
    "metadata": {
-    "papermill": {
-     "duration": 0.003259,
-     "end_time": "2026-06-11T01:38:19.296983",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.293724",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -94,13 +80,6 @@
    "cell_type": "markdown",
    "id": "8a74f771",
    "metadata": {
-    "papermill": {
-     "duration": 0.003882,
-     "end_time": "2026-06-11T01:38:19.303375",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.299493",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -147,13 +126,6 @@
      "iopub.status.idle": "2026-06-11T01:38:19.322391Z",
      "shell.execute_reply": "2026-06-11T01:38:19.322391Z"
     },
-    "papermill": {
-     "duration": 0.016857,
-     "end_time": "2026-06-11T01:38:19.323405",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.306548",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -198,13 +170,6 @@
    "cell_type": "markdown",
    "id": "a37ddb64",
    "metadata": {
-    "papermill": {
-     "duration": 0.00392,
-     "end_time": "2026-06-11T01:38:19.330328",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.326408",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -220,13 +185,6 @@
    "cell_type": "markdown",
    "id": "3c9c886b",
    "metadata": {
-    "papermill": {
-     "duration": 0.003397,
-     "end_time": "2026-06-11T01:38:19.337358",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.333961",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -262,13 +220,6 @@
      "iopub.status.busy": "2026-06-11T01:38:19.345397Z",
      "iopub.status.idle": "2026-06-11T01:38:20.667082Z",
      "shell.execute_reply": "2026-06-11T01:38:20.667082Z"
-    },
-    "papermill": {
-     "duration": 1.326733,
-     "end_time": "2026-06-11T01:38:20.668088",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:19.341355",
-     "status": "completed"
     },
     "tags": []
    },
@@ -317,13 +268,6 @@
    "cell_type": "markdown",
    "id": "d743b8cd",
    "metadata": {
-    "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-06-11T01:38:20.675085",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.672086",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -344,13 +288,6 @@
    "cell_type": "markdown",
    "id": "a63a9455",
    "metadata": {
-    "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-11T01:38:20.683085",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.679085",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -379,13 +316,6 @@
    "cell_type": "markdown",
    "id": "42301719",
    "metadata": {
-    "papermill": {
-     "duration": 0.002495,
-     "end_time": "2026-06-11T01:38:20.688599",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.686104",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -417,13 +347,6 @@
    "cell_type": "markdown",
    "id": "a587ba61",
    "metadata": {
-    "papermill": {
-     "duration": 0.0,
-     "end_time": "2026-06-11T01:38:20.688599",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.688599",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -474,13 +397,6 @@
      "iopub.status.idle": "2026-06-11T01:38:20.709682Z",
      "shell.execute_reply": "2026-06-11T01:38:20.709682Z"
     },
-    "papermill": {
-     "duration": 0.009752,
-     "end_time": "2026-06-11T01:38:20.709682",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.699930",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -522,13 +438,6 @@
    "cell_type": "markdown",
    "id": "cf65b1a3",
    "metadata": {
-    "papermill": {
-     "duration": 0.003658,
-     "end_time": "2026-06-11T01:38:20.718329",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.714671",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -549,13 +458,6 @@
    "cell_type": "markdown",
    "id": "38a4cd76",
    "metadata": {
-    "papermill": {
-     "duration": 0.004142,
-     "end_time": "2026-06-11T01:38:20.725591",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.721449",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -580,13 +482,6 @@
      "iopub.status.idle": "2026-06-11T01:38:20.736455Z",
      "shell.execute_reply": "2026-06-11T01:38:20.735937Z"
     },
-    "papermill": {
-     "duration": 0.008264,
-     "end_time": "2026-06-11T01:38:20.736973",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.728709",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -607,13 +502,6 @@
    "cell_type": "markdown",
    "id": "d65382cb",
    "metadata": {
-    "papermill": {
-     "duration": 0.004231,
-     "end_time": "2026-06-11T01:38:20.744858",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.740627",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -639,13 +527,6 @@
      "iopub.status.busy": "2026-06-11T01:38:20.752272Z",
      "iopub.status.idle": "2026-06-11T01:38:20.757421Z",
      "shell.execute_reply": "2026-06-11T01:38:20.757421Z"
-    },
-    "papermill": {
-     "duration": 0.010542,
-     "end_time": "2026-06-11T01:38:20.758554",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.748012",
-     "status": "completed"
     },
     "tags": []
    },
@@ -716,13 +597,6 @@
    "cell_type": "markdown",
    "id": "d6754d1f",
    "metadata": {
-    "papermill": {
-     "duration": 0.003042,
-     "end_time": "2026-06-11T01:38:20.764595",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.761553",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -741,13 +615,6 @@
      "iopub.status.busy": "2026-06-11T01:38:20.772198Z",
      "iopub.status.idle": "2026-06-11T01:38:20.776409Z",
      "shell.execute_reply": "2026-06-11T01:38:20.776409Z"
-    },
-    "papermill": {
-     "duration": 0.009215,
-     "end_time": "2026-06-11T01:38:20.777414",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.768199",
-     "status": "completed"
     },
     "tags": []
    },
@@ -790,13 +657,6 @@
      "iopub.status.busy": "2026-06-11T01:38:20.785412Z",
      "iopub.status.idle": "2026-06-11T01:38:23.559223Z",
      "shell.execute_reply": "2026-06-11T01:38:23.559223Z"
-    },
-    "papermill": {
-     "duration": 2.779817,
-     "end_time": "2026-06-11T01:38:23.560229",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:20.780412",
-     "status": "completed"
     },
     "tags": []
    },
@@ -850,13 +710,6 @@
    "cell_type": "markdown",
    "id": "147992b2",
    "metadata": {
-    "papermill": {
-     "duration": 0.003509,
-     "end_time": "2026-06-11T01:38:23.568018",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.564509",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -877,13 +730,6 @@
    "cell_type": "markdown",
    "id": "5b3e61d5",
    "metadata": {
-    "papermill": {
-     "duration": 0.003068,
-     "end_time": "2026-06-11T01:38:23.575086",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.572018",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -905,13 +751,6 @@
      "iopub.status.busy": "2026-06-11T01:38:23.583780Z",
      "iopub.status.idle": "2026-06-11T01:38:23.587780Z",
      "shell.execute_reply": "2026-06-11T01:38:23.587780Z"
-    },
-    "papermill": {
-     "duration": 0.009785,
-     "end_time": "2026-06-11T01:38:23.588870",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.579085",
-     "status": "completed"
     },
     "tags": []
    },
@@ -953,13 +792,6 @@
    "cell_type": "markdown",
    "id": "78330ac5",
    "metadata": {
-    "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-11T01:38:23.595870",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.591870",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -979,13 +811,6 @@
    "cell_type": "markdown",
    "id": "673668e2",
    "metadata": {
-    "papermill": {
-     "duration": 0.004016,
-     "end_time": "2026-06-11T01:38:23.602886",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.598870",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1009,13 +834,6 @@
      "iopub.status.busy": "2026-06-11T01:38:23.610870Z",
      "iopub.status.idle": "2026-06-11T01:38:23.614432Z",
      "shell.execute_reply": "2026-06-11T01:38:23.614432Z"
-    },
-    "papermill": {
-     "duration": 0.008578,
-     "end_time": "2026-06-11T01:38:23.615448",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.606870",
-     "status": "completed"
     },
     "tags": []
    },
@@ -1272,13 +1090,6 @@
    "cell_type": "markdown",
    "id": "6e917195",
    "metadata": {
-    "papermill": {
-     "duration": 0.003005,
-     "end_time": "2026-06-11T01:38:23.622453",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.619448",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1309,13 +1120,6 @@
      "iopub.status.busy": "2026-06-11T01:38:23.631457Z",
      "iopub.status.idle": "2026-06-11T01:38:23.636315Z",
      "shell.execute_reply": "2026-06-11T01:38:23.636315Z"
-    },
-    "papermill": {
-     "duration": 0.010876,
-     "end_time": "2026-06-11T01:38:23.637328",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.626452",
-     "status": "completed"
     },
     "tags": []
    },
@@ -1372,13 +1176,6 @@
    "cell_type": "markdown",
    "id": "22716a60",
    "metadata": {
-    "papermill": {
-     "duration": 0.004696,
-     "end_time": "2026-06-11T01:38:23.645015",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.640319",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1401,13 +1198,6 @@
    "cell_type": "markdown",
    "id": "6243c2f7",
    "metadata": {
-    "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-06-11T01:38:23.652173",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.648173",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1424,13 +1214,6 @@
    "cell_type": "markdown",
    "id": "83bdc0ee",
    "metadata": {
-    "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-06-11T01:38:23.659174",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.655173",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1458,13 +1241,6 @@
      "iopub.status.idle": "2026-06-11T01:38:23.670400Z",
      "shell.execute_reply": "2026-06-11T01:38:23.670400Z"
     },
-    "papermill": {
-     "duration": 0.008234,
-     "end_time": "2026-06-11T01:38:23.671407",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.663173",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1487,13 +1263,6 @@
    "cell_type": "markdown",
    "id": "b69afc8d",
    "metadata": {
-    "papermill": {
-     "duration": 0.003111,
-     "end_time": "2026-06-11T01:38:23.678519",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.675408",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1521,13 +1290,6 @@
      "iopub.status.idle": "2026-06-11T01:38:23.691862Z",
      "shell.execute_reply": "2026-06-11T01:38:23.690726Z"
     },
-    "papermill": {
-     "duration": 0.008135,
-     "end_time": "2026-06-11T01:38:23.691862",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.683727",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1547,13 +1309,6 @@
    "cell_type": "markdown",
    "id": "2fd3ee16",
    "metadata": {
-    "papermill": {
-     "duration": 0.004017,
-     "end_time": "2026-06-11T01:38:23.702248",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.698231",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1581,13 +1336,6 @@
      "iopub.status.idle": "2026-06-11T01:38:23.714171Z",
      "shell.execute_reply": "2026-06-11T01:38:23.713166Z"
     },
-    "papermill": {
-     "duration": 0.008309,
-     "end_time": "2026-06-11T01:38:23.714171",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.705862",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1608,13 +1356,6 @@
    "cell_type": "markdown",
    "id": "600ee74d",
    "metadata": {
-    "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-06-11T01:38:23.722517",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.718516",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1644,13 +1385,6 @@
      "iopub.status.idle": "2026-06-11T01:38:23.734969Z",
      "shell.execute_reply": "2026-06-11T01:38:23.734969Z"
     },
-    "papermill": {
-     "duration": 0.009455,
-     "end_time": "2026-06-11T01:38:23.735972",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.726517",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -1676,13 +1410,6 @@
    "cell_type": "markdown",
    "id": "ff3a8ee8",
    "metadata": {
-    "papermill": {
-     "duration": 0.003018,
-     "end_time": "2026-06-11T01:38:23.742991",
-     "exception": false,
-     "start_time": "2026-06-11T01:38:23.739973",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1769,18 +1496,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.9"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 5.714557,
-   "end_time": "2026-06-11T01:38:23.878004",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Lean-16f-Conway-Free-Will-Theorem.ipynb",
-   "output_path": "Lean-16f-Conway-Free-Will-Theorem.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-11T01:38:18.163447",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2024:CoursIA — prev: LIGHT/docs #15735

See #11703

## Tranche visibilité conway_lean : la frontière CHSH entre dans le notebook FWT

Mesure scanner (`scripts/lean/scan_lake_notebook_visibility.py`, rejeu 2026-09-12) : conway_lean porte **3/39 modules noirs** — `CHSH.lean`, `CHSHRandomized.lean`, `HashlifeMarginDemo.lean`. Les deux premiers sont les tranches CHSH livrées par #14132 (déterministe) et #14858 (randomisée) : théorèmes prouvés, 0 `sorry`, mais **aucun notebook du corpus ne cite leurs déclarations** — la machinerie est invisible au critère de l'epic #11703.

Cette tranche rend `CHSH.lean` + `CHSHRandomized.lean` visibles via **Lean-16f** (Le Théorème du Libre Arbitre) — l'hôte thématique naturel : la non-localité quantitative est le socle du FWT, et 16f utilise déjà le pattern subprocess + lake pour le port KochenSpecker / FreeWillTheorem.

## Changements (Lean-16f uniquement, +7 cellules, aucune cellule supprimée)

1. **Nouvelle section 6 « La non-localite quantitative : la frontiere CHSH »** :
   - miroir python des 16 profils déterministes (`itertools.product`) — sortie réelle : `|score|` observé = `[2]`, max 2 ;
   - inventaire **réel** des déclarations des deux modules — le code de la cellule lit les sources `.lean` et affiche leurs déclarations et leur compte de `sorry`, ce n'est pas une paraphrase : `Outcome.value`, `Outcome.value_sq`, `score`, `score_factorization`, `classical_abs_score`, `classical_bound`, `Profile`, `Profile.score`, `Profile.abs_score`, `Strategy`, `expectedScore`, `randomized_bound` ;
   - interprétations : pourquoi `|score| = 2` sur **tous** les profils (`score_factorization`), pourquoi la randomité partagée ne brise pas la frontière (`randomized_bound` : inégalité triangulaire + convexité + `Profile.abs_score`), lien avec les axiomes SPIN / TWIN / MIN du FWT ;
   - Exercice 4 (stratégie randomisée sur la frontière), stub conforme C.1 (`print("Exercice a completer")`).
2. Ancres renumérotées 6→7, 7→8 ; Plan porté à 8 entrées (liens internes mis à jour).
3. Registre (section 7) : +2 lignes CHSH déterministe / randomisé en `PROUVE`.
4. Résumé : +2 modules dans la table du port Lean 4.

## Résultat mesurable

| conway_lean — modules noirs | avant | après |
|---|---:|---:|
| mesure scanner (arbre de la PR) | **3/39** | **1/39** |

Rejeu `scan_lake_notebook_visibility.py --lake conway_lean` sur l'arbre de la PR : `conway_lean 810 decl · 267 citées (borne haute) · 195 (borne stricte) · **1/39 noirs**`, seul `HashlifeMarginDemo.lean` reste.

## Validation

- **Séquence d'exécution** — `python scripts/notebook_tools/check_exec_sequence.py <nb>` → **CLEAN (1..N)**, 1 notebook scanné, 0 dirty.
- **Exécution ciblée (règle C.3)** — les 3 cellules code ajoutées sont exécutées via `nbclient` (kernel `python3`) dans une session `setup + 3 cellules` ; les cellules préexistantes **gardent leurs sorties committées**. Leurs libellés `execution_count` sont renumérotés en ordre de fichier (permutation de labels, sources et sorties byte-identiques) pour satisfaire le ratchet — 5 labels décalés.
- **Preuve 0 `sorry`** — `grep -n sorry` sur `Conway/CHSH.lean` et `Conway/CHSHRandomized.lean` : **aucune occurrence** (exit 1, pas même en prose). Pour le lac entier, l'instrument canonique `python scripts/lean/count_code_sorry.py --json` rend conway_lean `distinct_code_sorry: 1`, résiduel localisé en `Conway/Life/HashlifeMarginFragment.lean:168` (+ sibling `_en`) — hors périmètre de cette tranche.
- **Navlinks** — `check_notebook_navlinks.py` → **0 lien cassé** (la renumérotation des ancres est vérifiée).
- **Hooks pré-commit** — tous verts : gitleaks, H.3 (notebook exécuté), source-list-missing-newlines, probeAddresses, scrub des chemins papermill.
- **0 erreur volontaire (C.1)** — stubs `print`, aucune occurrence de `raise NotImplementedError` / `assert False` / `1/0`.
- **Churn** — diff = **257 insertions / 16 suppressions**, aucune cellule préexistante touchée hors le registre (+2 lignes) et les 4 cellules de structure (Plan, 2 ancres, Résumé). Une première passe via `nbformat` a été **rejetée** : il normalise `source` et `outputs[].text` (liste de lignes → chaîne unique) et faisait churner 780 lignes de cellules non touchées ; la chaîne a été réécrite en JSON brut.

## Ce qui n'est pas dans cette PR — verdict explicite

**La cellule `lake build Conway.CHSH Conway.CHSHRandomized` a été retirée de la tranche.** Le blocage est **environnemental et nommé**, pas un contournement : les oleans Mathlib sont absents du poste (`lake exe cache get` télécharge 2,18 Go de ltars mais la décompression vers `/mnt/c` — 9p — ne pose aucun fichier ; `unpack` et `unpack!` rendent 0 fichier), et WSL échoue en `Wsl/Service/0x8007274c` sous la charge hôte (4 runners CI éphémères de la flotte, load average 21).

Le livrable du grain — la **visibilité** au sens de #11703 — ne dépend pas de ce build : il est porté par l'énumération python, l'inventaire des sources `.lean` et les citations markdown, qui **s'exécutent réellement sans WSL**. Ce ne sont donc pas des sorties dégradées substituées à un outil invocable : la cellule qui échouait a été **retirée** plutôt que committée en échec. La preuve de compilation des deux modules reste due par la CI du lac (`lean-conway.yml`), que #15831 migre vers le pool `coursia-lean`.

## Hors scope

`HashlifeMarginDemo.lean` (dernier module noir du lac ; hôte naturel = Lean-16j) · borne de Tsirelson 2√2 (piste analytique volontairement ouverte, cf docstring des modules) · grothendieck_lean 14/71 noirs (plus grosse poche résiduelle, grain séparé) · le `sorry` résiduel de `HashlifeMarginFragment.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
