### PR TITLE
fix(ci,#15864): refuser la continuation de lane apres un point de prose (lane fantome)

### DIFF
--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -192,6 +192,27 @@ _GRAIN_FULL_RE = re.compile(
 # body class widens to the corresponding lowercase range (`à-öø-ÿ` + ſ) so the
 # maximal-munch `(?![A-Za-z0-9._À-ſ-])` keeps working with the new characters.
 # Tested in `test_lane_workspace_accented` + the existing #12145 / #12719 set.
+# #15864 -- a PROSE PERIOD followed by an accented continuation word is the
+# fourth variant of the self-blocking class (#12145 space-workspace, #12719
+# bare date, #13830 accents, now #12719 x #13830). The founder marker of
+# issue #15674:
+#
+#     [DELIVERED] PR #15733 — lane myia-po-2023:CoursIA. Énoncé réécrit ...
+#
+# The workspace class admits `.` (hostnames need it, #12719), so it eats
+# `CoursIA.`; the continuation then legitimately admits `Énoncé` (#13830
+# accented uppercase) and the read token becomes `myia-po-2023:CoursIA.
+# Énoncé` -- a lane that exists nowhere, which check_lane_claim used to
+# block the declaring lane on (its OWN [DELIVERED] re-marker, #12320).
+#
+# Rule: a `.` followed by whitespace is PROSE PUNCTUATION, never part of a
+# `<machine>:<workspace>` token; a `.` INSIDE a token (hostname, `Foo.Bar`)
+# is followed by a non-blank and survives. Implemented by a `(?<!\.)`
+# lookbehind at the head of the continuation clause: after a token-ending
+# period every continuation iteration is refused, the capture stops at
+# `...CoursIA.` and the existing #12719 `rstrip(".")` in extract_lane /
+# parse_grain_tag lands the bare lane. `lane_marker_residues` keeps
+# declaring the malformed form (`trailing-period:`).
 _LANE_RE = re.compile(
     r"lane\s*:?\s+"
     # #13830 V2 -- union of #13869 (full Latin-1 + Latin Extended-A `À-ſ`)
@@ -213,7 +234,7 @@ _LANE_RE = re.compile(
     # `test_lane_workspace_accented` + the existing #12145 / #12719 set
     # + the #13869 comparative table (LivresAgités / Cours×IA / Łódź).
     r"([A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿĀ-ſ0-9._-]+"
-    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9À-ÖØ-ÞĀ-ſ])[A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-]*(?![A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-])(?![:@])){0,3})",
+    r"(?:(?<!\.)[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9À-ÖØ-ÞĀ-ſ])[A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-]*(?![A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-])(?![:@])){0,3})",
     re.IGNORECASE,
 )
 
@@ -257,7 +278,7 @@ _LANE_FALLBACK_RE = re.compile(
     # The twin MUST move with the primary or the founder's class of bug
     # (#12145) re-opens on the fallback only.
     r"\b(myia-[A-Za-z0-9._-]+:[A-Za-zÀ-ÖØ-öø-ÿĀ-ſ][A-Za-zÀ-ÖØ-öø-ÿĀ-ſ0-9._-]*"
-    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9À-ÖØ-ÞĀ-ſ])[A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-]*(?![A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-])(?![:@])){0,3})"
+    r"(?:(?<!\.)[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9À-ÖØ-ÞĀ-ſ])[A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-]*(?![A-Za-z0-9._À-ÖØ-öø-ÿĀ-ſ-])(?![:@])){0,3})"
 )
 
 # `prev` (case-insensitive), optional colon, whitespace, then the SAME

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -409,6 +409,38 @@ def test_check_no_paths_claim_in_prose_returns_exit_2_not_scoped(capsys):
     assert "myia-po-2025:CoursIA-2" in captured.out
 
 
+def test_prose_period_delivered_remarker_does_not_block_owning_lane(capsys):
+    """#15864 -- full-flow regression: the phantom-lane self-block.
+
+    The founder payload of issue #15674: a canonical [CLAIMED] plus the lane's
+    own [DELIVERED] whose prose after the lane token starts with an accented
+    uppercase word (`CoursIA. Énoncé ...`). Pre-fix, the [DELIVERED] re-marker
+    parsed as the phantom lane `myia-po-2023:CoursIA. Énoncé` -- a DIFFERENT
+    key -- and `lane_claim_required` blocked PR #15733 on its own delivery
+    (gate verdict FAIL, 8 reruns). Post-fix the re-marker parses to the
+    declaring lane and the check is CLEAR for it (exit 0), still blocking for
+    any OTHER lane.
+    """
+    claimed = (
+        "[CLAIMED] lane myia-po-2023:CoursIA — 2026-09-12T09:0xZ — paths: "
+        "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05-Stockage-Vectoriel.ipynb"
+    )
+    delivered = (
+        "[DELIVERED] PR #15733 — lane myia-po-2023:CoursIA. Énoncé réécrit en "
+        "deux gestes (chercher inchangé + recenser), le piège top-10 nommé "
+        "dans l'énoncé. Exéc complète 12.2s, validate 17 cells PASS."
+    )
+    p = payload(
+        comment(claimed, "2026-09-12T09:17:24Z", author="myia-po-2023"),
+        comment(delivered, "2026-09-12T20:41:00Z", author="myia-po-2023"),
+        number=15674,
+    )
+    # Acceptance #15864-4: CLEAR (exit 0) for the declaring lane.
+    assert clc._run_check(p, "myia-po-2023:CoursIA") == 0
+    captured = capsys.readouterr()
+    assert "myia-po-2023:CoursIA. Énoncé" not in captured.out + captured.err
+
+
 def test_parse_unattributed_marker():
     # Marker present but no `lane` keyword -> lane None (surfaced, not guessed).
     ev = clc.parse_claim_event(comment(

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -1102,6 +1102,62 @@ def test_lane_workspace_rejects_multiplication_sign():
     assert g == "myia-x:Cours", "× (U+00D7) must not be admitted as a letter"
 
 
+# --- #15864: prose period + accented continuation = phantom lane -----------
+#
+# Founder marker of issue #15674 (4th variant of the self-blocking class:
+# #12145 x #12719 x #13830). The workspace class eats the sentence period
+# (`CoursIA.`), the #13830 accented-continuation then admits `Énoncé`, and
+# the read token `myia-po-2023:CoursIA. Énoncé` blocked the declaring lane
+# on its OWN [DELIVERED] re-marker. The `(?<!\.)` lookbehind at the head of
+# the continuation clause makes the period a sentence boundary: the capture
+# stops at `...CoursIA.` and the #12719 rstrip lands the bare lane.
+
+_FOUNDER_MARKER_15864 = (
+    "[DELIVERED] PR #15733 — lane myia-po-2023:CoursIA. Énoncé réécrit en deux "
+    "gestes (chercher inchangé + recenser), le piège top-10 nommé dans "
+    "l'énoncé. Exéc complète 12.2s, validate 17 cells PASS."
+)
+
+
+def test_lane_prose_period_then_accented_word_not_swallowed():
+    # Acceptance #15864-1: the real #15674 marker parses to the BARE lane.
+    assert gt.extract_lane(_FOUNDER_MARKER_15864, marker_line=_FOUNDER_MARKER_15864) == "myia-po-2023:CoursIA"
+
+
+def test_lane_prose_period_fallback_twin_moves():
+    # Acceptance #15864-2: the fallback regex (marker line WITHOUT the literal
+    # `lane` keyword) renders the same verdict -- the twin MUST move (#12145).
+    no_keyword = _FOUNDER_MARKER_15864.replace("lane ", "", 1)
+    assert gt.extract_lane("no lane keyword here", marker_line=no_keyword) == "myia-po-2023:CoursIA"
+
+
+def test_lane_prose_period_parse_grain_tag_no_divergence():
+    # Acceptance #15864-3: parse_grain_tag (direct _LANE_RE read) and
+    # extract_lane agree on the same body.
+    body = "Grain: MED/notebook — lane myia-po-2023:CoursIA. Énoncé réécrit."
+    assert gt.parse_grain_tag(body)["lane"] == gt.extract_lane(body) == "myia-po-2023:CoursIA"
+
+
+def test_lane_prose_period_after_multiword_continuation():
+    # The sentence boundary also holds AFTER a continuation word: the period
+    # at the end of `Code.` refuses the next word, the rstrip cleans the tail.
+    assert gt.extract_lane("[CLAIMED] lane myia-po-2025:Microsoft VS Code. Suite de prose") == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_internal_dot_does_not_make_a_boundary():
+    # A `.` INSIDE the token (hostname, `Foo.Bar`) is followed by a non-blank
+    # and survives: the continuation after `A.B` is still admitted.
+    assert gt.extract_lane("[CLAIMED] lane myia-po-2023:A.B Suite -- paths") == "myia-po-2023:A.B Suite"
+    assert gt.extract_lane("[CLAIMED] lane myia.host.example:Baz -- paths") == "myia.host.example:Baz"
+
+
+def test_lane_marker_residues_witness_the_prose_period():
+    # The witness keeps declaring the malformed form instead of silently
+    # reinterpreting it (acceptance: `trailing-period:` on the founder line).
+    no_keyword = _FOUNDER_MARKER_15864.replace("lane ", "", 1)
+    assert gt.lane_marker_residues(no_keyword) == ["trailing-period:myia-po-2023:CoursIA."]
+
+
 def test_lane_workspace_rejects_division_sign():
     # U+00F7 (÷) is NOT a letter; the union class skips it (U+00F7 sits in
     # the gap between ö and ø of `à-öø-ÿ`, before `Ā-ſ`). The token


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/slides #15884

## Quoi

`(?<!\.)` en tête de clause de continuation sur les DEUX jumeaux `_LANE_RE` / `_LANE_FALLBACK_RE` (`scripts/grain_tag.py`) : un `.` suivi d'un blanc est de la ponctuation de prose, jamais une partie de `<machine>:<workspace>` ; un `.` interne (hostname, `Foo.Bar`) est suivi d'un non-blanc et survit. Après un point, toute itération de continuation est refusée, la capture s'arrête sur `...CoursIA.`, et le `rstrip(".")` #12719 existant (`extract_lane` :545 / `parse_grain_tag` :507) rend la lane nue. Le témoin `lane_marker_residues` continue de déclarer la forme malformée (`trailing-period:`).

## Preuve

Marqueur réel de #15674 (fetched verbatim) :

```
[DELIVERED] PR #15733 — lane myia-po-2023:CoursIA. Énoncé réécrit en deux gestes ...
```

| Contrôle | Résultat |
|---|---|
| `extract_lane` primaire (mot-clé `lane`) | `myia-po-2023:CoursIA` (pré-fix : `myia-po-2023:CoursIA. Énoncé`) |
| Jumeau fallback (sans mot-clé) | `myia-po-2023:CoursIA` — les deux regex bougent (#12145) |
| `parse_grain_tag` | idem, zéro divergence avec `extract_lane` |
| `lane_marker_residues` | `['trailing-period:myia-po-2023:CoursIA.']` — témoin intact |
| `_run_check(payload réel #15674, "myia-po-2023:CoursIA")` | **rc 0 CLEAR** (pré-fix : bloqué sur la lane fantôme — gate FAIL, 8 reruns sur #15733) |
| Pouvoir des tests : 6 nouveaux tests sur code pré-fix (stash) | **6/6 FAILED** ; post-fix **6/6 PASSED** |
| Suites : `test_grain_tag.py` + `test_check_lane_claim.py` | **402 passed** (7 nouveaux) |
| Consommateurs du lecteur unique (#9485) : `test_lane_claim_required` + `test_pick_idle_grain(_cache)` + `test_variation_prev_lane` + `test_lane_claim_epic_wide` + `test_pick_lane_record` | **208 passed** |
| Non-régressions | `LivresAgités Épisode` intact (#13830) ; `A.B Suite` / `myia.host.example:Baz` intacts ; date nue #12719 intacte ; point final #12719 intact ; `Microsoft VS Code. Suite` → coupe au point |

Acceptance #15864 : 6/6 cases cochées (marqueur réel, jumeau, non-divergence, `_run_check` CLEAR, non-régressions, suites vertes).

## Résiduel (documenté dans l'issue, hors périmètre)

- **PR #15733 restera rouge** jusqu'à (a) merge de ce fix + rafraîchissement de sa branche (le workflow `pull_request` lit le merge-ref), ou (b) `[OVERRIDE] lane myia-po-2023:CoursIA` par le coordinateur sur #15674.
- Classe voisine non traitée : `check_unaddressed_nits.py:231` `_OVERRIDE_LANE` laisse un point final dans la lane capturée (no-op silencieux d'un override écrit `lane X. suite`) — aucun cas observé, à traiter si un tel override apparaît.

Closes #15864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
