### PR TITLE
feat(guards,#15867): les deux organes de liens couvrent les decks slides/

### DIFF
--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -2,8 +2,8 @@
 """Check for broken relative markdown links and orphan docs across the repository.
 
 Scans CLAUDE.md, index.md, PARCOURS.md, docs/, .claude/rules/, .claude/agents/,
-.claude/skills/, and all README.md files for relative links and verifies targets
-exist.
+.claude/skills/, every ``slides/<deck>/slides.md`` deck, and all README.md files
+for relative links and verifies targets exist.
 
 Also detects orphan .md files in docs/ (not referenced by any scanned file).
 
@@ -14,6 +14,16 @@ Usage:
     python scripts/check_docs_links.py --check --base origin/main
     python scripts/check_docs_links.py --quiet                # Minimal output (for CI)
     python scripts/check_docs_links.py --orphans              # Also report orphan docs
+    python scripts/check_docs_links.py --expect-broken 1      # Positive control (see below)
+
+Positive control
+----------------
+``--expect-broken N`` arms an in-band control: the scan must find AT LEAST ``N``
+broken links, otherwise it exits 2. Without it, "no broken link" is
+indistinguishable from a dead detection path (model:
+``scripts/notebook_tools/scan_slidev_composition.py``, ``controle_positif_*``).
+Point it at a tree where a link was deliberately broken, and a healthy organ
+renders rc=1 (a real finding), while a dead one renders rc=2 (control unmet).
 
 ``--check`` accepts two independent excuses for a broken link. The frozen
 ``baseline_docs_links.json`` covers paths with no comparison revision (manual
@@ -53,6 +63,20 @@ SCAN_SCOPES = [
     ".claude/agents/",
     ".claude/skills/",
 ]
+
+# Deck scope (#15867). `slides/<deck>/slides.md` was watched by NO organ: the
+# #15023 content tranche wrote 17 dead relative links on `03-logique` (PR
+# #15865) and this organ still reported "0 broken". Same failure mode as the
+# root entry points above -- `index.md` rotted because nothing watched it.
+#
+# Decks are NOT added to SCAN_SCOPES on purpose: that list rglobs `*.md`, which
+# under `slides/` would drag in 119 non-deck markdown files (`analysis/`,
+# `extracted/`, the `.marp.md` siblings) holding 734 broken links of 1367 --
+# measured on `origin/main` 2026-09-13. Those are working artifacts, not the
+# delivered deck; merging them here would redden every PR. Only the deck file
+# the course actually ships is in scope.
+DECK_DIR = "slides"
+DECK_FILENAME = "slides.md"
 
 # Directories to skip when scanning and resolving.
 #
@@ -159,6 +183,38 @@ def _is_valid_target(target: str) -> bool:
     return True
 
 
+class DeckScopeEmpty(RuntimeError):
+    """`slides/` exists yet holds no deck file: the scope would be silently empty.
+
+    A scope that matches nothing renders "0 broken links" -- indistinguishable
+    from a detection path that never ran. Refusing loudly is the whole point
+    (#15867).
+    """
+
+
+def find_deck_files() -> list[Path]:
+    """Every `slides/<deck>/slides.md` under the deck directory, in path order.
+
+    Resolving the ``_archive/`` question the same way ``SKIP_DIRS`` does: an
+    archived deck is NOT skipped (this organ deliberately validates `_archive/`
+    READMEs -- see the SKIP_DIRS note). Returns [] only when `slides/` itself is
+    absent, which is the case in the tmp-tree tests; an existing but empty deck
+    scope raises instead.
+    """
+    slides = REPO_ROOT / DECK_DIR
+    if not slides.is_dir():
+        return []
+    decks = sorted(
+        p for p in slides.rglob(DECK_FILENAME) if not _should_skip(p)
+    )
+    if not decks:
+        raise DeckScopeEmpty(
+            f"{DECK_DIR}/ exists but no {DECK_DIR}/**/{DECK_FILENAME} was found -- "
+            f"refusing to report a clean scan from an empty scope (#15867)."
+        )
+    return decks
+
+
 def find_scan_files() -> list[Path]:
     """Collect all files to scan for links."""
     files = []
@@ -176,6 +232,11 @@ def find_scan_files() -> list[Path]:
         if not _should_skip(readme):
             if readme not in files:
                 files.append(readme)
+
+    # Add the slide decks (deck-only scope, see DECK_DIR).
+    for deck in find_deck_files():
+        if deck not in files:
+            files.append(deck)
 
     return files
 
@@ -523,10 +584,33 @@ def main():
                         help="Also report orphan docs")
     parser.add_argument("--quiet", action="store_true",
                         help="Minimal output")
+    parser.add_argument("--expect-broken", metavar="N", type=int, default=None,
+                        help="Positive control: require at least N broken links, "
+                             "else exit 2. Without it, 'no broken link' is "
+                             "indistinguishable from a dead detection path.")
     args = parser.parse_args()
 
     try:
         result = run_scan(report_orphans=args.orphans)
+
+        # The positive control is evaluated BEFORE any mode branch, so it is
+        # never silently ignored by --check/--baseline.
+        if args.expect_broken is None:
+            # Advisory, and only in the bare diagnostic scan: `--check` is the
+            # gate mode, whose contract is a single summary line on success
+            # (docs-link-check.yml), and a line printed on every green PR would
+            # be trained away within a week.
+            if not args.quiet and not args.check and not args.baseline:
+                print("WARNING: scan without an armed positive control -- "
+                      "'no broken link' is indistinguishable from a dead "
+                      "detection path (pass --expect-broken 1 to tell them apart).",
+                      file=sys.stderr)
+        elif len(result.broken) < args.expect_broken:
+            print(f"POSITIVE CONTROL FAILED: {len(result.broken)} broken link(s) "
+                  f"found, at least {args.expect_broken} expected -- the "
+                  f"instrument does not detect what it should.",
+                  file=sys.stderr)
+            sys.exit(2)
 
         if args.baseline:
             write_baseline(result)

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -433,7 +433,19 @@ TRANCHE1: list[Guard] = [
         source="docs-link-check.yml",
         paths=[
             "CLAUDE.md", "index.md", "PARCOURS.md",
-            ".claude/rules/**", "docs/**", "**/README.md",
+            # `.claude/agents/**` and `.claude/skills/**` were scanned by the
+            # organ since #7422 but watched by no gate path: editing a sub-agent
+            # or skill definition never ran check-links (#15867, found by the
+            # `test_every_declared_scope_is_reachable_from_the_gate` parity test
+            # that pins this list against SCAN_SCOPES).
+            ".claude/rules/**", ".claude/agents/**", ".claude/skills/**",
+            "docs/**", "**/README.md",
+            # Decks (#15867): the organ scans `slides/**/slides.md`, so the gate
+            # must fire when a deck changes -- otherwise a deck-only PR like
+            # #15865 (17 dead links) never runs it. Mirror of DECK_DIR in
+            # `scripts/check_docs_links.py`; pinned by
+            # `test_deck_scope_is_wired_into_the_fast_lane`.
+            "slides/**",
             "scripts/check_docs_links.py",
         ],
         argv=["python", "scripts/check_docs_links.py", "--check",

--- a/scripts/notebook_tools/check_link_label_agreement.py
+++ b/scripts/notebook_tools/check_link_label_agreement.py
@@ -35,6 +35,15 @@ Usage
 -----
     python scripts/notebook_tools/check_link_label_agreement.py [--json] [--fail]
     python scripts/notebook_tools/check_link_label_agreement.py --self-test
+
+Portee
+------
+Notebooks, READMEs de serie, `docs/`, et les decks `slides/**/slides.md`
+(#15867). Un deck cite ses notebooks par leur basename ; un renommage qui met a
+jour le href en laissant le libelle derriere produit exactement le defaut
+#13645. Le predicat n'a pas eu besoin d'etre assoupli pour la forme « basename
+sans extension » : il compare un identifiant de famille extrait des DEUX cotes,
+donc l'extension et la glose hors crochets ne le concernent pas.
 """
 
 from __future__ import annotations
@@ -49,6 +58,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 SCAN_GLOBS = ("MyIA.AI.Notebooks/**/*.ipynb", "MyIA.AI.Notebooks/**/README.md", "docs/**/*.md")
 EXCLUDE_PARTS = {".ipynb_checkpoints", "_archive", "_archives", ".lake", "node_modules", ".git"}
+
+# Decks (#15867). A deck cites its notebooks as `[Basename](../../MyIA.AI.Notebooks/...)`
+# -- the label IS the basename, so a rename that updates the href and leaves the
+# label behind is exactly the #13645 defect this organ exists for. Deck-only
+# scope: `slides/**/*.md` would pull in the `analysis/` trees and the `.marp.md`
+# siblings sourced from a different pipeline (see `scripts/check_docs_links.py`
+# DECK_DIR for the measured cost of the wider scope).
+DECK_DIR = "slides"
+DECK_GLOB = "slides/**/slides.md"
 
 # [texte](cible) -- cible non-http, non-ancre
 LINK_RE = re.compile(r"\[([^\]\n]{1,200})\]\(([^)\s]+?\.ipynb)(?:#[^)\s]*)?\)", re.I)
@@ -138,7 +156,7 @@ def main() -> int:
 
     findings, scanned = [], 0
     seen = set()
-    for glob in SCAN_GLOBS:
+    for glob in SCAN_GLOBS + (DECK_GLOB,):
         for p in REPO_ROOT.glob(glob):
             if not p.is_file() or p in seen or EXCLUDE_PARTS & set(p.parts):
                 continue
@@ -153,6 +171,16 @@ def main() -> int:
                     findings += check_text(p.read_text(encoding="utf-8"), rel)
                 except Exception:
                     pass
+
+    # Anti-silent-scan (#15867): `slides/` present but matching no deck would
+    # render "0 desaccord" indistinguishable from a scope that scanned nothing.
+    if (REPO_ROOT / DECK_DIR).is_dir() and not any(
+        (REPO_ROOT / DECK_DIR).rglob("slides.md")
+    ):
+        print(f"ERREUR : {DECK_DIR}/ existe mais aucun {DECK_DIR}/**/slides.md "
+              f"trouve -- refus de rendre un scan propre depuis une portee vide "
+              f"(#15867).", file=sys.stderr)
+        return 2
 
     if args.json:
         print(json.dumps({"scanned": scanned, "findings": findings}, indent=2, ensure_ascii=False))

--- a/scripts/notebook_tools/tests/test_check_link_label_agreement.py
+++ b/scripts/notebook_tools/tests/test_check_link_label_agreement.py
@@ -1,0 +1,147 @@
+"""Tests for scripts/notebook_tools/check_link_label_agreement.py -- deck scope.
+
+Why this test file exists
+-------------------------
+The organ was blind to `slides/` (#15867): its `SCAN_GLOBS` covered notebooks,
+series READMEs and `docs/`, so a deck could cite a notebook under a label that
+names a *different* notebook and nothing looked. The deck convention makes this
+the organ's home ground -- a deck cites `[Basename](../../MyIA.AI.Notebooks/...)`
+and a rename that updates the href while leaving the label behind is exactly the
+#13645 defect the organ exists for.
+
+Two things are pinned here:
+
+  1. **Coverage** -- decks are scanned, and the label predicate actually fires on
+     a deck carrying a lying label.
+  2. **The measured non-predicate** -- the existing ID-based comparison needed NO
+     loosening for the deck form. It compares a family identifier extracted from
+     BOTH sides, so the `.ipynb` extension and the glose outside the brackets
+     never enter the comparison. A future "fix" that loosens it to a raw
+     `label == basename` equality would break it: measured on `origin/main`
+     2026-09-13, that naive form mismatches on 108 of 108 deck links.
+  3. **Anti-silent-scan** -- `slides/` present but holding no deck must fail
+     loudly rather than report a clean scan from an empty scope.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import check_link_label_agreement as organ  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+DECK_GLOB = organ.DECK_GLOB
+
+
+def test_deck_glob_targets_deck_files_only():
+    """Deck-only scope: decks, not the `analysis/` / `.marp.md` working trees."""
+    assert DECK_GLOB == "slides/**/slides.md"
+
+
+def test_decks_reach_the_scan_on_the_repo():
+    """Acceptance 1 (#15867): decks are part of the scanned set."""
+    decks = sorted(REPO_ROOT.glob(DECK_GLOB))
+    assert decks, "no deck matched the deck glob"
+    assert all(p.name == "slides.md" for p in decks)
+    assert len([p for p in decks if not organ.EXCLUDE_PARTS & set(p.parts)]) >= 17
+
+
+def test_archived_deck_divergence_is_deliberate():
+    """The two organs treat `_archive/` differently, and that is on purpose.
+
+    `check_docs_links.py` validates archived READMEs (incident #9814) and so
+    keeps `slides/S4-trading-algorithmique/_archive/slides.md` in scope; this
+    organ excludes `_archive` for ALL its scopes, notebooks included, and
+    widening that is a separate subject. The archived deck carries no `.ipynb`
+    link, so the divergence costs nothing today -- pinned so it cannot start
+    costing something silently.
+    """
+    archived = [
+        p for p in REPO_ROOT.glob(DECK_GLOB) if organ.EXCLUDE_PARTS & set(p.parts)
+    ]
+    assert [p.relative_to(REPO_ROOT).as_posix() for p in archived] == [
+        "slides/S4-trading-algorithmique/_archive/slides.md"
+    ]
+    assert organ.LINK_RE.findall(archived[0].read_text(encoding="utf-8")) == []
+
+
+def test_repo_deck_links_produce_no_false_positive():
+    """Acceptance 3 (#15867): the 108 existing deck links yield 0 findings.
+
+    The deck labels are basenames; the organ must accept the form as-is.
+    """
+    findings = []
+    for deck in sorted(REPO_ROOT.glob(DECK_GLOB)):
+        if organ.EXCLUDE_PARTS & set(deck.parts):
+            continue
+        rel = deck.relative_to(REPO_ROOT).as_posix()
+        findings += organ.check_text(deck.read_text(encoding="utf-8"), rel)
+    assert findings == [], f"false positives on the existing decks: {findings}"
+
+
+def test_lying_label_on_a_deck_is_detected():
+    """A rename that updates the href and leaves the label behind must fire."""
+    src = (
+        "*Notebooks : [GameTheory-02-NormalForm]"
+        "(../../MyIA.AI.Notebooks/GameTheory/GameTheory-09-BackwardInduction.ipynb).*\n"
+    )
+    findings = organ.check_text(src, "slides/05-theorie-des-jeux/slides.md")
+    assert len(findings) == 1
+    assert findings[0]["says"] == "gametheory-2"
+    assert findings[0]["points_to"] == "gametheory-9"
+
+
+def test_deck_basename_form_is_accepted_without_loosening():
+    """The deck form passes on the existing predicate, not on a new one.
+
+    Same family, same number, no letter -- and the `.ipynb` extension plus the
+    glose outside the brackets are irrelevant to the comparison.
+    """
+    for src in (
+        "*Notebooks : [GameTheory-02-NormalForm]"
+        "(../../MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm.ipynb) (matrices).*\n",
+        "[Infer-1b-Premiers-Modeles](../../MyIA.AI.Notebooks/Probas/Infer/"
+        "Infer-1b-Premiers-Modeles.ipynb)\n",
+    ):
+        assert organ.check_text(src, "slides/x/slides.md") == []
+
+
+def test_naive_basename_equality_would_false_positive():
+    """Guard the measurement behind the design note above.
+
+    If the predicate were ever rewritten as `label == target basename`, the deck
+    corpus would light up: the label omits the extension.
+    """
+    label, target = "GameTheory-02-NormalForm", "GameTheory-02-NormalForm.ipynb"
+    assert label != target  # the naive form would flag this healthy link
+    src = f"*Notebooks : [{label}](../../MyIA.AI.Notebooks/GameTheory/{target}).*\n"
+    assert organ.check_text(src, "slides/x/slides.md") == []
+
+
+def test_empty_deck_scope_fails_loudly(tmp_path, monkeypatch, capsys):
+    """Anti-silent-scan: no deck found under an existing `slides/` is an error."""
+    (tmp_path / "slides" / "01-vide").mkdir(parents=True)
+    monkeypatch.setattr(organ, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["check_link_label_agreement.py"])
+    assert organ.main() == 2
+    assert "portee vide" in capsys.readouterr().err
+
+
+def test_absent_deck_dir_is_not_an_error(tmp_path, monkeypatch):
+    """A tree without `slides/` scans normally -- the guard is not a fixture tax."""
+    monkeypatch.setattr(organ, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["check_link_label_agreement.py"])
+    assert organ.main() == 0
+
+
+def test_self_test_still_passes():
+    """The organ's own #13645 control is untouched by the scope widening."""
+    assert organ.self_test() == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/scripts/tests/test_check_docs_links.py
+++ b/scripts/tests/test_check_docs_links.py
@@ -26,6 +26,7 @@ from check_docs_links import (
     ScanResult,
     check_link,
     check_regression,
+    find_deck_files,
     find_orphan_docs,
     find_scan_files,
     format_report,
@@ -663,6 +664,222 @@ class TestFormatReport:
         report = format_report(result)
         assert "Scanned 0 files, 0 links" in report
         assert "No broken links found" in report
+
+
+# ---------------------------------------------------------------------------
+# Deck scope (#15867)
+# ---------------------------------------------------------------------------
+
+
+class TestDeckScope:
+    """`slides/<deck>/slides.md` is scanned, and an empty scope fails loudly."""
+
+    def test_decks_are_scanned_on_the_repo(self):
+        """Acceptance 1: decks are part of the scanned file set."""
+        rel_paths = {
+            str(f.relative_to(REPO_ROOT)).replace("\\", "/")
+            for f in find_scan_files()
+        }
+        decks = {p for p in rel_paths if p.endswith("/slides.md")}
+        assert decks, "no deck file reached the scan"
+        assert all(p.startswith("slides/") for p in decks)
+
+    def test_deck_scope_is_not_the_whole_slides_tree(self):
+        """The deck scope must stay deck-only.
+
+        Measured on origin/main 2026-09-13: `slides/**/*.md` is 119 files and
+        734 broken links of 1367 (`analysis/`, `extracted/`, `*.marp.md`) --
+        widening the scope there would redden every PR.
+
+        Asserted on `find_deck_files()` itself: the pre-existing repo-wide
+        README sweep legitimately brings in `slides/**/README.md`, which is not
+        this scope's doing.
+        """
+        decks = find_deck_files()
+        assert decks
+        assert all(d.name == "slides.md" for d in decks)
+        assert not [
+            d for d in decks
+            if "/analysis/" in d.as_posix()
+            or "/extracted/" in d.as_posix()
+            or d.name.endswith(".marp.md")
+        ], f"non-deck markdown leaked into the deck scope: {decks}"
+
+    def test_existing_but_empty_deck_scope_raises(self, tmp_path, monkeypatch):
+        """Trap 1: `slides/` present yet holding no deck must not scan silently."""
+        (tmp_path / "slides" / "01-vide").mkdir(parents=True)
+        monkeypatch.setattr("check_docs_links.REPO_ROOT", tmp_path)
+        with pytest.raises(check_docs_links.DeckScopeEmpty):
+            find_deck_files()
+
+    def test_absent_deck_dir_is_not_an_error(self, tmp_path, monkeypatch):
+        """A tree without `slides/` (as in most fixtures) simply has no deck."""
+        monkeypatch.setattr("check_docs_links.REPO_ROOT", tmp_path)
+        assert find_deck_files() == []
+
+    def test_deck_linked_outside_slides_resolves(self, tmp_path, monkeypatch):
+        """Trap 2: a deck link may leave `slides/` and target a notebook.
+
+        `..` must be normalised before testing existence, or every deck link
+        reads as broken (or as valid).
+        """
+        repo = tmp_path
+        nb = repo / "MyIA.AI.Notebooks" / "GameTheory"
+        nb.mkdir(parents=True)
+        (nb / "GameTheory-02-NormalForm.ipynb").write_text("{}", encoding="utf-8")
+        deck_dir = repo / "slides" / "05-theorie-des-jeux"
+        deck_dir.mkdir(parents=True)
+        deck = deck_dir / "slides.md"
+        deck.write_text(
+            "*Notebooks : [GameTheory-02-NormalForm]"
+            "(../../MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm.ipynb).*\n"
+            "[mort](../../MyIA.AI.Notebooks/GameTheory/GameTheory-99-Absent.ipynb)\n",
+            encoding="utf-8",
+        )
+        refs = scan_file(deck)
+        assert [r.target for r in refs] == [
+            "../../MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm.ipynb",
+            "../../MyIA.AI.Notebooks/GameTheory/GameTheory-99-Absent.ipynb",
+        ]
+        assert check_link(refs[0].target, deck, root=repo) is True
+        assert check_link(refs[1].target, deck, root=repo) is False
+
+    def test_real_deck_links_are_all_valid(self):
+        """Acceptance 3: the 108 deck links on main stay all valid.
+
+        No false positive is introduced on the existing corpus; this is the
+        count the issue measured (#15867).
+        """
+        deck_broken = [
+            ref for ref in run_scan().broken
+            if ref.source.startswith("slides/")
+        ]
+        assert deck_broken == [], (
+            "the deck scope introduced false positives on the existing corpus: "
+            f"{[(r.source, r.line, r.target) for r in deck_broken]}"
+        )
+
+
+class TestPositiveControl:
+    """`--expect-broken N` -- the control that tells "clean" from "blind"."""
+
+    def _broken_tree(self, tmp_path, monkeypatch):
+        (tmp_path / "slides" / "03-logique").mkdir(parents=True)
+        (tmp_path / "slides" / "03-logique" / "slides.md").write_text(
+            "[cassee](../../MyIA.AI.Notebooks/absent.ipynb)\n", encoding="utf-8"
+        )
+        monkeypatch.setattr("check_docs_links.REPO_ROOT", tmp_path)
+        monkeypatch.setattr("check_docs_links.BASELINE_PATH",
+                            tmp_path / "baseline.json")
+
+    def test_control_is_met_on_a_deliberately_broken_tree(self, tmp_path, monkeypatch):
+        """Acceptance 2: a dead link written on a deck is detected."""
+        self._broken_tree(tmp_path, monkeypatch)
+        result = run_scan()
+        assert [r.target for r in result.broken] == [
+            "../../MyIA.AI.Notebooks/absent.ipynb"
+        ]
+
+    def test_met_control_does_not_exit_2(self, tmp_path, monkeypatch):
+        """Armed + broken == a genuine finding (rc=1), not a control failure."""
+        self._broken_tree(tmp_path, monkeypatch)
+        monkeypatch.setattr("sys.argv", ["check_docs_links.py", "--expect-broken", "1"])
+        with pytest.raises(SystemExit) as exc:
+            check_docs_links.main()
+        assert exc.value.code == 1
+
+    def test_same_tree_fails_the_control_under_a_higher_threshold(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Discrimination, on ONE tree: the threshold, not the tree, decides.
+
+        Raising the expectation above what the organ can see must flip rc=1
+        (finding) into rc=2 (control unmet) -- which is what makes a dead
+        detection path detectable instead of green.
+        """
+        self._broken_tree(tmp_path, monkeypatch)
+        monkeypatch.setattr("sys.argv", ["check_docs_links.py", "--expect-broken", "2"])
+        with pytest.raises(SystemExit) as exc:
+            check_docs_links.main()
+        assert exc.value.code == 2
+        assert "POSITIVE CONTROL FAILED" in capsys.readouterr().err
+
+    def test_clean_scan_under_an_armed_control_exits_2(self, monkeypatch, capsys):
+        """A genuinely clean tree under an armed control is a FAILURE, not a pass.
+
+        `run_scan` is stubbed: the claim under test is the control's verdict on
+        a zero-broken result, not path resolution.
+        """
+        monkeypatch.setattr("check_docs_links.run_scan", lambda report_orphans=False: ScanResult())
+        monkeypatch.setattr("sys.argv", ["check_docs_links.py", "--expect-broken", "1"])
+        with pytest.raises(SystemExit) as exc:
+            check_docs_links.main()
+        assert exc.value.code == 2
+        assert "POSITIVE CONTROL FAILED" in capsys.readouterr().err
+
+    def test_gate_mode_does_not_print_the_advisory(self, monkeypatch, capsys):
+        """`--check` success stays a single summary line: no advisory noise.
+
+        The gate runs on every PR; an advisory printed on every green run is
+        trained away within a week, so it is confined to the bare scan.
+        """
+        monkeypatch.setattr("check_docs_links.run_scan",
+                            lambda report_orphans=False: ScanResult())
+        monkeypatch.setattr("check_docs_links.load_baseline",
+                            lambda *a, **k: {"broken_links": []})
+        monkeypatch.setattr("sys.argv", ["check_docs_links.py", "--check"])
+        with pytest.raises(SystemExit) as exc:
+            check_docs_links.main()
+        assert exc.value.code == 0
+        assert "WARNING" not in capsys.readouterr().err
+
+
+class TestDeckScopeWiring:
+    """Adding the scope to the organ is worthless if the gate never runs it."""
+
+    def test_deck_scope_is_wired_into_the_fast_lane(self):
+        """The `check-links` gate must fire when a deck changes.
+
+        `docs-link-check.yml` is `workflow_dispatch`-only since #12567: for PRs
+        the organ is rendered by the fast lane, which decides from `paths`. A
+        scope added to the organ alone leaves deck-only PRs unchecked -- the
+        #15865 case.
+        """
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+        try:
+            import fast_lane_registry
+        finally:
+            sys.path.pop(0)
+        guard = next(
+            g for g in fast_lane_registry.TRANCHE1 if g.name == "check-links"
+        )
+        assert "slides/**" in guard.paths, (
+            "the check-links gate does not watch slides/ -- a deck-only PR "
+            "would never run the organ (#15867)"
+        )
+
+    def test_every_declared_scope_is_reachable_from_the_gate(self):
+        """Parity: each scanned scope must have a matching gate trigger."""
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+        try:
+            import fast_lane_registry
+        finally:
+            sys.path.pop(0)
+        guard = next(
+            g for g in fast_lane_registry.TRANCHE1 if g.name == "check-links"
+        )
+        for scope in check_docs_links.SCAN_SCOPES:
+            if scope.endswith("/"):
+                assert any(p.startswith(scope) for p in guard.paths), (
+                    f"scope {scope!r} is scanned but no gate path covers it"
+                )
+            else:
+                assert scope in guard.paths, (
+                    f"scope {scope!r} is scanned but the gate never watches it"
+                )
+        assert any(
+            p.startswith(f"{check_docs_links.DECK_DIR}/") for p in guard.paths
+        ), "the deck scope is scanned but the gate never watches it"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/docs #15792

## Summary

`slides/` n'était dans le scope d'aucun des deux organes de liens. La tranche de contenu #15023 (PR #15865) a écrit **17 liens relatifs morts** sur `03-logique` ; les deux organes rendaient « 0 lien cassé ». Même mode de défaillance que le précédent documenté dans `check_docs_links.py` lui-même (`#7422` : `index.md` pourrissait parce que rien ne le regardait).

## Ce qui change

| Fichier | Δ |
|---|---|
| `scripts/check_docs_links.py` | +88 — scope deck `slides/**/slides.md` (`DECK_DIR`), `DeckScopeEmpty`, `--expect-broken N` |
| `scripts/notebook_tools/check_link_label_agreement.py` | +30 — `DECK_GLOB`, garde anti-scan-silencieux |
| `scripts/ci/fast_lane_registry.py` | +14 −2 — le garde `check-links` déclenche sur `slides/**` (et `.claude/agents/**`, `.claude/skills/**`) |
| `scripts/tests/test_check_docs_links.py` | +217 — 12 tests (scope, pièges, contrôle positif, parité cablage) |
| `scripts/notebook_tools/tests/test_check_link_label_agreement.py` | +166 (neuf) — 9 tests |

## Le cablage, pas seulement le scope

Ajouter `slides/` à l'organe ne suffit pas : `docs-link-check.yml` est `workflow_dispatch`-only depuis #12567 — sur PR, l'organe est rendu par la **voie rapide**, qui décide depuis `paths`. Sans `slides/**` dans cette liste, une PR deck-only comme #15865 ne lance **jamais** le garde. Un **test de parité** épingle désormais chaque scope scanné (`SCAN_SCOPES` + decks) contre les `paths` du garde.

Ce test a trouvé un **second trou du même type** : `.claude/agents/**` et `.claude/skills/**` sont scannés par l'organe depuis #7422 sans jamais déclencher le garde. Couverts ici (même classe de défaut, même sujet).

## Les deux pièges de l'issue, couverts

1. **Jamais de scan silencieux** — `slides/` présent mais sans aucun deck ⇒ `DeckScopeEmpty` (exit 2, motif nommé), dans les DEUX organes. Un « 0 constat » depuis une portée vide est impossible.
2. **`..` normalisé avant le test d'existence** — un lien de deck sort de `slides/` vers `MyIA.AI.Notebooks/` : la résolution est deck-relative. **Rectification au passage** : `check_docs_links.py` résolvait déjà depuis le répertoire de la source (`check_link`, `l.257`), pas depuis la racine — la difficulté 1 de l'issue était un non-problème pour cet organe. Mesuré, pas supposé.

## Contrôle positif (`--expect-broken N`, modèle `scan_slidev_composition.py`)

Matrix mesurée sur `05-theorie-des-jeux` avec un lien cassé volontairement (restauré par `cp` backup) :

| Commande | rc |
|---|---|
| bare scan | **1** — `slides/05-theorie-des-jeux/slides.md:116 -> .../GameTheory-99-Absent.ipynb` nommé |
| `--expect-broken 1` | **1** — contrôle satisfait, vrai constat |
| `--expect-broken 2` | **2** — `POSITIVE CONTROL FAILED` explicite |
| `--check --base origin/main` | **1** — la régression n'est PAS excusée par la base |

L'advisory « contrôle non armé » est confiné au bare scan : `--check` garde son contrat d'une ligne unique sur vert (docs-link-check.yml).

## Acceptance

1. ✅ Deux organes scannent `slides/**/slides.md`. Mesure : 702→720 fichiers, 6845→6953 liens (**+108, le compte exact de l'issue**), 0 cassé avant/après. Label organ : 2076→2093 fichiers (+17 decks), 0 désaccord sur tout le dépôt.
2. ✅ Contrôle positif reproductible : la matrix ci-dessus + tests `TestPositiveControl` (le seuil, pas l'arbre, décide du verdict).
3. ✅ Les 108 liens restent tous valides — 0 faux positif (mesuré, et **épingle par test** sur le vrai dépôt : `test_real_deck_links_are_all_valid`).
4. ⚠️ **Démontré par reconstruction, pas par replay** : l'état cassé des 17 liens n'est **pas dans l'historique git** — les deux commits de #15865 sont déjà à 60 liens / 0 cassé (mesuré par `_link_exists_in_tree` sur les deux SHA ; la réparation est antérieure au premier push). Le lien cassé volontairement ci-dessus est le même acte de preuve, reproductible depuis la ligne de commande.

## Deux prémisses de l'issue, corrigées par mesure

- **« `check_docs_links.py` résout depuis la racine »** : non — résolution source-relative depuis `l.257` (`source_path.parent`), idem `_link_exists_in_tree`. Le correctif 1 de l'issue était déjà en place.
- **« le prédicat de labels doit être assoupli sous peine de faux positifs massifs »** : non — le prédicat existant compare un identifiant de famille extrait des DEUX côtés ; le basename sans extension et la glose hors crochets n'y entrent pas. Aucun changement de prédicat ; l'égalité naive `label == basename` ferait 108/108 faux positifs (mesuré, épingle par test `test_naive_basename_equality_would_false_positive`).

## Scope deck-only, et pourquoi

`slides/**/*.md` = 119 fichiers, **734 cassés / 1367** (`analysis/`, `extracted/`, `*.marp.md`), mesuré sur origin/main — l'élargir rougirait toute PR. Le scope reste `slides/**/slides.md`, épingle par test.

Divergence documentée : `check_docs_links.py` garde l'archive (`slides/S4-trading-algorithmique/_archive/slides.md`, doctrine `_archive` de #9814) ; `check_link_label_agreement.py` exclut `_archive` pour tous ses scopes (notebooks compris) — épinglée par test, l'archive ne porte aucun lien `.ipynb`.

```
$ python -m pytest scripts/tests/test_check_docs_links.py scripts/notebook_tools/tests/test_check_link_label_agreement.py scripts/tests/test_fast_lane.py -q
161 passed
```

Closes #15867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
