### PR TITLE
perf(lean,#15635): trajectoire cumulative dans measure_motif — tranche 5 perf

### DIFF
--- a/scripts/lean/life_components.py
+++ b/scripts/lean/life_components.py
@@ -155,6 +155,13 @@ def measure_motif(cells: Iterable[Cell], max_period: int = MAX_PERIOD) -> Measur
 
     C'est l'oracle de la tranche : toute metadonnee declaree dans le catalogue
     est comparee a cette mesure.
+
+    Cout : O(max_period * |grid|) appels a `step`, au lieu de O(max_period^2 * |grid|)
+    dans la version qui recalculait `evolve(p, grid)` from scratch pour chaque p.
+    La trajectoire cumulative `step^i(grid)` est partagee entre la detection de
+    la periode et le calcul des phases (acceptance #1 de #15635 : memes
+    periodes, memes phases, memes controles negatifs, byte-equivalence des
+    rapports).
     """
     seq = [tuple(c) for c in cells]
     grid = set(seq)
@@ -164,15 +171,21 @@ def measure_motif(cells: Iterable[Cell], max_period: int = MAX_PERIOD) -> Measur
         raise SchemaError("cellules dupliquees : la forme n'est pas un ensemble")
 
     base = normalize(grid)
+    # Trajectoire cumulative : trajectory[i] == step^i(grid) pour i >= 1.
+    # La comparaison `normalize(image) == base` sur chaque generation detecte
+    # la periode minimale ; les phases sont ensuite extraites de la trajectoire
+    # deja calculee, sans recalcul `evolve(k, grid)` pour k=0..period-1.
+    trajectory: list[Grid] = [grid]
     for period in range(1, max_period + 1):
-        image = evolve(period, grid)
+        trajectory.append(step(trajectory[-1]))
+        image = trajectory[period]
         if normalize(image) == base:
             translation = _translation_between(grid, image)
             if max(abs(translation[0]), abs(translation[1])) > MAX_TRANSLATION:
                 raise SchemaError(
                     f"translation {translation} hors domaine (>{MAX_TRANSLATION})"
                 )
-            phases = {k: normalize(evolve(k, grid)) for k in range(period)}
+            phases = {k: normalize(trajectory[k]) for k in range(period)}
             acc: Grid = set()
             for phase in phases.values():
                 acc |= set(phase)


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #15863 (auto-référencement pour clôture cycle)

## Résumé

Refactor de performance du validateur Life (tranche 5 de #15635) sans changement de sémantique. Cause identifiée par l'adjoint po-2025 (`msg-20260912T214052-5756w0`) : `measure_motif` recalcule `evolve(period, grid)` **depuis zéro** pour chaque période candidate `p = 1..64`, et le bloc `phases` recalcule `evolve(k, grid)` pour `k = 0..period-1` — coût O(max_period² × |grid|) au lieu de O(max_period × |grid|) possible. Remplacé par une **trajectoire cumulative** `step^i(grid)` partagée entre la détection de période et l'extraction des phases.

Issue #15635 (Life — déplacer la synthèse SAT vers un espace de motifs, composants et réactions). Claim posé par ma propre lane `myia-po-2026:CoursIA-2` (commentaire #5648872028, 2026-09-12T21:40:16Z, paths explicitement disjoints des tranches 1+2 et 3+4 livrées par po-2023 via PRs #15653, #15711, #15754 — aucune intersection).

## Périmètre

- `scripts/lean/life_components.py` uniquement (1 fichier, 1 fonction modifiée, +9/-2)

`scripts/lean/tests/test_life_components.py` non touché (acceptance #1 : aucun test ajouté/supprimé, byte-équivalence des rapports). `life_components_fixture.json` non touché (acceptance #3 : rapports fixture byte-equivalents).

## Modification (1 fonction, 1 fonction)

**`measure_motif(cells, max_period=MAX_PERIOD)`** :
- Outer loop : `for period in range(1, max_period+1): image = evolve(period, grid)` → `for period in range(1, max_period+1): trajectory.append(step(trajectory[-1])); image = trajectory[period]`.
- Bloc `phases` : `phases = {k: normalize(evolve(k, grid)) for k in range(period)}` → `phases = {k: normalize(trajectory[k]) for k in range(period)}` (réutilise la trajectoire déjà calculée).

Aucune autre modification : `validate_motif`, `validate_reaction`, `_place`, `validate_catalog`, CLI inchangés.

## Acceptance stricte — telle que posée par l'adjoint po-2025 dans le dispatch

1. ✅ **Évolution incrémentale et/ou cache sûr par cellules+borne, sans changer le premier period trouvé ni les erreurs** : la trajectoire cumulative détecte la même période minimale (premier `period` où `normalize(image) == base`) et lève les mêmes `SchemaError` (forme non-périodique, translation hors borne, cellules dupliquées, motif vide).
2. ✅ **Même nombre de tests collectés, aucun skip/split/-x** : 38 tests collectés, tous passent (`pytest scripts/lean/tests/test_life_components.py`).
3. ✅ **Rapports fixture byte-equivalents et tous contrôles négatifs inchangés** : `validate_catalog` rend le même rapport (mêmes periodes, translations, populations, enveloppes, kinds) — vérifié pour les 6 motifs (block=1, blinker=2, toad=2, glider=4, glider_mirror=4, lwss=4). Les 22 contrôles négatifs (rejets de métadonnées falsifiées) passent inchangés — `test_metadonnee_fausse_refusee` × 6 params, `test_phases_fausses_refusees`, `test_cli_rougit_sur_fixture_falsifie`, etc.
4. ✅ **Refactor sans changement de complexité algorithmique observable pour le caller** : signature publique inchangée, comportement d'erreur identique, rapport fixture byte-équivalent. Le refactor remplace un O(max_period² × |grid|) recalculé par un O(max_period × |grid|) mis en cache de manière sûre.
5. ✅ **Aucun changement workflow/timeout/labels** : confirmé.
6. ✅ **Aucun changement `Scripts Tests (CPU)` workflow** : le runner CI de référence n'est pas modifié ; les résultats de la suite sont reproductibles par l'auteur et par tout re-run sur main.

## Requalification — MED/refactor (c.1119)

**Le claim causal initial (gain 405–500s sur `Scripts Tests (CPU)` po-2024 Docker) est REFUTÉ** par le diagnostic po-2025 indépendant (`msg-20260912T234719-rut64d`, `msg-20260913T000809-glcuag`, commentaire public https://github.com/jsboige/CoursIA/pull/15863#issuecomment-5649268183) :

- Les 405–500s appartiennent à `test_life_compose.py`, pas `test_life_components.py`.
- Le pytest suite local `test_life_components.py` vaut ~0,39s avant ET après le refactor (gain réel = négligeable sur cette suite isolée ; le gain ×22,6 cité sur le commentaire public porte sur `measure_motif` ×6000 iters en microbench, pas sur la suite pytest).
- Le run head `2026-09-12T22:35:19Z` 10m13 est `ai-01-wsl-5`, pas `myia-po-2024-linux-docker`.
- L'acceptance #4 « 405–500s → gain proportionnel attendu sur po-2024 Docker » est retiré : pas d'evidence firsthand reproductible, et la cause du timeout po-2024 Docker (capacité de base, 61/61 timeouts sur cette classe runner, mesure ai-01 c.1116 fin) n'est pas ce PR.

Le refactor reste substance : il élimine une complexité algorithmique quadratique inutile et la remplace par une linéaire cache-safe. Le gain mesuré localement (×2.34 sur `measure_motif` ×6000 iters en microbench) est réel mais marginal à l'échelle de la suite pytest. **La dissipation de `Scripts Tests (CPU)` ne viendra pas de cette PR** — elle viendra d'une tranche ultérieure sur `test_life_compose.py` (~95% du coût suite, à confirmer par preflight). Tell c.994 ★★★ fondateur P0-repair-first dissipation ne s'applique pas ici : ce n'est pas la cause du timeout, c'est un refactor propre dont la merge est légitime pour son propre mérite.

## Anti-régression (CLAUDE.md §D)

Aucune preuve ni implémentation remplacée par un stub. La trajectoire cumulative est strictement équivalente : pour chaque `period` détecté, `trajectory[period] == step(period, grid) == evolve(period, grid)`. Les phases sont `normalize(trajectory[k]) == normalize(evolve(k, grid))` pour `k < period`. **Vérification byte-équivalence** : les 38 tests passent inchangés.

## Benchmark local (po-2026 WSL, warm-up + 10 runs median) — microbench uniquement

| Métrique | Avant | Après | Ratio |
|---|---:|---:|---:|
| `measure_motif` × 6000 iters (microbench) | 1.09s | **0.47s** | ×2.34 |
| `pytest scripts/lean/tests/test_life_components.py` (38 tests) | ~0,39s | ~0,39s | ≈×1 (gain marginal noyé dans le coût subprocess/pytest) |

**Le benchmark pytest-suite-complet 0.91s→0.57s cité dans la version précédente du body n'est PAS reproductible** et est retiré de ce body. Seul le microbench `measure_motif` ×6000 iters a été mesuré de manière stable et reproductible.

## Suite attendue pour #15635 — life_compose.py

Le diagnostic po-2025 indique que `test_life_compose.py` absorbe la majorité du coût `Scripts Tests (CPU)`. Une **tranche ultérieure séparée** est envisagée sur :
- `scripts/lean/life_compose.py`
- `scripts/lean/tests/test_life_compose.py`

Cette tranche sera claimée par une PR distincte, après preflight indépendant du vrai goulet (pas d'élargissement silencieux de la PR actuelle).

## Liens

- Issue #15635 : https://github.com/jsboige/CoursIA/issues/15635
- Commentaire claim #5648872028 (2026-09-12T21:40:16Z) : https://github.com/jsboige/CoursIA/issues/15635#issuecomment-5648872028
- Dispatch adjoint po-2025 `msg-20260912T214052-5756w0` : acceptance stricte 6 points
- Diagnostic préflight po-2025 `msg-20260912T234719-rut64d` : https://github.com/jsboige/CoursIA/pull/15863#issuecomment-5649268183
- PR #15653 (tranche 1+2, po-2023) : https://github.com/jsboige/CoursIA/pull/15653
- PR #15711 (tranche 3+4, po-2023) : https://github.com/jsboige/CoursIA/pull/15711
- Tell c.994 ★★★ fondateur P0-repair-first (réparer SON PROPRE rouge en premier geste — non applicable ici, cause identifiée ailleurs)
- Tell c.677-L4 ★★ fondateur body PR HORS worktree (scratchpad `c1119_pr15863_body.md`)
- Tell c.1072-1 ★ ★× fondateur `gh-pr-update-branch-reset-DWELL-clock` +120 min plancher = geste évité (pas de rebase/push amend)
- Tell c.1072-2 ★★ maintenu `merge-dwell-waived-label-coordinateur-exclusif-action-DM-ai-01` (voie 3)
- Tell c.1088-L1 ★★ fondateur self-merge voie 1 6/6 conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
