### PR TITLE
feat(game-theory): institutions transparentes bornées

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06h-Transparent-Institutions.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06h-Transparent-Institutions.ipynb
@@ -1,0 +1,1757 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "28da1638",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004336,
+     "end_time": "2026-09-13T04:08:59.305217+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.300881+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-06h — Programmes transparents comme institutions : CUPOD, DUPOC, PrudentBot, CIMCIC\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](GameTheory-06g-Simulation-Based-Program-Equilibria.ipynb)\n",
+    "\n",
+    "Le Dilemme du prisonnier (PD) en un coup a un unique équilibre de Nash `(D, D)` par dominance\n",
+    "stricte. Ce verdict suppose que chaque joueur ignore le **programme** de l'autre. Critch, Dennis\n",
+    "et Russell (2022) étudient le régime inverse : deux **institutions** — ou deux programmes — qui\n",
+    "lisent mutuellement leurs statuts publics (« bylaws », code source) avant de jouer une partie\n",
+    "unique. Ils y montrent que des institutions formelles qui devraient se trahir coopèrent, et\n",
+    "réciproquement (arXiv:2208.07006, p. 1 et 3).\n",
+    "\n",
+    "Ce notebook en tire un modèle **borné et terminant** dont les quatre agents sont `CUPOD`,\n",
+    "`DUPOC`, `PrudentBot` et `CIMCIC`, exécutable pas à pas, sans prétendre trancher une question\n",
+    "ouverte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75e528d5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002878,
+     "end_time": "2026-09-13T04:08:59.311206+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.308328+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Source primaire et conventions de nommage\n",
+    "\n",
+    "**Source primaire** : Andrew Critch, Michael Dennis, Stuart Russell, « Cooperative and\n",
+    "uncooperative institution designs: Surprises and problems in open-source game theory »,\n",
+    "arXiv:2208.07006 (v1, 15 août 2022), Center for Human-Compatible AI, UC Berkeley.\n",
+    "\n",
+    "| Élément cité | Localisation exacte |\n",
+    "| --- | --- |\n",
+    "| Cadre « open-source game theory », lecture du code source avant l'action | p. 3 |\n",
+    "| Définition de `CUPOD` (coopérer sauf preuve de défection) | p. 9 |\n",
+    "| Définition de `DUPOC` (faire défection sauf preuve de coopération) | p. 9 et 10 |\n",
+    "| Exemples 2.1, 3.1 et 3.2 (rôle de la borne `k`) | p. 7, 10 et notes 3 et 4 |\n",
+    "| Propositions 3.1 et 3.2 (non-exploitabilité de `CUPOD` et de `DUPOC`) | p. 11 |\n",
+    "| Théorème 3.4 : pour `k` grand, `outcome(CUPOD(k), CUPOD(k)) == (D, D)` | p. 13 |\n",
+    "| Théorème 3.7 : pour `k` grand, `outcome(DUPOC(k), DUPOC(k)) == (C, C)` | p. 14 |\n",
+    "| Lemme 3.6 (PBLT, Parametric Bounded Löb Theorem) | p. 13 |\n",
+    "| `PDUPOC` et Théorème 4.1 | p. 19 |\n",
+    "| Définition de `CIMCIC` et Proposition 5.1 | p. 20 et 21 |\n",
+    "| Théorème 5.2 : (a) `CIMCIC` contre `CIMCIC`, (b) `DUPOC` contre `CIMCIC` | p. 21 et 22 |\n",
+    "| « Cooperative affidavit » pour des institutions de type DUPOC | p. 16 |\n",
+    "| `PrudentBot` (agent non borné de LaVictoire et al. 2017) et Open Problem 9 | p. 26 |\n",
+    "| Les dix problèmes ouverts | p. 15, 18, 20, 22, 24, 25, 26 et 27 |\n",
+    "\n",
+    "**Conventions de nommage** : les analogues bornés des définitions publiées portent le nom publié\n",
+    "sans suffixe (`CUPOD`, `DUPOC`, `CIMCIC`). Les sigles anglais d'origine sont `CUPOD`\n",
+    "(`Cooperate Unless Proof Of Defection`) et `DUPOC` (`Defect Unless Proof Of Cooperation`, p. 9).\n",
+    "`PrudentBot_borne` est un **candidat** : l'existence\n",
+    "même d'une version bornée de PrudentBot est l'Open Problem 9 (p. 26), qui n'est pas résolu ici.\n",
+    "`CooperateBot`, `DefectBot` et `CooperateBotOpake` sont des agents de référence ou de contrôle ;\n",
+    "les deux premiers reprennent les noms de la p. 6, le troisième est un contrôle local."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff9cda6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002792,
+     "end_time": "2026-09-13T04:08:59.316868+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.314076+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "- énoncer pourquoi `(D, D)` est l'unique équilibre de Nash du PD canonique, et pourquoi la\n",
+    "  transparence des programmes change ce verdict (Critch-Dennis-Russell 2022, p. 3) ;\n",
+    "- définir une sémantique **bornée, totale et terminante** des agents `CUPOD`, `DUPOC`,\n",
+    "  `PrudentBot` et `CIMCIC`, à partir d'un certificat public et d'une clôture finie ;\n",
+    "- distinguer rigoureusement trois régimes de preuve : **observation finie**, **résultat\n",
+    "  reproduit**, **théorème cité** ;\n",
+    "- reproduire une matrice de confrontations avec **deux implémentations indépendantes** et\n",
+    "  comparer mécaniquement les relations et les matrices obtenues ;\n",
+    "- exhiber un **contrôle négatif** où la transparence seule ne crée pas la coopération ;\n",
+    "- lire le tableau des **dix problèmes ouverts** de l'article, dont l'Open Problem 3, laissé\n",
+    "  explicitement ouvert — ni exercice à solution attendue, ni résultat de notebook.\n",
+    "\n",
+    "### Prérequis\n",
+    "\n",
+    "- Python 3 (kernel `python3` de Jupyter) et sa bibliothèque standard seulement.\n",
+    "- La notion d'équilibre de Nash en stratégies pures, et le PD sous forme normale.\n",
+    "- Lecture utile (facultative) : `GameTheory-06e-Open-Source-Game-Theory.ipynb` pour le cadre\n",
+    "  des jeux-programmes, et `GameTheory-06g-Simulation-Based-Program-Equilibria.ipynb` pour un\n",
+    "  analogue fondé sur la simulation.\n",
+    "\n",
+    "### Durée estimée : 45 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07b793ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003289,
+     "end_time": "2026-09-13T04:08:59.323081+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.319792+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le Dilemme du prisonnier canonique\n",
+    "\n",
+    "On pose la matrice canonique `(T=5, R=3, P=1, S=0)` avec `T > R > P > S` et `2R > T + S`.\n",
+    "\n",
+    "| | C | D |\n",
+    "| --- | --- | --- |\n",
+    "| **C** | R, R | S, T |\n",
+    "| **D** | T, S | P, P |\n",
+    "\n",
+    "`D` domine strictement `C` pour chaque joueur, quelle que soit l'action adverse : l'unique\n",
+    "équilibre de Nash en stratégies pures est `(D, D)`. C'est le point de départ que la\n",
+    "transparence des programmes va déplacer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a01088b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.330137Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.329872Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.337213Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.336334Z"
+    },
+    "papermill": {
+     "duration": 0.011736,
+     "end_time": "2026-09-13T04:08:59.337898+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.326162+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C/C -> 3  C/D -> 0\n",
+      "D/C -> 5  D/D -> 1\n",
+      "D domine C pour chaque joueur : (D, D) est l'unique equilibre de Nash en strategies pures.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parametrage canonique du Dilemme du prisonnier (Shoham & Leyton-Brown 2009, §3.4.2).\n",
+    "T, R, P, S = 5, 3, 1, 0\n",
+    "assert T > R > P > S, \"parametres PD non canoniques\"\n",
+    "assert 2 * R > T + S, \"PD strict : la cooperation mutuelle bat l'alternance\"\n",
+    "\n",
+    "\n",
+    "def gain(mien, adverse):\n",
+    "    '''Gain du joueur dont l'action est `mien`, face a l'action `adverse`.'''\n",
+    "    if mien == \"C\":\n",
+    "        return R if adverse == \"C\" else S\n",
+    "    return T if adverse == \"C\" else P\n",
+    "\n",
+    "\n",
+    "for mien in (\"C\", \"D\"):\n",
+    "    print(\"  \".join(f\"{mien}/{adv} -> {gain(mien, adv)}\" for adv in (\"C\", \"D\")))\n",
+    "\n",
+    "for mien in (\"C\", \"D\"):\n",
+    "    for adv in (\"C\", \"D\"):\n",
+    "        assert gain(\"D\", adv) >= gain(\"C\", adv), \"D doit dominer C\"\n",
+    "print(\"D domine C pour chaque joueur : (D, D) est l'unique equilibre de Nash en strategies pures.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e543989",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002964,
+     "end_time": "2026-09-13T04:08:59.343920+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.340956+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Sémantique bornée et terminante du modèle\n",
+    "\n",
+    "L'article définit les agents au moyen d'un `proof_search` (p. 7, §2.1) : un agent cherche une\n",
+    "**preuve formelle**, bornée en longueur par `k` caractères, d'un énoncé portant sur le code de\n",
+    "l'adversaire. Cette recherche présuppose un système de preuve (arithmétique de Peano ou une\n",
+    "extension) et une énumération des preuves ; elle n'est pas exécutable telle quelle dans un\n",
+    "notebook, et elle n'est pas décidable dans le cas non borné.\n",
+    "\n",
+    "Ce notebook remplace la recherche de preuve par une **clôture finie et totale** :\n",
+    "\n",
+    "1. chaque programme publie un **certificat** — un ensemble fini d'atomes tirés d'un vocabulaire\n",
+    "   fixe. C'est l'analogue des « bylaws » d'une institution, que la partie adverse peut lire ;\n",
+    "2. une liste finie de **règles d'inférence** dérive des faits sur l'adversaire à partir de son\n",
+    "   **seul** certificat ;\n",
+    "3. `proof_search(k, source, but)` teste si le but appartient à la clôture obtenue en **au plus\n",
+    "   `k` tours** d'application des règles ;\n",
+    "4. `k` compte des **tours d'inférence**, et non des caractères de preuve comme dans l'article :\n",
+    "   les seuils numériques ne sont donc **pas comparables**, seule la **monotonie** (`k` plus grand\n",
+    "   rend davantage de faits dérivables) est reproduite.\n",
+    "\n",
+    "Trois limites de ce choix, à garder en tête pendant toute la lecture :\n",
+    "\n",
+    "- la clôture est **finie** — l'univers des atomes dérivables est fixé à l'avance — donc la\n",
+    "  sémantique est **totale** et **terminante**, contrairement au `proof_search` non borné ;\n",
+    "- elle est **incomplète** vis-à-vis de l'article : elle ne peut pas dériver les faits qui\n",
+    "  exigent le lemme PBLT (lemme 3.6, p. 13), dont dépendent les théorèmes 3.4 et 3.7 ;\n",
+    "- un agent **opaque** (certificat vide) n'est jamais récompensé — c'est exactement le point (3)\n",
+    "  de la p. 18 : un adversaire illisible (« spaghetti code ») n'est pas récompensé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0f7efff7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.350767Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.350503Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.355999Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.355261Z"
+    },
+    "papermill": {
+     "duration": 0.009845,
+     "end_time": "2026-09-13T04:08:59.356568+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.346723+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Atomes certifies : 6 | regles : 9\n",
+      "  uncond_coop  =>  intent_coop\n",
+      "  uncond_defect  =>  intent_defect\n",
+      "  self_cond_coop  =>  implies_own_coop\n",
+      "  intent_coop  =>  coops_against_any,coops_with_db\n",
+      "  intent_defect  =>  defects_against_any,defects_with_db\n",
+      "  needs_proof_of_coop  =>  defects_with_db\n",
+      "  needs_proof_of_defect  =>  defects_with_db\n",
+      "  self_cond_coop  =>  defects_with_db\n",
+      "  prudent  =>  defects_with_db\n",
+      "\n",
+      "Les quatre regles a conclusion `defects_with_db` encodent un fait relatif au DefectBot\n",
+      "canonique : un agent qui n'obtient jamais de preuve de cooperation fait defection contre lui.\n",
+      "C'est l'ancrage utilise par PrudentBot dans LaVictoire et al. 2017 (cite p. 26).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Modele borne : univers fini d'atomes certifies et regles d'inference.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "K_DEFAUT = 3\n",
+    "\n",
+    "ATOMES_CERTIFIES = (\n",
+    "    \"uncond_coop\",             # cooperer inconditionnellement\n",
+    "    \"uncond_defect\",           # faire defection inconditionnellement\n",
+    "    \"self_cond_coop\",          # condition de cooperation auto-referentielle (CIMCIC)\n",
+    "    \"needs_proof_of_coop\",     # cooperer seulement avec une preuve de cooperation (DUPOC)\n",
+    "    \"needs_proof_of_defect\",   # faire defection seulement sur preuve de defection (CUPOD)\n",
+    "    \"prudent\",                 # exiger en plus une preuve que l'adversaire fait defection contre DefectBot\n",
+    ")\n",
+    "\n",
+    "REGLES = (\n",
+    "    (frozenset({\"uncond_coop\"}),           frozenset({\"intent_coop\"})),\n",
+    "    (frozenset({\"uncond_defect\"}),         frozenset({\"intent_defect\"})),\n",
+    "    (frozenset({\"self_cond_coop\"}),        frozenset({\"implies_own_coop\"})),\n",
+    "    (frozenset({\"intent_coop\"}),           frozenset({\"coops_against_any\", \"coops_with_db\"})),\n",
+    "    (frozenset({\"intent_defect\"}),         frozenset({\"defects_against_any\", \"defects_with_db\"})),\n",
+    "    (frozenset({\"needs_proof_of_coop\"}),   frozenset({\"defects_with_db\"})),\n",
+    "    (frozenset({\"needs_proof_of_defect\"}), frozenset({\"defects_with_db\"})),\n",
+    "    (frozenset({\"self_cond_coop\"}),        frozenset({\"defects_with_db\"})),\n",
+    "    (frozenset({\"prudent\"}),               frozenset({\"defects_with_db\"})),\n",
+    ")\n",
+    "\n",
+    "print(f\"Atomes certifies : {len(ATOMES_CERTIFIES)} | regles : {len(REGLES)}\")\n",
+    "for premisse, conclusions in REGLES:\n",
+    "    print(\"  \" + \",\".join(sorted(premisse)) + \"  =>  \" + \",\".join(sorted(conclusions)))\n",
+    "print()\n",
+    "print(\"Les quatre regles a conclusion `defects_with_db` encodent un fait relatif au DefectBot\")\n",
+    "print(\"canonique : un agent qui n'obtient jamais de preuve de cooperation fait defection contre lui.\")\n",
+    "print(\"C'est l'ancrage utilise par PrudentBot dans LaVictoire et al. 2017 (cite p. 26).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44ebdf9c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002915,
+     "end_time": "2026-09-13T04:08:59.362406+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.359491+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.1 Les sept programmes et leur certificat\n",
+    "\n",
+    "Chaque programme est un texte Python : une fonction `nom(opp_source, k)` et un champ\n",
+    "`bylaws_json` qui publie son certificat. Le certificat est **la** source d'information de\n",
+    "l'adversaire — un agent sans certificat est opaque.\n",
+    "\n",
+    "| Programme | Rôle | Certificat publié |\n",
+    "| --- | --- | --- |\n",
+    "| `CooperateBot` | coopère toujours (p. 6) | `uncond_coop` |\n",
+    "| `DefectBot` | fait toujours défection (p. 6) | `uncond_defect` |\n",
+    "| `CooperateBotOpake` | coopère toujours, mais ne publie rien | aucun atome |\n",
+    "| `CUPOD` | fait défection s'il détient une preuve de défection (p. 9) | `needs_proof_of_defect` |\n",
+    "| `DUPOC` | coopère seulement sur preuve de coopération (p. 9 et 10) | `needs_proof_of_coop` |\n",
+    "| `CIMCIC` | coopère si sa coopération implique celle de l'autre (p. 20) | `self_cond_coop` |\n",
+    "| `PrudentBot_borne` | candidat borné de PrudentBot (Open Problem 9, p. 26) | `prudent`, `needs_proof_of_coop` |\n",
+    "\n",
+    "Le certificat est publié **deux fois**, sous deux formes destinées à deux lecteurs distincts :\n",
+    "des marqueurs `# BYLAW:` lus par le moteur principal, et le champ `bylaws_json` lu par le\n",
+    "vérificateur indépendant. Cette redondance est délibérée : elle rend la comparaison des deux\n",
+    "implémentations significative (cf. section 8)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b15eb996",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.369466Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.369198Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.374050Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.373492Z"
+    },
+    "papermill": {
+     "duration": 0.009372,
+     "end_time": "2026-09-13T04:08:59.374732+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.365360+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CooperateBot       def CooperateBot(opp_source, k):\n",
+      "DefectBot          def DefectBot(opp_source, k):\n",
+      "CooperateBotOpake  def CooperateBotOpake(opp_source, k):\n",
+      "CUPOD              def CUPOD(opp_source, k):\n",
+      "DUPOC              def DUPOC(opp_source, k):\n",
+      "CIMCIC             def CIMCIC(opp_source, k):\n",
+      "PrudentBot_borne   def PrudentBot_borne(opp_source, k):\n",
+      "\n",
+      "7 programmes publies, chacun avec sa fonction et son certificat.\n"
+     ]
+    }
+   ],
+   "source": [
+    "SOURCES = {\n",
+    "    \"CooperateBot\": '''def CooperateBot(opp_source, k):\n",
+    "    return \"C\"\n",
+    "# BYLAW: uncond_coop\n",
+    "bylaws_json = '{\"atoms\": [\"uncond_coop\"]}'\n",
+    "''',\n",
+    "    \"DefectBot\": '''def DefectBot(opp_source, k):\n",
+    "    return \"D\"\n",
+    "# BYLAW: uncond_defect\n",
+    "bylaws_json = '{\"atoms\": [\"uncond_defect\"]}'\n",
+    "''',\n",
+    "    \"CooperateBotOpake\": '''def CooperateBotOpake(opp_source, k):\n",
+    "    _code = 67\n",
+    "    return chr(_code)\n",
+    "# BYLAW:\n",
+    "bylaws_json = '{\"atoms\": []}'\n",
+    "''',\n",
+    "    \"CUPOD\": '''def CUPOD(opp_source, k):\n",
+    "    if proof_search(k, opp_source, \"defects_against_any\"):\n",
+    "        return \"D\"\n",
+    "    return \"C\"\n",
+    "# BYLAW: needs_proof_of_defect\n",
+    "bylaws_json = '{\"atoms\": [\"needs_proof_of_defect\"]}'\n",
+    "''',\n",
+    "    \"DUPOC\": '''def DUPOC(opp_source, k):\n",
+    "    if proof_search(k, opp_source, \"coops_against_any\"):\n",
+    "        return \"C\"\n",
+    "    return \"D\"\n",
+    "# BYLAW: needs_proof_of_coop\n",
+    "bylaws_json = '{\"atoms\": [\"needs_proof_of_coop\"]}'\n",
+    "''',\n",
+    "    \"CIMCIC\": '''def CIMCIC(opp_source, k):\n",
+    "    if proof_search(k, opp_source, \"implies_own_coop\"):\n",
+    "        return \"C\"\n",
+    "    return \"D\"\n",
+    "# BYLAW: self_cond_coop\n",
+    "bylaws_json = '{\"atoms\": [\"self_cond_coop\"]}'\n",
+    "''',\n",
+    "    \"PrudentBot_borne\": '''def PrudentBot_borne(opp_source, k):\n",
+    "    if not proof_search(k, opp_source, \"coops_against_any\"):\n",
+    "        return \"D\"\n",
+    "    if not proof_search(k, opp_source, \"defects_with_db\"):\n",
+    "        return \"D\"\n",
+    "    return \"C\"\n",
+    "# BYLAW: prudent\n",
+    "# BYLAW: needs_proof_of_coop\n",
+    "bylaws_json = '{\"atoms\": [\"prudent\", \"needs_proof_of_coop\"]}'\n",
+    "''',\n",
+    "}\n",
+    "\n",
+    "ORDRE = (\"CooperateBot\", \"DefectBot\", \"CooperateBotOpake\",\n",
+    "         \"CUPOD\", \"DUPOC\", \"CIMCIC\", \"PrudentBot_borne\")\n",
+    "\n",
+    "for _nom in ORDRE:\n",
+    "    print(f\"{_nom:18s} {SOURCES[_nom].splitlines()[0]}\")\n",
+    "print()\n",
+    "print(f\"{len(SOURCES)} programmes publies, chacun avec sa fonction et son certificat.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80824e37",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003337,
+     "end_time": "2026-09-13T04:08:59.381110+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.377773+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Moteur principal (implémentation 1)\n",
+    "\n",
+    "Le moteur lit le certificat par ses marqueurs `# BYLAW:`, calcule la clôture bornée et expose\n",
+    "`proof_search(k, source, but)` aux programmes. La clôture s'arrête dès qu'un tour n'ajoute\n",
+    "plus rien : elle est donc terminante, et le résultat est **monotone** en `k`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3205afc8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.388434Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.388183Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.393924Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.393132Z"
+    },
+    "papermill": {
+     "duration": 0.010594,
+     "end_time": "2026-09-13T04:08:59.394641+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.384047+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CooperateBot   cert=['uncond_coop']\n",
+      "               clot(k=3)=['coops_against_any', 'coops_with_db', 'intent_coop', 'uncond_coop']\n",
+      "DUPOC          cert=['needs_proof_of_coop']\n",
+      "               clot(k=3)=['defects_with_db', 'needs_proof_of_coop']\n",
+      "CIMCIC         cert=['self_cond_coop']\n",
+      "               clot(k=3)=['defects_with_db', 'implies_own_coop', 'self_cond_coop']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "\n",
+    "_MARQUEUR_BYLAW = re.compile(r\"^#\\s*BYLAW:\\s*([a-z_]+)\\s*$\", re.MULTILINE)\n",
+    "\n",
+    "\n",
+    "def parse_certificat_A(source):\n",
+    "    '''Certificat lu par le moteur : marqueurs `# BYLAW: <atome>`.'''\n",
+    "    return frozenset(_MARQUEUR_BYLAW.findall(source))\n",
+    "\n",
+    "\n",
+    "def cloture_A(graine, k):\n",
+    "    '''Cloture en au plus k tours d'application des regles (terminante, monotone).'''\n",
+    "    faits = set(graine)\n",
+    "    for _ in range(k):\n",
+    "        grossi = set(faits)\n",
+    "        for premisse, conclusions in REGLES:\n",
+    "            if premisse <= faits:\n",
+    "                grossi |= conclusions\n",
+    "        if grossi == faits:\n",
+    "            break\n",
+    "        faits = grossi\n",
+    "    return frozenset(faits)\n",
+    "\n",
+    "\n",
+    "def proof_search(k, opp_source, but):\n",
+    "    '''Le `but` est-il derivable du certificat publie par l'adversaire en <= k tours ?'''\n",
+    "    return but in cloture_A(parse_certificat_A(opp_source), k)\n",
+    "\n",
+    "\n",
+    "for _nom in (\"CooperateBot\", \"DUPOC\", \"CIMCIC\"):\n",
+    "    print(f\"{_nom:14s} cert={sorted(parse_certificat_A(SOURCES[_nom]))}\")\n",
+    "    print(f\"{'':14s} clot(k=3)={sorted(cloture_A(parse_certificat_A(SOURCES[_nom]), K_DEFAUT))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3d21949",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002943,
+     "end_time": "2026-09-13T04:08:59.401314+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.398371+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.1 Exécution des programmes\n",
+    "\n",
+    "La transparence est ici **effective** : chaque fonction reçoit le **texte** du programme adverse\n",
+    "et s'en sert pour interroger `proof_search`. On charge les sept programmes depuis leur texte,\n",
+    "en leur donnant accès au seul `proof_search` borné."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cdc19a01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.408890Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.408640Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.413370Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.412701Z"
+    },
+    "papermill": {
+     "duration": 0.009221,
+     "end_time": "2026-09-13T04:08:59.413920+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.404699+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CooperateBot       contre DefectBot   -> C\n",
+      "DefectBot          contre DefectBot   -> D\n",
+      "CooperateBotOpake  contre DefectBot   -> C\n",
+      "CUPOD              contre DefectBot   -> D\n",
+      "DUPOC              contre DefectBot   -> D\n",
+      "CIMCIC             contre DefectBot   -> D\n",
+      "PrudentBot_borne   contre DefectBot   -> D\n",
+      "\n",
+      "7 programmes charges et appelables.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def charger(source):\n",
+    "    '''Charge un programme depuis son texte, avec le `proof_search` borne en portee.'''\n",
+    "    espace = {\"proof_search\": proof_search}\n",
+    "    exec(source, espace)\n",
+    "    return espace\n",
+    "\n",
+    "\n",
+    "PROGRAMMES = {nom: charger(SOURCES[nom])[nom] for nom in ORDRE}\n",
+    "\n",
+    "for _nom in ORDRE:\n",
+    "    _adversaire = \"DefectBot\"\n",
+    "    _action = PROGRAMMES[_nom](SOURCES[_adversaire], K_DEFAUT)\n",
+    "    print(f\"{_nom:18s} contre {_adversaire:11s} -> {_action}\")\n",
+    "print()\n",
+    "print(f\"{len(PROGRAMMES)} programmes charges et appelables.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aedfc98d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003198,
+     "end_time": "2026-09-13T04:08:59.420519+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.417321+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.2 Issue d'une confrontation en un coup\n",
+    "\n",
+    "Une confrontation `(A, B)` fournit à chaque programme le texte de l'autre. L'issue est le\n",
+    "couple d'actions, suivi des deux gains."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e6f5249c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.427850Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.427595Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.434065Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.433090Z"
+    },
+    "papermill": {
+     "duration": 0.011045,
+     "end_time": "2026-09-13T04:08:59.434604+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.423559+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Legende : CB=CooperateBot, DB=DefectBot, CBo=CooperateBotOpake, CU=CUPOD, DU=DUPOC, CI=CIMCIC, PB=PrudentBot_borne\n",
+      "\n",
+      "Action du programme en ligne contre le programme en colonne :\n",
+      "         CB   DB  CBo   CU   DU   CI   PB\n",
+      "  CB      C    C    C    C    C    C    C\n",
+      "  DB      D    D    D    D    D    D    D\n",
+      " CBo      C    C    C    C    C    C    C\n",
+      "  CU      C    D    C    C    C    C    C\n",
+      "  DU      C    D    D    D    D    D    D\n",
+      "  CI      D    D    D    D    D    C    D\n",
+      "  PB      D    D    D    D    D    D    D\n",
+      "\n",
+      "Gain du programme en ligne (celui du programme en colonne s'en deduit par transposition,\n",
+      "le jeu etant symetrique : gain_colonne(A, B) == gain_ligne(B, A)) :\n",
+      "  CB      3    0    3    3    3    0    0\n",
+      "  DB      5    1    5    1    1    1    1\n",
+      " CBo      3    0    3    3    0    0    0\n",
+      "  CU      3    1    3    3    0    0    0\n",
+      "  DU      3    1    5    5    1    1    1\n",
+      "  CI      5    1    5    5    1    3    1\n",
+      "  PB      5    1    5    5    1    1    1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "\n",
+    "def issue(nom_a, nom_b, k=K_DEFAUT):\n",
+    "    '''(action_a, action_b, (gain_a, gain_b)) pour une confrontation en un coup.'''\n",
+    "    act_a = PROGRAMMES[nom_a](SOURCES[nom_b], k)\n",
+    "    act_b = PROGRAMMES[nom_b](SOURCES[nom_a], k)\n",
+    "    return act_a, act_b, (gain(act_a, act_b), gain(act_b, act_a))\n",
+    "\n",
+    "\n",
+    "ETIQUETTE = {\"CooperateBot\": \"CB\", \"DefectBot\": \"DB\", \"CooperateBotOpake\": \"CBo\",\n",
+    "             \"CUPOD\": \"CU\", \"DUPOC\": \"DU\", \"CIMCIC\": \"CI\", \"PrudentBot_borne\": \"PB\"}\n",
+    "\n",
+    "ISSUE_MOTEUR = {(a, b): issue(a, b) for a, b in itertools.product(ORDRE, repeat=2)}\n",
+    "\n",
+    "print(\"Legende : \" + \", \".join(f\"{ETIQUETTE[n]}={n}\" for n in ORDRE))\n",
+    "print()\n",
+    "print(\"Action du programme en ligne contre le programme en colonne :\")\n",
+    "print(\"      \" + \"\".join(f\"{ETIQUETTE[n]:>5s}\" for n in ORDRE))\n",
+    "for _a in ORDRE:\n",
+    "    print(f\"{ETIQUETTE[_a]:>4s}  \" + \"\".join(f\"{ISSUE_MOTEUR[(_a, _b)][0]:>5s}\" for _b in ORDRE))\n",
+    "print()\n",
+    "print(\"Gain du programme en ligne (celui du programme en colonne s'en deduit par transposition,\")\n",
+    "print(\"le jeu etant symetrique : gain_colonne(A, B) == gain_ligne(B, A)) :\")\n",
+    "for _a in ORDRE:\n",
+    "    print(f\"{ETIQUETTE[_a]:>4s}  \" + \"\".join(f\"{ISSUE_MOTEUR[(_a, _b)][2][0]:>5d}\" for _b in ORDRE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "595ff576",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003103,
+     "end_time": "2026-09-13T04:08:59.441065+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.437962+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture de la matrice\n",
+    "\n",
+    "Quatre phénomènes sont visibles dans cette table (verdict **calculé** dans le modèle borné,\n",
+    "jamais une preuve) :\n",
+    "\n",
+    "1. **Coopération mutuelle** : `DUPOC` contre `CooperateBot` donne `(C, C)` — le patient\n",
+    "   coopère parce que le certificat de `CooperateBot` est lisible, et réciproquement.\n",
+    "2. **Inexploitation** : `DUPOC` contre `CooperateBotOpake` donne `(D, C)`. Le contrôle opaque\n",
+    "   se comporte pourtant exactement comme `CooperateBot` ; seule sa **représentation** diffère.\n",
+    "3. **Défection révélée par la lecture** : `CUPOD` contre `DefectBot` donne `(D, D)` : `CUPOD`\n",
+    "   trouve dans le certificat de `DefectBot` la preuve qu'il va faire défection.\n",
+    "4. **Non-coopération sous transparence totale** : `DUPOC` contre `DUPOC` donne `(D, D)` — les\n",
+    "   deux programmes lisent tout le texte de l'autre et ne coopèrent pas pour autant. C'est le\n",
+    "   contrôle négatif de la section 5.\n",
+    "\n",
+    "Les théorèmes 3.4 et 3.7 de l'article prévoient respectivement `(D, D)` et `(C, C)` pour ces\n",
+    "deux derniers cas **quand `k` est grand** : l'écart entre ces énoncés et la table ci-dessus est\n",
+    "le sujet du classement de la section 4."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d018fe4c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003006,
+     "end_time": "2026-09-13T04:08:59.447233+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.444227+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Classification : observation finie, résultat reproduit, théorème cité\n",
+    "\n",
+    "Chaque affirmation de ce notebook appartient à **un seul** de ces trois régimes.\n",
+    "\n",
+    "| Régime | Définition | Exemple dans ce notebook |\n",
+    "| --- | --- | --- |\n",
+    "| **Résultat reproduit** | Une affirmation de la source que le modèle borné retrouve, et qui **ne dépend pas** du lemme PBLT | Exemple 2.1, exemples 3.1 et 3.2, propositions 3.1 et 3.2, proposition 5.1, théorème 5.2(a) |\n",
+    "| **Observation finie** | Un calcul du modèle borné, **sans** énoncé correspondant dans la source, ou avec un énoncé qui en diffère | La table complète des 49 paires, la ligne de `PrudentBot_borne`, l'Open Problem 3 (laissé ouvert, section 9) |\n",
+    "| **Théorème cité** | Un énoncé de la source **cité** pour mémoire, que le modèle borné **ne reproduit pas** | Théorèmes 3.4 et 3.7 (PBLT), théorème 5.2(b) |\n",
+    "\n",
+    "Le théorème 5.2(a) mérite une note : l'article le démontre **sans** invoquer PBLT pour l'essentiel,\n",
+    "car la preuve requise se réduit à l'implication `X => X` — une tautologie (p. 21). C'est pourquoi\n",
+    "le modèle borné le retrouve, alors qu'il échoue sur les théorèmes 3.4 et 3.7, dont la preuve passe\n",
+    "par le point fixe de PBLT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dba0f156",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.454548Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.454264Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.460150Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.459475Z"
+    },
+    "papermill": {
+     "duration": 0.010352,
+     "end_time": "2026-09-13T04:08:59.460661+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.450309+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple 2.1 reproduit : outcome(CB, DB) = ('C', 'D') (0, 5)\n",
+      "Exemples 3.1 et 3.2 reproduits qualitativement : k=1 -> ('C', 'D') | k=3 -> ('D', 'D')\n",
+      "  (l'article mesure k en caracteres de preuve, ici en tours d'inference)\n",
+      "Theoreme 5.2(a) reproduit : outcome(CIMCIC, CIMCIC) = ('C', 'C') (3, 3)\n",
+      "Proposition 3.1 (p. 11) : CUPOD n'est jamais dans l'issue DC sur les paires du registre.\n",
+      "Proposition 3.2 (p. 11) : DUPOC n'est jamais dans l'issue CD sur les paires du registre.\n",
+      "Proposition 5.1 (p. 20) : CIMCIC n'est jamais dans l'issue CD sur les paires du registre.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Verification mecanique des affirmations classees « resultat reproduit ».\n",
+    "# ---------------------------------------------------------------------------\n",
+    "ex21 = issue(\"CooperateBot\", \"DefectBot\")\n",
+    "assert ex21[:2] == (\"C\", \"D\"), ex21\n",
+    "print(\"Exemple 2.1 reproduit : outcome(CB, DB) =\", ex21[:2], ex21[2])\n",
+    "\n",
+    "bas = issue(\"CUPOD\", \"DefectBot\", k=1)[:2]\n",
+    "haut = issue(\"CUPOD\", \"DefectBot\", k=K_DEFAUT)[:2]\n",
+    "assert bas == (\"C\", \"D\") and haut == (\"D\", \"D\"), (bas, haut)\n",
+    "print(\"Exemples 3.1 et 3.2 reproduits qualitativement : k=1 ->\", bas, \"| k=3 ->\", haut)\n",
+    "print(\"  (l'article mesure k en caracteres de preuve, ici en tours d'inference)\")\n",
+    "\n",
+    "ci = issue(\"CIMCIC\", \"CIMCIC\")\n",
+    "assert ci[:2] == (\"C\", \"C\"), ci\n",
+    "print(\"Theoreme 5.2(a) reproduit : outcome(CIMCIC, CIMCIC) =\", ci[:2], ci[2])\n",
+    "\n",
+    "\n",
+    "def exploite_par(agent, issue_interdite):\n",
+    "    '''Rend une paire temoin si `agent` est dans l'issue interdite, sinon None.'''\n",
+    "    for (x, y), (ax, ay, _) in ISSUE_MOTEUR.items():\n",
+    "        if x == agent and ax + ay == issue_interdite:\n",
+    "            return (x, y)\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "for _agent, _interdite, _source in ((\"CUPOD\", \"DC\", \"Proposition 3.1 (p. 11)\"),\n",
+    "                                    (\"DUPOC\", \"CD\", \"Proposition 3.2 (p. 11)\"),\n",
+    "                                    (\"CIMCIC\", \"CD\", \"Proposition 5.1 (p. 20)\")):\n",
+    "    _temoin = exploite_par(_agent, _interdite)\n",
+    "    assert _temoin is None, (_agent, _interdite, _temoin)\n",
+    "    print(f\"{_source} : {_agent} n'est jamais dans l'issue {_interdite} sur les paires du registre.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad30d0a5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003136,
+     "end_time": "2026-09-13T04:08:59.466994+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.463858+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Contrôle négatif : la transparence seule ne crée pas la coopération\n",
+    "\n",
+    "Les programmes lisent ici **tout** le texte de l'adversaire. La question est de savoir si cette\n",
+    "transparence suffit à produire la coopération mutuelle. La réponse du modèle borné est non, et\n",
+    "c'est précisément l'endroit où il se sépare de l'article."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "90f63352",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.474426Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.474247Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.478416Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.477825Z"
+    },
+    "papermill": {
+     "duration": 0.009184,
+     "end_time": "2026-09-13T04:08:59.479440+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.470256+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Observation finie : outcome(DUPOC, DUPOC) = ('D', 'D') (1, 1)\n",
+      "Theoreme cite      : Theoreme 3.7 (p. 14) : pour k grand,\n",
+      "                     outcome(DUPOC(k), DUPOC(k)) == (C, C), via PBLT.\n",
+      "  -> sans PBLT, la transparence mutuelle ne suffit pas : les deux font defection.\n",
+      "\n",
+      "Observation finie : outcome(CUPOD, CUPOD) = ('C', 'C') (3, 3)\n",
+      "Theoreme cite      : Theoreme 3.4 (p. 13) : pour k grand,\n",
+      "                     outcome(CUPOD(k), CUPOD(k)) == (D, D), via PBLT.\n",
+      "  -> ecart en miroir : le modele borne est incomplet dans les deux sens.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Controle negatif : transparence mutuelle totale, sans cooperation.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "du = issue(\"DUPOC\", \"DUPOC\")\n",
+    "cu = issue(\"CUPOD\", \"CUPOD\")\n",
+    "assert du[:2] == (\"D\", \"D\"), du\n",
+    "assert cu[:2] == (\"C\", \"C\"), cu\n",
+    "\n",
+    "print(\"Observation finie : outcome(DUPOC, DUPOC) =\", du[:2], du[2])\n",
+    "print(\"Theoreme cite      : Theoreme 3.7 (p. 14) : pour k grand,\")\n",
+    "print(\"                     outcome(DUPOC(k), DUPOC(k)) == (C, C), via PBLT.\")\n",
+    "print(\"  -> sans PBLT, la transparence mutuelle ne suffit pas : les deux font defection.\")\n",
+    "print()\n",
+    "print(\"Observation finie : outcome(CUPOD, CUPOD) =\", cu[:2], cu[2])\n",
+    "print(\"Theoreme cite      : Theoreme 3.4 (p. 13) : pour k grand,\")\n",
+    "print(\"                     outcome(CUPOD(k), CUPOD(k)) == (D, D), via PBLT.\")\n",
+    "print(\"  -> ecart en miroir : le modele borne est incomplet dans les deux sens.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00ab9d95",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005494,
+     "end_time": "2026-09-13T04:08:59.489927+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.484433+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Sortie non triviale : la représentation change une issue\n",
+    "\n",
+    "`CooperateBot` et `CooperateBotOpake` ont un **comportement observable identique** : ils\n",
+    "coopèrent contre n'importe quel adversaire. Ils ne diffèrent que par le certificat publié.\n",
+    "Faites les confronter à `DUPOC`, et observez si la transparence du certificat change l'issue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4ad224ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.503028Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.502767Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.507482Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.506857Z"
+    },
+    "papermill": {
+     "duration": 0.011731,
+     "end_time": "2026-09-13T04:08:59.508457+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.496726+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comportement identique verifie : les deux programmes cooperent contre tous les adversaires.\n",
+      "\n",
+      "DUPOC vs CooperateBot      : ('C', 'C') (3, 3)\n",
+      "DUPOC vs CooperateBotOpake : ('D', 'C') (5, 0)\n",
+      "\n",
+      "La seule difference est la representation publiee : certificat non vide contre certificat vide.\n",
+      "C'est le point (3) de la p. 18 : un adversaire illisible n'est pas recompense.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# La representation publiee change une issue de PD en un coup.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "for _adversaire in ORDRE:\n",
+    "    assert PROGRAMMES[\"CooperateBot\"](SOURCES[_adversaire], K_DEFAUT) == \"C\"\n",
+    "    assert PROGRAMMES[\"CooperateBotOpake\"](SOURCES[_adversaire], K_DEFAUT) == \"C\"\n",
+    "print(\"Comportement identique verifie : les deux programmes cooperent contre tous les adversaires.\")\n",
+    "\n",
+    "legible = issue(\"DUPOC\", \"CooperateBot\")\n",
+    "opaque = issue(\"DUPOC\", \"CooperateBotOpake\")\n",
+    "assert legible[:2] != opaque[:2], (legible[:2], opaque[:2])\n",
+    "print()\n",
+    "print(\"DUPOC vs CooperateBot      :\", legible[:2], legible[2])\n",
+    "print(\"DUPOC vs CooperateBotOpake :\", opaque[:2], opaque[2])\n",
+    "print()\n",
+    "print(\"La seule difference est la representation publiee : certificat non vide contre certificat vide.\")\n",
+    "print(\"C'est le point (3) de la p. 18 : un adversaire illisible n'est pas recompense.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74442ab0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003604,
+     "end_time": "2026-09-13T04:08:59.515915+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.512311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — une paire lisible / opaque, et la bascule qu'elle provoque\n",
+    "\n",
+    "L'exemple guidé de la section 6 montre la bascule `(C, C)` vers `(D, C)` sur une paire fournie.\n",
+    "À vous de la reconstruire avec **vos propres** sources.\n",
+    "\n",
+    "Objectif : écrire deux programmes de comportement identique (« coopérer toujours ») dont l'un\n",
+    "publie un certificat `uncond_coop` et l'autre rien, les charger, puis confronter `DUPOC` à\n",
+    "chacun et montrer que les issues diffèrent.\n",
+    "\n",
+    "Contraintes :\n",
+    "\n",
+    "- les deux fonctions doivent porter **le même nom** `CooperateBot` — c'est le nom que\n",
+    "  l'adversaire lit dans le texte ;\n",
+    "- le programme opaque ne doit pas contenir le littéral `\"C\"` dans un `return` : utilisez\n",
+    "  `chr(67)` ;\n",
+    "- ne pas modifier `SOURCES` ni `PROGRAMMES`.\n",
+    "\n",
+    "Indices : `charger(SOURCE)[\"CooperateBot\"]` rend la fonction chargeable ; `issue` exige un nom\n",
+    "présent dans `SOURCES`, donc appelez directement `PROGRAMMES[\"DUPOC\"](SOURCE_TEST, K_DEFAUT)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "174ef14c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.524265Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.524091Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.527819Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.527240Z"
+    },
+    "papermill": {
+     "duration": 0.009715,
+     "end_time": "2026-09-13T04:08:59.529105+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.519390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_1():\n",
+    "    # Etape 1 : ecrire SOURCE_LEGIBLE (certificat `uncond_coop`, retour \"C\").\n",
+    "    # Etape 2 : ecrire SOURCE_OPAQUE (certificat vide, retour chr(67)).\n",
+    "    # Etape 3 : charger les deux sources.\n",
+    "    # Etape 4 : confronter DUPOC a chacune et renvoyer les deux issues.\n",
+    "    # TODO etudiant : completer les etapes ci-dessus.\n",
+    "    result = None\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 1 a completer ->\", exercice_1())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4aed03c3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004797,
+     "end_time": "2026-09-13T04:08:59.537982+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.533185+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Rôle de la borne `k`\n",
+    "\n",
+    "La borne `k` est le seul paramètre libre du modèle. Un tour d'inférence ne peut produire un fait\n",
+    "que si ses prémisses sont déjà présentes : les bascules se produisent donc à des seuils précis.\n",
+    "L'exemple guidé ci-dessous balaie `k` de 0 à 4 sur quatre confrontations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5c491bf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.545883Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.545470Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.550724Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.550022Z"
+    },
+    "papermill": {
+     "duration": 0.010573,
+     "end_time": "2026-09-13T04:08:59.551898+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.541325+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " k |  CUPOD vs DB |  DUPOC vs CB |   CIMCIC/CIMCIC |   DUPOC/DUPOC\n",
+      " 0 |   ('C', 'D') |   ('D', 'C') |      ('D', 'D') |    ('D', 'D')\n",
+      " 1 |   ('C', 'D') |   ('D', 'C') |      ('C', 'C') |    ('D', 'D')\n",
+      " 2 |   ('D', 'D') |   ('C', 'C') |      ('C', 'C') |    ('D', 'D')\n",
+      " 3 |   ('D', 'D') |   ('C', 'C') |      ('C', 'C') |    ('D', 'D')\n",
+      " 4 |   ('D', 'D') |   ('C', 'C') |      ('C', 'C') |    ('D', 'D')\n",
+      "\n",
+      "CUPOD contre DefectBot bascule de (C, D) a (D, D) des que k atteint 2 tours.\n",
+      "La cloture est monotone et se stabilise : k plus grand n'ajoute plus aucun fait.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Balayage de la borne k : le seul parametre libre du modele.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "print(f\"{'k':>2s} | {'CUPOD vs DB':>12s} | {'DUPOC vs CB':>12s} | {'CIMCIC/CIMCIC':>15s} | {'DUPOC/DUPOC':>13s}\")\n",
+    "for k in range(5):\n",
+    "    a = issue(\"CUPOD\", \"DefectBot\", k=k)[:2]\n",
+    "    b = issue(\"DUPOC\", \"CooperateBot\", k=k)[:2]\n",
+    "    c = issue(\"CIMCIC\", \"CIMCIC\", k=k)[:2]\n",
+    "    d = issue(\"DUPOC\", \"DUPOC\", k=k)[:2]\n",
+    "    print(f\"{k:>2d} | {str(a):>12s} | {str(b):>12s} | {str(c):>15s} | {str(d):>13s}\")\n",
+    "\n",
+    "assert issue(\"CUPOD\", \"DefectBot\", k=1)[:2] == (\"C\", \"D\")\n",
+    "assert issue(\"CUPOD\", \"DefectBot\", k=2)[:2] == (\"D\", \"D\")\n",
+    "print()\n",
+    "print(\"CUPOD contre DefectBot bascule de (C, D) a (D, D) des que k atteint 2 tours.\")\n",
+    "print(\"La cloture est monotone et se stabilise : k plus grand n'ajoute plus aucun fait.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad1ec223",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004871,
+     "end_time": "2026-09-13T04:08:59.560443+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.555572+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — borne de stabilisation sur toutes les paires\n",
+    "\n",
+    "L'exemple guidé balaie quatre confrontations choisies. À vous de traiter le registre entier.\n",
+    "\n",
+    "Objectif : écrire `borne_de_stabilisation(nom_a, nom_b, k_max=5)` qui rend la **plus petite**\n",
+    "borne `k` telle que l'issue ne change plus pour tout `k` jusqu'à `k_max`, puis l'appliquer aux\n",
+    "49 paires ordonnées et afficher la table.\n",
+    "\n",
+    "Contraintes : n'utiliser que `issue`, `ORDRE` et `itertools.product` ; ne pas recopier la table\n",
+    "déjà affichée.\n",
+    "\n",
+    "Indices : « l'issue ne change plus » signifie que l'issue en `k` est égale à l'issue en `k_max`.\n",
+    "Cas limite à signaler explicitement : une paire peut déjà être stable en `k = 0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "176ec90a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.569846Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.569583Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.573449Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.572735Z"
+    },
+    "papermill": {
+     "duration": 0.00915,
+     "end_time": "2026-09-13T04:08:59.574160+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.565010+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_2():\n",
+    "    # Etape 1 : pour une paire (a, b), calculer l'issue de reference en k_max.\n",
+    "    # Etape 2 : balayer k de 0 a k_max et renvoyer le premier k stable.\n",
+    "    # Etape 3 : appliquer la fonction aux paires de itertools.product(ORDRE, repeat=2)\n",
+    "    #           et renvoyer la table {paire: borne}.\n",
+    "    # TODO etudiant : completer les etapes ci-dessus.\n",
+    "    result = None\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 2 a completer ->\", exercice_2())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6064ff98",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003575,
+     "end_time": "2026-09-13T04:08:59.581832+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.578257+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Vérificateur indépendant (implémentation 2)\n",
+    "\n",
+    "Un résultat calculé par un seul programme n'est pas vérifié. On recalcule toute la table par un\n",
+    "**second chemin de calcul**, écrit indépendamment sur trois plans :\n",
+    "\n",
+    "| Plan | Moteur principal | Vérificateur |\n",
+    "| --- | --- | --- |\n",
+    "| Lecture du certificat | marqueurs `# BYLAW:` (expression régulière) | champ `bylaws_json` (`json.loads`) |\n",
+    "| Clôture | parcours d'une liste de couples d'ensembles, avec arrêt anticipé | itération naïve jusqu'au point fixe sur un dictionnaire prémisses vers conclusions |\n",
+    "| Décision | **exécution** de la fonction programme | **réécriture** de la règle de décision par rôle, sans appel au moteur |\n",
+    "\n",
+    "La **spécification** — atomes, règles, table de gains — est commune : c'est elle que la\n",
+    "comparaison met à l'épreuve. Ce qui est indépendant, c'est le code qui l'implémente."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b25d3d47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.591418Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.591144Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.598393Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.597705Z"
+    },
+    "papermill": {
+     "duration": 0.013118,
+     "end_time": "2026-09-13T04:08:59.599181+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.586063+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyses du certificat : accord sur les sept programmes.\n",
+      "  marqueurs `# BYLAW:` (moteur) == champ `bylaws_json` (verificateur).\n",
+      "Regles du verificateur : 8 premisses, ecrites independamment.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Implementation 2 : verificateur ecrit independamment du moteur.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "import json as _json\n",
+    "import re as _re\n",
+    "\n",
+    "REGLES_B = {\n",
+    "    \"uncond_coop\": (\"intent_coop\",),\n",
+    "    \"uncond_defect\": (\"intent_defect\",),\n",
+    "    \"self_cond_coop\": (\"implies_own_coop\", \"defects_with_db\"),\n",
+    "    \"intent_coop\": (\"coops_against_any\", \"coops_with_db\"),\n",
+    "    \"intent_defect\": (\"defects_against_any\", \"defects_with_db\"),\n",
+    "    \"needs_proof_of_coop\": (\"defects_with_db\",),\n",
+    "    \"needs_proof_of_defect\": (\"defects_with_db\",),\n",
+    "    \"prudent\": (\"defects_with_db\",),\n",
+    "}\n",
+    "\n",
+    "_JSON_BYLAW = _re.compile(r\"bylaws_json\\s*=\\s*'([^']*)'\")\n",
+    "\n",
+    "\n",
+    "def parse_certificat_B(source):\n",
+    "    '''Certificat lu par le verificateur : champ JSON `bylaws_json`.'''\n",
+    "    trouve = _JSON_BYLAW.search(source)\n",
+    "    assert trouve is not None, \"champ bylaws_json absent\"\n",
+    "    return frozenset(_json.loads(trouve.group(1))[\"atoms\"])\n",
+    "\n",
+    "\n",
+    "def cloture_B(graine, k):\n",
+    "    '''Cloture par iteration naive jusqu'au point fixe, bornee par k tours.'''\n",
+    "    faits = set(graine)\n",
+    "    for _ in range(k):\n",
+    "        ajouts = set()\n",
+    "        for premisse, conclusions in REGLES_B.items():\n",
+    "            if premisse in faits:\n",
+    "                ajouts.update(conclusions)\n",
+    "        if ajouts <= faits:\n",
+    "            return frozenset(faits)\n",
+    "        faits |= ajouts\n",
+    "    return frozenset(faits)\n",
+    "\n",
+    "\n",
+    "def decision_verificateur(nom, source, k):\n",
+    "    '''Decision reecrite par role, sans appeler les fonctions programme du moteur.'''\n",
+    "    faits = cloture_B(parse_certificat_B(source), k)\n",
+    "    if nom in (\"CooperateBot\", \"CooperateBotOpake\"):\n",
+    "        return \"C\"\n",
+    "    if nom == \"DefectBot\":\n",
+    "        return \"D\"\n",
+    "    if nom == \"CUPOD\":\n",
+    "        return \"D\" if \"defects_against_any\" in faits else \"C\"\n",
+    "    if nom == \"DUPOC\":\n",
+    "        return \"C\" if \"coops_against_any\" in faits else \"D\"\n",
+    "    if nom == \"CIMCIC\":\n",
+    "        return \"C\" if \"implies_own_coop\" in faits else \"D\"\n",
+    "    if nom == \"PrudentBot_borne\":\n",
+    "        if \"coops_against_any\" not in faits:\n",
+    "            return \"D\"\n",
+    "        return \"C\" if \"defects_with_db\" in faits else \"D\"\n",
+    "    raise KeyError(f\"role inconnu : {nom}\")\n",
+    "\n",
+    "\n",
+    "def issue_verificateur(nom_a, nom_b, k=K_DEFAUT):\n",
+    "    act_a = decision_verificateur(nom_a, SOURCES[nom_b], k)\n",
+    "    act_b = decision_verificateur(nom_b, SOURCES[nom_a], k)\n",
+    "    return act_a, act_b, (gain(act_a, act_b), gain(act_b, act_a))\n",
+    "\n",
+    "\n",
+    "for _nom in ORDRE:\n",
+    "    assert parse_certificat_A(SOURCES[_nom]) == parse_certificat_B(SOURCES[_nom]), _nom\n",
+    "print(\"Analyses du certificat : accord sur les sept programmes.\")\n",
+    "print(\"  marqueurs `# BYLAW:` (moteur) == champ `bylaws_json` (verificateur).\")\n",
+    "print(f\"Regles du verificateur : {len(REGLES_B)} premisses, ecrites independamment.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db12c32f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003713,
+     "end_time": "2026-09-13T04:08:59.607968+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.604255+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 8.1 Comparaison mécanique des deux implémentations\n",
+    "\n",
+    "On compare non seulement les actions, mais la **relation de coopération** et la **matrice de\n",
+    "gains**. Un désaccord sur n'importe laquelle des trois serait un diagnostic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0b2af2f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.616643Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.616437Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.623162Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.622498Z"
+    },
+    "papermill": {
+     "duration": 0.012422,
+     "end_time": "2026-09-13T04:08:59.624201+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.611779+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paires ordonnees comparees : 49\n",
+      "Desaccords moteur / verificateur : 0\n",
+      "Relation de cooperation identique : True\n",
+      "Matrice de gains identique        : True\n",
+      "\n",
+      "Deux implementations independantes, un seul verdict sur les trois objets compares.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Comparaison mecanique : actions, relation de cooperation, matrice de gains.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "paires = list(itertools.product(ORDRE, repeat=2))\n",
+    "desaccords = [(a, b, ISSUE_MOTEUR[(a, b)], issue_verificateur(a, b))\n",
+    "              for a, b in paires\n",
+    "              if ISSUE_MOTEUR[(a, b)] != issue_verificateur(a, b)]\n",
+    "assert not desaccords, desaccords\n",
+    "\n",
+    "relation_moteur = {p for p in paires if ISSUE_MOTEUR[p][0] == \"C\"}\n",
+    "relation_verif = {p for p in paires if issue_verificateur(*p)[0] == \"C\"}\n",
+    "gains_moteur = {p: ISSUE_MOTEUR[p][2] for p in paires}\n",
+    "gains_verif = {p: issue_verificateur(*p)[2] for p in paires}\n",
+    "\n",
+    "assert relation_moteur == relation_verif\n",
+    "assert gains_moteur == gains_verif\n",
+    "\n",
+    "print(f\"Paires ordonnees comparees : {len(paires)}\")\n",
+    "print(\"Desaccords moteur / verificateur :\", len(desaccords))\n",
+    "print(\"Relation de cooperation identique :\", relation_moteur == relation_verif)\n",
+    "print(\"Matrice de gains identique        :\", gains_moteur == gains_verif)\n",
+    "print()\n",
+    "print(\"Deux implementations independantes, un seul verdict sur les trois objets compares.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f042de88",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00353,
+     "end_time": "2026-09-13T04:08:59.633406+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.629876+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — une troisième vérification, indépendante des deux premières\n",
+    "\n",
+    "Le vérificateur de la section 8 est un second chemin. Écrivez un **troisième** contrôle, lui\n",
+    "aussi indépendant, qui retrouve la non-exploitabilité de `CUPOD`, `DUPOC` et `CIMCIC`\n",
+    "(propositions 3.1, 3.2 et 5.1) sur **toutes** les paires du registre.\n",
+    "\n",
+    "Objectif : rendre un dictionnaire de témoins `{role: paire_temoin ou None}`, où une paire\n",
+    "témoin est une paire dont le couple d'actions est l'issue interdite du rôle\n",
+    "(`CUPOD` interdit `DC`, `DUPOC` interdit `CD`, `CIMCIC` interdit `CD`).\n",
+    "\n",
+    "Contraintes : ne pas utiliser `ISSUE_MOTEUR` (c'est le but), ni `issue_verificateur`, ni\n",
+    "`exploite_par`. Partir de `decision_verificateur` et `gain` uniquement.\n",
+    "\n",
+    "Indice : `decision_verificateur(nom, source, k)` rend une action isolée ; appelez-la deux fois\n",
+    "pour reconstruire un couple d'actions. Le contrôle réussi rend trois valeurs `None`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f9841659",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.642601Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.642349Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.646079Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.645478Z"
+    },
+    "papermill": {
+     "duration": 0.00913,
+     "end_time": "2026-09-13T04:08:59.646908+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.637778+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_3():\n",
+    "    # Etape 1 : issues_interdites = {\"CUPOD\": \"DC\", \"DUPOC\": \"CD\", \"CIMCIC\": \"CD\"}\n",
+    "    # Etape 2 : parcourir les paires ordonnees et reconstruire l'issue via decision_verificateur.\n",
+    "    # Etape 3 : collecter un temoin par role, puis renvoyer le dictionnaire.\n",
+    "    # TODO etudiant : completer les etapes ci-dessus.\n",
+    "    result = None\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 3 a completer ->\", exercice_3())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56d82de1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003572,
+     "end_time": "2026-09-13T04:08:59.655131+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.651559+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Open Problem 3 : DUPOC(k) contre CUPOD(k)\n",
+    "\n",
+    "L'Open Problem 3 (p. 18) conjecture, pour `k` grand,\n",
+    "`outcome(DUPOC(k), CUPOD(k)) == (D, C)`, et demande si c'est bien le cas. L'article explique\n",
+    "pourquoi la question est difficile : l'argument de symétrie naïf est invalide, car `DUPOC(k)`\n",
+    "n'est pas le miroir exact de `CUPOD(k)` — les lettres `C` et `D` ne sont pas échangées dans le\n",
+    "`proof_checker`. Il faut raisonner sur l'échec d'une recherche de preuve d'un agent pendant que\n",
+    "l'autre ne peut pas prouver cet échec, ce que PBLT ne permet pas.\n",
+    "\n",
+    "**Cet Open Problem reste explicitement ouvert.** Le modèle borné calcule une issue pour cette\n",
+    "paire, comme pour toutes les autres, mais ce calcul **ne tranche pas** la conjecture : il\n",
+    "n'implémente pas la notion de preuve non bornée sur laquelle porte l'énoncé. La cellule qui suit\n",
+    "affiche l'observation et le dit ; aucun exercice du notebook ne porte sur ce problème."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3eb84c61",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T04:08:59.664937Z",
+     "iopub.status.busy": "2026-09-13T04:08:59.664686Z",
+     "iopub.status.idle": "2026-09-13T04:08:59.669708Z",
+     "shell.execute_reply": "2026-09-13T04:08:59.669056Z"
+    },
+    "papermill": {
+     "duration": 0.011844,
+     "end_time": "2026-09-13T04:08:59.670652+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.658808+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Observation bornee : outcome(DUPOC, CUPOD) = ('D', 'C') (5, 0)\n",
+      "Observation bornee : outcome(CUPOD, DUPOC) = ('C', 'D') (0, 5)\n",
+      "\n",
+      "Open Problem 3 (p. 18) : la conjecture outcome(DUPOC(k), CUPOD(k)) == (D, C) reste OUVERTE.\n",
+      "Le present modele ne la tranche pas : sa cloture finie ne reproduit pas le raisonnement sur\n",
+      "l'echec d'une recherche de preuve non bornee dont l'article a besoin, et PBLT ne s'y\n",
+      "applique pas (l'article mentionne lui-meme l'absence de 'self-fulfilling prophecy' evident).\n",
+      "\n",
+      "Aucune cellule de ce notebook ne presente cette observation comme un resultat, et aucun\n",
+      "exercice ne porte sur Open Problem 3.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Open Problem 3 : observation bornee, sans valeur de resolution.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "du_cu = issue(\"DUPOC\", \"CUPOD\")\n",
+    "cu_du = issue(\"CUPOD\", \"DUPOC\")\n",
+    "print(\"Observation bornee : outcome(DUPOC, CUPOD) =\", du_cu[:2], du_cu[2])\n",
+    "print(\"Observation bornee : outcome(CUPOD, DUPOC) =\", cu_du[:2], cu_du[2])\n",
+    "print()\n",
+    "print(\"Open Problem 3 (p. 18) : la conjecture outcome(DUPOC(k), CUPOD(k)) == (D, C) reste OUVERTE.\")\n",
+    "print(\"Le present modele ne la tranche pas : sa cloture finie ne reproduit pas le raisonnement sur\")\n",
+    "print(\"l'echec d'une recherche de preuve non bornee dont l'article a besoin, et PBLT ne s'y\")\n",
+    "print(\"applique pas (l'article mentionne lui-meme l'absence de 'self-fulfilling prophecy' evident).\")\n",
+    "print()\n",
+    "print(\"Aucune cellule de ce notebook ne presente cette observation comme un resultat, et aucun\")\n",
+    "print(\"exercice ne porte sur Open Problem 3.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e66c4ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003715,
+     "end_time": "2026-09-13T04:08:59.678211+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.674496+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. Les dix problèmes ouverts de la source\n",
+    "\n",
+    "| # | Énoncé | Statut dans la source | Prérequis | Expérience finie possible |\n",
+    "| --- | --- | --- | --- | --- |\n",
+    "| 1 | Prouver le théorème de Löb sans le point fixe modal `Psi <-> (Box Psi -> C)` | Open Problem 1, p. 15, théorie de la preuve | Logique de la prouvabilité, théorème du point fixe modal | Non : la question est l'existence d'une preuve, non un calcul. Au mieux, tester une formalisation partielle. |\n",
+    "| 2 | Conditions sous lesquelles une population contenant des DUPOC évolue vers des agents G-fair | Open Problem 2, p. 18, dynamique de populations | Dynamique évolutionnaire, simulations | Oui : tournoi répété sur une population finie de petits certificats, mesurer la part de G-fair. |\n",
+    "| 3 | Pour `k` grand, `outcome(DUPOC(k), CUPOD(k)) == (D, C)` | Open Problem 3, p. 18 — **problème explicitement ouvert** | Raisonner sur l'échec d'une recherche de preuve non bornée ; PBLT ne s'applique pas | **Non résolutoire** : le modèle borné calcule une issue, mais celle-ci ne tranche pas l'énoncé. Aucun exercice ne porte sur ce problème. |\n",
+    "| 4 | Implémenter DUPOC par recherche heuristique de preuve en HOL/ML ou Coq, et vérifier l'arrêt coopératif sur une machine de bureau | Open Problem 4, p. 20, ingénierie de la preuve | HOL/ML ou Coq, tactiques heuristiques | Oui, mais hors notebook : exige un assistant de preuve réel. |\n",
+    "| 5 | Que vaut `outcome(CUPOD(k), CIMCIC(k))` | Open Problem 5, p. 22 | Même difficulté que le problème 3 | Non résolutoire : observation bornée possible, sans valeur de preuve. |\n",
+    "| 6 | Que vaut `outcome(DUPOC(k), DIMCID(k))` | Open Problem 6, p. 24 | Définition de DIMCID, p. 22 | Non résolutoire ; DIMCID n'est pas défini dans ce notebook. |\n",
+    "| 7 | Généraliser PBLT en analogue borné de Gödel-Löb suivant les longueurs de preuve | Open Problem 7, p. 25 et 26 | Logique modale, PBLT, Critch 2016 théorème 4.2 | Partielle : instrumenter les longueurs dans un système de preuve jouet. |\n",
+    "| 8 | Appliquer le résultat du problème 7 pour améliorer l'algorithme Haskell du dépôt publique `klao/provability` | Open Problem 8, p. 26 | Haskell, sémantique de Kripke | Oui, mais dépend du problème 7. |\n",
+    "| 9 | Existe-t-il une version bornée de PrudentBot | Open Problem 9, p. 26 | Définition de PrudentBot (LaVictoire et al. 2017, cité p. 26) | Oui : le candidat `PrudentBot_borne` de ce notebook en est un essai. Il ne coopère avec aucun agent du registre, ce qui **illustre** la difficulté sans résoudre le problème 9. |\n",
+    "| 10 | Implémenter un CDEBot borné obtenant `(C, C)` contre DUPOC(k) et `(D, D)` contre EUPOD(k) | Open Problem 10, p. 27 | PD étendu à trois actions (E), application conditionnelle de PBLT | Oui : matrice bornée sur le jeu étendu à trois actions. |\n",
+    "\n",
+    "Les dix énoncés ci-dessus sont ceux de la source, avec leur numérotation et leur page. Les\n",
+    "problèmes 3, 5 et 6 sont ceux que l'article désigne lui-même comme ne relevant pas d'une\n",
+    "« self-fulfilling prophecy » démontrable par PBLT (p. 32 et 33)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "113fd1ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003483,
+     "end_time": "2026-09-13T04:08:59.685196+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.681713+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 11. Limites et résidu\n",
+    "\n",
+    "- **Le modèle n'est pas la source.** La clôture finie n'est pas le `proof_search` de l'article :\n",
+    "  aucun énoncé impliquant PBLT (théorèmes 3.4, 3.7, 5.2(b)) n'est reproduit. Ces énoncés sont\n",
+    "  cités comme tels dans le tableau de la section 4 et dans le contrôle négatif.\n",
+    "- **Les seuils de `k` ne sont pas transposables.** L'article compte des caractères de preuve, ce\n",
+    "  notebook des tours d'inférence. Seule la monotonie est commune.\n",
+    "- **`PrudentBot_borne` est un candidat, pas une solution.** Sa ligne dans la matrice est\n",
+    "  entièrement `D` : au sens du modèle, il ne coopère avec aucun agent du registre. C'est\n",
+    "  cohérent avec le fait que le PrudentBot de LaVictoire et al. repose sur une **recherche de\n",
+    "  preuve supplémentaire** dont l'analogue borné est précisément l'Open Problem 9, laissé ouvert.\n",
+    "- **Les certificats sont déclaratifs.** Un programme peut mentir sur son certificat ; le modèle\n",
+    "  suppose la publication sincère, comme l'article suppose un `proof_check` correct. La question\n",
+    "  de la vérification des certificats n'est pas traitée ici.\n",
+    "- **`CooperateBotOpake` est un contrôle local**, sans équivalent publié : il sert uniquement à\n",
+    "  isoler l'effet de la représentation dans la section 6."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "508d0b89",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004185,
+     "end_time": "2026-09-13T04:08:59.692903+00:00",
+     "exception": false,
+     "start_time": "2026-09-13T04:08:59.688718+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 12. Conclusion\n",
+    "\n",
+    "Ce notebook a défini une sémantique **bornée et terminante** des agents `CUPOD`, `DUPOC`,\n",
+    "`PrudentBot` et `CIMCIC`, puis a classé chaque affirmation dans un des trois régimes\n",
+    "— **observation finie**, **résultat reproduit**, **théorème cité**.\n",
+    "\n",
+    "À retenir :\n",
+    "\n",
+    "1. La transparence des programmes déplace bien l'issue du PD en un coup : `DUPOC` obtient\n",
+    "   `(C, C)` contre `CooperateBot`, et `(D, D)` contre `DefectBot`.\n",
+    "2. La transparence **seule** ne suffit pas : `DUPOC` contre `DUPOC` donne `(D, D)` dans le\n",
+    "   modèle borné, alors que le théorème 3.7 donne `(C, C)` via PBLT. Le lemme manquant est\n",
+    "   exactement ce que le modèle ne peut pas reproduire.\n",
+    "3. La **représentation** change l'issue à comportement constant : `CooperateBot` et\n",
+    "   `CooperateBotOpake` coopèrent tous deux contre tous, mais `DUPOC` ne récompense que le\n",
+    "   premier — le point (3) de la p. 18.\n",
+    "4. Les propositions 3.1, 3.2 et 5.1 sont reproduites sur tout le registre, et le théorème 5.2(a)\n",
+    "   l'est aussi, parce que sa preuve se réduit à une tautologie.\n",
+    "5. Vérifier demande **deux chemins** : le moteur et le vérificateur sont indépendants dans leur\n",
+    "   lecture du certificat, leur algorithme de clôture et leur évaluateur de décision, et\n",
+    "   s'accordent sur les actions, la relation de coopération et la matrice de gains.\n",
+    "6. **Open Problem 3 reste ouvert** : le notebook l'observe sans le trancher, et n'en fait ni un\n",
+    "   exercice ni un résultat.\n",
+    "\n",
+    "Pour aller plus loin : les dix problèmes ouverts de la section 10, et les notebooks voisins\n",
+    "`GameTheory-06e` (cadre des jeux-programmes) et `GameTheory-06g` (analogue par simulation)."
+   ]
+  }
+ ],
+ "metadata": {
+  "coursia": {
+   "grain": "DEEP/notebook-python",
+   "issue": 15906,
+   "lane": "agent-a5dfafa4eb3bb6b6c:CoursIA",
+   "status": "pedagogical-finite-model"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.321602,
+   "end_time": "2026-09-13T04:08:59.940600+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-06h-Transparent-Institutions.ipynb",
+   "output_path": "GameTheory-06h-Transparent-Institutions.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-13T04:08:57.618998+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/lean #15899

## Résumé

- ajoute le notebook exécuté `GameTheory-06h-Transparent-Institutions.ipynb` (39 cellules, dont 16 cellules de code) ;
- relie programmes publics, règlements institutionnels et résultats du dilemme du prisonnier en un coup à partir de Critch–Dennis–Russell (2022) ;
- formalise une sémantique finie et terminante pour DUPOC, CUPOD, PrudentBot et CIMCIC, puis compare mécaniquement un moteur principal à un vérificateur indépendant ;
- classe les dix problèmes ouverts du papier sans transformer l’Open Problem 3 en résultat ni en exercice résolu.

## Résultats exécutés

- Papermill : exécution complète sous `python3`, 39/39 cellules parcourues ;
- 16/16 cellules de code portent les compteurs contigus `1..16`, des sorties réelles, et aucune sortie `error` ;
- 49 paires ordonnées comparées par deux implémentations indépendantes : 0 désaccord, relation de coopération identique, matrice de gains identique ;
- contrôle négatif : le modèle borné obtient `DUPOC vs DUPOC = (D,D)`, contrairement au résultat cité du théorème 3.7 qui dépend de PBLT ;
- contrôle de représentation : `DUPOC vs CooperateBot = (C,C)` mais `DUPOC vs CooperateBotOpake = (D,C)` à comportement observable identique ;
- trois exercices C.1 exécutables, non résolus et répartis après les exemples guidés.

## Statut scientifique et limites

Le notebook distingue explicitement :

1. les observations finies calculées par son modèle borné ;
2. les résultats du papier reproduits dans ce fragment ;
3. les théorèmes asymptotiques seulement cités.

L’Open Problem 3 (`DUPOC(k)` contre `CUPOD(k)`) reste **OUVERT** : aucune cellule ne le présente comme un résultat et aucun exercice ne demande de le résoudre. La clôture finie ne reproduit pas les énoncés qui dépendent de PBLT, notamment les théorèmes 3.4, 3.7 et 5.2(b). Le paramètre `k` compte ici des tours d’inférence et n’est pas directement comparable à la longueur de preuve du papier.

Verdict SOTA : **SOTA-OK pour le livrable déclaré** — le notebook exécute le modèle pédagogique fini annoncé et cite la source primaire pour chaque claim théorique ; il ne substitue pas cette expérience bornée à une preuve asymptotique.

## Validation

- `count_exercises.py` : 3/3, conforme ;
- `check_c2_compliance.py --path` : 1/1 notebook conforme ;
- mesure JSON indépendante : 39 cellules, 16 code, compteurs `1..16`, 0 erreur, 0 cellule code sans sortie, 39 identifiants nbformat ;
- motifs interdits `raise NotImplementedError`, `assert False`, `1/0` : 0 ;
- `git diff --check origin/main...HEAD` : vert ;
- contrôles applicables passés lors de la construction : ordre et séquence d’exécution, outputs requis, chemins machine, hiérarchie markdown, positionnement des interprétations, prose répétée, LaTeX, plan-loss, navlinks, solution leaks et ratchets output-failure/collapse/flood.

L’advisory de désaccentuation conserve 17 homographes français corrects (`borne`, `point fixe`, `publie`, `calcule`) ; il est non bloquant et les réécrire dégraderait la prose. Deux anomalies d’outillage hors périmètre ont été reproduites sur fichier neuf : `detect_degraded_mode` en sortie texte et `detect_paragraph_length` appliqué hors de son scope `*.md`.

Part of #15906.
Part of #15062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
