### PR TITLE
fix(notebooks,#15210): retirer les chemins machine de metadata.papermill (classe username, 11 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-04-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-04-NashEquilibrium.ipynb
@@ -1800,7 +1800,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-04-NashEquilibrium.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/0a493017-8d7b-4254-b4d3-d0fb31f0c91a/scratchpad/gt04_reexec.ipynb",
+   "output_path": "GameTheory-04-NashEquilibrium.ipynb",
    "parameters": {},
    "start_time": "2026-09-06T21:46:18.519298",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
@@ -2145,7 +2145,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## CHALLENGE BONUS - Narration Multi-Voix\n",
     "\n",
@@ -2176,7 +2176,7 @@
     "- Vitesse cohérente (speed=1.0 pour tous)\n",
     "- Durée totale < 30 secondes\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Soumission** : PR avec titre \"Challenge #8 - [Votre Nom]\", script et fichier audio combiné\n"
    ]
@@ -2274,8 +2274,8 @@
    "end_time": "2026-08-16T01:12:25.975987",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-h3-nits-recal/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\d--Dev-CoursIA\\e3012e6f-27f8-43c8-a9f0-6d11fc09c529\\scratchpad\\trancheA/out_01-1-OpenAI-TTS-Intro.ipynb",
+   "input_path": "01-1-OpenAI-TTS-Intro.ipynb",
+   "output_path": "01-1-OpenAI-TTS-Intro.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
@@ -1996,7 +1996,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## CHALLENGE BONUS - Sous-titrage Automatique\n",
     "\n",
@@ -2027,7 +2027,7 @@
     "- Regrouper les mots en segments de 5-8 mots maximum\n",
     "- Format SRT standard avec numérotation\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Soumission** : PR avec titre \"Challenge #9 - [Votre Nom]\", fichier SRT et extrait audio\n"
    ]
@@ -2046,7 +2046,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion : Whisper STT - Synthese\n",
     "\n",
@@ -2121,8 +2121,8 @@
    "end_time": "2026-08-16T01:12:53.049600",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-h3-nits-recal/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\d--Dev-CoursIA\\e3012e6f-27f8-43c8-a9f0-6d11fc09c529\\scratchpad\\trancheA/out_01-2-OpenAI-Whisper-STT.ipynb",
+   "input_path": "01-2-OpenAI-Whisper-STT.ipynb",
+   "output_path": "01-2-OpenAI-Whisper-STT.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
@@ -500,7 +500,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\.conda\\envs\\dia-tts\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "<USER_PATH>\\.conda\\envs\\dia-tts\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     },
@@ -2131,7 +2131,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\.conda\\envs\\dia-tts\\lib\\site-packages\\torch\\nn\\utils\\weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
+      "<USER_PATH>\\.conda\\envs\\dia-tts\\lib\\site-packages\\torch\\nn\\utils\\weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
       "  WeightNorm.apply(module, name, dim)\n"
      ]
     },
@@ -4720,7 +4720,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\.conda\\envs\\dia-tts\\lib\\site-packages\\torch\\nn\\utils\\weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
+      "<USER_PATH>\\.conda\\envs\\dia-tts\\lib\\site-packages\\torch\\nn\\utils\\weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.\n",
       "  WeightNorm.apply(module, name, dim)\n"
      ]
     },
@@ -5362,7 +5362,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## CHALLENGE BONUS - Musique pour Scène Vidéo\n",
     "\n",
@@ -5398,7 +5398,7 @@
     "- Modèle: `musicgen-medium` (ou `musicgen-small` si VRAM limitée)\n",
     "- Noter: fidélité au contexte (1-5), qualité audio (1-5)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Soumission** : PR avec titre \"Challenge #6 - [Votre Nom]\", description, paramètres testés et justification du choix\n"
    ]
@@ -5446,7 +5446,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-3-MusicGen-Generation.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\d--Dev-CoursIA\\e3012e6f-27f8-43c8-a9f0-6d11fc09c529\\scratchpad\\trancheA\\out_02_3c.ipynb",
+   "output_path": "02-3-MusicGen-Generation.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
@@ -3038,7 +3038,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-8-Expressive-TTS.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/6383dcb3-02ba-456a-84da-d599e434d6c3/scratchpad/02-8-executed.ipynb",
+   "output_path": "02-8-Expressive-TTS.ipynb",
    "parameters": {
     "notebook_mode": "batch",
     "skip_widgets": true

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
@@ -287,7 +287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\.conda\\envs\\acestep\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "<USER_PATH>\\.conda\\envs\\acestep\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     },
@@ -7528,8 +7528,8 @@
    "end_time": "2026-08-16T01:37:58.719436",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-h3-nits-recal\\MyIA.AI.Notebooks\\GenAI\\Audio\\02-Advanced/02-9-AceStep-Music-Generation.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\d--Dev-CoursIA\\e3012e6f-27f8-43c8-a9f0-6d11fc09c529\\scratchpad\\trancheA/out_02_9.ipynb",
+   "input_path": "02-9-AceStep-Music-Generation.ipynb",
+   "output_path": "02-9-AceStep-Music-Generation.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
@@ -1623,7 +1623,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "02-Claude-CLI-Sessions.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/2b36da1d-b3d6-48d7-97f2-37a6d5c34555/scratchpad/exec_02-Claude-CLI-Sessions.ipynb",
+   "output_path": "02-Claude-CLI-Sessions.ipynb",
    "parameters": {},
    "start_time": "2026-08-23T19:33:10.919775",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
@@ -1709,7 +1709,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "04-Claude-CLI-Agents.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/2b36da1d-b3d6-48d7-97f2-37a6d5c34555/scratchpad/04_ratchet_reexec2.ipynb",
+   "output_path": "04-Claude-CLI-Agents.ipynb",
    "parameters": {},
    "start_time": "2026-08-23T23:43:46.436341",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
@@ -1839,7 +1839,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "05-Claude-CLI-Automatisation.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/2b36da1d-b3d6-48d7-97f2-37a6d5c34555/scratchpad/exec_05-Claude-CLI-Automatisation.ipynb",
+   "output_path": "05-Claude-CLI-Automatisation.ipynb",
    "parameters": {},
    "start_time": "2026-08-23T19:41:46.363031",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3d-Modele-Gaussien-LDA-QDA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3d-Modele-Gaussien-LDA-QDA.ipynb
@@ -1026,7 +1026,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "2.3d-Modele-Gaussien-LDA-QDA.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/c--dev-CoursIA-2/75828c40-18c4-44b4-824d-0cebb5775c1e/scratchpad/2.3d-exec.ipynb",
+   "output_path": "2.3d-Modele-Gaussien-LDA-QDA.ipynb",
    "parameters": {},
    "start_time": "2026-08-25T18:34:08.276473+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
@@ -1063,7 +1063,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/c--dev-CoursIA-2/10ac7e0c-f66d-482a-8a02-150b7a45c479/scratchpad/2.5b-executed.ipynb",
+   "output_path": "2.5b-Calibration-Probabilites.ipynb",
    "parameters": {},
    "start_time": "2026-08-23T00:52:50.395114+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-ai-01:CoursIA — prev: MED/tooling #15809

Porte la substance de #15729 (fermée : branche CONFLICTING, 8 merge commits parasites) à l'échelle de la **classe** plutôt que d'un notebook. Travail de fond original : lane `myia-po-2024:CoursIA-2`, commit `f945a49b4a`.

## Ce que fait l'organe, et ce que les hooks ont ajouté par-dessus

Worktree propre sur `origin/main` = `9198cbdbc8b4`, organe sanctionné `scripts/notebook_tools/scrub_papermill_paths.py --apply` :

```
avant : scan summary: 40 notebook(s) with 71 absolute papermill path(s)
apply : apply summary: 11 notebook(s) with 14 absolute papermill path(s)  (fixed 14, skipped 0)
après : scan summary: 29 notebook(s) with 57 absolute papermill path(s)
```

40 − 11 = 29 et 71 − 14 = 57 : le retrait se referme exactement.

**Le commit ne se limite pas à ça, et je le déclare plutôt que de le laisser découvrir.** Au `git commit`, deux hooks pre-commit sanctionnés ont modifié des fichiers et fait échouer la première passe (comportement normal : `files were modified by this hook`). J'ai re-stagé et recommité — jamais `--no-verify`. Ventilation du diff réellement commité (`067ad605`), mesurée **par chemin JSON**, pas par ligne-clé :

| Chemin JSON | Champs / cellules | Appliqué par |
|---|---:|---|
| `metadata.papermill.output_path` | 11 | `scrub_papermill_paths.py` (l'objet de cette PR) |
| `metadata.papermill.input_path` | 3 | idem |
| `cell.source` — markdown `---` → `***` | 4 cellules (7 séparateurs) | hook `fix-hr-separator` |
| `cell.outputs` — `C:\Users\jsboi\...` → `<USER_PATH>\...` | 3 cellules | hook `strip-dotnet-nuget-ext` |

Total : 11 fichiers, +25/−25.

**Oui, le diff touche des `outputs` — et c'est la voie sanctionnée, pas une main-édition.** `secrets-hygiene.md` règle 6 bannit le *hand-scrub* d'une sortie de cellule. Ici la réécriture est faite par `strip_machine_paths.py` via le hook `strip-dotnet-nuget-ext`, que [`regles-validation-detail.md`](docs/reference/regles-validation-detail.md) documente comme **le fix durable** de la classe category-A (leak ré-injecté par le kernel à chaque exécution, même famille que `probeAddresses`). Les 3 lignes concernées sont des warnings `tqdm` / `torch.nn.utils.weight_norm` portant `.conda\envs\dia-tts` et `.conda\envs\acestep` sous le profil utilisateur. Un reviewer qui applique la règle 6 mécaniquement doit voir cette distinction écrite ici, pas la reconstituer.

`fix-hr-separator` ne touche que du markdown → l'exception C.2 s'applique, aucune ré-exécution due. Aucune cellule de code, aucun `execution_count`, aucune sortie **de calcul** n'est modifiée.

## Périmètre : la sous-classe portant un NOM D'UTILISATEUR

Les 40 se répartissent en deux sous-classes que j'avais d'abord confondues :

| sous-classe | compte | ce qui fuit |
|---|---:|---|
| **porte un username** (`jsboi`) | 12 | identité de la machine — traitée ici |
| topologie de worktree seule (`D:\Dev\CoursIA-12513-app10b\…`, `/mnt/d/dev/CoursIA-16h-patterntour/…`) | 28 | arborescence locale, pas d'identité |

Cette PR traite **11** des 12 : `GameTheory-06e` est exclu parce que #15862 est ouverte dessus (+209/−195). Les 28 restants et la classe `--outputs` (24 notebooks / 42 fuites) relèvent de grains séparés.

## Contrôle indépendant de l'organe

Relecture `json.loads` des 11 notebooks committés : `metadata.papermill` → **0/11** porte encore un username ou un chemin absolu.

**Mon premier contrôle était faux et je l'ai attrapé par l'arithmétique, pas par la sonde.** Je grepais `^[+-].*"outputs"` et `^[+-].*"source"` : rendus `0`, donc « aucune sortie touchée ». Faux — dans un `.ipynb`, la ligne qui change est **l'élément du tableau** (`"***\n"`), jamais la ligne-clé `"source":`. La sonde ne pouvait structurellement pas matcher. C'est exactement le défaut qui a produit le verdict OBSOLETE de #15729 (`grep "metadata\.papermill"` rend `0` sur tout notebook, la clé étant du JSON imbriqué). Le tell qui l'a révélé : 14 lignes attendues, 25 commitées, et 11 = 4 + 7 = précisément ce que les deux hooks annonçaient.

See #15210 (06e reste ouvert, porté par #15862).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
