### PR TITLE
docs(curriculum,#15821): pilote 4 vise trading-narratif.md, pas l'id genere trading (arbitrage ai-01)

### DIFF
--- a/docs/curriculum/_inventory.md
+++ b/docs/curriculum/_inventory.md
@@ -49,7 +49,7 @@
 | 14 | `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md` L63-107 + table L113-122 | Multi-profil (Dev Solidity, crypto, alt-chains, sécurité) | 8h + 3h + 4h + 7h + 22h complet | Phase 1-7 + 4 alternatifs + table « Quel parcours choisir » | **RELOCATE** — table « Quel parcours choisir » modèle canonique, à reprendre dans la doc racine |
 | 15 | `MyIA.AI.Notebooks/Search/README.md` L51 + `Part1-Foundations/README.md` + `Part4-Metaheuristics/README.md` L152 | Apprenant algorithmique de recherche | Variable (cf Phases) | « Parcours d'apprentissage » racine + phases par partie | **INTEGRATE** — structure socle pour `aima-walk.md` (AIMA chapters 3-4) |
 | 16 | `MyIA.AI.Notebooks/IIT/README.md` L36-59 | Apprenant Integrated Information Theory | Non chiffré | « Parcours recommandés » (3 parcours) | **ARCHIVE** — embryon ténu, hors-scope Phase 2 |
-| 17 | `MyIA.AI.Notebooks/QuantConnect/Python/README.md` L140-184 | Quant Python (LEAN → ML → multi-actifs → RL) | Phase 1-4 (~25h) | « Phase N : titre » tabulaire | **RELOCATE** — modèle tabulaire, à reprendre dans `docs/curriculum/trading.md` (refonte du catalogue trading) |
+| 17 | `MyIA.AI.Notebooks/QuantConnect/Python/README.md` L140-184 | Quant Python (LEAN → ML → multi-actifs → RL) | Phase 1-4 (~25h) | « Phase N : titre » tabulaire | **RELOCATE** — modèle tabulaire, à reprendre dans `docs/curriculum/trading-narratif.md` (pilote 4, #15821) |
 | 18 | `MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/README.md` L269 | Cours public QC partner | Variable | « Parcours d'Apprentissage Recommandé » | **ARCHIVE** — lié au partenariat, hors périmètre |
 | 19 | `MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md` L49-70 + `Track2-GoogleADK/README.md` L213-231 | Data scientist → multi-agents | 1j à 7j selon parcours | 4 parcours tabulaires (analyste / ingénieur / complet / rapide) | **RELOCATE** — modèle profil/durée pour `genai-rush.md` (pilote accéléré GenAI) |
 | 20 | `MyIA.AI.Notebooks/GenAI/README.md` L41 | Apprenant GenAI multimodal | Non chiffré | « Parcours recommandés » (liste plutôt narrative) | **INTEGRATE** — narratif racine à refactorer |
@@ -130,7 +130,7 @@ serve de référence à l'EPIC #13844.
 - **Pilot 1 — `docs/curriculum/genai-rush.md`** : GenAI/Image + Audio + Video + Texte + SemanticKernel + FineTuning + RL (le « ~8-10 h, 3-4 mois »).
 - **Pilot 2 — `docs/curriculum/symbolic-formalization.md`** : GameTheory + Tweety + Lean + Planners + SmartContracts + SemanticWeb (le « ~20 h, ~6 mois »).
 - **Pilot 3 — `docs/curriculum/aima-walk.md`** : AIMA chapters 1-26 mappés aux notebooks (le « ~30 h, ~9 mois »).
-- **Pilot 4 — `docs/curriculum/trading.md`** : QuantConnect/Python refonte + partner-course + C# (cf. EPIC #10805 #10806).
+- **Pilot 4 — `docs/curriculum/trading-narratif.md`** : QuantConnect/Python refonte + partner-course + C# (cf. EPIC #10805 #10806). Cible renommée depuis `trading.md` (#15821, arbitrage ai-01 option 1) : `trading` est un id du dict `PARCOURS` de `generate_parcours.py`, la page est régénérée chaque jour par `catalog-cron.yml` — le nom du pilote ne doit être **aucun des cinq ids** (`ia-classique`, `ia-symbolique`, `genai`, `trading`, `recherche`).
 - **Pilot 5 — `docs/curriculum/research.md`** : IIT + ML + cross-series + cas d'usage livresagites.
 
 cf. **EPIC #13844** pour le plan en 4 phases et les critères d'acceptation globaux.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/guard #15850

## Resume

Application de l'arbitrage ai-01 sur #15821 (option 1) : la cible du **pilote 4** du plan Phase 2 de #13844 ne désigne plus un nom de fichier que le cron écrase. `docs/curriculum/trading.md` est l'un des cinq ids du dict `PARCOURS` de `scripts/notebook_tools/generate_parcours.py` — régénéré chaque jour par `catalog-cron.yml` (preuve directe mesurée par ai-01 : les cinq pages ids horodatées à la même minute). La cible devient **`docs/curriculum/trading-narratif.md`**.

## Changements — 1 fichier, +2/-2

| Ligne | Avant | Apres |
|---|---|---|
| `_inventory.md:133` (§ Phase 2+, Pilot 4) | `docs/curriculum/trading.md` | `docs/curriculum/trading-narratif.md` + note nommant la contrainte (aucun des cinq ids du dict) et la provenance (#15821, arbitrage ai-01) |
| `_inventory.md:52` (row 17, disposition RELOCATE) | « à reprendre dans `docs/curriculum/trading.md` (refonte du catalogue trading) » | « à reprendre dans `docs/curriculum/trading-narratif.md` (pilote 4, #15821) » |

La note de L133 est deliberement redigee pour empecher le retour-arriere : le prochain lecteur qui voudra « simplifier » en `trading.md` y lira pourquoi ce nom est interdit pour un pilote.

## Ce qui reste intact (mesuré, pas suppose)

- Les **liens catalogue** vers la page générée — `PARCOURS.md:11`, `docs/README.md:173`, `MyIA.AI.Notebooks/README.md:346` — pointent la page catalogue qui reste générée : inchangés (l'arbitrage écarte explicitement l'option 2).
- Le générateur `generate_parcours.py` : zéro ligne touchée.
- Les pilotes 1-3 et 5 : cibles déjà hors dict (`genai-rush.md`, `symbolic-formalization.md`, `aima-walk.md`, `research.md` ≠ `recherche.md`).
- Le body de l'EPIC #13844 : aucune désignation directe du fichier cible du pilote 4 (grep « trading » = 1 occurrence, la ligne de constat décrivant les 5 pages générées).

## Recensement exhaustif `trading.md` sur origin/main@54853d8087

`git grep "trading\.md" origin/main` : 6 occurrences — les 2 corrigées ici + les 3 liens catalogue légitimes + la page générée elle-même. Rien d'autre ne désigne le pilote 4 vers un id du dict.

## Rider coordination (hors PR)

Issue fille **#15882** ouverte pour la garde fail-closed du générateur suggérée par l'arbitrage (« refuse d'écrire un fichier qui ne porte pas déjà son header FICHIER GENERE ») — le défaut de classe survit au renommage.

## Validation

- `grep -n "trading" docs/curriculum/_inventory.md` : plus aucune désignation du pilote 4 vers `trading.md` (les occurrences restantes = row 18 « quant-trading » chemin QC, et la note de contrainte elle-même).
- Ligne tableau L52 : 6 cellules avant / 6 cellules après (parité pipes vérifiée sur le diff).
- Diff limité au périmètre déclaré : 1 fichier markdown manuel (`_inventory.md` n'est pas dans le dict du générateur — fichier manuel, horodatage indépendant mesuré par ai-01).

Closes #15821 (l'acceptance — « le plan Phase 2 ne désigne plus un nom de fichier que le cron écrase, AVANT tout dispatch du pilote 4 » — est satisfaite ; le pilote 4 n'est pas encore dispatché).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

