### PR TITLE
docs(slides,#15023): deck 05 extensions -- MARL, agents bornes, jeux ouverts (+3 slides, 11 refs)

### DIFF
--- a/slides/05-theorie-des-jeux/slides.md
+++ b/slides/05-theorie-des-jeux/slides.md
@@ -934,6 +934,55 @@ layout: default
 *Notebooks : [GameTheory-14-DifferentialGames](../../MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb) (equilibres, LQ) · [GameTheory-09c-Stackelberg-SecurityGame](../../MyIA.AI.Notebooks/GameTheory/GameTheory-09c-Stackelberg-SecurityGame.ipynb) (Stackelberg). Poursuite-evasion par RRT : pas de notebook dedie.*
 
 ---
+layout: dense
+---
+
+# Apprentissage multi-agents -- self-play, NFSP, PSRO
+
+## Quand l'equilibre s'apprend au lieu de se calculer
+
+- Self-play : l'agent devient son propre adversaire -- la population des strategies passees tient lieu d'opposant
+  - Fictitious Play : meilleure reponse a la frequence empirique des coups adverses
+  - NFSP : un reseau apprend la meilleure reponse, un autre la politique moyenne -- l'equilibre emerge de leur melange
+  - PSRO (Policy-Space Response Oracles) : population de meilleures reponses imbriquees, l'echelle ou FP s'essouffle
+- La serie se decline en jumeau C# pour les TP .NET
+
+*Notebooks : [GameTheory-17-MultiAgent-RL](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL.ipynb) (self-play, FP, NFSP, PSRO) · [GameTheory-17-MultiAgent-RL-Csharp](../../MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL-Csharp.ipynb) (jumeau C#).*
+
+---
+layout: dense
+---
+
+# Rationalite bornee -- agents-programmes a budget
+
+## Le cout du raisonnement entre dans le modele
+
+- Agent-programme : code public + budget de raisonnement fini (Barasz et al. 2014, Critch 2016)
+  - Interprete total : budget nul = action immediate, budget epuise = arret -- la terminaison est structurelle, pas esperee
+  - Simuler l'adversaire coute des steps : chaque borne `MAX_DEPTH` / `STEP_BUDGET` deplace l'equilibre atteignable
+- Equilibre de programmes par simulation : deux adversaires au comportement identique sont traites pareil -- l'inspection syntaxique, elle, se trompe
+- Compagnon formel : module `ProgramGames.Bounded` du lake `game_theory_lean` -- code public, budget, interprete `act`
+- Oracles reflexifs (Fallenstein, Taylor, Christiano 2015) : decider sur sa propre decision sans paradoxe
+
+*Notebooks : [GameTheory-06e-Open-Source-Game-Theory](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06e-Open-Source-Game-Theory.ipynb) · [GameTheory-06f-Bounded-Agents-Python](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Agents-Python.ipynb) · [GameTheory-06f-Bounded-Proofs-Reasoning-Costs](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06f-Bounded-Proofs-Reasoning-Costs.ipynb) (preuves bornees) · [GameTheory-06g-Bounded-Agents-Lean](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06g-Bounded-Agents-Lean.ipynb) · [GameTheory-06g-Simulation-Based-Program-Equilibria](../../MyIA.AI.Notebooks/GameTheory/GameTheory-06g-Simulation-Based-Program-Equilibria.ipynb) · [GameTheory-04e-Reflective-Oracles](../../MyIA.AI.Notebooks/GameTheory/GameTheory-04e-Reflective-Oracles.ipynb).*
+
+---
+layout: dense
+---
+
+# Jeux ouverts et lentilles -- composer les jeux
+
+## La theorie des jeux compositionnelle
+
+- Open game : un jeu a frontieres -- entrees, sorties, couts, strategies locales
+  - Lentille (get/set) : le regard qui lit l'etat global et reecrit localement -- composer les jeux, c'est composer les lentilles
+  - Propriete de Hedges : la meilleure reponse de la composition est la composition des meilleures reponses -- quand elle tient
+- Casser la composition : deux surfaces d'attaque ou la meilleure reponse composee cesse d'etre l'equilibre du jeu compose
+- Abstraction a dette mesurable (Kroer & Sandholm) : resoudre le jeu abstrait puis retransporter la strategie -- avec une borne sur ce que le detour coute au pire cas
+
+*Notebooks : [GameTheory-18-Open-Games-et-Lentilles](../../MyIA.AI.Notebooks/GameTheory/GameTheory-18-Open-Games-et-Lentilles.ipynb) (lentilles, Hedges) · [GameTheory-18b-Casser-la-Composition](../../MyIA.AI.Notebooks/GameTheory/GameTheory-18b-Casser-la-Composition.ipynb) (attaques) · [GameTheory-19-Abstraction-a-Dette](../../MyIA.AI.Notebooks/GameTheory/GameTheory-19-Abstraction-a-Dette.ipynb) (bornes d'abstraction).*
+
+---
 layout: section
 ---
 


### PR DESCRIPTION
Grain: DEEP/slides — lane myia-po-2026:CoursIA — prev: DEEP/slides #15880

## Tranche CONTENU #15023 — deck 05 « extensions modernes » (+3 slides, 11 refs)

Diff systématique disque↔decks (origin/main) : ~20 notebooks GameTheory non couverts par aucun deck. Cette tranche couvre le bloc thématique « au-delà de l'équilibre classique » inséré en fin d'arc du deck 05 (après « Méthodes calculatoires », avant le `Questions?` final — ancre distincte de la tranche #15880 pour éviter tout conflit de merge) :

1. **Apprentissage multi-agents — self-play, NFSP, PSRO** (slide 50) : self-play, Fictitious Play, NFSP, PSRO — cite `GameTheory-17-MultiAgent-RL` + jumeau C#.
2. **Rationalité bornée — agents-programmes à budget** (slide 51) : code public + budget de raisonnement fini (Barasz et al. 2014, Critch 2016), interprète total, `MAX_DEPTH`/`STEP_BUDGET`, équilibres de programmes par simulation, oracles réflexifs (Fallenstein/Taylor/Christiano 2015) — cite 06e, 06f×2, 06g×2, 04e.
3. **Jeux ouverts et lentilles** (slide 52) : open games, lentilles get/set, propriété de Hedges, casser la composition, abstraction à dette mesurable (Kroer & Sandholm) — cite 18, 18b, 19.

## Contrôles

| Contrôle | Résultat |
|---|---|
| Cibles des 11 liens sur disque (worktree frais origin/main) | 11/11 OK |
| Compte de slides (split_slides_source) | 49 → 52 |
| Organe composition A/B (dev 8781 main vs 8782 branche, 2 sondes chacune) | nouvelles slides 50/51/52 : **0 hors-canvas, 0 chevauchement, 0 occupation** |
| Build production (`npx slidev build`) | **52/52 pages** pré-rendues |
| Contrôles texte prod build (textContent, pas innerText) | **16/16 OK** (titres, NFSP/PSRO, MAX_DEPTH, Hedges, Kroer, 11 refs nominatives) |

Note A/B : les asymétries inter-instances observées sur les slides 1-49 identiques (5 hors-canvas côté instance main, 4 chevauchements LI 1px côté instance branche — classe FP connue, correctif en review PR #15877) sont attribuées à l'environnement dev-server, pas au contenu : aucune modification globale (aucun CSS ajouté, insertion en fin de deck, slides 1-49 inchangées byte-identiques).

## Résiduel (non couvert, prochaine tranches potentielles)

02c dilemme du voyageur · 02-Part2-Python · 04e→couvert · 06d sympathie vs engagement · 15c-Python · 15e coalition power SMT · 16d échange de reins · 16e LLM players Othman-Sandholm · 17c×2 lemons/market-to-balance-sheet · 21 translateur Life · 22 ensembles limites Poincaré-Bendixson · 23/23b Munkres assignment (+Lean natif) · 24/24b humour banc (+Dur) · jumeaux C# (couverture partielle selon slides).

See #15023 (contribution partielle à l'EPIC CONTENU — l'EPIC reste ouvert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
