### PR TITLE
fix(lean,#15856): table per-toolchain du REPL alignee sur les lakes + _wsl depuis un worktree

### DIFF
--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -37,11 +37,20 @@ docs/reference/wsl-kernels-detail.md.
 """
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+# The Windows console stdout is cp1252, while WSL/lake output carries glyphs it
+# cannot encode (the build stamps ``✔ [n/m] Built ...``, and Lean echoes ∀ / ↦).
+# Unreconciled, ``print(r.stdout...)`` raises UnicodeEncodeError *after* the
+# build has already succeeded, so the run reports a failure that did not happen
+# (same class as #13140). Reconcile stdout once here instead of at each print.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 WSL_DISTRO = "Ubuntu"
 # Canonical matched-REPL install paths (one per toolchain tag).
@@ -50,6 +59,7 @@ REPL_TOOLCHAIN_TAGS = {
     "v4.31.0-rc1": "repl-4.31.0-rc1",
     "v4.32.0": "repl-4.32.0",
     "v4.32.1": "repl-4.32.1",
+    "v4.33.0": "repl-4.33.0",
     "v4.33.1": "repl-4.33.1",
     "v4.34.0-rc1": "repl-4.34.0-rc1",
 }
@@ -98,6 +108,7 @@ REPL_PY_PATCH = '''    @staticmethod
                    'v4.31.0-rc1': 'repl-4.31.0-rc1',
                    'v4.32.0': 'repl-4.32.0',
                    'v4.32.1': 'repl-4.32.1',
+                   'v4.33.0': 'repl-4.33.0',
                    'v4.33.1': 'repl-4.33.1',
                    'v4.34.0-rc1': 'repl-4.34.0-rc1'}
         try:
@@ -201,12 +212,29 @@ def _reorder_lean_path_drvfs_first(lean_path, elan_root):
 
 
 def _wsl(cmd, timeout=120):
-    """Run a command inside WSL, return CompletedProcess."""
+    """Run a command inside WSL, return CompletedProcess.
+
+    cwd is forced to a neutral directory, and the GIT_* repo-redirection vars are
+    dropped. wsl.exe already puts the WSL process in the *Windows* cwd, and every
+    ``_wsl`` command is self-contained (each one ``cd`` where it needs to). When
+    the caller runs from a git WORKTREE that matters: the worktree's ``.git`` is a
+    FILE holding ``gitdir: D:/.../.git/worktrees/<name>``, a Windows path WSL
+    resolves into ``<wsl-cwd>/D:/.../...`` -- git then dies with "not a git
+    repository" and returns an EMPTY stdout, which ``_resolve_repl_source_tag``
+    reads as "no tag <= want" and reports as a misleading ``NO-SOURCE-TAG``.
+    Workers are mandated to work in worktrees, so this made ``build-repl``
+    silently unusable exactly where it is needed (measured 2026-09-12: v4.33.0
+    resolution returned None from a worktree, and the same silent empty-stdout
+    path is why the ``repl-4.33.1`` key was advertised but never built).
+    """
     full = ["wsl.exe", "-d", WSL_DISTRO, "--", "bash", "-lc", cmd]
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
     # encoding explicite : la sortie WSL porte de l'unicode Lean (forall, mapsto).
     # text=True seul decode via la locale -> crash sur hote cp1252 (#12811).
     return subprocess.run(full, capture_output=True, text=True, timeout=timeout,
-                          encoding="utf-8", errors="replace")
+                          encoding="utf-8", errors="replace",
+                          cwd=os.path.expanduser("~"), env=env)
 
 
 def _find_repl_py():
@@ -385,13 +413,29 @@ def cmd_build_repl(tag, default=False):
     # test brackets piped through wsl.exe -> bash -lc get mangled at the
     # argument boundary (a [ \"$(...)\" = tag ] check reported a mismatch on
     # a checkout that was in fact correct).
-    _wsl(
+    #
+    # ``git checkout --force`` (not the bare form): when the requested tag has
+    # no exact repl source tag, the build overrides ``lean-toolchain`` in place
+    # (see ``override`` above) and leaves the checkout DIRTY. A later
+    # ``build-repl`` then aborts mid-sequence with "Your local changes to the
+    # following files would be overwritten by checkout: lean-toolchain" -- and
+    # because the old form piped through ``| tail -1``, the abort was silent and
+    # the operator only saw a bare CHECKOUT-MISMATCH with no cause. That is how
+    # the ``v4.33.1`` key came to be advertised in REPL_TOOLCHAIN_TAGS yet never
+    # built. The override is the script's own artifact and is regenerated on
+    # every build, so discarding it here is the intended semantics; the failure
+    # is now surfaced instead of swallowed.
+    prep = _wsl(
         f"export PATH=$HOME/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
         f"mkdir -p ~/repl-build && cd ~/repl-build && "
         f"if [ ! -d repl ]; then git clone https://github.com/leanprover-community/repl.git; fi && "
-        f"cd repl && git fetch --tags --force origin 2>&1 | tail -1; "
-        f"git checkout {src_tag} 2>&1 | tail -1",
+        f"cd repl && git fetch --tags --force -q origin && "
+        f"git checkout --force {src_tag} && echo CHECKOUT-OK",
         timeout=300)
+    if "CHECKOUT-OK" not in (prep.stdout or ""):
+        print("CHECKOUT-FAILED: "
+              + " ".join(((prep.stdout or "") + " " + (prep.stderr or "")).split())[-600:])
+        return 1
     head = (_wsl("cd ~/repl-build/repl && git rev-parse HEAD", timeout=30).stdout or "").strip()
     tagc = (_wsl(f"cd ~/repl-build/repl && git rev-parse {src_tag}^{{commit}}",
                  timeout=30).stdout or "").strip()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA — prev: LIGHT/docs #15583

## Résumé

`scripts/lean/setup_native_lean4_import.py` résout et construit le binaire REPL
apparié à un lake. Quatre défauts sur ce chemin, dont un qui rendait le kernel
Lean **silencieusement inutilisable** sur 14 des 32 lakes du dépôt.

Aucun fichier `.lean`, aucun notebook, aucun catalogue n'est touché.

## 1. La table per-toolchain a dérivé des lakes (le défaut qui compte)

`REPL_TOOLCHAIN_TAGS` (et son mirror inline dans `REPL_PY_PATCH`) associe un tag
de toolchain au binaire REPL correspondant. Un lake absent de la table tombe sur
le `~/.elan/bin/repl` **stable-locked**, dont le sysroot n'est pas celui du lake :
les imports sont acceptés **silencieusement** (`{"env": 0}`, aucun message) puis
**tout** identifiant devient `Unknown identifier` — `IO.println` compris.

Mesure du 2026-09-12 sur `main` (`77575efeb999`) :

| Toolchain pinné | Lakes | Entrée en table | Binaire présent |
|---|---:|---|---|
| `v4.32.1` | 15 | oui | oui |
| **`v4.33.0`** | **14** | **non** | non |
| `v4.33.1` | 1 | oui | non |
| `v4.31.0-rc2` | 1 | non (la table a `rc1`) | non |
| `v4.25.0` | 1 | non | non |

`ls ~/.elan/bin/repl*` ne rendait que `repl` et `repl-4.32.1`. Les clés
`v4.31.0-rc1`, `v4.32.0`, `v4.33.1`, `v4.34.0-rc1` **existaient dans la table
sans binaire construit** — une clé annoncée n'est pas une clé servie.

C'est le symptôme de #11874 (`Unknown constant OfNat`) par une **cause
différente** : là où #11874 avait un binaire cassé, ici la table est incomplète.

Correction : la clé `v4.33.0` est ajoutée aux **deux** endroits (la constante et
le mirror inliné, qui doit rester verbatim sous peine de divergence silencieuse).

## 2. `_wsl()` ne neutralisait ni le cwd ni `GIT_*`

`wsl.exe` place le process WSL dans le cwd **Windows**. Lancé depuis un
**worktree** — dont le `.git` est un *fichier* contenant
`gitdir: D:/.../.git/worktrees/<nom>`, un chemin Windows que WSL résout en
`<cwd-wsl>/D:/...` — git meurt avec `fatal: not a git repository` et rend un
**stdout vide**. `_resolve_repl_source_tag` lit ce vide comme « aucun tag ≤
voulu » et rapporte un `NO-SOURCE-TAG` **trompeur**.

Les workers sont mandatés pour travailler en worktree : `build-repl` était donc
inutilisable exactement là où il sert. C'est le défaut le plus coûteux des
quatre, parce qu'il **ment sur sa cause**.

Correction : `cwd` forcé au home (chaque commande `_wsl` est auto-portante et
`cd` elle-même où il faut), et `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` /
`GIT_COMMON_DIR` retirés de l'environnement.

## 3. L'échec de checkout était avalé par `| tail -1`

Un build précédent laisse `~/repl-build/repl` **sale** : quand le tag demandé n'a
pas de source exacte, le script override `lean-toolchain` **en place** et laisse
cette modification. Le `git checkout {src_tag} 2>&1 | tail -1` suivant échouait
alors que le pipe rendait `rc=0` — l'opérateur ne voyait qu'un
`CHECKOUT-MISMATCH` sans cause. **C'est par ce chemin que `repl-4.33.1` a été
annoncée dans la table sans jamais être construite.**

Correction : `git checkout --force` (l'override est l'artefact du script,
régénéré à chaque build — le jeter est la sémantique voulue) qui rend
`CHECKOUT-OK`, sinon un `CHECKOUT-FAILED` nommant la sortie brute et un `rc=1`.

## 4. `os` jamais importé, et stdout en cp1252

`cmd_patch` appelle `os.unlink` alors que `os` n'est **jamais importé** :
`NameError` latent (vérifié : `hasattr(m, 'os') == False`).

Et la sortie lake porte des glyphes que cp1252 ne sait pas encoder (le tampon de
build `✔ [n/m]`, et Lean écho `∀` / `↦`) : `print(r.stdout…)` levait un
`UnicodeEncodeError` **après** un build réussi, donc rapportait en échec un run
qui avait abouti. Même classe que #13140. `stdout` est réconcilié en UTF-8 une
fois, en tête de module, plutôt qu'à chaque `print`.

## Preuve — contrôle positif du défaut 1

Le correctif a été validé en construisant réellement le binaire manquant, pas en
relisant le diff :

```
~/.elan/bin/repl-4.33.0   229 875 648 octets
```

puis en exécutant le compagnon `grothendieck_lean` (toolchain `v4.33.0`) par le
kernel `lean4-wsl-groth` : **25 `#check`, 0 erreur**, et les 4 `#print axioms`
répondant `[propext, Classical.choice, Quot.sound]` — PR #15855. Avant le
correctif, la même cellule rendait `Unknown identifier` sur chacun des 25 noms,
`IO.println` compris.

Contrôle négatif du défaut 2 (résolution depuis un worktree) documenté dans le
docstring de `_wsl` : la résolution de `v4.33.0` rendait `None` depuis un
worktree, et la même sortie-vide-silencieuse est ce qui a laissé la clé
`repl-4.33.1` annoncée sans binaire.

## Ce que cette PR ne ferme pas

- `v4.31.0-rc2` et `v4.25.0` n'ont **toujours pas** d'entrée dans la table (un
  lake chacun). Le correctif traite le cas mesuré (14 lakes), pas la classe.
- Le fork `jsboige/lean4_jupyter@v0.0.1-native-import` porte encore la table
  ancienne : **un `pip install --force-reinstall` réintroduirait le défaut**. Le
  venv est patché en place aujourd'hui, ce qui est précaire.
- **La voie durable** — dériver le nom du binaire du tag de toolchain au lieu de
  tenir une troisième table à la main — est l'acceptance non cochée de #15856,
  laissée ouverte sciemment : c'est un changement de conception, pas un correctif.

Closes #15856
See #11703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
