### PR TITLE
feat(slides,#15023): deck 05 content tranche - combinatorial games (Grundy) + imperfect info (CFR)

### DIFF
--- a/slides/05-theorie-des-jeux/slides.md
+++ b/slides/05-theorie-des-jeux/slides.md
@@ -325,6 +325,21 @@ layout: dense
 layout: dense
 ---
 
+# Jeux combinatoires -- Grundy et les nimbers
+
+## Sprague-Grundy
+
+- Classe : information parfaite, sans hasard, somme nulle, fini (Nim)
+  - Théorème de Sprague-Grundy : chaque position vaut un nimber, la somme disjointe vaut le XOR
+  - Position perdante (P-position) ssi Grundy = 0 -- l'induction arrière devient un calcul
+- Compagnons formels du corpus : port Lean « from scratch », puis lake natif dédié
+
+*Notebooks : [GameTheory-08-CombinatorialGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-08-CombinatorialGames.ipynb) (Nim, Grundy) · [GameTheory-08b-Lean-CombinatorialGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-08b-Lean-CombinatorialGames.ipynb) (port Lean from scratch) · [GameTheory-08c-CombinatorialGames-Python](../../MyIA.AI.Notebooks/GameTheory/GameTheory-08c-CombinatorialGames-Python.ipynb) · [GameTheory-08d-Lean-CGT-Native](../../MyIA.AI.Notebooks/GameTheory/GameTheory-08d-Lean-CGT-Native.ipynb) (lake `conway_cgt_lean`).*
+
+---
+layout: dense
+---
+
 # Formes stratégiques avancees
 
 ## Raisonner avec des variables
@@ -538,6 +553,22 @@ layout: dense
 <img src="./images/img_037.png" alt="Exemples de PBE : pooling, separating et semi-separation" style="display:block; margin:4px auto; max-height:90px; width:auto; max-width:100%; object-fit:contain;">
 
 *Notebooks : [GameTheory-12-ReputationGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb) (pooling/separating) · [GameTheory-17d-Lean-Screening-Signaling](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17d-Lean-Screening-Signaling.ipynb) (screening formalise).*
+
+---
+layout: dense
+---
+
+# Information imparfaite -- le regret contraposé (CFR)
+
+## Poker et apprentissage auto-centré
+
+- Théorème de Kuhn : à rappel parfait, stratégies comportementales = mixtes
+  - L'information set porte la croyance qui pilote la meilleure réponse
+- CFR (Counterfactual Regret Minimization) : minimiser le regret contraposé
+  - Convergence vers l'équilibre de Nash -- la famille qui a révolutionné la résolution du poker
+  - Safe subgame solving : recoller une sous-partie sans supposer les croyances (le mauvais recollement produit un témoin adversarial)
+
+*Notebooks : [GameTheory-13-ImperfectInfo-CFR](../../MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb) (CFR, Kuhn) · [GameTheory-13b-Safe-Subgame-Solving](../../MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb) · [GameTheory-13c-Safe-Subgame-Solving-Csharp](../../MyIA.AI.Notebooks/GameTheory/GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb) (jumeau C#) · [GameTheory-13d-Optimistic-CFR](../../MyIA.AI.Notebooks/GameTheory/GameTheory-13d-Optimistic-CFR.ipynb).*
 
 ---
 layout: section


### PR DESCRIPTION
Grain: DEEP/slides — lane myia-po-2026:CoursIA — prev: DEEP/ml #15548

Tranche #15023 sur le deck `05-theorie-des-jeux` : **2 slides de contenu neuves** (+31/-0, `slides.md` uniquement) couvrant deux pans entiers du corpus absents du deck.

## Contenu ajouté (grounded dans les notebooks cités)

1. **Jeux combinatoires — Grundy et les nimbers** (clôt l'arc jeux répétés/formels, avant « Formes stratégiques avancées ») : classe information parfaite/sans hasard/somme nulle/fini (Nim) ; théorème de Sprague-Grundy (position = nimber, somme disjointe = XOR) ; P-position ssi Grundy = 0. Citations : [GameTheory-08-CombinatorialGames] · [08b-Lean] (port from scratch) · [08c-Python] · [08d-Lean-CGT-Native] (lake `conway_cgt_lean`).
2. **Information imparfaite — le regret contraposé (CFR)** (clôt l'arc bayésien/signalling, avant le Questions? de section) : théorème de Kuhn (rappel parfait ⇒ comportementales = mixtes) ; CFR et convergence vers l'équilibre de Nash (la famille qui a révolutionné la résolution du poker) ; safe subgame solving (recollement sans supposer les croyances, témoin adversarial). Citations : [GameTheory-13-ImperfectInfo-CFR] · [13b-Safe-Subgame-Solving] · [13c jumeau C#] · [13d-Optimistic-CFR].

## Pourquoi ces sujets

Diff disque ↔ deck : 95 notebooks GameTheory sur `main`, 44 cités avant la tranche — les 51 non-cités contenaient deux pans entiers sans AUCUNE présence dans le deck (jeux combinatoires 08x ; information imparfaite/CFR 13x). Note d'honnêteté : la mesure « 0 réf `.ipynb` » de l'EPIC datait d'avant les tranches récentes — le deck porte déjà 36 refs sur `main` ; cette tranche cible donc les **contenus non couverts**, pas des refs manquantes. (Deck inchangé depuis `5f58dd9d9f`, vérifié par diff vide.)

## Validation

- **8 cibles de liens vérifiées sur disque** (worktree frais = origin/main).
- **Composition A/B** (organe canonique `scan_slidev_composition.py`, états BASE/BRANCHE servis en parallèle sur ports distincts) : `n_slides` 49 → 51, `hors_canvas` 2 → 2 (pré-existants, autres slides), `chevauchements` 0 → 0, `recouvrements` 0 → 0 — **zéro régression**. Scanner = version corrigée #15695 (PR #15877).
- **Build production** : `slidev build` exit 0, 0 erreur au log ; **51/51 slides rendues** dans le SPA bâti (comptage `#slideshow` via Playwright sur le `dist` servi) ; contrôle positif texte : « Sprague-Grundy » ✓, « regret contraposé » ✓, dernière slide « Merci » ✓.

## Résiduel signalé (sujets distincts, non traités)

Autres contenus du corpus sans présence deck : agents bornés / équilibres de programmes (06f/06g), jeux ouverts et lentilles (18/18b), MARL (17), abstraction à dette (19). Par ailleurs la slide « Ce qui reste ouvert » (Folk STRETCH) mériterait une mise à jour après merge de #15876 (énoncé normalisé + réfutation formelle de l'ancien énoncé brut) — fait exprès de ne pas l'anticiper ici (une PR = un sujet).

See #15023 — tranche partielle, l'EPIC reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
