### PR TITLE
fix(ci,#15545): exempter la fixture de contrôle positif du piège symétrique du denominator check

### DIFF
--- a/scripts/slides/build_advisory.sh
+++ b/scripts/slides/build_advisory.sh
@@ -57,9 +57,33 @@ is_deck_dir() {
 # deck_dirs() feeds a process substitution (subshell), a probe side-effect set
 # here could not reach the parent; the symmetric probe runs in check_denominator
 # itself (where exit status is decided). deck_dirs() stays stdout-pure.
+# A positive-control fixture declared by ANOTHER organ is exempt from the
+# symmetric trap below. `slides/_composition-control/slides.md` is the fixture
+# armed by #15545 for slides-composition-advisory.yml: that workflow REQUIRES
+# the deck at exactly this path (`CTRL_DIR=slides/_composition-control`, it
+# copies `slides.md` -> `dev.md` to arm a deterministic HORS_CANVAS defect) and
+# excludes it from its own discovery by name (`-not -path
+# '*/_composition-control/*'`). Without the reciprocal exemption here, one
+# organ's positive control is the other organ's permanent red -- and it was:
+# `Shebang + dry-run advisory` fails on `main` itself, and on every PR, since
+# 6c903ed6af.
+#
+# The exemption is deliberately NARROW -- an exact basename, not a `_*` glob.
+# A `_`-prefixed dir carrying a REAL deck must keep tripping the trap: that is
+# the hole #8929 closed, and a glob here would reopen it for free.
+_is_control_fixture_dir() {
+  case "$(basename "$1")" in
+    _composition-control) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 _warn_nonconvention_with_deck() {
   # Emit ERROR to stderr if $1 carries a deck; always returns 0 (set -e safe).
   local d="$1" dk has_deck=0
+  if _is_control_fixture_dir "$d"; then
+    return 0
+  fi
   [ -f "$d/slides.md" ] && has_deck=1
   for dk in "$d"/deck-*.md; do [ -f "$dk" ] && has_deck=1; done
   if [ "$has_deck" -eq 1 ]; then


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #15761

## Le défaut : deux organes, une fixture, un rouge permanent

`Shebang + dry-run advisory` échoue **sur `main` lui-même**, et donc sur chaque PR ouverte, depuis `6c903ed6af`. Ce n'est pas une régression d'une lane : ce sont deux organes dont les contrats se contredisent sur le même fichier.

| Organe | Ce qu'il exige de `slides/_composition-control/slides.md` |
|---|---|
| `slides-composition-advisory.yml` (#15545) | qu'il **existe à exactement ce chemin** — `CTRL_DIR=slides/_composition-control`, copie `slides.md` → `dev.md` pour armer un défaut `HORS_CANVAS` déterministe. Il l'exclut de sa propre découverte par son nom (`-not -path '*/_composition-control/*'`, `grep -v '^slides/_composition-control/'`) |
| `build_advisory.sh check` (#8929) | qu'**aucun** dir hors convention `NN/SN` ne porte de `slides.md` — le piège symétrique, qui attrape le deck invisible à la découverte |

Le contrôle positif d'un organe était le rouge permanent de l'autre. Aucun des deux n'a tort isolément ; il manquait la réciproque de l'exclusion que #15545 s'accorde déjà à lui-même.

## Le correctif, et pourquoi il est étroit

Une exemption nommée par **basename exact**, jamais un glob `_*`. Un dir préfixé `_` qui porterait un **vrai** deck doit continuer à rougir — c'est précisément le trou que #8929 a fermé, et un glob le rouvrirait gratuitement.

## Mesure — le contrôle négatif, pas seulement le vert

Un motif de détection se valide **par ses faux négatifs**. Trois passes sur un arbre jetable via `SLIDES_DIR`, plus le dépôt réel :

| Cas | Attendu | Mesuré |
|---|---|---|
| fixture `_composition-control` seule | PASS | `rc=0`, `Denominator check: PASS` |
| **+ un autre dir non-convention portant un deck** | **FAIL** | `rc=1`, `ERROR: '_zz-vrai-deck-cache' porte un deck ... #8929` |
| dépôt réel, après correctif | PASS | `rc=0`, `17 dirs / 20 decks, 17/17 couverts` |

La deuxième ligne est celle qui compte : elle prouve que l'exemption n'a pas désarmé le piège, elle l'a rendu compatible avec la fixture d'un autre organe.

## Portée

`Shebang + dry-run advisory` est **non bloquant** : ce correctif ne débloque mécaniquement aucune PR. Il retire un rouge permanent que trois lanes ont déjà cité ce cycle comme « rouge imputé à la base » dans leur justification de `--ignore-red`. Un advisory rouge en permanence n'est plus un signal : c'est du bruit qui apprend à ignorer la colonne.

**Genre** : `guard` (le script porte son propre statut d'échec, consommé par un job) — classe META, ce grain **ne tient pas** le plancher G-VAR-1 de mon cycle, et je le déclare comme tel.

See #15545, #8929, #8817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
