### PR TITLE
docs(lean,#15892): exposer le chemin de découverte prover de StableMarriage (sans changement mathématique)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -119,10 +119,10 @@ préservé ici — anti-régression 4 étapes respectée).
 | Sous-module | Lignes (FR / EN) | Sorries (FR / EN) | Contenu |
 |-------------|------------------|------------------|---------|
 | [`StableMarriage.Definitions`](StableMarriage/Definitions.lean) | 125 / 132 | 0 / 0 | `PrefProfile`, `Matching`, `IsStable`, ordre `ManLE` |
-| [`StableMarriage.GSState`](StableMarriage/GSState.lean) | 168 / 177 | 0 / 0 | État de l'algorithme Gale-Shapley, file d'hommes libres, propositions |
+| [`StableMarriage.GSState`](StableMarriage/GSState.lean) | 178 / 187 | 0 / 0 | État de l'algorithme Gale-Shapley, file d'hommes libres, propositions |
 | [`StableMarriage.Lemmas`](StableMarriage/Lemmas.lean) | 898 / 907 | 0 / 0 | Lemmes intermédiaires (44 lemmes, 0 sorry) |
 | [`StableMarriage.Lattice`](StableMarriage/Lattice.lean) | 885 / 881 | 0 / 0 | Treillis des mariages (join/meet), optimalité homme/femme ; les énoncés contrefactuels `man_optimality_key_step` et `doctor_optimal_eq_top` ont été **retirés et réfutés** (`NoCrossCounterexample.*_is_false`, carré latin 3×3), Lattice est sorry-free |
-| [`StableMarriage.GaleShapley`](StableMarriage/GaleShapley.lean) | 181 / 171 | 0 / 0 | Terminaison, stabilité, optimalité homme, existence d'un stable |
+| [`StableMarriage.GaleShapley`](StableMarriage/GaleShapley.lean) | 191 / 184 | 0 / 0 | Terminaison, stabilité, optimalité homme, existence d'un stable |
 
 **Théorèmes clés** (`namespace StableMarriage`) :
 
@@ -139,6 +139,36 @@ préservé ici — anti-régression 4 étapes respectée).
   dans le treillis des mariages préserve la stabilité
 - `man_optimality_key_step_is_false` — l'**énoncé contrefactuel**
   documenté qui démontre pourquoi une approche intuitive échoue
+
+#### Chemin de découverte (traces prover)
+
+Ces preuves ne sont pas sorties d'un coup : le harnais prover du dépôt
+(`MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/`) conserve le
+chemin — objectifs résiduels (`partial_progress`), motifs d'échec
+(`failure_patterns`), tentatives infructueuses (`failed_approaches`,
+245 entrées dont une trentaine pour le mariage stable) — et `StableMarriage`
+en est l'illustration la plus complète.
+
+- **Un verdict d'intractabilité qui a cadré la solution.** Avant le port de
+  l'algorithme, le prover a marqué `gale_shapley_stable`,
+  `gale_shapley_man_optimal` et `gale_shapley_woman_pessimal`
+  `INTRACTABLE_UNTIL_GS_IMPL` : les tentatives stagnaient de façon
+  **reproductible** (138 s sur l'énoncé de stabilité, 83 s sur l'optimalité
+  homme), et le diagnostic nommait la seule condition déblocante — le port
+  complet de l'algorithme (~1000 lignes de lemmes), livré par #997. Les
+  trois théorèmes ci-dessus sont le produit direct de cette condition
+  diagnostiquée.
+- **Un résiduel fermé par l'indice conservé.** `gsChooseMax_maximal` est
+  resté en `partial_progress` avec un objectif résiduel explicite (la
+  stricte inégalité de maximalité sous l'ordre personnalisé `gsMenPrefLE`)
+  et un indice de fermeture : `Nat.lt_trichotomy` sur la préférence `Nat`
+  sous-jacente. La preuve actuelle matérialise exactement cet indice, et
+  évite le piège tracé par ailleurs : `Finset.exists_maximal` ne fournit
+  qu'une maximalité **conditionnelle**, pas absolue.
+
+Le tableau ci-dessus conserve le même genre d'enseignement pour `Lattice`
+(énoncés contrefactuels réfutés, non des preuves abandonnées) — mais par
+documentation directe, les traces prover ne couvrant pas ce module.
 
 ### `CooperativeGames` — Jeux coopératifs à utilité transférable
 

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
@@ -86,6 +86,13 @@ lemma gsMenPref_trans (m : Fin n) : IsTrans (Fin n) (gsMenPrefLE prof m) :=
       | inl hbc => subst hbc; exact Or.inr hab
       | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
 
+/-- Candidate la mieux classée parmi celles que `m` n'a pas encore proposées,
+    choisie via `Finset.exists_maximal` sous l'ordre personnalisé `gsMenPrefLE`.
+    Subtilité (consignée dans les traces du prover, `agent_tests/prover/`) :
+    `Finset.exists_maximal` ne donne qu'une maximalité **conditionnelle**
+    (`∀ y ∈ s, x ≤ y → y ≤ x`), pas `∀ y ∈ s, y ≤ x` — le pont vers la
+    maximalité absolue passe par la trichotomie sur la préférence `Nat`
+    sous-jacente, voir `gsChooseMax_maximal`. -/
 noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
     (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
   letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
@@ -143,7 +150,10 @@ lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
   exact hmem
 
 /-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
-    Directement depuis la maximalité : ∀ y ∈ candidates, y ≤ choose. -/
+    Fermeture par **trichotomie** (`Nat.lt_trichotomy`) sur la préférence `Nat`
+    sous-jacente : c'est exactement l'indice de fermeture (`closure_hint`)
+    enregistré pour cet objectif dans les traces du prover (`partial_progress`
+    de `stable_marriage`), ici matérialisé. -/
 lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
     (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
     (hw : w ∈ gsCandidates prof σ m) :

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
@@ -95,6 +95,13 @@ lemma gsMenPref_trans (m : Fin n) : IsTrans (Fin n) (gsMenPrefLE prof m) :=
       | inl hbc => subst hbc; exact Or.inr hab
       | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
 
+/-- Best-ranked candidate among those `m` has not proposed to yet, chosen
+    via `Finset.exists_maximal` under the custom order `gsMenPrefLE`.
+    Subtlety (recorded in the prover traces, `agent_tests/prover/`):
+    `Finset.exists_maximal` only yields **conditional** maximality
+    (`∀ y ∈ s, x ≤ y → y ≤ x`), not `∀ y ∈ s, y ≤ x` — bridging to absolute
+    maximality goes through trichotomy on the underlying `Nat` preference,
+    see `gsChooseMax_maximal`. -/
 noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
     (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
   letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
@@ -151,8 +158,11 @@ lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
   obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
   exact hmem
 
-/-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
-    Directly from maximality: ∀ y ∈ candidates, y ≤ choose. -/
+/-- No unproposed candidate is preferred over the chosen maximal candidate.
+    Closure by **trichotomy** (`Nat.lt_trichotomy`) on the underlying `Nat`
+    preference: this is exactly the closure hint (`closure_hint`) recorded
+    for this goal in the prover traces (`partial_progress` of
+    `stable_marriage`), materialised here. -/
 lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
     (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
     (hw : w ∈ gsCandidates prof σ m) :

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
@@ -95,6 +95,11 @@ constructive** : la machine à étapes d'acceptation différée (`gsRunSteps pro
 `gsNoBlockingPairs` (portés et adaptés depuis `mmaaz-git/stable-marriage-lean`,
 ~1000 lignes de lemmes auxiliaires) démontrent la stabilité. Cette déclaration
 est complète : aucune tactique stub et aucun axiome ne sont utilisés.
+
+Chemin de découverte (traces prover) : ce but a d'abord été diagnostiqué
+`INTRACTABLE_UNTIL_GS_IMPL` — les tentatives stagnaient de façon reproductible
+(138 s ici, 83 s sur l'optimalité homme), et le diagnostic nommait la seule
+condition déblocante : le port complet de l'algorithme GS, livré par #997.
 -/
 theorem gale_shapley_stable (prof : PrefProfile n) :
     ∃ μ : Matching n, IsStable prof μ := by

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
@@ -88,6 +88,11 @@ deferred-acceptance step machine (`gsRunSteps prof (gsProposalBound n)`) is run
 to termination, and `gsFinalMatching` / `gsNoBlockingPairs` (ported and adapted
 from `mmaaz-git/stable-marriage-lean`, ~1000 lines of supporting lemmas) discharge
 stability. This declaration is complete: no placeholder tactic and no axiom are used.
+
+Discovery path (prover traces): this goal was first diagnosed
+`INTRACTABLE_UNTIL_GS_IMPL` — attempts stalled reproducibly (138 s here,
+83 s on man-optimality), and the diagnosis named the single unblocking
+condition: the full GS algorithm port, delivered by #997.
 -/
 theorem gale_shapley_stable (prof : PrefProfile n) :
     ∃ μ : Matching n, IsStable prof μ := by


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2024:CoursIA — prev: DEEP/genai #15872

## Sujet

Cas d'exposition de l'EPIC #13105 (Axe A) : le chemin de découverte du prover pour `StableMarriage`, conservé depuis les traces réelles — sans changer une ligne de preuve. Sous-grain #15892 (ouvert ce cycle, groundé firsthand).

## Livrable

1. **Section README « Chemin de découverte (traces prover) »** (`game_theory_lean/README.md`, dans la section StableMarriage) :
   - le verdict `INTRACTABLE_UNTIL_GS_IMPL` sur `gale_shapley_stable` / `_man_optimal` / `_woman_pessimal` (stagnations reproductibles 138 s / 83 s, condition déblocante nommée = port GS ~1000 lignes, livré par #997) ;
   - le résiduel `gsChooseMax_maximal` (`partial_progress` : objectif résiduel + `closure_hint` = trichotomie) et le piège `Finset.exists_maximal` (maximalité conditionnelle seulement).
2. **Docstrings FR + siblings EN** : `gsChooseMax` (nouvelle), `gsChooseMax_maximal` (l'ancienne était inexacte — « directement depuis la maximalité » — remplacée par le schéma de fermeture réel), `gale_shapley_stable` (complétée du chemin prover).
3. Table README : comptes de lignes réconciliés (GSState 168/177 → 178/187, GaleShapley 181/171 → 191/184 — la table était déjà stale sur ces deux lignes).

## Preuves

- **Byte-identity preuves/signatures** : les 3 seules lignes supprimées du diff sont les 2 anciennes docstrings de `gsChooseMax_maximal` (FR + EN) ; toutes les additions sont des lignes de docstring. Diff inspecté ligne à ligne.
- **Sorry** : `python scripts/lean/count_code_sorry.py --json` → game_theory_lean `distinct_code_sorry` **1 avant / 1 après** (naive 35/35, code 2/2) — inchangé.
- **i18n siblings** : `python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/GameTheory/game_theory_lean` → **22/23 byte-identical | 1 consumer-pattern | 0 drift | 0 orphan**.
- **Lake build + proof-integrity** : portés par la CI (`lean-game-theory.yml` → lean-axiom) ; diff docstring-only, attendus identiques à main — checks visibles sur la PR.
- **Traçabilité des faits** : chaque fait de la section découverte est cité depuis un artefact tracé — `agent_tests/prover/session_state/lessons_learned.json` (`stable_marriage.partial_progress[0]`, `.failure_patterns` : c'est la trace elle-même qui nomme #997 comme condition déblocante), `proof_knowledge.json` (`failed_approaches`, `proved_theorems_inventory`). Les traces ne couvrent PAS le module Lattice (0 hit mesuré) — dit explicitement dans le README, aucune attribution fabriquée.

## Frontières #13105 respectées

Pas d'ingestion Palomar, pas de rapport d'audit committé (la sortie est de la prose pédagogique dans le README existant), pas de rollout sur les autres lakes — un cas, pas un genre.

See #15892 (sous-grain), #13105 (EPIC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
