### PR TITLE
ci(#15228): cabler la suite de controle du dry-run de dimensionnement (acceptance A)

### DIFF
--- a/.github/workflows/dryrun-sizing-control.yml
+++ b/.github/workflows/dryrun-sizing-control.yml
@@ -1,0 +1,106 @@
+name: Dry-run sizing control (ai-01 reference copies)
+
+# Acceptance A de #15228 (les trois reserves NanoClaw du 2026-09-08 sur #15214).
+#
+# La suite de controle du dry-run de dimensionnement existe, elle est serieuse
+# -- 674 lignes, ~70 assertions, et son sujet est le MODE DE DEFAILLANCE (la
+# premiere version du script rendait « passe » quand le budget etait illisible)
+# -- mais elle n'etait appelee par AUCUN workflow. Un test que personne ne lance
+# est un test qui cessera de passer sans que personne ne l'apprenne : il ne
+# reste de lui que la confiance qu'il a value. Le cablage est presque gratuit,
+# la suite s'injecte deja par variables d'environnement et ne demande aucun
+# service.
+#
+# Aucune machine reelle n'est touchee par la suite : pas de systemd (un faux
+# `systemctl` est fabrique sous un TMPDIR efface a la sortie), pas de `/etc`,
+# pas de redemarrage, pas de docker. D'ou un runner GitHub-hosted : le job ne
+# reclame ni slot auto-heberge (ressource rare, cf la famine de #12817) ni
+# secret, et n'entre donc pas dans `SELF_HOSTED_WORKFLOW_ALLOWLIST`.
+#
+# DEUX ECHECS DISTINCTS, jamais confondus (doctrine #8819 « non mesure n'est
+# pas verifie ») :
+#
+#   rc=1  une assertion est tombee          -> la configuration REGRESSE
+#   rc=2  le harnais a ABANDONNE            -> la suite n'a RIEN mesure
+#
+# Le second n'est pas un succes deguise : il est rouge lui aussi, avec un
+# message qui dit qu'on ne sait rien -- surtout pas que tout va bien. C'est
+# exactement le piege que ce harnais a ete ecrit pour fermer (un budget
+# illisible rendait « passe »), et le cabler en confondant les deux le
+# rouvrirait au niveau du workflow.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'scripts/ci/docker/linux-runner/persist/ai-01/**'
+      # Self-cover (#8822) : un workflow filtre par chemins doit lister son
+      # propre fichier en premier. Sans cela, la PR qui retire le dernier
+      # chemin filtre ne le re-declenche plus -- le job ne peut alors plus ni
+      # re-mesurer ni retirer ce qu'il a pose, et son verdict survit a sa cause.
+      - '.github/workflows/dryrun-sizing-control.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dryrun-sizing-control-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dryrun-sizing-control:
+    name: "Dry-run sizing control (ai-01 reference copies)"
+    # GitHub-hosted, et non auto-heberge : la suite est du bash pur, sans
+    # secret ni acces machine, et dure quelques minutes. Un `runs-on`
+    # auto-heberge exigerait une entree dans SELF_HOSTED_WORKFLOW_ALLOWLIST et
+    # une garde anti-fork pour un job qui n'en a pas besoin.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Syntaxe des deux scripts
+        run: |
+          set -euo pipefail
+          bash -n scripts/ci/docker/linux-runner/persist/ai-01/dryrun-sizing-control.sh
+          bash -n scripts/ci/docker/linux-runner/persist/ai-01/test-dryrun-sizing-control.sh
+          echo "Les deux scripts parsent."
+
+      - name: Suite de controle (fixtures, aucune machine reelle)
+        run: |
+          # `set -e` est volontairement ABSENT : il faut lire le code de retour
+          # de la suite pour distinguer une assertion cassee d'un abandon du
+          # harnais. `pipefail` n'a pas d'objet ici (aucun pipe).
+          set -uo pipefail
+
+          SUITE=scripts/ci/docker/linux-runner/persist/ai-01/test-dryrun-sizing-control.sh
+
+          # TMPDIR POSIX explicite. La suite sonde elle-meme que ses faux
+          # gagnent sur PATH et ABANDONNE (rc=2) sinon -- avec un TMPDIR en
+          # forme Windows, `command -v systemctl` resout le VRAI binaire et la
+          # suite appellerait le vrai `chown`. On ne devine pas la forme de
+          # TMPDIR (un proxy) : la suite mesure l'effet, et on lui donne le
+          # repertoire canonique.
+          TMPDIR=/tmp bash "$SUITE"
+          rc=$?
+
+          case "$rc" in
+            0)
+              echo "::notice::Suite verte -- les refus attendus et les succes attendus sont tous tenus."
+              ;;
+            1)
+              echo "::error::ASSERTION CASSEE. Le dry-run de dimensionnement ne tient plus son contrat : voir le detail 'KO' ci-dessus. La suite A mesure, et elle a trouve une regression."
+              exit 1
+              ;;
+            2)
+              echo "::error::ABANDON DU HARNAIS. L'isolation a echoue (faux binaires non prioritaires sur PATH, ou script sous test introuvable) : la suite n'a RIEN mesure. Ni conformite ni non-conformite ne sont etablies -- ne pas lire ce rouge comme une regression de la configuration."
+              exit 1
+              ;;
+            *)
+              echo "::error::Code de retour inattendu ($rc) -- verdict indetermine, ne pas conclure."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA — prev: LIGHT/readme #15811

See #15228

## Le defaut

`scripts/ci/docker/linux-runner/persist/ai-01/test-dryrun-sizing-control.sh` (674 lignes) tenait 76 assertions et **n'etait appelee par aucun workflow** — verifie : `git grep -rn "dryrun-sizing-control" origin/main -- .github/` ne rend rien. Un test que personne ne lance cessera de passer sans que personne ne l'apprenne ; il ne reste de lui que la confiance qu'il a value.

La suite ne controle pas une fonctionnalite : elle controle le **mode de defaillance** du dry-run. La premiere version de `dryrun-sizing-control.sh` rendait « passe » quand le budget etait illisible, et le refus n'est apparu qu'au redemarrage suivant, 6 h 35 plus tard (en-tete du script). Le cablage est presque gratuit : la suite s'injecte deja par variables d'environnement et ne demande aucun service.

## Ce que la PR fait

Un workflow `dryrun-sizing-control.yml`, filtre sur `persist/ai-01/**`, plus l'auto-couverture de son propre fichier (#8822).

## Acceptance A — la dependance annoncee est levee

po-2023 avait verifie le 2026-09-10 que A/B/C ciblaient des fichiers absents de `origin/main` (branche #15214 encore ouverte). Ce constat etait **correct a cette date**. Depuis, **#15214 est mergee (2026-09-12T00:12:43Z)** et les deux scripts sont sur `origin/main` (`git ls-tree`). A est donc executable ; seule A est dans cette PR.

## Verification — sur la plateforme cible, pas sur Windows

La suite a d'abord ete passee dans un conteneur `ubuntu:24.04`, ce que la CI utilisera, et **non** sur Git Bash ou deux refus ne sont pas exercables (leur `SKIP` y masquerait un ecart de plateforme) :

| Run | Resultat |
|---|---|
| Baseline, arbre intact | `reussis=76  echoues=0  non-exercables=1` — **rc=0** |
| **Controle positif**, SUT sabote | `reussis=75  echoues=1  non-exercables=1` — **rc=1** |

Le sabotage est du type exact que la suite existe pour attraper : dans `verdict_of()`, la branche `over "$1" "$BUDGET"` rendait `-> REFUSE`, elle rend `-> passe`. Le fichier parse (`bash -n` OK), le harnais n'abandonne pas, et **une** assertion tombe — la bonne. L'ecart entre les deux runs est d'exactement une assertion : c'est ce qui fait du second run un controle, et pas une simple observation.

## Les deux rouges ne se confondent pas

Le workflow distingue `rc=1` (une assertion est tombee -> la configuration regresse) de `rc=2` (le harnais a **ABANDONNE** : faux binaires non prioritaires sur PATH, ou script sous test introuvable -> **rien n'a ete mesure**). Les deux sont rouges, mais le second porte un message qui dit qu'on ne sait rien — surtout pas que tout va bien. Les confondre rouvrirait, au niveau du workflow, le piege que ce harnais a ete ecrit pour fermer : c'est la doctrine #8819 « non mesure n'est pas verifie ».

## Gardes du depot passees

- `check_self_hosted_runner_policy.py` -> `OK -- all self-hosted jobs satisfy isolation policy` (le job est GitHub-hosted : il n'entre pas dans l'allowlist).
- `check_workflow_label_paths.py` -> `Non-self-covered (VIOLATION): 0`.

Runner **GitHub-hosted** et non auto-heberge, a dessein : la suite est du bash pur sous `TMPDIR`, sans secret ni acces machine (pas de systemd — un faux `systemctl` est fabrique —, pas de `/etc`, pas de redemarrage, pas de docker). Le job ne reclame donc ni entree d'allowlist, ni slot auto-heberge — ressource rare (#12817).

## Hors perimetre, declare

- **Acceptance B** (exercer les deux refus symlink / ACL la ou la plateforme le permet) : **non traitee**.
- **Acceptance C** (organe periodique comparant copies de reference et fichiers vivants) : **non traitee**.
- **Acceptance D** (l'artefact tracke demande 16 vCPU pour un budget de 8) : **non traitee**.

`See #15228` — contribution partielle, pas `Closes`.

## G-VAR-1, declare honnetement

`guard` est un genre **META** : cette PR **ne tient pas le plancher G-VAR-1**, quel que soit son tier. Le cycle doit encore un grain DEEP/MED de genre CONTENU. Je le declare plutot que de requalifier le genre pour la forme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
