### PR TITLE
feat(folk,#15655): refute unnormalized discounted Folk payoff + normalize by (1-d)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
@@ -111,15 +111,151 @@ noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
     (a : ℕ → PDAction × PDAction) : ℝ :=
   ∑' n : ℕ, δ^n * stagePayoff g (a n).1 (a n).2
 
-/-- Le théorème de Folk ACTUALISÉ (Fudenberg–Maskin 1986, simplifié pour 2x2) :
+/-- Témoin de réfutation (#15655) : le DP `T = 3, R = 2, P = 1, S = 0` —
+lecture positionnelle de `(3, 2, 1, 0)` dans l'ordre des champs `(T, R, P, S)`.
+Les quatre axiomes de `PrisonersDilemma` se vérifient par `norm_num` (aucune
+donnée numérique citée en aval : tout est porté par la structure). Ce jeu
+porte la cible faisable strictement IR `u = (2, 2)` (le sommet coopératif
+`(R, R)`), qui réfute l'énoncé non normalisé du théorème de Folk actualisé —
+voir `folk_theorem_discounted_unnormalized_refuted`. -/
+def folkCounterexample : PrisonersDilemma where
+  T := 3
+  R := 2
+  P := 1
+  S := 0
+  hTR := by norm_num
+  hRP := by norm_num
+  hPS := by norm_num
+  hPD := by norm_num
+
+/-- Les hypothèses du théorème de Folk sont SATISFAITES par le témoin : pour
+`folkCounterexample` (T3, R2, P1, S0), la cible `u = (2, 2)` est
+individuellement rationnelle, faisable (le sommet coopératif `(R, R)` : poids
+`pCC = 1`, autres nuls) et strictement individuellement rationnelle
+(`2 > P`). La réfutation ci-dessous porte donc sur l'énoncé lui-même, pas sur
+un artefact d'hypothèse. -/
+theorem folkCounterexample_hypotheses :
+    IndividuallyRational folkCounterexample 2 2 ∧
+      Feasible folkCounterexample 2 2 ∧
+      (2 > folkCounterexample.P ∧ 2 > folkCounterexample.P) := by
+  refine ⟨⟨?_, ?_⟩, ⟨1, 0, 0, 0, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, ⟨?_, ?_⟩⟩ <;>
+    norm_num [folkCounterexample]
+
+/-- Somme des paiements de stage symétrisée sur le jeu témoin : toute paire
+de coups rapporte au total au moins `2`. Les quatre cas possibles donnent
+`R + R = 4` (coopération), `S + T = 3` et `T + S = 3` (exploitation),
+`P + P = 2` (défection mutuelle) — le minimum est le niveau de défection. -/
+lemma stage_sum_ge_two (x y : PDAction) :
+    2 ≤ stagePayoff folkCounterexample x y + stagePayoff folkCounterexample y x := by
+  cases x <;> cases y <;> simp only [stagePayoff, folkCounterexample] <;> norm_num
+
+/-- **Réfutation de l'énoncé NON NORMALISÉ** (#15655). L'ancienne conclusion du
+théorème de Folk actualisé — `discountedPayoff g d a = u_row ∧ … = u_col` sur
+les séries BRUTES — est FAUSSE, et ce pour n'importe quel seuil `δ_star < 1` :
+sur le jeu témoin `folkCounterexample` (T3, R2, P1, S0) et la cible faisable
+strictement IR `u = (2, 2)`, aucune trajectoire ne peut réaliser le couple
+`(2, 2)` dès que `d > 1/2`.
+
+    Argument (par l'absurde) : chaque profil de stage rapporte au total au
+    moins `2` (`stage_sum_ge_two`), donc la somme des deux séries vaut
+    `Σ' dⁿ · (p_row + p_col) ≥ 2 · Σ' dⁿ = 2 / (1 - d)`. Si les deux paiements
+    actualisés valaient `2` chacun, la somme vaudrait `4` — or `2 / (1 - d) > 4`
+    dès que `d > 1/2`. Pour tout `δ_star < 1` on choisit `d = max δ_star (3/4)`
+    (qui vérifie `δ_star ≤ d < 1` et `d > 1/2`) et la contradiction éclate.
+
+    Détail technique : chaque série est sommable car sa somme vaut `2 ≠ 0`
+    (`tsum_eq_zero_of_not_summable`), ce qui permet `Summable.tsum_add` puis la
+    comparaison `Summable.tsum_le_tsum` avec la série géométrique (dé doublée
+    `dⁿ + dⁿ` pour rester dans les lemmes de base des sommes infinies). L'énoncé
+    corrigé `folk_theorem_discounted` normalise les deux équations par
+    `1 - d` : la cible est le paiement MOYEN actualisé, dont la somme vaut
+    `u_row + u_col`, compatible avec la minoration en `2`. -/
+theorem folk_theorem_discounted_unnormalized_refuted :
+    ¬ ∃ (δ_star : ℝ), δ_star < 1 ∧
+      ∀ (d : ℝ), d ≥ δ_star → d < 1 →
+        ∃ (a : ℕ → PDAction × PDAction),
+          discountedPayoff folkCounterexample d a = 2 ∧
+          discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) = 2 := by
+  rintro ⟨δ_star, hδs, hall⟩
+  have hdl : max δ_star (3 / 4) < 1 := max_lt_iff.mpr ⟨hδs, by norm_num⟩
+  obtain ⟨a, ha1, ha2⟩ := hall (max δ_star (3 / 4)) (le_max_left _ _) hdl
+  set d := max δ_star (3 / 4)
+  have hd0 : (1 / 2 : ℝ) < d := lt_of_lt_of_le (by norm_num) (le_max_right _ _)
+  have hdnn : 0 ≤ d := by linarith
+  have hs1 : Summable fun n : ℕ =>
+      d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2 := by
+    by_contra hns
+    simp only [discountedPayoff] at ha1
+    rw [tsum_eq_zero_of_not_summable hns] at ha1
+    norm_num at ha1
+  have hs2 : Summable fun n : ℕ =>
+      d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by
+    by_contra hns
+    simp only [discountedPayoff] at ha2
+    rw [tsum_eq_zero_of_not_summable hns] at ha2
+    norm_num at ha2
+  have h4 : discountedPayoff folkCounterexample d a
+      + discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) = 4 := by
+    rw [ha1, ha2]; norm_num
+  have hgeo : Summable fun n : ℕ => d ^ n := summable_geometric_of_lt_one hdnn hdl
+  have hlb : ∀ n : ℕ, d ^ n + d ^ n
+      ≤ d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+        + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by
+    intro n
+    have hp : 2 ≤ stagePayoff folkCounterexample (a n).1 (a n).2
+        + stagePayoff folkCounterexample (a n).2 (a n).1 :=
+      stage_sum_ge_two (a n).1 (a n).2
+    have hdn : 0 ≤ d ^ n := pow_nonneg (by linarith) n
+    calc d ^ n + d ^ n = d ^ n * 2 := by ring
+      _ ≤ d ^ n * (stagePayoff folkCounterexample (a n).1 (a n).2
+          + stagePayoff folkCounterexample (a n).2 (a n).1) :=
+        mul_le_mul_of_nonneg_left hp hdn
+      _ = d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by ring
+  have hbound : 2 / (1 - d) ≤ discountedPayoff folkCounterexample d a
+      + discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) := by
+    have hgeo' : ∑' n : ℕ, (d ^ n + d ^ n) = 2 / (1 - d) := by
+      rw [Summable.tsum_add hgeo hgeo, tsum_geometric_of_lt_one hdnn hdl]; ring
+    rw [← hgeo']
+    simp only [discountedPayoff]
+    calc ∑' n : ℕ, (d ^ n + d ^ n)
+        ≤ ∑' n : ℕ, (d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1) :=
+        Summable.tsum_le_tsum hlb (hgeo.add hgeo) (hs1.add hs2)
+      _ = ∑' n : ℕ, d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + ∑' n : ℕ, d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 :=
+        Summable.tsum_add hs1 hs2
+  rw [h4] at hbound
+  have h1pos : 0 < 1 - d := by linarith
+  rw [div_le_iff₀ h1pos] at hbound
+  ring_nf at hbound
+  have h4d : (2 : ℝ) < 4 * d := by
+    have hmul := mul_lt_mul_of_pos_left hd0 (show (0 : ℝ) < 4 by norm_num)
+    norm_num at hmul
+    exact hmul
+  linarith
+
+/-- Le théorème de Folk ACTUALISÉ (Fudenberg–Maskin 1986, simplifié pour 2x2),
+    forme NORMALISÉE (#15655) :
 
       Pour tout paiement faisable strictement individuellement rationnel
       `u = (u_row, u_col)`, il existe δ* < 1 tel que pour tout δ ∈ [δ*, 1) le
-      vecteur `u` est réalisé comme paiement actualisé d'une trajectoire
-      d'actions conjointes.
+      vecteur `u` est réalisé comme paiement MOYEN actualisé d'une trajectoire
+      d'actions conjointes — chaque équation porte le facteur `1 - d` :
+      `(1 - d) · Σ' dⁿ · payoff = u`.
 
-    La conclusion est une **équation réelle** (`discountedPayoff … = u_row ∧
-    … = u_col`), pas un `True` : le `sorry` porte donc la dette authentique
+    La normalisation n'est pas décorative : l'énoncé BRUT
+    (`discountedPayoff … = u` sans facteur) est réfuté formellement par
+    `folk_theorem_discounted_unnormalized_refuted` ci-dessus — sur le jeu
+    témoin (T3, R2, P1, S0) et la cible faisable strictement IR (2, 2), la
+    somme des deux séries est minorée par `2 / (1 - d) > 4` dès que `d > 1/2`,
+    donc aucune trajectoire ne peut réaliser le couple brut près de 1. Le
+    paiement MOYEN, lui, échappe à la réfutation : sa somme vaut
+    `u_row + u_col`, dans la plage permise par la minoration.
+
+    La conclusion reste une **équation réelle** (`(1 - d) * discountedPayoff …
+    = u_row ∧ … = u_col`), pas un `True` : le `sorry` porte donc la dette
+    authentique
     (existence de la trajectoire réalisant le vecteur cible — construction de
     Fudenberg–Maskin par alternance action-cible / phase de punition, avec la
     convexité du polytope des paiements faisables). Ne PAS fermer sur `True` :
@@ -139,13 +275,21 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       ∃ (δ_star : ℝ), δ_star < 1 ∧
         ∀ (d : ℝ), d ≥ δ_star → d < 1 →
           ∃ (a : ℕ → PDAction × PDAction),
-            discountedPayoff g d a = u_row ∧
-            discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+            (1 - d) * discountedPayoff g d a = u_row ∧
+            (1 - d) * discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+  -- Énoncé normalisé (2026-09-13, #15655) : facteur `1 - d` sur les DEUX
+  -- équations — c'est le paiement MOYEN actualisé, la conclusion standard de
+  -- Fudenberg–Maskin. L'ancienne conclusion non normalisée était FAUSSE :
+  -- réfutée formellement par `folk_theorem_discounted_unnormalized_refuted`
+  -- (témoin T3/R2/P1/S0, u = (2, 2) : chaque stage rapporte au total ≥ 2,
+  -- donc la somme des deux séries ≥ 2 / (1 - d) > 4 = u_row + u_col dès que
+  -- d > 1/2 — aucune trajectoire ne réalise le couple brut près de 1).
+  --
   -- STRETCH (Fudenberg–Maskin 1986) : existence d'une trajectoire d'actions
   -- conjointes réalisant le vecteur de paiement cible (u_row, u_col) comme
-  -- paiement actualisé, pour tout δ assez proche de 1. Requiert la convexité
-  -- du polytope des paiements faisables et un argument de point extrême ;
-  -- preuve de plusieurs pages, pas une seule tactique.
+  -- paiement moyen actualisé, pour tout δ assez proche de 1. Requiert la
+  -- convexité du polytope des paiements faisables et un argument de point
+  -- extrême ; preuve de plusieurs pages, pas une seule tactique.
   --
   -- Bord d'énoncé réparé (2026-08-15) : l'ancien quantificateur « ∀ d ≥ δ* »
   -- (sans borne d < 1) rendait le théorème FAUX — à d ≥ 1 les séries

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
@@ -130,15 +130,151 @@ noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
     (a : ℕ → PDAction × PDAction) : ℝ :=
   ∑' n : ℕ, δ^n * stagePayoff g (a n).1 (a n).2
 
-/-- The DISCOUNTED Folk theorem (Fudenberg–Maskin 1986, simplified for 2x2):
+/-- Refutation witness (#15655): the PD `T = 3, R = 2, P = 1, S = 0` — the
+positional reading of `(3, 2, 1, 0)` in field order `(T, R, P, S)`. The four
+`PrisonersDilemma` axioms hold by `norm_num` (no numerical data cited
+downstream: everything is carried by the structure). This game carries the
+feasible strictly-IR target `u = (2, 2)` (the cooperative vertex `(R, R)`),
+which refutes the unnormalized statement of the discounted Folk theorem —
+see `folk_theorem_discounted_unnormalized_refuted`. -/
+def folkCounterexample : PrisonersDilemma where
+  T := 3
+  R := 2
+  P := 1
+  S := 0
+  hTR := by norm_num
+  hRP := by norm_num
+  hPS := by norm_num
+  hPD := by norm_num
+
+/-- The Folk-theorem hypotheses ARE satisfied by the witness: for
+`folkCounterexample` (T3, R2, P1, S0), the target `u = (2, 2)` is
+individually rational, feasible (the cooperative vertex `(R, R)`: weights
+`pCC = 1`, others zero) and strictly individually rational (`2 > P`). The
+refutation below thus hits the statement itself, not a hypothesis artefact. -/
+theorem folkCounterexample_hypotheses :
+    IndividuallyRational folkCounterexample 2 2 ∧
+      Feasible folkCounterexample 2 2 ∧
+      (2 > folkCounterexample.P ∧ 2 > folkCounterexample.P) := by
+  refine ⟨⟨?_, ?_⟩, ⟨1, 0, 0, 0, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩, ⟨?_, ?_⟩⟩ <;>
+    norm_num [folkCounterexample]
+
+/-- Symmetrized stage-payoff sum on the witness game: any pair of moves earns
+at least `2` in total. The four possible cases give `R + R = 4` (cooperation),
+`S + T = 3` and `T + S = 3` (exploitation), `P + P = 2` (mutual defection) —
+the minimum is the defection level. -/
+lemma stage_sum_ge_two (x y : PDAction) :
+    2 ≤ stagePayoff folkCounterexample x y + stagePayoff folkCounterexample y x := by
+  cases x <;> cases y <;> simp only [stagePayoff, folkCounterexample] <;> norm_num
+
+/-- **Refutation of the UNNORMALIZED statement** (#15655). The old conclusion
+of the discounted Folk theorem — `discountedPayoff g d a = u_row ∧ … = u_col`
+on the RAW series — is FALSE, for any threshold `δ_star < 1`: on the witness
+game `folkCounterexample` (T3, R2, P1, S0) with the feasible strictly-IR
+target `u = (2, 2)`, no trajectory can realize the pair `(2, 2)` once
+`d > 1/2`.
+
+    Argument (by contradiction): every stage profile earns at least `2` in
+    total (`stage_sum_ge_two`), so the sum of the two series equals
+    `Σ' dⁿ · (p_row + p_col) ≥ 2 · Σ' dⁿ = 2 / (1 - d)`. If both discounted
+    payoffs were `2` each, the sum would be `4` — yet `2 / (1 - d) > 4`
+    whenever `d > 1/2`. For any `δ_star < 1` pick `d = max δ_star (3/4)`
+    (which satisfies `δ_star ≤ d < 1` and `d > 1/2`) and the contradiction
+    fires.
+
+    Technical detail: each series is summable because its sum is `2 ≠ 0`
+    (`tsum_eq_zero_of_not_summable`), enabling `Summable.tsum_add` then the
+    `Summable.tsum_le_tsum` comparison with the geometric series (doubled as
+    `dⁿ + dⁿ` to stay within the basic infinite-sum lemmas). The repaired
+    statement `folk_theorem_discounted` normalizes both equations by
+    `1 - d`: the target is the discounted MEAN payoff, whose sum is
+    `u_row + u_col`, compatible with the lower bound `2`. -/
+theorem folk_theorem_discounted_unnormalized_refuted :
+    ¬ ∃ (δ_star : ℝ), δ_star < 1 ∧
+      ∀ (d : ℝ), d ≥ δ_star → d < 1 →
+        ∃ (a : ℕ → PDAction × PDAction),
+          discountedPayoff folkCounterexample d a = 2 ∧
+          discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) = 2 := by
+  rintro ⟨δ_star, hδs, hall⟩
+  have hdl : max δ_star (3 / 4) < 1 := max_lt_iff.mpr ⟨hδs, by norm_num⟩
+  obtain ⟨a, ha1, ha2⟩ := hall (max δ_star (3 / 4)) (le_max_left _ _) hdl
+  set d := max δ_star (3 / 4)
+  have hd0 : (1 / 2 : ℝ) < d := lt_of_lt_of_le (by norm_num) (le_max_right _ _)
+  have hdnn : 0 ≤ d := by linarith
+  have hs1 : Summable fun n : ℕ =>
+      d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2 := by
+    by_contra hns
+    simp only [discountedPayoff] at ha1
+    rw [tsum_eq_zero_of_not_summable hns] at ha1
+    norm_num at ha1
+  have hs2 : Summable fun n : ℕ =>
+      d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by
+    by_contra hns
+    simp only [discountedPayoff] at ha2
+    rw [tsum_eq_zero_of_not_summable hns] at ha2
+    norm_num at ha2
+  have h4 : discountedPayoff folkCounterexample d a
+      + discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) = 4 := by
+    rw [ha1, ha2]; norm_num
+  have hgeo : Summable fun n : ℕ => d ^ n := summable_geometric_of_lt_one hdnn hdl
+  have hlb : ∀ n : ℕ, d ^ n + d ^ n
+      ≤ d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+        + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by
+    intro n
+    have hp : 2 ≤ stagePayoff folkCounterexample (a n).1 (a n).2
+        + stagePayoff folkCounterexample (a n).2 (a n).1 :=
+      stage_sum_ge_two (a n).1 (a n).2
+    have hdn : 0 ≤ d ^ n := pow_nonneg (by linarith) n
+    calc d ^ n + d ^ n = d ^ n * 2 := by ring
+      _ ≤ d ^ n * (stagePayoff folkCounterexample (a n).1 (a n).2
+          + stagePayoff folkCounterexample (a n).2 (a n).1) :=
+        mul_le_mul_of_nonneg_left hp hdn
+      _ = d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 := by ring
+  have hbound : 2 / (1 - d) ≤ discountedPayoff folkCounterexample d a
+      + discountedPayoff folkCounterexample d (fun n => ((a n).2, (a n).1)) := by
+    have hgeo' : ∑' n : ℕ, (d ^ n + d ^ n) = 2 / (1 - d) := by
+      rw [Summable.tsum_add hgeo hgeo, tsum_geometric_of_lt_one hdnn hdl]; ring
+    rw [← hgeo']
+    simp only [discountedPayoff]
+    calc ∑' n : ℕ, (d ^ n + d ^ n)
+        ≤ ∑' n : ℕ, (d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1) :=
+        Summable.tsum_le_tsum hlb (hgeo.add hgeo) (hs1.add hs2)
+      _ = ∑' n : ℕ, d ^ n * stagePayoff folkCounterexample (a n).1 (a n).2
+          + ∑' n : ℕ, d ^ n * stagePayoff folkCounterexample (a n).2 (a n).1 :=
+        Summable.tsum_add hs1 hs2
+  rw [h4] at hbound
+  have h1pos : 0 < 1 - d := by linarith
+  rw [div_le_iff₀ h1pos] at hbound
+  ring_nf at hbound
+  have h4d : (2 : ℝ) < 4 * d := by
+    have hmul := mul_lt_mul_of_pos_left hd0 (show (0 : ℝ) < 4 by norm_num)
+    norm_num at hmul
+    exact hmul
+  linarith
+
+/-- The DISCOUNTED Folk theorem (Fudenberg–Maskin 1986, simplified for 2x2),
+
+    NORMALIZED form (#15655):
 
       For every strictly individually rational feasible payoff
       `u = (u_row, u_col)`, there exists δ* < 1 such that for all δ ∈ [δ*, 1) the
-      vector `u` is realized as the discounted payoff of a trajectory of
-      joint actions.
+      vector `u` is realized as the discounted MEAN payoff of a trajectory of
+      joint actions — each equation carries the `1 - d` factor:
+      `(1 - d) · Σ' dⁿ · payoff = u`.
 
-    The conclusion is a **real equation** (`discountedPayoff … = u_row ∧
-    … = u_col`), not `True`: the `sorry` thus carries the genuine debt
+    The normalization is not cosmetic: the RAW statement
+    (`discountedPayoff … = u` without the factor) is formally refuted by
+    `folk_theorem_discounted_unnormalized_refuted` above — on the witness
+    game (T3, R2, P1, S0) with the feasible strictly-IR target (2, 2), the
+    sum of the two series is bounded below by `2 / (1 - d) > 4` whenever
+    `d > 1/2`, so no trajectory can realize the raw pair near 1. The MEAN
+    payoff escapes the refutation: its sum is `u_row + u_col`, within the
+    range allowed by the lower bound.
+
+    The conclusion is a **real equation** (`(1 - d) * discountedPayoff … =
+    u_row ∧ … = u_col`), not `True`: the `sorry` thus carries the genuine debt
     (existence of a trajectory realizing the target vector — the
     Fudenberg–Maskin construction alternating target action / punishment
     phase, using convexity of the feasible-payoff polytope). Do NOT close on
@@ -157,12 +293,21 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       ∃ (δ_star : ℝ), δ_star < 1 ∧
         ∀ (d : ℝ), d ≥ δ_star → d < 1 →
           ∃ (a : ℕ → PDAction × PDAction),
-            discountedPayoff g d a = u_row ∧
-            discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+            (1 - d) * discountedPayoff g d a = u_row ∧
+            (1 - d) * discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
+  -- Normalized statement (2026-09-13, #15655): the `1 - d` factor sits on
+  -- BOTH equations — this is the discounted MEAN payoff, the standard
+  -- Fudenberg–Maskin conclusion. The old unnormalized conclusion was FALSE:
+  -- formally refuted by `folk_theorem_discounted_unnormalized_refuted`
+  -- (witness T3/R2/P1/S0, u = (2, 2): every stage earns at least 2 in total,
+  -- so the sum of the two series is ≥ 2 / (1 - d) > 4 = u_row + u_col once
+  -- d > 1/2 — no trajectory realizes the raw pair near 1).
+  --
   -- STRETCH (Fudenberg–Maskin 1986): existence of a joint-action trajectory
-  -- realizing the target payoff vector (u_row, u_col) as a discounted payoff,
-  -- for all δ close enough to 1. Requires convexity of the feasible-payoff
-  -- polytope and an extreme-point argument; a multi-page proof, not one tactic.
+  -- realizing the target payoff vector (u_row, u_col) as a discounted mean
+  -- payoff, for all δ close enough to 1. Requires convexity of the
+  -- feasible-payoff polytope and an extreme-point argument; a multi-page
+  -- proof, not one tactic.
   --
   -- Statement edge repaired (2026-08-15): the old quantifier "∀ d ≥ δ*"
   -- (no d < 1 bound) made the theorem FALSE — at d ≥ 1 the series


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: DEEP/ml #15548

`folk_theorem_discounted` concluait sur les séries BRUTES (`discountedPayoff g d a = u_row ∧ … = u_col`). Cet énoncé est FAUX — la PR le réfute formellement (0 sorry), puis le répare en normalisant les deux équations par `1 - d` (paiement MOYEN actualisé, conclusion standard de Fudenberg–Maskin). Le `sorry` STRETCH sur l'existence normalisée est conservé honnêtement.

## 1. Réfutation : `folk_theorem_discounted_unnormalized_refuted` (0 sorry)

Témoin `folkCounterexample` = `(T=3, R=2, P=1, S=0)` et cible `u = (2, 2)` :

- `folkCounterexample_hypotheses` (prouvé) : la cible est individuellement rationnelle, faisable (sommet coopératif `(R, R)`, poids `pCC = 1`) et strictement IR — la réfutation porte sur l'énoncé lui-même, pas sur un artefact d'hypothèse.
- `stage_sum_ge_two` (prouvé) : toute paire de coups rapporte au total ≥ `2` (`R+R = 4`, `S+T = T+S = 3`, `P+P = 2`).
- Alors la somme des deux séries vaut `Σ' dⁿ·(p_row+p_col) ≥ 2·Σ' dⁿ = 2/(1-d)`, strictement `> 4 = u_row + u_col` dès que `d > 1/2` — pour TOUT seuil `δ_star < 1` on prend `d = max δ_star (3/4)` et la contradiction éclate.

Détail technique : chaque série est sommable parce que sa somme vaut `2 ≠ 0` (`tsum_eq_zero_of_not_summable`), puis `Summable.tsum_add`, `Summable.tsum_le_tsum` et `tsum_geometric_of_lt_one` / `summable_geometric_of_lt_one` (noms post-refactor SummationFilter de ce Mathlib) contre la géométrique doublée `dⁿ + dⁿ` — aucune nouvelle dépendance.

## 2. Normalisation de l'énoncé

| | Avant | Après |
|---|---|---|
| Conclusion | `discountedPayoff g d a = u_row ∧ discountedPayoff g d (swap) = u_col` | `(1 - d) * discountedPayoff g d a = u_row ∧ (1 - d) * discountedPayoff g d (swap) = u_col` |

Hypothèses, quantificateurs et le `sorry` STRETCH : inchangés (l'existence Fudenberg–Maskin normalisée reste la dette authentique, cf #4880 critère 1).

## Preuves d'intégrité

| Contrôle | Avant | Après |
|---|---|---|
| `count_code_sorry.py --lake game_theory_lean` | code 2 / distinct 1 / 0 vacuous | code 2 / distinct 1 / 0 vacuous |
| `grep -c sorry` brut (Folk / Folk_en) | 6 / 6 (le sorry + prose docstrings) | 6 / 6 |
| `#print axioms` (3 nouveaux théorèmes) | — | aucun `sorryAx` : `[propext, Classical.choice, Quot.sound]` |
| `#print axioms folk_theorem_discounted` | `sorryAx` (STRETCH) | `sorryAx` (STRETCH, inchangé) |
| i18n checker (`check_i18n_siblings.py`) | OK | OK — 4/4 pairs byte-identical, 0 drift, 0 half-done |

`lake build RepeatedGames.Folk RepeatedGames.Folk_en` : SUCCESS (exit 0) sous le toolchain épinglé `leanprover/lean4:v4.32.1` ; seuls avertissements : `declaration uses 'sorry'` sur `folk_theorem_discounted` (Folk.lean:270 / Folk_en.lean:288), le STRETCH conservé.

## Périmètre

2 fichiers — `RepeatedGames/Folk.lean` + `RepeatedGames/Folk_en.lean` (siblings #4980 : code byte-identique, seules les docstrings/commentaires diffèrent). Aucun autre module, inventaire, README ou catalogue modifié.

Closes #15655

🤖 Generated with [Claude Code](https://claude.com/claude-code)
