### PR TITLE
fix(guard,#15278): reprise du nom de conteneur, journal nomme sur rc!=0

### DIFF
--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -639,10 +639,11 @@ rotate_log() {
 # use ») vivait dans $STATE_DIR/<nom>.log, que le journal ne nommait pas.
 #
 # Ce que ce garde fait, et ce qu'il ne fait pas :
-#   - il ATTEND la liberation du nom, en sondant : la reprise est immediate au
-#     lieu d'attendre la prochaine marche du backoff -- jusqu'a 82 s de plus
-#     que le job orphelin, exactement le « au-dela de la duree du job
-#     orphelin » que l'acceptance ferme ;
+#   - il ATTEND la liberation du nom, en sondant : la reprise se fait dans la
+#     seconde qui suit la liberation (au plus un intervalle de sondage), au lieu
+#     d'attendre la prochaine marche du backoff -- `BACKOFF_BASE` ->
+#     `BACKOFF_CAP` a 300 s (cf le bloc BORNES). C'est ce « au-dela de la duree
+#     du job orphelin » que l'acceptance ferme ;
 #   - il ne retire un conteneur que si son etat est PROUVE non en cours
 #     (`created`, `exited`, `dead`), c'est-a-dire s'il n'execute aucun job.
 #     C'est la SEULE force admise : `docker rm -f` sur un conteneur en cours

--- a/scripts/ci/docker/linux-runner/supervise.sh
+++ b/scripts/ci/docker/linux-runner/supervise.sh
@@ -60,6 +60,10 @@
 #   COURSIA_RUNNER_BACKOFF_MAX_SEC      slot. NON inertes : 5 s -> 300 s.
 #   COURSIA_RUNNER_BACKOFF_JITTER_PCT   dispersion du backoff. NON inerte :
 #                                       25 %. 0 = rafale synchronisee.
+#   COURSIA_RUNNER_NAME_RECLAIM_POLL_SECS  sondage du nom de conteneur avant
+#   COURSIA_RUNNER_NAME_RECLAIM_WARN_SECS  docker run, et cadence de
+#                                       l'avertissement de reprise (#15278).
+#                                       NON inertes : 5 s et 60 s.
 #
 # Le detail de chaque borne -- ce qu'elle couvre, ce qu'elle ne peut PAS
 # couvrir, et la mesure qui l'etablit -- est dans le bloc BORNES plus bas et
@@ -297,22 +301,28 @@ assert_docker_daemon() {
 # max < 2^60 : tout produit garde du calcul iteratif reste < 2^61, loin de
 # la borne signee), et BASE <= CAP (le plafond doit dominer la base).
 _validate_backoff_value() {
-  # $1 = nom de la variable d'environnement, $2 = valeur
-  case "$2" in
+  # $1 = nom de la variable d'environnement, $2 = valeur, $3 = reference
+  local var="$1" val="$2" ref="${3:-#15166}"
+  case "$val" in
     ''|*[!0-9]*)
-      die "COURSIA_RUNNER_* : $1='$2' n'est pas un entier decimal (#15166)."
+      die "COURSIA_RUNNER_* : $var='$val' n'est pas un entier decimal ($ref)."
       ;;
   esac
-  [ "${#2}" -le 18 ] \
-    || die "COURSIA_RUNNER_* : $1='$2' depasse le domaine arithmetique (18 chiffres max, #15166)."
-  [ "$2" -ge 1 ] \
-    || die "COURSIA_RUNNER_* : $1='$2' doit etre strictement positif (#15166)."
+  [ "${#val}" -le 18 ] \
+    || die "COURSIA_RUNNER_* : $var='$val' depasse le domaine arithmetique (18 chiffres max, $ref)."
+  [ "$val" -ge 1 ] \
+    || die "COURSIA_RUNNER_* : $var='$val' doit etre strictement positif ($ref)."
 }
 
 validate_backoff_env() {
   _validate_backoff_value HEALTHY_CYCLE_SECS "$HEALTHY_CYCLE_SECS"
   _validate_backoff_value BACKOFF_BASE "$BACKOFF_BASE"
   _validate_backoff_value BACKOFF_CAP "$BACKOFF_CAP"
+  # #15278 : les deux bornes du garde de reprise du nom obeissent a la meme
+  # exigence fail-closed -- une valeur non numerique atteindrait `[ -ge ]` et
+  # `sleep` dans la boucle de sondage.
+  _validate_backoff_value NAME_RECLAIM_POLL_SECS "$NAME_RECLAIM_POLL_SECS" "#15278"
+  _validate_backoff_value NAME_RECLAIM_WARN_SECS "$NAME_RECLAIM_WARN_SECS" "#15278"
   [ "$BACKOFF_BASE" -le "$BACKOFF_CAP" ] \
     || die "COURSIA_RUNNER_* : BACKOFF_BASE=$BACKOFF_BASE > BACKOFF_CAP=$BACKOFF_CAP -- le plafond doit dominer la base (#15166)."
 }
@@ -348,10 +358,20 @@ cycle_backoff() {
       worked=1
     fi
   fi
+  # #15278 : un echec au journal doit NOMMER ou lire la cause. `rc=125` seul
+  # n'oriente vers rien -- le message docker (« Conflict. The container name
+  # ... is already in use », image perimee, daemon mort) part dans le log du
+  # slot par la redirection du `docker run`, jamais sur le stderr du
+  # superviseur. Le rappel n'est pose que sur rc != 0 : sur rc=0 le journal
+  # reste lisible sans lui.
+  local hint=""
+  if [ "$rc" -ne 0 ] && [ -n "$work_log" ]; then
+    hint=" -- voir $work_log"
+  fi
   if [ "$lifetime" -lt "$HEALTHY_CYCLE_SECS" ]; then
     if [ "$worked" -eq 1 ]; then
       SHORT_CYCLES=0
-      echo "$tag cycle court AVEC travail (rc=$rc, ${lifetime}s) -- travail reel, pas une boucle vide : pas de backoff (#15166)" >&2
+      echo "$tag cycle court AVEC travail (rc=$rc, ${lifetime}s) -- travail reel, pas une boucle vide : pas de backoff (#15166)$hint" >&2
       sleep 2
       return
     fi
@@ -372,14 +392,14 @@ cycle_backoff() {
       i=$(( i + 1 ))
     done
     [ "$i" -lt "$exp" ] && d="$BACKOFF_CAP"
-    echo "$tag cycle court (rc=$rc, ${lifetime}s, consecutifs=$SHORT_CYCLES) -- backoff ${d}s (#15095)" >&2
+    echo "$tag cycle court (rc=$rc, ${lifetime}s, consecutifs=$SHORT_CYCLES) -- backoff ${d}s (#15095)$hint" >&2
     sleep "$d"
   elif [ "$rc" -eq 0 ]; then
     SHORT_CYCLES=0
     echo "$tag conteneur termine sainement (rc=$rc, ${lifetime}s)"
     sleep 2
   else
-    echo "$tag cycle long mais rc=$rc (${lifetime}s) -- non qualifie sain, compteur de courts conserve a $SHORT_CYCLES (#15166)" >&2
+    echo "$tag cycle long mais rc=$rc (${lifetime}s) -- non qualifie sain, compteur de courts conserve a $SHORT_CYCLES (#15166)$hint" >&2
     sleep "$BACKOFF_MIN_SEC"
   fi
 }
@@ -608,6 +628,85 @@ rotate_log() {
   fi
 }
 
+# --- Reprise du nom de conteneur (#15278) -----------------------------------
+
+# Le nom d'un conteneur est un verrou GLOBAL au daemon, pas au client. Un
+# `systemctl restart` tue le CLIENT `docker run` mais PAS le conteneur, qui
+# garde son nom jusqu'a la fin de son job. La generation suivante relancait
+# alors sous un nom deja pris et bouclait en rc=125 -- mesure ai-01 2026-09-09
+# pendant le passage de 6 a 10 slots : 3 slots sur 10 bloques, ~4 minutes, et
+# le seul message utile (« Conflict. The container name ... is already in
+# use ») vivait dans $STATE_DIR/<nom>.log, que le journal ne nommait pas.
+#
+# Ce que ce garde fait, et ce qu'il ne fait pas :
+#   - il ATTEND la liberation du nom, en sondant : la reprise est immediate au
+#     lieu d'attendre la prochaine marche du backoff -- jusqu'a 82 s de plus
+#     que le job orphelin, exactement le « au-dela de la duree du job
+#     orphelin » que l'acceptance ferme ;
+#   - il ne retire un conteneur que si son etat est PROUVE non en cours
+#     (`created`, `exited`, `dead`), c'est-a-dire s'il n'execute aucun job.
+#     C'est la SEULE force admise : `docker rm -f` sur un conteneur en cours
+#     tuerait un job legitime, ce que l'acceptance interdit. Le discriminant
+#     n'est pas une precaution : un runner ephemere qui travaille est en etat
+#     `running` par definition. La liste est une ALLOWLIST, pas une liste
+#     d'exclusion -- un etat que ce script ne qualifie pas (`restarting`,
+#     `removing`, ou un etat qu'une version future de docker introduirait)
+#     retombe sur l'attente. C'est le seul cote ou se tromper tue un job ;
+#   - il n'abandonne pas et ne relance pas sous un nom de generation. Un second
+#     conteneur pour le meme slot doublerait la reservation CPU de ce slot,
+#     dans un fichier dont la clause de tete est « l'hote prime sur la CI ».
+#     Un job orphelin qui ne rend JAMAIS son nom est un probleme docker
+#     (conteneur bloque), pas un probleme de boucle : on le dit
+#     periodiquement, avec l'etat et le nom du journal, pour que l'operateur
+#     puisse agir -- et `stop` reste prioritaire sur l'attente.
+NAME_RECLAIM_POLL_SECS="${COURSIA_RUNNER_NAME_RECLAIM_POLL_SECS:-5}"
+NAME_RECLAIM_WARN_SECS="${COURSIA_RUNNER_NAME_RECLAIM_WARN_SECS:-60}"
+
+# Etat docker du conteneur portant ce nom, VIDE s'il n'existe pas. `docker
+# inspect` et non `docker ps` : le second ne voit pas un conteneur arrete --
+# precisement le residu qu'on veut pouvoir retirer sans risque.
+container_state() {
+  docker inspect -f '{{.State.Status}}' "$1" 2>/dev/null || true
+}
+
+# Rend 0 quand le nom est libre. Bloque tant qu'un conteneur EN COURS le
+# detient (cf le bloc ci-dessus : c'est voulu, le seul plafond est la duree du
+# job orphelin lui-meme). Rend 1 si un arret a ete demande pendant l'attente.
+reclaim_container_name() {
+  local name="$1" state waited=0 next_warn="$NAME_RECLAIM_WARN_SECS"
+  while :; do
+    [ -f "$STOP_FILE" ] && return 1
+    state="$(container_state "$name")"
+    [ -z "$state" ] && return 0
+    case "$state" in
+      created|exited|dead)
+        # Etat PROUVE non en cours : aucun job dedans, le retrait ne peut
+        # tuer aucun travail. C'est la SEULE force que ce garde s'autorise,
+        # et elle est bornee par cette liste -- pas par une liste d'exclusion.
+        if docker rm -f "$name" >/dev/null 2>&1; then
+          echo "[$name] residu de conteneur en etat '$state' retire -- aucun job n'y tournait (#15278)" >&2
+        else
+          echo "[$name] residu en etat '$state' non retirable (docker rm -f a echoue) -- nouvelle tentative (#15278)" >&2
+          sleep "$NAME_RECLAIM_POLL_SECS"
+          waited=$(( waited + NAME_RECLAIM_POLL_SECS ))
+        fi
+        ;;
+      *)
+        # `running`, `paused`, et TOUT etat non qualifie (`restarting`,
+        # `removing`, etat inconnu d'une version future). Fail-closed : le nom
+        # est considere DETENU. Un etat qu'on n'a pas qualifie n'autorise pas
+        # une destruction -- c'est le seul cote ou l'erreur tue un job.
+        if [ "$waited" -ge "$next_warn" ]; then
+          echo "[$name] nom toujours detenu ($state) apres ${waited}s -- conteneur d'une generation precedente. Il n'est PAS retire (etat '$state' : un job peut y tourner) ; le slot reprendra des que le nom sera rendu. Journal : $STATE_DIR/$name.log (#15278)" >&2
+          next_warn=$(( next_warn + NAME_RECLAIM_WARN_SECS ))
+        fi
+        sleep "$NAME_RECLAIM_POLL_SECS"
+        waited=$(( waited + NAME_RECLAIM_POLL_SECS ))
+        ;;
+    esac
+  done
+}
+
 # --- Backoff exponentiel avec jitter ----------------------------------------
 
 # Rend le delai a attendre apres `n` echecs consecutifs : min * 2^(n-1),
@@ -695,6 +794,12 @@ slot_loop() {
       sleep "$wait_s"
       continue
     fi
+    # #15278 : reprendre le nom AVANT de mesurer le cycle -- l'attente due a un
+    # job orphelin n'est pas un cycle de conteneur et ne doit donc pas etre
+    # comptee dans `lifetime` (une attente de plusieurs minutes suivie d'un
+    # echec instantane se lirait sinon comme un cycle long, donc « pas un
+    # emballement », et masquerait l'echec reel). `continue` sur arret demande.
+    reclaim_container_name "$name" || continue
     # #15095 : la duree de vie du conteneur est mesuree depuis AVANT le run
     # (offset pris avant rotate_log, comme le log_off du signal de travail).
     local t0=$SECONDS
@@ -953,6 +1058,11 @@ waiter_loop() {
       sleep "$wait_s"
       continue
     fi
+    # #15278 : meme garde que slot_loop -- un waiter orphelin d'un restart
+    # detient son nom de la meme facon, et le conflit de nom n'est pas un
+    # echec de job : il ne doit ni tuer le conteneur en vol, ni nourrir le
+    # backoff. `continue` sur arret demande.
+    reclaim_container_name "$name" || continue
     local t0=$SECONDS
     rotate_log "$STATE_DIR/$name.log"
     local log_off

--- a/scripts/ci/docker/linux-runner/test_supervise_guards.sh
+++ b/scripts/ci/docker/linux-runner/test_supervise_guards.sh
@@ -1473,6 +1473,417 @@ echo "Test 32 : hostname donne -> les trois prefixes de famille derives (#15152)
 )
 echo ""
 
+# --- Test 33 : nom detenu par un conteneur EN COURS -- on attend, on ne tue
+# pas (#15278). Le verrou de nom est GLOBAL au daemon : un restart tue le
+# client `docker run` mais PAS le conteneur, qui garde son nom jusqu'a la fin
+# de son job. Le garde doit attendre la liberation -- jamais retirer un
+# conteneur en cours (ce serait tuer un job legitime) -- et le dire, en
+# nommant le journal ou lire la cause.
+echo "Test 33 : nom detenu par un conteneur EN COURS -- attente, AUCUN retrait, avertissement nommant le journal (#15278)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin33" "$TEST_DIR/state-33"
+  cat > "$TEST_DIR/bin33/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "info" ]; then exit 0; fi
+if [ "\$1" = "image" ] || [ "\$1" = "volume" ]; then exit 0; fi
+if [ "\$1" = "inspect" ]; then
+  # Le job orphelin rend le nom au sondage STUB_ORPHAN_POLLS+1.
+  N="\$(cat "\$STUB_INSPECT_COUNT" 2>/dev/null || echo 0)"
+  N=\$(( N + 1 ))
+  echo "\$N" > "\$STUB_INSPECT_COUNT"
+  if [ "\$N" -le "\${STUB_ORPHAN_POLLS:-3}" ]; then echo "running"; fi
+  exit 0
+fi
+if [ "\$1" = "rm" ]; then echo "\$*" >> "\$STUB_RM_LOG"; exit 0; fi
+if [ "\$1" = "run" ] && [ "\$3" = "--entrypoint" ]; then
+  case "\$*" in
+    *work_cache_health.sh*)
+      echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh"
+      ;;
+    *)
+      echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+      ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  RUNS="\$(cat "\$STUB_RUN_COUNT" 2>/dev/null || echo 0)"
+  RUNS=\$(( RUNS + 1 ))
+  echo "\$RUNS" > "\$STUB_RUN_COUNT"
+  touch "\$STUB_STOP_FILE"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin33/docker"
+  cat > "$TEST_DIR/bin33/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$SLEEP_LOG"
+STUB
+  chmod +x "$TEST_DIR/bin33/sleep"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin33/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin33/ps"
+  rm -f "$TEST_DIR/state-33/stop" "$TEST_DIR/state-33/pids" \
+        "$TEST_DIR/run33.count" "$TEST_DIR/inspect33.count"
+  : > "$TEST_DIR/sleep33.log"; : > "$TEST_DIR/rm33.log"
+  (
+    export PATH="$TEST_DIR/bin33:$PATH"
+    export COURSIA_RUNNER_NAME_PREFIX="test-prefix-33"
+    export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-33"
+    export COURSIA_RUNNER_HEALTHY_CYCLE_SECS=9999
+    export COURSIA_RUNNER_BACKOFF_BASE=3
+    export COURSIA_RUNNER_BACKOFF_CAP=6
+    export COURSIA_RUNNER_NAME_RECLAIM_POLL_SECS=5
+    export COURSIA_RUNNER_NAME_RECLAIM_WARN_SECS=10
+    export STUB_STOP_FILE="$TEST_DIR/state-33/stop"
+    export STUB_RUN_COUNT="$TEST_DIR/run33.count"
+    export STUB_INSPECT_COUNT="$TEST_DIR/inspect33.count"
+    export STUB_RM_LOG="$TEST_DIR/rm33.log"
+    export SLEEP_LOG="$TEST_DIR/sleep33.log"
+    timeout --kill-after=2 30 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/err33.log"
+  )
+  # Le conteneur en cours NE DOIT JAMAIS etre retire : c'est l'acceptance
+  # « la solution retenue ne peut pas tuer un conteneur executant un job
+  # legitime ». Un `docker rm` sur le nom, meme une fois, la viole.
+  if [ ! -s "$TEST_DIR/rm33.log" ]; then
+    ok "aucun docker rm sur le nom detenu par un conteneur en cours (le job legitime survit)"
+  else
+    ko "retrait interdit d'un conteneur EN COURS : $(cat "$TEST_DIR/rm33.log")"
+  fi
+  polls="$(head -3 "$TEST_DIR/sleep33.log" | paste -sd,)"
+  if [ "$polls" = "5,5,5" ]; then
+    ok "3 sondages de 5 s pendant que le nom est detenu (attente, pas de relance en conflit)"
+  else
+    ko "attendu 3 sondages de 5 s, obtenu [$polls]"
+  fi
+  if grep -q "nom toujours detenu (running)" "$TEST_DIR/err33.log" \
+     && grep -q "state-33/test-prefix-33-1.log" "$TEST_DIR/err33.log"; then
+    ok "l'attente est journalisee, nomme l'etat et NOMME le journal du slot (diagnostic possible)"
+  else
+    ko "avertissement de reprise absent ou sans chemin de journal : $(head -3 "$TEST_DIR/err33.log")"
+  fi
+  runs="$(cat "$TEST_DIR/run33.count" 2>/dev/null || echo 0)"
+  inspects="$(cat "$TEST_DIR/inspect33.count" 2>/dev/null || echo 0)"
+  if [ "$runs" = "1" ] && [ "$inspects" = "4" ]; then
+    ok "le slot reprend des que le nom est rendu (1 run apres 4 sondages, pas de cycle perdu)"
+  else
+    ko "reprise attendue apres liberation : runs=$runs inspects=$inspects"
+  fi
+)
+echo ""
+
+# --- Test 34 : nom detenu par un residu NON en cours -- retire, sans risque
+# (#15278). Un conteneur `exited`/`created`/`dead` n'execute AUCUN job : le
+# retirer ne peut tuer aucun travail. C'est la seule force que le garde
+# s'autorise, et elle est bornee par ce discriminant d'etat.
+echo "Test 34 : nom detenu par un residu NON en cours -- retire, aucun job en vol (#15278)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin34" "$TEST_DIR/state-34"
+  cat > "$TEST_DIR/bin34/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "info" ]; then exit 0; fi
+if [ "\$1" = "image" ] || [ "\$1" = "volume" ]; then exit 0; fi
+if [ "\$1" = "inspect" ]; then
+  # Le residu existe tant que docker rm ne l'a pas enleve.
+  if [ -f "\$STUB_RESIDUE" ]; then echo "exited"; fi
+  exit 0
+fi
+if [ "\$1" = "rm" ]; then
+  echo "\$*" >> "\$STUB_RM_LOG"
+  rm -f "\$STUB_RESIDUE"
+  exit 0
+fi
+if [ "\$1" = "run" ] && [ "\$3" = "--entrypoint" ]; then
+  case "\$*" in
+    *work_cache_health.sh*)
+      echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh"
+      ;;
+    *)
+      echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+      ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  RUNS="\$(cat "\$STUB_RUN_COUNT" 2>/dev/null || echo 0)"
+  RUNS=\$(( RUNS + 1 ))
+  echo "\$RUNS" > "\$STUB_RUN_COUNT"
+  touch "\$STUB_STOP_FILE"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin34/docker"
+  cat > "$TEST_DIR/bin34/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$SLEEP_LOG"
+STUB
+  chmod +x "$TEST_DIR/bin34/sleep"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin34/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin34/ps"
+  rm -f "$TEST_DIR/state-34/stop" "$TEST_DIR/state-34/pids" "$TEST_DIR/run34.count"
+  : > "$TEST_DIR/residue34"; : > "$TEST_DIR/rm34.log"; : > "$TEST_DIR/sleep34.log"
+  (
+    export PATH="$TEST_DIR/bin34:$PATH"
+    export COURSIA_RUNNER_NAME_PREFIX="test-prefix-34"
+    export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-34"
+    export COURSIA_RUNNER_HEALTHY_CYCLE_SECS=9999
+    export COURSIA_RUNNER_BACKOFF_BASE=3
+    export COURSIA_RUNNER_BACKOFF_CAP=6
+    export STUB_STOP_FILE="$TEST_DIR/state-34/stop"
+    export STUB_RUN_COUNT="$TEST_DIR/run34.count"
+    export STUB_RESIDUE="$TEST_DIR/residue34"
+    export STUB_RM_LOG="$TEST_DIR/rm34.log"
+    export SLEEP_LOG="$TEST_DIR/sleep34.log"
+    timeout --kill-after=2 30 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/err34.log"
+  )
+  if [ "$(wc -l < "$TEST_DIR/rm34.log")" = "1" ] \
+     && grep -q "rm -f test-prefix-34-1" "$TEST_DIR/rm34.log"; then
+    ok "le residu non en cours est retire exactement une fois, par son nom"
+  else
+    ko "retrait du residu attendu une fois sur test-prefix-34-1, obtenu [$(paste -sd';' "$TEST_DIR/rm34.log")]"
+  fi
+  if grep -q "residu de conteneur en etat 'exited' retire" "$TEST_DIR/err34.log"; then
+    ok "le retrait est journalise avec l'etat qui l'autorise"
+  else
+    ko "ligne de retrait du residu absente : $(head -3 "$TEST_DIR/err34.log")"
+  fi
+  # Controle negatif : aucun avertissement de job en cours ne doit apparaitre --
+  # le garde a distingue le residu du job vivant, il n'a pas simplement attendu.
+  if ! grep -q "nom toujours detenu" "$TEST_DIR/err34.log" \
+     && [ "$(cat "$TEST_DIR/run34.count" 2>/dev/null || echo 0)" = "1" ]; then
+    ok "aucune attente declenchee (discriminant d'etat, pas un sursis) et le slot a repris"
+  else
+    ko "attente indue ou reprise manquante : err=$(head -2 "$TEST_DIR/err34.log") runs=$(cat "$TEST_DIR/run34.count" 2>/dev/null || echo 0)"
+  fi
+)
+echo ""
+
+# --- Test 35 : un rc != 0 NOMME le journal ou lire la cause (#15278) --------
+# Defaut 2 de l'issue : le journal systemd ne portait que « rc=125 », alors que
+# le message docker (« Conflict. The container name ... is already in use »,
+# image perimee, daemon) part dans $STATE_DIR/<nom>.log par la redirection du
+# `docker run`. Sans ce rappel, l'operateur n'est oriente vers rien.
+echo "Test 35 : un cycle rc != 0 nomme le journal du slot dans le message d'echec (#15278)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin35" "$TEST_DIR/state-35"
+  cat > "$TEST_DIR/bin35/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "info" ]; then exit 0; fi
+if [ "\$1" = "image" ] || [ "\$1" = "volume" ]; then exit 0; fi
+if [ "\$1" = "run" ] && [ "\$3" = "--entrypoint" ]; then
+  case "\$*" in
+    *work_cache_health.sh*)
+      echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh"
+      ;;
+    *)
+      echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+      ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  RUNS="\$(cat "\$STUB_RUN_COUNT" 2>/dev/null || echo 0)"
+  RUNS=\$(( RUNS + 1 ))
+  echo "\$RUNS" > "\$STUB_RUN_COUNT"
+  touch "\$STUB_STOP_FILE"
+  exit "\${STUB_DOCKER_RC:-1}"
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin35/docker"
+  cat > "$TEST_DIR/bin35/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$SLEEP_LOG"
+STUB
+  chmod +x "$TEST_DIR/bin35/sleep"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin35/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin35/ps"
+  rm -f "$TEST_DIR/state-35/stop" "$TEST_DIR/state-35/pids" "$TEST_DIR/run35.count"
+  : > "$TEST_DIR/sleep35.log"
+  (
+    export PATH="$TEST_DIR/bin35:$PATH"
+    export COURSIA_RUNNER_NAME_PREFIX="test-prefix-35"
+    export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-35"
+    export COURSIA_RUNNER_HEALTHY_CYCLE_SECS=9999
+    export COURSIA_RUNNER_BACKOFF_BASE=3
+    export COURSIA_RUNNER_BACKOFF_CAP=6
+    export STUB_STOP_FILE="$TEST_DIR/state-35/stop"
+    export STUB_RUN_COUNT="$TEST_DIR/run35.count"
+    export STUB_DOCKER_RC=1
+    export SLEEP_LOG="$TEST_DIR/sleep35.log"
+    timeout --kill-after=2 30 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/err35.log"
+  )
+  if grep -q "cycle court (rc=1" "$TEST_DIR/err35.log" \
+     && grep -q -- "-- voir $TEST_DIR/state-35/test-prefix-35-1.log" "$TEST_DIR/err35.log"; then
+    ok "le message de cycle court rc=1 nomme $TEST_DIR/state-35/test-prefix-35-1.log"
+  else
+    ko "journal non nomme sur rc=1 : $(head -3 "$TEST_DIR/err35.log")"
+  fi
+)
+echo ""
+
+# --- Test 36 : controle negatif du precedent -- rc=0 ne nomme RIEN (#15278)
+# Le rappel est pose sur rc != 0 seulement. Sans ce controle, un `-- voir`
+# ajoute inconditionnellement passerait le test 35 tout en alourdissant chaque
+# cycle sain du journal.
+echo "Test 36 : controle negatif -- un cycle rc=0 ne porte PAS le rappel de journal (#15278)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin36" "$TEST_DIR/state-36"
+  cat > "$TEST_DIR/bin36/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "info" ]; then exit 0; fi
+if [ "\$1" = "image" ] || [ "\$1" = "volume" ]; then exit 0; fi
+if [ "\$1" = "run" ] && [ "\$3" = "--entrypoint" ]; then
+  case "\$*" in
+    *work_cache_health.sh*)
+      echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh"
+      ;;
+    *)
+      echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+      ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  RUNS="\$(cat "\$STUB_RUN_COUNT" 2>/dev/null || echo 0)"
+  RUNS=\$(( RUNS + 1 ))
+  echo "\$RUNS" > "\$STUB_RUN_COUNT"
+  touch "\$STUB_STOP_FILE"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin36/docker"
+  cat > "$TEST_DIR/bin36/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$SLEEP_LOG"
+STUB
+  chmod +x "$TEST_DIR/bin36/sleep"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin36/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin36/ps"
+  rm -f "$TEST_DIR/state-36/stop" "$TEST_DIR/state-36/pids" "$TEST_DIR/run36.count"
+  : > "$TEST_DIR/sleep36.log"
+  (
+    export PATH="$TEST_DIR/bin36:$PATH"
+    export COURSIA_RUNNER_NAME_PREFIX="test-prefix-36"
+    export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-36"
+    export COURSIA_RUNNER_HEALTHY_CYCLE_SECS=9999
+    export COURSIA_RUNNER_BACKOFF_BASE=3
+    export COURSIA_RUNNER_BACKOFF_CAP=6
+    export STUB_STOP_FILE="$TEST_DIR/state-36/stop"
+    export STUB_RUN_COUNT="$TEST_DIR/run36.count"
+    export SLEEP_LOG="$TEST_DIR/sleep36.log"
+    timeout --kill-after=2 30 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/err36.log"
+  )
+  if grep -q "cycle court (rc=0" "$TEST_DIR/err36.log" \
+     && ! grep -q -- "-- voir " "$TEST_DIR/err36.log"; then
+    ok "cycle rc=0 journalise sans rappel de journal (le rappel reste reserve aux echecs)"
+  else
+    ko "rappel indu sur rc=0, ou ligne rc=0 absente : $(head -3 "$TEST_DIR/err36.log")"
+  fi
+)
+echo ""
+# --- Test 37 : etat NON QUALIFIE -- fail-closed, jamais retire (#15278) -----
+# Le retrait est borne par une LISTE d'etats prouves non en cours
+# (created/exited/dead), pas par une liste d'exclusion. Un etat que ce script
+# ne qualifie pas (`restarting`, ou un etat qu'une version future de docker
+# introduirait) ne doit donc PAS autoriser une destruction : c'est le seul
+# cote ou l'erreur tue un job legitime.
+echo "Test 37 : etat non qualifie (restarting) -- nom considere detenu, jamais retire (#15278)"
+(
+  cd "$SCRIPT_DIR"
+  unset PS_OUTPUT
+  mkdir -p "$TEST_DIR/bin37" "$TEST_DIR/state-37"
+  cat > "$TEST_DIR/bin37/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "info" ]; then exit 0; fi
+if [ "\$1" = "image" ] || [ "\$1" = "volume" ]; then exit 0; fi
+if [ "\$1" = "inspect" ]; then
+  # 'restarting' n'est ni en cours ni prouve mort : le garde doit attendre.
+  # Le conteneur rend le nom au sondage STUB_ORPHAN_POLLS+1.
+  N="\$(cat "\$STUB_INSPECT_COUNT" 2>/dev/null || echo 0)"
+  N=\$(( N + 1 ))
+  echo "\$N" > "\$STUB_INSPECT_COUNT"
+  if [ "\$N" -le "\${STUB_ORPHAN_POLLS:-2}" ]; then echo "restarting"; fi
+  exit 0
+fi
+if [ "\$1" = "rm" ]; then echo "\$*" >> "\$STUB_RM_LOG"; exit 0; fi
+if [ "\$1" = "run" ] && [ "\$3" = "--entrypoint" ]; then
+  case "\$*" in
+    *work_cache_health.sh*)
+      echo "\${STUB_IMG_HEALTH_SHA:-$REPO_HEALTH_SHA}  /opt/runner/work_cache_health.sh"
+      ;;
+    *)
+      echo "\${STUB_IMG_ENTRYPOINT_SHA:-$REPO_ENTRYPOINT_SHA}  /opt/runner/entrypoint.sh"
+      ;;
+  esac
+  exit 0
+fi
+if [ "\$1" = "run" ]; then
+  RUNS="\$(cat "\$STUB_RUN_COUNT" 2>/dev/null || echo 0)"
+  RUNS=\$(( RUNS + 1 ))
+  echo "\$RUNS" > "\$STUB_RUN_COUNT"
+  touch "\$STUB_STOP_FILE"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin37/docker"
+  cat > "$TEST_DIR/bin37/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$SLEEP_LOG"
+STUB
+  chmod +x "$TEST_DIR/bin37/sleep"
+  cp "$TEST_DIR/bin/gh" "$TEST_DIR/bin37/gh"
+  cp "$TEST_DIR/bin/ps" "$TEST_DIR/bin37/ps"
+  rm -f "$TEST_DIR/state-37/stop" "$TEST_DIR/state-37/pids" \
+        "$TEST_DIR/run37.count" "$TEST_DIR/inspect37.count"
+  : > "$TEST_DIR/rm37.log"; : > "$TEST_DIR/sleep37.log"
+  (
+    export PATH="$TEST_DIR/bin37:$PATH"
+    export COURSIA_RUNNER_NAME_PREFIX="test-prefix-37"
+    export COURSIA_RUNNER_STATE_DIR="$TEST_DIR/state-37"
+    export COURSIA_RUNNER_HEALTHY_CYCLE_SECS=9999
+    export COURSIA_RUNNER_BACKOFF_BASE=3
+    export COURSIA_RUNNER_BACKOFF_CAP=6
+    export COURSIA_RUNNER_NAME_RECLAIM_POLL_SECS=5
+    export COURSIA_RUNNER_NAME_RECLAIM_WARN_SECS=10
+    # 3 sondages tenus : c'est ce qui fait atteindre le seuil d'avertissement
+    # (waited=10 au 3e) avant que le nom ne soit rendu au 4e. A 2 sondages la
+    # boucle sort a waited=5 et l'avertissement ne peut pas tomber -- c'est un
+    # fait de cadence, pas un defaut du garde.
+    export STUB_ORPHAN_POLLS=3
+    export STUB_STOP_FILE="$TEST_DIR/state-37/stop"
+    export STUB_RUN_COUNT="$TEST_DIR/run37.count"
+    export STUB_INSPECT_COUNT="$TEST_DIR/inspect37.count"
+    export STUB_RM_LOG="$TEST_DIR/rm37.log"
+    export SLEEP_LOG="$TEST_DIR/sleep37.log"
+    timeout --kill-after=2 30 bash "$SCRIPT_DIR/supervise.sh" start 1 >/dev/null 2>"$TEST_DIR/err37.log"
+  )
+  if [ ! -s "$TEST_DIR/rm37.log" ]; then
+    ok "aucun retrait sur un etat non qualifie (fail-closed : l'inconnu ne detruit rien)"
+  else
+    ko "retrait interdit sur etat non qualifie : $(cat "$TEST_DIR/rm37.log")"
+  fi
+  if grep -q "nom toujours detenu (restarting)" "$TEST_DIR/err37.log" \
+     && [ "$(cat "$TEST_DIR/run37.count" 2>/dev/null || echo 0)" = "1" ]; then
+    ok "l'etat non qualifie est traite comme 'detenu', puis le slot reprend a la liberation"
+  else
+    ko "attente sur etat non qualifie attendue : err=$(head -2 "$TEST_DIR/err37.log") runs=$(cat "$TEST_DIR/run37.count" 2>/dev/null || echo 0)"
+  fi
+)
+echo ""
+
+
 # --- Verdict agrege ---------------------------------------------------------
 # `|| echo 0` serait un piege ici, et il l'a ete : `grep -c` IMPRIME "0" avant
 # de sortir 1 quand il ne trouve rien, donc le repli SUFFIXE un second zero au


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-lean #15803

See #15278

## Le defaut

Le nom d'un conteneur est un verrou **global au daemon**, pas au client. Un `systemctl restart` du superviseur tue le **client** `docker run` mais **pas** le conteneur, qui garde son nom jusqu'a la fin de son job. La generation suivante relance donc sous un nom deja pris et boucle en `rc=125` — mesure `ai-01` du 2026-09-09 pendant le passage de 6 a 10 slots (`#15278`) : **3 slots sur 10 bloques, ~4 minutes**.

Le seul message qui explique la cause (« `Conflict. The container name ... is already in use` ») part sur la **redirection du `docker run`**, donc dans `$STATE_DIR/<nom>.log` — et le journal ne nommait aucun fichier. L'operateur lisait `rc=125` et n'etait oriente vers rien.

## Ce que fait le garde

`reclaim_container_name()` est appele juste avant `docker run`, dans `slot_loop` **et** `waiter_loop` (un waiter orphelin detient son nom de la meme facon).

Trois proprietes, dans cet ordre d'importance :

1. **Il attend la liberation en sondant** (`docker inspect -f '{{.State.Status}}'`, intervalle `COURSIA_RUNNER_NAME_RECLAIM_POLL_SECS`, defaut 5 s). La reprise se fait dans la seconde qui suit la liberation, **au lieu d'attendre la prochaine marche du backoff** (`BACKOFF_BASE` -> `BACKOFF_CAP`, 300 s). C'est ce « au-dela de la duree du job orphelin » que l'acceptance ferme : la borne devient *la duree du job orphelin + un intervalle de sondage*.
2. **Il ne retire un conteneur que si son etat est PROUVE non en cours** — allowlist `created` / `exited` / `dead`. `docker inspect` et non `docker ps` : le second ne voit pas un conteneur arrete, precisement le residu qu'on veut pouvoir retirer sans risque.
3. **Il n'abandonne pas et ne derive pas de nom de generation.** Un second conteneur pour le meme slot doublerait la reservation CPU de ce slot, contre la clause de tete du fichier (« l'hote prime sur la CI »). Un job orphelin qui ne rend jamais son nom est un probleme **docker**, pas un probleme de boucle : on le dit periodiquement, avec l'etat observe et le nom du journal, pour que l'operateur puisse agir. `stop` reste prioritaire sur l'attente.

Le defaut 2 de l'issue est traite dans le meme geste : sur `rc != 0`, `cycle_backoff` suffixe le message d'un ` -- voir $STATE_DIR/<nom>.log`.

## Critere d'acceptation 3 — pourquoi la solution ne peut pas tuer un job legitime

L'argument tient a **la forme du predicat**, pas a la prudence de l'auteur.

Le retrait est borne par une **allowlist** (`created|exited|dead`), pas par une liste d'exclusion. La difference est le sens de l'erreur :

| Etat observe | Allowlist (cette PR) | Liste d'exclusion (`running|paused` puis `*` -> rm) |
|---|---|---|
| `running`, `paused` | attend | attend |
| `created`, `exited`, `dead` | **retire** (aucun job dedans) | retire |
| `restarting`, `removing`, etat inconnu d'une version future de docker | **attend** (fail-closed) | **retire** — tue un job |

Avec une liste d'exclusion, tout etat qu'on n'a pas anticipe autorise une destruction. Avec l'allowlist, il faut avoir **nomme** l'etat pour que la destruction soit permise : l'inconnu ne detruit rien. C'est le seul cote ou se tromper tue un travail legitime, et un runner ephemere qui travaille est en etat `running` par definition.

**Controle de non-regression** : le test 33 verifie que `docker rm` n'est **jamais** appele sur un nom detenu par un conteneur en cours (le job legitime survit), et le test 37 verifie la meme propriete sur un etat **non qualifie** (`restarting`) — la ou l'allowlist et la liste d'exclusion divergent. Le test 34 est le controle positif : sur un etat prouve mort (`exited`), le residu **est** retire, une fois, et le log le dit. Sans 34, un garde qui n'appelle jamais `rm` passerait 33 et 37.

## L'acceptance, critere par critere

| Critere de #15278 | Reponse |
|---|---|
| Aucun slot bloque au-dela de la duree du job orphelin (ou borne documentee) | **Premiere branche tenue.** La reprise survient des que `docker inspect` ne rend plus d'etat, soit au plus un intervalle de sondage (5 s) apres la liberation. La borne est aussi documentee en tete de la fonction. |
| Un `rc != 0` nomme le fichier ou lire la cause | Le message porte ` -- voir $STATE_DIR/<nom>.log`. Le controle negatif (test 36) verifie qu'un cycle `rc=0` ne porte **pas** ce rappel : la mention reste reservee aux echecs, elle ne devient pas decorative. |
| La solution ne peut pas tuer un conteneur executant un job legitime — argumente | Section precedente : allowlist fail-closed, plus les tests 33 et 37. |

## Validation

**Suite `test_supervise_guards.sh` — 81 PASS / 0 FAIL, `rc=0`**, sur les deux plateformes :

| Plateforme | Resultat | Note |
|---|---|---|
| Linux / WSL (la plateforme sur laquelle la CI execute la suite) | **81 PASS / 0 FAIL**, `rc=0` | test 25 a 70/70 |
| MSYS / Git Bash (poste Windows) | **81 PASS / 0 FAIL**, `rc=0` | test 25 a 70/70 sur ce run |

Le test 25 est un **flake de cadencement hote preexistant** (budget de 70 cycles en 60 s ; sur MSYS chaque spawn de stub coute ~200 ms). Il a deja ete mesure en echec sur `origin/main` pristine (63/70), donc sans rapport avec cette PR — et il passe sur les deux plateformes au run de validation ci-dessus.

**Tests ajoutes** : 33, 34, 35, 36, 37. Diff du fichier de test = **411 insertions, 0 suppression, un seul hunk contigu** — aucun test existant n'est touche, aucun n'est desactive.

**Diff total** : 2 fichiers, +531 / -10.

**Invariants verifies dans le code** :

- l'appel a `reclaim_container_name` est place **avant** `local t0=$SECONDS`, pour que l'attente ne soit pas comptee dans `lifetime` — une attente de plusieurs minutes suivie d'un echec instantane se lirait sinon comme un « cycle long », donc « pas un emballement », et **masquerait l'echec reel** ;
- les deux nouvelles bornes passent `_validate_backoff_value` (entier decimal, <= 18 chiffres, >= 1). Le parametre `ref` de cette fonction etait **fige sur `#15166`** : il est generalise pour que ces deux bornes soient attribuees a `#15278` ;
- `STOP_FILE` est teste a chaque tour de sondage : un `stop` demande pendant l'attente rend la main immediatement (`continue` sur `return 1`).

## Hors scope

- Le cas « le job orphelin ne rend JAMAIS son nom » (conteneur docker reellement bloque) reste un probleme docker : le garde le **signale periodiquement** avec l'etat et le journal, il ne le resout pas — c'est exactement le comportement que l'acceptance autorise en seconde branche.
- Le `rc=125` lui-meme n'est pas supprime : il est rendu **diagnosticable**. Le conflit de nom ne devrait plus se produire, mais s'il se produit encore pour une autre raison, le journal est nomme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
