### PR TITLE
fix(curriculum,#15882): generate_parcours refuse d'ecraser une page manuelle (fail-closed)

### DIFF
--- a/scripts/notebook_tools/generate_parcours.py
+++ b/scripts/notebook_tools/generate_parcours.py
@@ -30,6 +30,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CATALOG_PATH = REPO_ROOT / "COURSE_CATALOG.generated.json"
 PARCOURS_DIR = REPO_ROOT / "docs" / "curriculum"
 
+# Fail-closed (#15882): docs/curriculum/ mixes generated pages (ids of the
+# PARCOURS dict, rewritten daily by catalog-cron.yml) with manual pages, and
+# nothing in the name tells them apart. A target that exists WITHOUT this
+# marker in its opening lines is presumed manual and must never be
+# overwritten -- the regen refuses instead. The scan window is limited to the
+# head of the file: generated pages carry the marker as their opening comment
+# block, and a manual page quoting the phrase mid-body must not opt in by
+# accident.
+GENERATED_MARKER = "FICHIER GENERE"
+GENERATED_MARKER_SCAN_LINES = 15
+
 PARCOURS = {
     "ia-classique": {
         "title": "IA Classique",
@@ -93,6 +104,20 @@ PARCOURS = {
         "icon": "research",
     },
 }
+
+
+def _carries_generated_marker(path: Path) -> bool:
+    """True si le fichier existant porte l'en-tete de page generee en tete.
+
+    Un echec de lecture (fichier verrouille, illisible) vaut False : ne pas
+    pouvoir prouver l'en-tete, c'est ne pas pouvoir ecraser (fail-closed).
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    head = text.splitlines()[:GENERATED_MARKER_SCAN_LINES]
+    return any(GENERATED_MARKER in line for line in head)
 
 
 def load_catalog() -> list[dict]:
@@ -263,6 +288,7 @@ def main():
 
     targets = [args.parcours] if args.parcours else list(PARCOURS.keys())
 
+    refused: list[Path] = []
     unresolved: list[str] = []
     for pid in targets:
         filtered = filter_for_parcours(entries, pid)
@@ -276,6 +302,17 @@ def main():
         else:
             PARCOURS_DIR.mkdir(parents=True, exist_ok=True)
             out_path = PARCOURS_DIR / f"{pid}.md"
+            if out_path.exists() and not _carries_generated_marker(out_path):
+                refused.append(out_path)
+                print(
+                    f"REFUS (fail-closed, #15882): {out_path} existe sans "
+                    f"l'en-tete '{GENERATED_MARKER}' -- page presumee "
+                    "MANUELLE, regeneration refusee. Renommer la page "
+                    "manuelle, ou lui faire porter l'en-tete si elle doit "
+                    "etre generee.",
+                    file=sys.stderr,
+                )
+                continue
             # newline="\n" forces LF: on Windows, Path.write_text's default
             # text mode translates "\n" -> "\r\n", polluting the committed LF
             # files (docs/curriculum/*.md are LF per .gitattributes) with a
@@ -291,6 +328,14 @@ def main():
         )
         for p in sorted(set(unresolved)):
             print(f"  {p}", file=sys.stderr)
+
+    if refused:
+        print(
+            f"{len(refused)} page(s) presumee(s) manuelle(s) refusee(s) par "
+            "la regen: " + ", ".join(str(p) for p in refused),
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     if not args.dry_run and not args.parcours:
         print(f"\nGenerated {len(targets)} parcours pages in {PARCOURS_DIR}")

--- a/scripts/notebook_tools/tests/test_generate_parcours.py
+++ b/scripts/notebook_tools/tests/test_generate_parcours.py
@@ -4,13 +4,17 @@ Tests focus on pure functions: filter_for_parcours, generate_parcours_page,
 check_coverage. Uses synthetic catalog entries.
 """
 
+import json
 import sys
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import generate_parcours as gp
 from generate_parcours import (
+    GENERATED_MARKER,
+    GENERATED_MARKER_SCAN_LINES,
     PARCOURS,
     check_coverage,
     filter_for_parcours,
@@ -200,3 +204,92 @@ class TestParcoursConstants:
         assert "Search" in all_series
         assert "GenAI" in all_series
         assert "QuantConnect" in all_series
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed write guard (#15882): refuser d'ecraser une page sans en-tete
+# ---------------------------------------------------------------------------
+
+MANUAL_BODY = "# Mon parcours manuel\n\nContenu ecrit a la main.\n"
+
+
+def _run_main(monkeypatch, tmp_path, argv):
+    """Isole le generateur sur tmp_path (catalogue vide + PARCOURS_DIR)."""
+    (tmp_path / "catalog.json").write_text(json.dumps([]), encoding="utf-8")
+    monkeypatch.setattr(gp, "CATALOG_PATH", tmp_path / "catalog.json")
+    monkeypatch.setattr(gp, "PARCOURS_DIR", tmp_path / "curriculum")
+    monkeypatch.setattr(sys, "argv", ["generate_parcours.py", *argv])
+
+
+class TestFailClosedWrite:
+    def test_manual_page_without_marker_is_refused_and_preserved(
+            self, monkeypatch, tmp_path, capsys):
+        _run_main(monkeypatch, tmp_path, [])
+        out = tmp_path / "curriculum" / "trading.md"
+        out.parent.mkdir(parents=True)
+        out.write_text(MANUAL_BODY, encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc:
+            gp.main()
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "trading.md" in err, "le message doit nommer le fichier refuse"
+        assert "REFUS" in err
+        # Fail-closed : le contenu manuel survit integralement.
+        assert out.read_text(encoding="utf-8") == MANUAL_BODY
+
+    def test_page_with_marker_is_regenerated(self, monkeypatch, tmp_path):
+        _run_main(monkeypatch, tmp_path, ["--parcours", "trading"])
+        out = tmp_path / "curriculum" / "trading.md"
+        out.parent.mkdir(parents=True)
+        # La page existante est une vraie page generee (en-tete marque) mais
+        # perimee : la regen doit la reecrire.
+        stale = generate_parcours_page("trading", []) + "\nSTALE RESIDU\n"
+        out.write_text(stale, encoding="utf-8")
+
+        gp.main()  # pas de SystemExit
+        fresh = out.read_text(encoding="utf-8")
+        assert "# Trading Algorithmique" in fresh
+        assert "STALE RESIDU" not in fresh
+
+    def test_absent_file_is_created(self, monkeypatch, tmp_path):
+        _run_main(monkeypatch, tmp_path, ["--parcours", "genai"])
+        gp.main()
+        out = tmp_path / "curriculum" / "genai.md"
+        assert out.exists()
+        assert out.read_text(encoding="utf-8").startswith("<!--")
+
+    def test_marker_deep_in_body_does_not_opt_in(
+            self, monkeypatch, tmp_path):
+        _run_main(monkeypatch, tmp_path, ["--parcours", "genai"])
+        out = tmp_path / "curriculum" / "genai.md"
+        out.parent.mkdir(parents=True)
+        # Le marqueur cite au-dela de la fenetre de scan = prose, pas opt-in.
+        pad = "\n".join(f"ligne {i}" for i in range(GENERATED_MARKER_SCAN_LINES + 5))
+        out.write_text(
+            MANUAL_BODY + pad + f"\nmention tardive : {GENERATED_MARKER}\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            gp.main()
+        assert exc.value.code == 2
+        assert MANUAL_BODY.splitlines()[0] in out.read_text(encoding="utf-8")
+
+    def test_refused_target_does_not_block_clean_targets(
+            self, monkeypatch, tmp_path, capsys):
+        _run_main(monkeypatch, tmp_path, [])
+        poisoned = tmp_path / "curriculum" / "genai.md"
+        poisoned.parent.mkdir(parents=True)
+        poisoned.write_text(MANUAL_BODY, encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc:
+            gp.main()
+        assert exc.value.code == 2
+        # Les cibles propres sont regenerees malgre le refus de la cible sale.
+        clean = tmp_path / "curriculum" / "trading.md"
+        assert clean.exists()
+        assert "# Trading Algorithmique" in clean.read_text(encoding="utf-8")
+        assert MANUAL_BODY.splitlines()[0] in poisoned.read_text(encoding="utf-8")
+        summary = capsys.readouterr().err
+        assert "genai.md" in summary


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/ml #15548

## Le défaut

`docs/curriculum/` mélange deux régimes de propriété indiscernables : cinq pages **générées** (ids du dict `PARCOURS`, réécrites chaque jour par `catalog-cron.yml`) et des pages **manuelles** (`_inventory.md`, `stage5_mamba_ssm.md`, et bientôt les parcours narratifs Phase 2). Une page manuelle créée sous un nom d'id du dict était **écrasée silencieusement** au passage du cron suivant — sans PR, sans diff, sans rouge (#15821 a traité le symptôme ; cette PR traite le défaut de classe, voie 1 de l'arbitrage).

## Le correctif (voie 1, la moins invasive)

`generate_parcours.py` **refuse d'écrire** un fichier cible qui existe sans son en-tête `FICHIER GENERE` :

- Refus **par cible** : une cible sale ne bloque pas la régénération des cibles propres.
- Refus **explicite** : message stderr `REFUS (fail-closed, #15882): <chemin> existe sans l'en-tete…` **nommant le fichier**, + récapitulatif agrégé, + `sys.exit(2)` (distinct du `1` de catalogue absent).
- Fenêtre de scan limitée aux 15 premières lignes : l'en-tête de page générée est le commentaire d'ouverture ; une page manuelle citant la phrase en milieu de corps **n'opte pas** par accident.
- Cible **illisible** (verrouillée, OSError) = non marquée = refus (fail-closed aussi sur ce chemin).

## Acceptance #15882 — les 3 critères, preuves

| # | Critère | Preuve |
|---|---------|--------|
| 1 | Le générateur échoue explicitement si la cible existe sans header | Contrôle positif **sur l'arbre réel** : `trading.md` remplacé par une page manuelle → `REFUS (fail-closed, #15882): …trading.md existe sans l'en-tete 'FICHIER GENERE'` + `EXIT=2`, contenu manuel **intact byte-à-byte**, puis restauration (`git checkout --`, arbre re-clean) |
| 2 | Tests : stub sans header → refus nommant le fichier ; absent ou avec header → regen normale | **5 tests nouveaux** dans `scripts/notebook_tools/tests/test_generate_parcours.py` (`TestFailClosedWrite`) : refus+préservation / page avec header régénérée (STALE disparaît) / fichier absent créé / marqueur hors fenêtre ≠ opt-in / cible propre régénérée malgré cible sale. Suite fichier : **27 passed**. Voisins catalogue : **264 passed** |
| 3 | Le cron propage l'échec, pas de contournement silencieux | Structurel, **zéro changement workflow** : `catalog-cron.yml` invoque le générateur (:135) dans un step `set -euo pipefail` (:123) → `exit 2` fail le step → job rouge. Vérifié sur le YAML d'origine |

## Non-régression du cron quotidien (mesurée)

Regen complète **sur l'arbre réel** : `python scripts/notebook_tools/generate_parcours.py` → **EXIT=0**, 5/5 pages réécrites (173/264/201/222/256 notebooks), `git status -- docs/curriculum/` **vide** (regen byte-clean) — les 5 pages commises portent toutes le marqueur, aucune n'est refusée à tort, et cette PR ne commit **aucun** artefact généré (catalogue et pages restent la propriété de l'automatisation).

## Périmètre

2 fichiers, +138/−0 : `scripts/notebook_tools/generate_parcours.py` (constante + helper + garde au site d'écriture) et son test. Catalogue, READMEs et `docs/curriculum/**` inchangés.

Closes #15882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
