### PR TITLE
fix(genai,#15767): MCP searxng du support Vibe-Coding sur instance locale docker (json active)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/README.md
@@ -110,9 +110,13 @@ Délègue l'analyse de sécurité à un agent spécialisé.
 **MCP (Model Context Protocol)** : Connexion à des services externes.
 
 ```bash
-claude mcp add searxng https://search.myia.io/
+claude mcp add --transport http searxng http://localhost:8181/
 claude mcp add github https://api.githubcopilot.com/mcp/
 ```
+
+> L'URL locale suppose une instance SearXNG lancée en Docker sur le port 8181
+> avec le format JSON activé — recette complète dans
+> `docs/INSTALLATION-CLAUDE-CODE.md` § « Serveur de Recherche Web ».
 
 **Hooks** : Actions automatiques sur des événements.
 
@@ -170,7 +174,7 @@ projet/
 {
   "mcpServers": {
     "searxng": {
-      "url": "https://search.myia.io/",
+      "url": "http://localhost:8181/",
       "transport": "http"
     },
     "github": {

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/demo-3-mcp-hooks/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/demo-3-mcp-hooks/README.md
@@ -45,6 +45,25 @@ Les Hooks sont des actions automatiques déclenchées par des événements.
 
 ### Étape 1 : Configurer un serveur MCP (15 min)
 
+#### Lancer l'instance SearXNG (Docker, une seule fois)
+
+Le conteneur `searxng/searxng:latest` désactive le format JSON par défaut (requis
+par le MCP) et exige une `secret_key` dès qu'on monte son propre `settings.yml` :
+
+```bash
+mkdir -p searxng
+cat > searxng/settings.yml << 'EOF'
+use_default_settings: true
+server:
+  secret_key: "remplacez-par-une-chaine-aleatoire-longue"
+search:
+  formats:
+    - html
+    - json
+EOF
+docker run -d --name searxng -p 8181:8080 -v "$(pwd)/searxng:/etc/searxng" searxng/searxng:latest
+```
+
 #### Configuration locale (.mcp.json)
 
 ```bash
@@ -52,7 +71,7 @@ cat > .mcp.json << 'EOF'
 {
   "mcpServers": {
     "searxng": {
-      "url": "https://search.myia.io/",
+      "url": "http://localhost:8181/",
       "transport": "http",
       "description": "Moteur de recherche web distribué"
     }
@@ -83,7 +102,7 @@ cat > .mcp.json << 'EOF'
 {
   "mcpServers": {
     "searxng": {
-      "url": "https://search.myia.io/",
+      "url": "http://localhost:8181/",
       "transport": "http"
     },
     "github": {
@@ -254,7 +273,7 @@ Créez une configuration MCP + Hooks complète pour votre projet.
 {
   "mcpServers": {
     "searxng": {
-      "url": "https://search.myia.io/",
+      "url": "http://localhost:8181/",
       "transport": "http"
     },
     "github": {
@@ -329,8 +348,8 @@ Configuration fonctionnelle testée.
 # Vérifier la configuration
 claude mcp list
 
-# Tester manuellement (HTTP)
-curl https://search.myia.io/
+# Tester manuellement (HTTP) — l'instance locale doit repondre 200
+curl 'http://localhost:8181/search?q=test&format=json'
 
 # Vérifier les logs
 claude --debug

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/taches-demo.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/05-automatisation-avancee/taches-demo.md
@@ -278,7 +278,7 @@ Vous voulez étendre Claude Code avec des capacités de recherche web et d'accè
    {
      "mcpServers": {
        "searxng": {
-         "url": "https://search.myia.io/",
+         "url": "http://localhost:8181/",
          "transport": "http",
          "description": "Recherche web distribuée"
        },

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
@@ -213,8 +213,8 @@ claude mcp add --transport http nom https://url
 ### Serveurs Populaires
 
 ```bash
-# Recherche Web (SearXNG)
-claude mcp add --transport http searxng https://search.myia.io/
+# Recherche Web (SearXNG) — instance locale requise (cf. INSTALLATION-CLAUDE-CODE.md)
+claude mcp add --transport http searxng http://localhost:8181/
 
 # Playwright (automatisation navigateur)
 claude mcp add --transport stdio playwright -- \

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CONCEPTS-AVANCES.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CONCEPTS-AVANCES.md
@@ -905,7 +905,7 @@ claude mcp add --scope user --transport http myserver https://...
     },
     "searxng": {
       "type": "http",
-      "url": "https://search.myia.io/"
+      "url": "http://localhost:8181/"
     }
   }
 }
@@ -949,7 +949,7 @@ export MAX_MCP_OUTPUT_TOKENS=50000
   "mcpServers": {
     "search": {
       "type": "http",
-      "url": "https://search.myia.io/"
+      "url": "http://localhost:8181/"
     },
     "github": {
       "type": "http",

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -495,9 +495,39 @@ Les serveurs MCP etendent les capacités de Claude Code.
 
 #### 1. Serveur de Recherche Web (SearXNG)
 
+Le MCP SearXNG requiert une instance dont le format JSON est activé (le conteneur
+`searxng/searxng:latest` le désactive par défaut : `/search?...&format=json` répond
+alors `403`). Lancez une instance locale :
+
 ```bash
-claude mcp add --transport http searxng https://search.myia.io/
+mkdir -p searxng
+cat > searxng/settings.yml << 'EOF'
+use_default_settings: true
+server:
+  secret_key: "remplacez-par-une-chaine-aleatoire-longue"
+search:
+  formats:
+    - html
+    - json
+EOF
+docker run -d --name searxng -p 8181:8080 -v "$(pwd)/searxng:/etc/searxng" searxng/searxng:latest
 ```
+
+> `server.secret_key` est obligatoire dès que vous montez votre propre
+> `settings.yml` — sans elle, le worker SearXNG refuse de démarrer.
+
+Puis déclarez le serveur MCP :
+
+```bash
+claude mcp add --transport http searxng http://localhost:8181/
+```
+
+Vérification : `curl 'http://localhost:8181/search?q=test&format=json'` doit
+répondre `200` avec un objet JSON.
+
+Si vous disposez d'une instance privée authentifiée (fournie par l'établissement),
+remplacez l'URL locale par la sienne et ajoutez les en-têtes d'authentification
+correspondants (`claude mcp add --help`) — ce n'est jamais le chemin par défaut.
 
 #### 2. Serveur Playwright (Automatisation Navigateur)
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2023:CoursIA — prev: MED/guard #15850

## Resume

Les consignes d'installation du support Vibe-Coding branchaient le MCP searxng sur `https://search.myia.io/`, endpoint prive place derriere l'authentification Basic IIS (401 mesure dans l'issue) : tout etudiant qui suivait la consigne obtenait un MCP mort, sans moyen de lever l'erreur. Cours EPF MSMIN5IN52 demarre le 2026-09-09 — guides suivis en ce moment.

Cette PR rebasetoutes les consignes sur une **instance locale docker :8181**, et relgue l'instance privee en **option** explicite (modele `INSTALLATION-ROO.md:110`), jamais chemin par defaut.

## La recette livree est mesuree, pas copiee de l'issue

La commande proposee dans l'issue (`docker run -d -p 8181:8080 searxng/searxng:latest` seul) **ne suffit pas** — trois sondes firsthand sur cette machine (conteneurs ephemeres detruits apres mesure) :

| Sonde | Conteneur | `/` | `/search?...&format=json` |
|---|---|---|---|
| 1 | stock, aucun mount | 200 | **403** (format json desactive par defaut) |
| 2 | settings.yml sans `server.secret_key` | 200 | **404** (worker exit : `server.secret_key is not changed`, log cite) |
| 3 | settings.yml avec secret_key + `formats: [html, json]` | 200 | **200** + resultats JSON reels |

La recette documentee (dans `INSTALLATION-CLAUDE-CODE.md` et la demo 3) est donc le trio complet : `settings.yml` minimal (`use_default_settings` + `secret_key` + formats) + mount `-v .../searxng:/etc/searxng` + `claude mcp add --transport http searxng http://localhost:8181/`, avec verification `curl` attendue 200. C'est exactement la configuration que la flotte fait tourner (conteneur `searxng/searxng:latest` sur :8181, `formats: [html, json]` dans son settings.yml monte — verifie sur le conteneur live po-2023).

## Sites corriges — 11 sites / 6 fichiers

| Fichier | Sites |
|---|---|
| `Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md` | L499 (recette complete + option privee) |
| `Claude-Code/docs/CHEAT-SHEET.md` | L217 (forme courte + pointeur) |
| `Claude-Code/docs/CONCEPTS-AVANCES.md` | L908, L952 (**hors inventaire de l'issue**) |
| `Claude-Code/05-automatisation-avancee/README.md` | L113 (+ `--transport http` ajoute : la forme courte sans transport echoue), L173 |
| `Claude-Code/05-automatisation-avancee/demo-3-mcp-hooks/README.md` | L55, L86, L257, L333 (**L86/L257/L333 hors inventaire**) |
| `Claude-Code/05-automatisation-avancee/taches-demo.md` | L281 |

5 des 11 sites ne figuraient pas dans l'inventaire de l'issue — trouves par le sweep `grep myia.io` demande par l'acceptance.

## Sweep de verification (acceptance : « aucune autre consigne du support ne pointe un *.myia.io authentifie »)

Recensement exhaustif `myia.io` sur `MyIA.AI.Notebooks/GenAI/Vibe-Coding/` + `docs/` — mentions restantes, toutes legitimes :

- `Roo-Code/docs/INSTALLATION-ROO.md:110` — le **modele** de l'option privee, garde tel quel.
- `Audio/04-Applications/v4/p0_narrative_research.py:72` — defaut jumeau explicitement **hors scope** (dispatche #15002, autre grain).
- `QuantConnect/ML-Training-Pipeline/research_what_dl_can_predict.ipynb` (x2) + `docs/archive/research/dl_predictability_finance_2026.md` — notes methodologiques historiques (« systematic review via search.myia.io »), pas des consignes d'installation ; outputs commites = preuves d'execution, non modifiables.
- `models.myia.io` / `whisper-api.myia.io` / `mcp-tools.myia.io` (docs Claudish / Claw-Systems) — services differents, docs de deploiement flotte avec cles prescrites, hors scope.
- `pauwels.open-webui.myia.io` / `whisper-webui.myia.io` (INTRO-GENAI) — UIs hebergees du cours avec leur propre auth/login etudiant, pas des endpoints API a consigne d'installation.

## Hors scope respecte (organes gestionnaires)

`Configure-IISAuthentication.ps1`, `Manage-ApiKeys.{ps1,sh}`, `scripts/security/audit_exposed_services.py` et son test : non touches.

## Validation

- `grep -rn "search.myia.io" MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/` : 0 occurrence restante.
- Parite des fences markdown verifiee sur les 6 fichiers (comptes pairs).
- 6 fichiers markdown, +66/-13 — aucune table, aucun notebook, aucun script touches.
- Diff limite au perimetre declare : 6 fichiers du support Vibe-Coding Claude-Code, rien d'autre.

Closes #15767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
