### PR TITLE
fix(qc,#11601): separateurs --- en *** — tranche QC/Python yaml_block_open_no_close (6 notebooks, 43 cellules)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction au Workflow de Recherche (5 min)\n",
     "\n",
@@ -744,7 +744,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Test de Stratégie en Mode Recherche (20 min)\n",
     "\n",
@@ -1308,7 +1308,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Transition Notebook → Algorithm (15 min)\n",
     "\n",
@@ -1549,7 +1549,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exemple Complet : Feature Engineering pour ML (10 min)\n",
     "\n",
@@ -1876,7 +1876,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -1969,7 +1969,7 @@
     "- [Pandas Time Series](https://pandas.pydata.org/docs/user_guide/timeseries.html)\n",
     "- Helpers : `shared/features.py`, `shared/backtest_helpers.py`\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complété. Prêt pour QC-Py-05-Universe-Sélection.**"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -13,7 +13,7 @@
     "> **Analyse technique et signaux de trading**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire | Python + QuantConnect\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'Apprentissage\n",
     "\n",
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook est un **document de reference** (non executable).\n",
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
@@ -67,7 +67,7 @@
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
-    "---"
+    "***"
    ],
    "id": "cell-d9b8393c"
   },
@@ -76,7 +76,7 @@
    "id": "cell-1",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Introduction aux Indicateurs Techniques\n",
     "\n",
@@ -144,7 +144,7 @@
    "id": "cell-3",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Indicateurs Built-In (30 min)\n",
     "\n",
@@ -604,7 +604,7 @@
    "id": "cell-9",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Indicateurs Avances (20 min)\n",
     "\n",
@@ -934,7 +934,7 @@
    "id": "cell-13",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Rolling Windows (15 min)\n",
     "\n",
@@ -1350,7 +1350,7 @@
    "id": "cell-17",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Custom Indicators (25 min)\n",
     "\n",
@@ -1875,7 +1875,7 @@
    "id": "cell-24",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Multi-Timeframe Analysis (15 min)\n",
     "\n",
@@ -2065,7 +2065,7 @@
    "id": "cell-26",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Stratégie Complete Multi-Indicator (20 min)\n",
     "\n",
@@ -2349,7 +2349,7 @@
    "id": "cell-29",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -2428,7 +2428,7 @@
     "- [Technical Analysis Library](https://www.investopedia.com/terms/t/technicalindicator.asp)\n",
     "- [shared/indicators.py](../shared/indicators.py) - Bibliotheque d'indicateurs du projet\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. Pret pour QC-Py-12.**"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -12,7 +12,7 @@
     "> **Evaluer et analyser les performances de vos stratégies de trading**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire | Python + QuantConnect\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'Apprentissage\n",
     "\n",
@@ -787,7 +787,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice 1 : Sharpe Ratio conditionnel par regime de volatilite\n",
     "\n",
@@ -1477,7 +1477,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice 2 : Analyse de robustesse d'une serie de trades\n",
     "\n",
@@ -1552,7 +1552,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4: Comparaison avec Benchmark (15 min)\n",
     "\n",
@@ -2250,7 +2250,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice 3 : Simulation Monte Carlo avec contraintes\n",
     "\n",
@@ -2761,7 +2761,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -2816,7 +2816,7 @@
     "- Helpers: `shared/backtest_helpers.py`, `shared/plotting.py`\n",
     "- Notebook suivant: **QC-Py-13** (selon curriculum)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. Les metriques de backtest sont essentielles pour evaluer objectivement vos stratégies.**"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -92,7 +92,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook a **deux parties** :\n",
     "> 1. **Sections analyse/ML** (pandas, sklearn, matplotlib) : **executables en Jupyter local**\n",
@@ -100,7 +100,7 @@
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -117,7 +117,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 1 : Configuration PyTorch et GPU\n",
     "\n",
@@ -304,7 +304,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 2 : Chargement des données (30 stocks + macro)\n",
     "\n",
@@ -720,7 +720,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 3 : Feature engineering avec features macro\n",
     "\n",
@@ -978,7 +978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 4 : Split temporel strict et normalisation\n",
     "\n",
@@ -1215,7 +1215,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 5 : Modèle Transformer Encoder\n",
     "\n",
@@ -1576,7 +1576,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 6 : Entrainement GPU\n",
     "\n",
@@ -2027,7 +2027,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 7 : Courbes d'apprentissage\n",
     "\n",
@@ -2186,7 +2186,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 8 : Evaluation sur le set de test\n",
     "\n",
@@ -2322,7 +2322,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 9 : Visualisation des predictions\n",
     "\n",
@@ -2454,7 +2454,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 10 : Visualisation de l'attention\n",
     "\n",
@@ -2616,7 +2616,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 11 : Backtest simplifie du signal\n",
     "\n",
@@ -2839,7 +2839,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 12 : Sauvegarde du modèle\n",
     "\n",
@@ -2978,7 +2978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 13 : Integration QuantConnect Cloud\n",
     "\n",
@@ -3046,7 +3046,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Section 14 : Resume et conclusions"
    ]
@@ -3211,7 +3211,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et prochaines étapes\n",
     "\n",
@@ -3274,7 +3274,7 @@
     "- Whaley, R.E. (2000). The Investor Fear Gauge. Journal of Portfolio Management 26(3):12-17.\n",
     "\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "[< Retour au sommaire](../README.md) | [Suivant : DQN Trading >](QC-Py-32-RL-DQN-Trading.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
@@ -9,7 +9,7 @@
     "> **Companion notebook pour QC-Py-19-ML-Supervised-Classification**\n",
     "> Duree: 45 minutes | Niveau: Intermediaire | Python + QuantConnect\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -30,7 +30,7 @@
     "\n",
     "### Duree estimee : 45 minutes\n",
     "\n",
-    "---"
+    "***"
    ],
    "id": "cell-7d844bbf"
   },
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **IMPORTANT - Mode d'emploi de ce notebook**\n",
     ">\n",
@@ -52,7 +52,7 @@
     ">\n",
     "> Voir le notebook QC-Py-19 pour la théorie complete sur la classification ML.\n",
     "\n",
-    "---"
+    "***"
    ],
    "id": "cell-c78453b1"
   },
@@ -151,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Data Loading with QuantBook (10 min)\n",
     "\n",
@@ -310,7 +310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Feature Engineering (15 min)\n",
     "\n",
@@ -553,7 +553,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Model Training (10 min)\n",
     "\n",
@@ -658,7 +658,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Model Evaluation (10 min)\n",
     "\n",
@@ -874,7 +874,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. ObjectStore Pattern (5 min)\n",
     "\n",
@@ -1092,7 +1092,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -1136,7 +1136,7 @@
     "- [Object Store Documentation](https://www.quantconnect.com/docs/v2/our-platform/object-store)\n",
     "- [Sklearn RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. Modèle pret pour integration dans un algorithme.**"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 1. Configuration et Imports\n",
     "\n",
     "Import des librairies necessaires et configuration de l'environnement QuantBook."
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 2. Chargement des Données\n",
     "\n",
     "Utilisation de QuantBook pour recuperer l'historique des prix de SPY."
@@ -221,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 3. Pretraitement et Creation de Sequences\n",
     "\n",
     "Normalisation des données et creation des fenêtres glissantes pour LSTM."
@@ -366,7 +366,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 4. Definition du Modèle LSTM\n",
     "\n",
     "Architecture LSTM avec couche lineaire finale pour la prediction."
@@ -452,7 +452,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 5. Entrainement du Modèle\n",
     "\n",
     "Boucle d'entrainement avec loss MSE et optimiseur Adam."
@@ -618,7 +618,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 6. Evaluation et Visualisation\n",
     "\n",
     "Prediction sur l'ensemble de test et calcul des metriques."
@@ -764,7 +764,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 7. Sauvegarde via ObjectStore\n",
     "\n",
     "Le modèle est sauvegarde dans l'ObjectStore QuantConnect pour etre charge dans main.py."
@@ -856,7 +856,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## 8. Integration dans main.py\n",
     "\n",
     "Code a copier dans votre algorithme pour utiliser le modèle."
@@ -948,7 +948,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
     "### Resume\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/readme #15811

See #11601

## Le defaut et son remede nomme

Le body de #11601 (mise a jour du 2026-08-30) nomme la remediation : les separateurs `---` en tete de cellule markdown ouvrent un bloc `yaml_metadata_block` non ferme au sens Pandoc — prose et titres des cellules suivantes sont lus comme paires cle/valeur, `quarto render` echoue, et un seul notebook fait tomber tout le site (incident #11451). Le remede outille du depot (`RULE_REPAIR` de `detect_markdown_rendering.py`, #12089/#12109) est la conversion `---` -> `***` (meme rendu `<hr>`, aucune semantique YAML).

Cette PR execute la tranche **QC/Python** de cette campagne, sur mesure le pool de l'umbrella.

## Perimetre (6 notebooks, 63 conversions)

| Notebook | Conversions |
|---|---|
| QC-Py-04-Research-Workflow | 6 |
| QC-Py-11-Technical-Indicators | 12 |
| QC-Py-12-Backtesting-Analysis | 7 |
| QC-Py-31-Transformer-Training | 18 |
| research/research_classification | 11 |
| research/research_lstm | 9 |

## Mesure avant/apres (detecteur du depot, meme arbre)

| Mesure | Avant | Apres |
|---|---|---|
| `yaml_block_open_no_close` sur `QuantConnect/Python` | **43** | **0** |
| Lignes du diff | — | 63 insertions / 63 deletions, toutes `"---"` -> `"***"` (audit `git diff -U0` : 59x `"---
"`->`"***
"`, 4x `"---"`->`"***"` fin de liste, zero autre ligne touchee) |

Modifs **uniquement markdown** : exception C.2 (pas de re-execution requise), aucune cellule code touchee, execution_count/outputs inchanges (H.3 passe). Les 10 hooks pre-commit passes (gitleaks, probeAddresses, papermill paths, auto-fix yaml, oversized, source-newlines, H.3, #13326).

Le fixer garde ce qu'il ne doit pas toucher : `---` dans les blocs de code, soulignements setext (titres H2), vrais blocs frontmatter.

## Hors perimetre, declare

- **3 `oversized_hint`** restants dans QC/Python (QC-Py-02 cellules 12/19/26, sections `### Indices`) : regle differente, choix pedagogique a arbitrer, pas une conversion mecanique.
- **Recensement repo-wide au moment de la PR** : 255 `yaml_block_open_no_close` restants HORS QC/Python (GameTheory, GenAI Audio/Image/Video/Texte, IIT, Probas, CaseStudies...). Cette tranche ne clôt pas la campagne — familles restantes a trancher par familles.
- Claim pool-QC po-2023 du 2026-09-04 (densite round 3) : perime >48h sans livraison, perimetre distinct (enrichissement vs reparation) — note au claim #issuecomment-5649383422.

## G-VAR-1, declare honnetement

Requalifie **LIGHT** apres recensement : une tranche de famille via fixer outillee, avec 255 instances scannables sur les familles suivantes et un hook pre-commit qui auto-fixe la regle, repond OUI au litmus « generable en scannant l'instance suivante ». `notebook-python` est un genre CONTENU mais le tier ne tient pas le plancher G-VAR-1 — declare, pas maquille. Budget G-VAR-2 : 0 grain merge ce jour pour la lane, budget 1, cette PR = 1. Genre precedent LIGHT/readme (#15811) : pas de run G-VAR-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
