### PR TITLE
feat(security): .rooignore racine — le watcher d'index ne lit pas les .gitignore imbriqués

### DIFF
--- a/.rooignore
+++ b/.rooignore
@@ -1,0 +1,75 @@
+# .rooignore — exclusions de l'index sémantique Roo (code-index watcher)
+#
+# POURQUOI CE FICHIER EXISTE, ET POURQUOI UN .gitignore NE SUFFISAIT PAS
+#
+# Le watcher d'indexation de Roo Code ne lit que le `.gitignore` de la RACINE
+# du workspace : les `.gitignore` imbriqués lui sont invisibles. Le dépôt en
+# porte au moins un qui protège un fichier de configuration réel —
+# `MyIA.AI.Notebooks/Config/.gitignore` (première ligne : `*.json`) — et Git
+# l'honore parfaitement : le fichier couvert n'est ni suivi ni présent dans
+# l'historique. Mais l'indexeur, lui, ne l'a jamais vu : il a ingéré le
+# contenu et l'a resservi en clair comme extrait de recherche.
+#
+# La conséquence est contre-intuitive et mérite d'être écrite : un fichier
+# PEUT être correctement gitignored, absent de tout commit, et néanmoins
+# exposé — parce que la surface d'exposition n'était pas Git. L'incident qui
+# a motivé ce fichier est index-side, pas Git-side. Aucune réécriture
+# d'historique ne l'aurait corrigé, et aucun scan de commits ne l'aurait
+# détecté.
+#
+# Ce fichier est donc l'organe manquant : il déclare à la RACINE ce que les
+# `.gitignore` imbriqués déclarent localement, pour le seul consommateur qui
+# ne sait pas les lire.
+#
+# PORTÉE — ce qu'il fait et ce qu'il ne fait pas
+#
+# Il empêche l'indexation FUTURE. Il ne purge PAS ce qui est déjà indexé :
+# les points déjà écrits dans les collections vectorielles doivent être
+# supprimés séparément. Un `.rooignore` posé sans cette purge ferme la porte
+# derrière le cambrioleur.
+#
+# Il ne remplace pas non plus la rotation d'une clé qui a été servie en
+# clair. Une valeur exposée reste exposée après son exclusion.
+#
+# TENUE À JOUR — le critère
+#
+# Toute famille de fichiers qui porte des secrets, des identifiants ou de la
+# configuration machine-locale entre ici, même si un `.gitignore` la couvre
+# déjà : la redondance est le mécanisme, pas un oubli de factorisation.
+
+# --- Configuration locale portant des clés d'API -----------------------------
+# Couvert côté Git par MyIA.AI.Notebooks/Config/.gitignore (`*.json`), que le
+# watcher ne lit pas. Le second motif rattrape les autres dossiers `Config/`.
+MyIA.AI.Notebooks/Config/settings.json
+**/Config/settings.json
+
+# --- Fichiers d'environnement ------------------------------------------------
+# `.env.*` couvre aussi les sauvegardes horodatées (`.env.bak-<ts>`), qui
+# portent le même contenu que l'original et se créent en dehors de toute revue.
+.env
+.env.*
+**/.env
+**/.env.*
+
+# Les gabarits sont publics par construction : ils ne portent que des noms de
+# variables et servent de documentation. Les ré-inclure garde l'index utile.
+# Si le parseur n'honorait pas la négation, ces fichiers resteraient exclus —
+# une perte de confort, jamais une fuite : la dégradation est fail-closed.
+!**/.env.example
+!**/.env.sample
+!**/.env.template
+
+# --- Secrets centralisés -----------------------------------------------------
+# Source unique des secrets partagés (cf .claude/rules/secrets-hygiene.md).
+.secrets/
+.secrets/**
+
+# --- Identifiants et clés ----------------------------------------------------
+*.pem
+*.key
+*.pfx
+*.p12
+credentials.json
+client_secret*.json
+service-account*.json
+token.json


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #15873

## Un fichier peut être correctement gitignored, absent de tout commit, et néanmoins exposé

C'est le cœur de l'incident, et c'est ce qui le rend facile à mal diagnostiquer : la surface d'exposition n'était pas Git.

**RAPPORTÉ** (audit de la lane `myia-po-2025:CoursIA`, reçu en DM privé) : l'indexeur sémantique de Roo ne lit que le `.gitignore` de la **racine** du workspace. Les `.gitignore` imbriqués lui sont invisibles. Un fichier de configuration couvert par un `.gitignore` imbriqué a donc été ingéré par l'index, puis resservi **en clair** comme extrait de recherche. Je n'ai pas relu le code du watcher moi-même : je qualifie cette cause comme rapportée, pas comme vérifiée.

**VÉRIFIÉ firsthand sur `main` à l'instant** :

| Mesure | Résultat |
|---|---|
| `.rooignore` à la racine | **absent** (`ls` et `find` sur tout l'arbre) |
| `MyIA.AI.Notebooks/Config/.gitignore` | existe, première ligne `*.json` — imbriqué, donc hors de portée du watcher |
| `git log --all -- MyIA.AI.Notebooks/Config/settings.json` | **vide** |
| `git ls-files MyIA.AI.Notebooks/Config/settings.json` | **vide** |
| `MyIA.AI.Notebooks/Config/settings.json` sur le disque d'ai-01 | **n'existe pas** — le dossier ne porte que `.gitignore`, trois `.cs`, et deux gabarits `settings.json.*-example` |

Git a donc parfaitement fait son travail : le fichier n'est ni suivi, ni présent dans l'historique. Aucune réécriture d'historique n'aurait corrigé cet incident, et aucun scan de commits ne l'aurait détecté — ce sont les deux réflexes que la formulation « fuite de secret » déclenche, et ils auraient tous deux échoué ici.

La dernière ligne du tableau mérite d'être lue pour ce qu'elle est : le chemin nommé dans l'audit **n'existe pas sur cette machine**. Le motif reste justifié — il protège le chemin sur toutes les machines de la flotte, et sur celle-ci pour l'avenir — mais je ne prétends pas avoir reproduit l'ingestion : je ne peux pas la reproduire à partir d'un fichier absent.

## Ce que fait cette PR

Un `.rooignore` à la racine, qui déclare à l'endroit que le watcher lit ce que les `.gitignore` imbriqués déclarent là où il ne regarde pas. Trois familles :

- la configuration locale portant des clés (`MyIA.AI.Notebooks/Config/settings.json`, plus `**/Config/settings.json` pour les autres dossiers homonymes) ;
- les fichiers d'environnement (`.env`, `.env.*`, et leurs équivalents à toute profondeur) — le motif `.env.*` couvre aussi les sauvegardes horodatées `.env.bak-<ts>`, qui portent le même contenu que l'original et se créent en dehors de toute revue ;
- les secrets centralisés (`.secrets/**`) et les familles d'identifiants classiques (`*.pem`, `*.key`, `credentials.json`, `service-account*.json`…).

Les gabarits `.env.example` / `.sample` / `.template` sont **ré-inclus** par négation : ils ne portent que des noms de variables et servent de documentation, donc les garder indexés préserve l'utilité de la recherche. Si le parseur de `.rooignore` n'honorait pas la négation, ces trois lignes seraient inertes et les gabarits resteraient exclus — une perte de confort, jamais une fuite. La dégradation est **fail-closed**, et c'est délibéré.

## Portée — ce que cette PR ne fait pas, et qui reste dû

Elle empêche l'indexation **future**. Elle ne fait rien d'autre, et il serait dangereux de la lire autrement :

1. **Elle ne purge pas l'index.** Les points déjà écrits dans les collections vectorielles restent servables. Un `.rooignore` posé sans purge ferme la porte derrière le cambrioleur. La purge doit cibler par `filePath` / `pathSegments` et **ne jamais demander le champ `codeChunk`** — le redemander re-exposerait en clair exactement ce qu'on cherche à retirer. Elle est traitée séparément.
2. **Elle ne remplace pas la rotation.** Une valeur servie en clair reste compromise après son exclusion. La rotation est une action utilisateur ; elle est relancée par le canal prévu, sans que la valeur soit republiée nulle part — ni en clair, ni masquée, ni sous forme d'empreinte.

## Tests

`gitleaks` (hook de pre-commit, pin du dépôt) : **Passed**. Aucun hook contourné. Le fichier n'est que des motifs et du commentaire : il n'ajoute aucune surface exécutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
