### PR TITLE
fix(guards,#15833): le mot de portee se teste en mot entier au site d'extraction aussi

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -1572,7 +1572,24 @@ def _extract_line_candidates(text: str) -> list[tuple[int, str]]:
                 continue
             candidates.append((idx, line))
             continue
-        if _has_exclusivity(low) and any(w in low for w in STRONG_SCOPE_WORDS):
+        # #15833/#15846: the scope-word test goes through `_has_strong_scope`,
+        # NOT a plain substring scan. The whole-word guard already exists and is
+        # already used by the two other call sites (l.~1168, l.~1257); this one
+        # was never migrated, so it kept matching scope words INSIDE longer
+        # words. Two measured misfires, both on a line whose subject is not the
+        # PR perimeter at all:
+        #   #15833 l.45 "`--dist loadscope`, jamais `load` [...] il est sur
+        #     **uniquement** grace a ce groupement" -- 'scope' inside
+        #     "loadscope". #12718 added the `(?<![-\w])scope(?![-\w])`
+        #     lookbehind to `_has_strong_scope` for exactly this shape.
+        #   #15846 l.44 "cette ligne ne peut pas **changer** le comportement de
+        #     build" (marker "seulement" earlier on the line) -- 'change'
+        #     inside "changer". #11800 added the `\b` boundary to
+        #     `_has_strong_scope` for exactly this shape ("inchanges").
+        # Both guards were built, tested, and then bypassed here. Same failure
+        # family as the "read-only" (#11654) and "pas seulement" (#12547)
+        # misfires above: the marker is present, its force is not.
+        if _has_exclusivity(low) and _has_strong_scope(low):
             if _markers_all_quoted(line):
                 continue  # quoting an exclusivity claim, not making one
             candidates.append((idx, line))

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -230,6 +230,57 @@ def test_extract_skips_read_only_compound():
         "permissions read-only inchangées")
 
 
+def test_extract_skips_scope_word_inside_a_longer_word():
+    r"""A strong scope word must be a WHOLE word -- at the extraction site too.
+
+    `_has_strong_scope` has carried that guard for a while: #11800 added the
+    `\b` boundary so "inchanges" stops supplying 'change', and #12718 added
+    the `(?<![-\w])scope(?![-\w])` lookbehind so "out-of-scope" stops
+    supplying 'scope'. Two of its three call sites went through it;
+    `_extract_line_candidates` kept a plain substring scan, so the guard was
+    built, tested, and then bypassed on the path that feeds the report.
+
+    Both lines below are measured, taken verbatim from PRs whose real
+    perimeter is a single file and whose bodies assert nothing false about
+    it -- the misfire turned the required `Always-on guards` red on two lanes
+    at once:
+
+    * #15833 l.45 -- 'scope' inside "loadscope", marker "uniquement".
+    * #15846 l.44 -- 'change' inside "changer", marker "seulement".
+
+    Same failure family as the "read-only" compound above (#11654) and "pas
+    seulement" (#12547): the marker is present, its force is not.
+    """
+    loadscope = (
+        "1. **`--dist loadscope`, jamais `load`.** `loadscope` groupe par "
+        "module, donc les tests d'un module ne tournent jamais concurremment "
+        "entre eux : il est sur **uniquement** grace a ce groupement."
+    )
+    changer = (
+        "Le workflow de `main` est `c631a7a9` : `schedule` + `dispatch` "
+        "seulement, aucune jambe PR. Cette ligne ne peut pas changer le "
+        "comportement de build."
+    )
+    assert extract_perimeter_assertions(loadscope) == []
+    assert extract_perimeter_assertions(changer) == []
+    assert not _has_strong_scope(loadscope.lower())
+    assert not _has_strong_scope(changer.lower())
+
+
+def test_whole_word_scope_still_extracts_real_declarations():
+    """Positive control for the guard above: it must not silence the real
+    thing. Each line carries a STANDALONE scope word and stays a perimeter
+    assertion -- first among them the founding #11227 sentence, which is what
+    this organ exists to catch."""
+    for line in (
+        "**Perimetre** : 2 fichiers twins uniquement, aucune autre modification.",
+        "Cette PR touche uniquement ces fichiers, aucune autre modification.",
+        "Scope: only the workflow file, nothing else.",
+        "lake 70 fichiers uniquement, scope = perimetre PR",
+    ):
+        assert extract_perimeter_assertions(line), line
+
+
 def test_only_standalone_still_flags():
     """The control positive side: a standalone "only" with a scope word stays
     a live exclusivity assertion -- the fix must not kill the English arm."""


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #15870

## Ce que ça répare

`Always-on guards` / organe `perimeter` (#11268) rougissait sur **deux PRs de deux lanes différentes** — #15833 (`myia-ai-01:CoursIA`) et #15846 (`myia-po-2026:CoursIA`) — pour une assertion de périmètre **qu'aucune des deux ne fait**. Les deux bodies déclarent un périmètre d'un seul fichier, et ce périmètre est exact.

## Cause

`_extract_line_candidates` (l.1575) retenait une ligne comme assertion dès qu'elle portait un marqueur d'exclusivité **et** un mot de portée — le mot de portée étant cherché en **sous-chaîne** :

```python
if _has_exclusivity(low) and any(w in low for w in STRONG_SCOPE_WORDS):
```

`STRONG_SCOPE_WORDS` contient `'modif'`, `'change'` et `'scope'`. En sous-chaîne, ils sont fournis par « modifie », « changer », « échange », `loadscope`, « out-of-scope »…

Le garde qui corrige exactement cette classe **existe déjà** : `_has_strong_scope()` (l.931) fait le même test en mot entier, et ses deux rustines nomment le défaut dans leurs propres commentaires —

| Rustine | Ajout | Motif écrit dans le code |
|---|---|---|
| #11800 | frontière `\b` | « `change` must not fire on `inchanges` » |
| #12718 | `(?<![-\w])scope(?![-\w])` | « `scope` as a hyphenated compound (`in-scope`, `out-of-scope`) is an adjective describing scope-inclusion, never a perimeter-count label » |

Il est appelé aux lignes **1168** et **1257**. Pas à la **1575**. Le garde a été construit, testé, puis contourné sur le chemin qui alimente le rapport.

## Mesure — prédicat pur, hors API, sur les corps réels

| PR | ligne | fragment porteur | avant | après |
|---|---:|---|---:|---:|
| #15833 | 45 | `'scope'` dans `loadscope`, marqueur « uniquement » | 1 assertion fabriquée | **0** |
| #15846 | 44 | `'change'` dans « changer », marqueur « seulement » | 1 assertion fabriquée | **0** |
| #15870 | — | — | 0 | 0 |

**#15870 est le contrôle négatif** : même organe, même job, un fichier, `success` avant comme après.

**Et l'organe n'est pas affaibli.** Confronté à la liste effective réelle, #15846 conserve sa vraie déclaration de la l.108 — « 1 fichier : `.github/workflows/slides-build-advisory.yml` », prise par la branche `COUNT_CLAIM` — et elle ressort à **0 problème**. #15833 n'a plus aucune assertion à confronter, ce qui est le verdict correct : son body n'en formule aucune.

## Validation par les faux négatifs

Un prédicat de détection se valide par ce qu'il doit attraper, pas par ses hits. `test_whole_word_scope_still_extracts_real_declarations` pinne quatre formes réelles qui **doivent** rester prises, la première étant la sentence fondatrice de #11227 :

- `**Perimetre** : 2 fichiers twins uniquement, aucune autre modification.`
- `Cette PR touche uniquement ces fichiers, aucune autre modification.`
- `Scope: only the workflow file, nothing else.`
- `lake 70 fichiers uniquement, scope = perimetre PR`

## Tests

`202 passed` sur `scripts/tests/test_check_pr_perimeter.py` — les 200 existants inchangés, plus les 2 neufs.

## Périmètre

2 fichiers : le site d'appel dans `scripts/check_pr_perimeter.py` avec son commentaire, et les deux tests dans `scripts/tests/test_check_pr_perimeter.py`. Aucun autre organe, aucun workflow.

## Gates de variation — déclarés, pas esquivés

Grain **META** (`guard`) : il **ne tient pas** le plancher G-VAR-1 de mon cycle, et c'est mon deuxième META consécutif après #15870. Ma lane est par ailleurs au-delà de son plafond de genre (`cap_exceeded_by_genre: true`, `light_genre` 5 pour un `genre_cap` de 3). Je l'écris plutôt que de laisser le merge-gate le découvrir : **mon prochain grain propre est de CONTENU.**

Et ce que je refuse de faire passer pour une excuse : ce correctif est de la remise en capacité de digestion — un check **requis** cassé qui bloque deux lanes — que R0 demande d'ouvrir *en parallèle* de la production, jamais à sa place.

See #15833, #15846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
