### PR TITLE
fix(tooling,#15905): pr-gate names timeout hits, fixes rerun remedy

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -161,8 +161,9 @@ import re
 import subprocess
 import sys
 import time
+from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Iterable, Mapping, Sequence
 
 try:  # Used only by the rule-8 delivery canary (derive_always_on_jobs).
     import yaml  # type: ignore
@@ -381,6 +382,98 @@ def _workflow_job_names(data: dict) -> list[str]:
     return names
 
 
+def derive_declared_timeouts(
+    workflows_dir: str = DEFAULT_WORKFLOWS_DIR,
+) -> dict[str, int]:
+    """Map a job name to its declared ``timeout-minutes``, when unambiguous.
+
+    #15905: the gate annotated a job that had hit its own wall as a "check
+    that never concluded". ``Scripts Tests (CPU)`` declares
+    ``timeout-minutes: 20`` and was measured six times at 20m21s-20m25s --
+    GitHub renders a ``timeout-minutes`` breach as ``conclusion: cancelled``,
+    so the conclusion alone cannot tell a wall hit from a runner famine. The
+    declared limit lives only in the workflow YAML, so it is read here, the
+    same way ``derive_advisory_jobs`` reads the advisory marker.
+
+    A job name is NOT unique across workflows (``sweep``, ``guard``, ``ci``,
+    ``build`` and ``target-coverage`` all repeat). A name resolving to several
+    DISTINCT limits is dropped rather than guessed: the gate must not name a
+    limit it cannot attribute to the check it is looking at. Names resolving
+    to one repeated value keep it -- the ambiguity is in the value, not in the
+    repetition.
+
+    Same robustness contract as ``derive_advisory_jobs``: an unreadable state
+    returns an empty mapping rather than weaponising the gate against every PR.
+    """
+    if yaml is None:
+        return {}
+    root = Path(workflows_dir)
+    if not root.is_dir():
+        return {}
+    seen: dict[str, set[int]] = {}
+    for yml in sorted(root.glob("*.yml")):
+        try:
+            data = yaml.safe_load(yml.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        for job_key, job in (data.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            limit = job.get("timeout-minutes")
+            if not isinstance(limit, int) or isinstance(limit, bool):
+                continue
+            name = job.get("name") or job_key
+            if isinstance(name, str) and name:
+                seen.setdefault(name, set()).add(limit)
+    return {
+        name: next(iter(limits))
+        for name, limits in seen.items()
+        if len(limits) == 1
+    }
+
+
+def _parse_ts(value: object) -> datetime | None:
+    """Parse a check-run timestamp (ISO-8601, ``Z`` suffix), or None."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _check_duration(check: dict) -> float | None:
+    """Seconds between ``started_at`` and ``completed_at``, or None.
+
+    None when either stamp is missing or unparseable. The gate reports a
+    duration only when it can actually read one (#15905): a fabricated or
+    defaulted duration would be worse than none, because the whole point is to
+    let a reader compare it against the declared wall.
+    """
+    started = _parse_ts(check.get("started_at"))
+    finished = _parse_ts(check.get("completed_at"))
+    if started is None or finished is None:
+        return None
+    delta = (finished - started).total_seconds()
+    return delta if delta >= 0 else None
+
+
+def _format_duration(seconds: float) -> str:
+    """Human duration, e.g. ``20m21s`` / ``1h02m``.
+
+    Kept to the second: the margin #15905 is about is one to five minutes
+    against a 20-minute wall, which a coarse "20 minutes" would erase.
+    """
+    total = max(0, int(round(seconds)))
+    hours, rest = divmod(total, 3600)
+    minutes, secs = divmod(rest, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    return f"{minutes}m{secs:02d}s"
+
+
 def platform_delivered(checks: Sequence[dict], always_on_jobs: frozenset[str]) -> bool:
     """True when at least one always-on job is represented among observed checks.
 
@@ -583,7 +676,20 @@ def classify(
             # reds from checks that never concluded (same annotation style
             # as the advisory list below -- the bare name loses exactly the
             # information the published message needs).
-            bad.append(f"{name} ({conclusion})")
+            #
+            # #15905: an unconcluded check also carries its OBSERVED DURATION
+            # when the two stamps are readable -- that is what lets `verdict`
+            # tell "hit its declared wall" from "no verdict, cause unknown".
+            # Real reds keep the bare conclusion: their repair does not depend
+            # on how long they ran.
+            annotation = f"{name} ({conclusion})"
+            if conclusion in CONCLUSION_UNCONCLUDED:
+                observed = _check_duration(check)
+                if observed is not None:
+                    annotation = (
+                        f"{name} ({conclusion}, {_format_duration(observed)})"
+                    )
+            bad.append(annotation)
         else:
             # Unknown conclusion: bias to fail (rule 1). A conclusion GitHub
             # adds later must not silently become a pass.
@@ -608,8 +714,48 @@ def _report_advisory(advisory: Sequence[str]) -> None:
 # without re-reading the check set; anchored at end-of-string because the
 # annotation is always the LAST parenthesised group of the entry.
 _UNCONCLUDED_SUFFIX_RE = re.compile(
-    r" \((?:cancelled|timed_out|stale|startup_failure)\)$"
+    r" \((?:cancelled|timed_out|stale|startup_failure)"
+    r"(?:, (?:\d+m\d{2}s|\d+h\d{2}m))?\)$"
 )
+
+# Same annotation, with the optional duration CAPTURED (#15905). `verdict`
+# needs the observed duration to tell a wall hit from an unknown-cause
+# cancellation, and the annotation is the only carrier (`classify` returns
+# plain strings, by design -- see its docstring).
+_UNCONCLUDED_ENTRY_RE = re.compile(
+    r"^(?P<name>.+) \((?P<conclusion>cancelled|timed_out|stale|startup_failure)"
+    r"(?:, (?P<duration>\d+m\d{2}s|\d+h\d{2}m))?\)$"
+)
+
+
+def _parse_duration(text: str) -> int | None:
+    """Seconds from the human duration this module renders. None if malformed.
+
+    Round-trips ``_format_duration``. The `XhYYm` shape is minute-granular, so
+    a sub-minute remainder is lost for jobs past the hour -- irrelevant when
+    the comparison is against a wall declared in whole minutes.
+    """
+    match = re.fullmatch(r"(?:(\d+)h(\d{2})m|(\d+)m(\d{2})s)", text)
+    if match is None:
+        return None
+    if match.group(1) is not None:
+        return int(match.group(1)) * 3600 + int(match.group(2)) * 60
+    return int(match.group(3)) * 60 + int(match.group(4))
+
+
+def _parse_bad_entry(entry: str) -> tuple[str, str, int | None] | None:
+    """Split an unconcluded annotation into (name, conclusion, seconds).
+
+    None when the entry is not an unconcluded annotation at all (a bare name,
+    a real red, or an unknown conclusion) -- the caller treats those as the
+    real reds they are.
+    """
+    match = _UNCONCLUDED_ENTRY_RE.match(entry)
+    if match is None:
+        return None
+    raw_duration = match.group("duration")
+    seconds = _parse_duration(raw_duration) if raw_duration else None
+    return match.group("name"), match.group("conclusion"), seconds
 
 
 def _split_bad(bad: Sequence[str]) -> tuple[list[str], list[str]]:
@@ -630,7 +776,48 @@ def _split_bad(bad: Sequence[str]) -> tuple[list[str], list[str]]:
     return failed, unconcluded
 
 
-def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[int, str]:
+def _split_timed_out(
+    unconcluded: Sequence[str],
+    declared_timeouts: "Mapping[str, int] | None",
+) -> tuple[list[str], list[str]]:
+    """Split unconcluded entries into (hit-its-declared-wall, cause unknown).
+
+    #15905: GitHub renders a ``timeout-minutes`` breach as ``conclusion:
+    cancelled``, so the conclusion alone cannot tell a job that ran into its
+    own wall from one killed by a runner famine. The discriminator is the pair
+    (observed duration, declared limit), both of which must be READ -- when
+    either is unavailable the entry stays in the unknown bucket. The gate
+    reports what it read and never guesses a cause.
+
+    The wall-hit entries come back with the limit appended, so the published
+    message names both numbers: an annotation carrying only a duration leaves
+    the reader to guess which wall it hit.
+    """
+    if not declared_timeouts:
+        return [], list(unconcluded)
+    timed_out: list[str] = []
+    unknown: list[str] = []
+    for entry in unconcluded:
+        parsed = _parse_bad_entry(entry)
+        if parsed is None:
+            unknown.append(entry)
+            continue
+        name, _conclusion, seconds = parsed
+        limit = declared_timeouts.get(name)
+        if seconds is not None and limit is not None and seconds >= limit * 60:
+            timed_out.append(f"{entry[:-1]}, declared timeout-minutes: {limit})")
+        else:
+            unknown.append(entry)
+    return timed_out, unknown
+
+
+def verdict(
+    pending: Sequence[str],
+    bad: Sequence[str],
+    settled: bool,
+    *,
+    declared_timeouts: "Mapping[str, int] | None" = None,
+) -> tuple[int, str]:
     """Final decision. Returns (exit_code, human message).
 
     `settled` is False when the wait loop ran out of time. Unsettled is a
@@ -648,6 +835,17 @@ def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[
     the CHILD run carrying the frozen check-run, never the aggregator gate --
     because that is what actually clears the wedge (#14967 measured it).
 
+    #15905: `declared_timeouts` (job name -> `timeout-minutes`, from
+    `derive_declared_timeouts`) splits the unconcluded clause in two. A job
+    whose observed duration reached its declared wall is reported as such --
+    with both numbers -- and no longer as a check that "never concluded", and
+    the phrase "this is not a code failure" is gone: a timeout *can* be code
+    that is too slow, and the gate cannot tell from a check-run. When the
+    mapping is absent or the limit is unknown the entry stays in the
+    unknown-cause clause, which now reports the duration and prescribes the
+    CHILD rerun without asserting anything about the code. The fail-closed
+    rule is untouched: every branch here still exits 1.
+
     Note (#11751): the wait loop now re-reads the check set one last time at
     the deadline; an empty `pending` AND empty `bad` at that point is treated
     as `settled=True` BEFORE this function is reached, so this `not settled`
@@ -657,20 +855,36 @@ def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[
     not look like a benign display issue.
     """
     if bad:
-        # #15693: one FAIL prefix, two clauses with OPPOSITE repairs. A real
+        # #15693: one FAIL prefix, clauses with OPPOSITE repairs. A real
         # red names the check under "failing checks" (the historical phrase --
         # greppable, and what the log annotation has carried since #15472).
         # A check that never concluded is named separately with its repair
         # gesture: "failing checks: X" on a cancelled X told #15548's lane
         # its code was broken when the runner famine had eaten the verdict.
         failed, unconcluded = _split_bad(bad)
+        # #15905: a third clause. A job that ran into its declared
+        # `timeout-minutes` is NOT a check that "never concluded" -- it
+        # concluded by hitting its own wall (six measured at 20m21s-20m25s
+        # against a 20m wall). It gets its own clause, its own repair, and it
+        # reports the duration and the limit instead of asserting a cause the
+        # gate cannot establish from a check-run alone.
+        timed_out, unconcluded = _split_timed_out(unconcluded, declared_timeouts)
         parts = []
         if failed:
             parts.append("failing checks: " + ", ".join(failed))
+        if timed_out:
+            parts.append(
+                "checks that hit their declared timeout-minutes: "
+                + ", ".join(timed_out)
+                + " -- rerunning the gate re-reads the same frozen check-run:"
+                " rerun the CHILD run that owns the job (gh run rerun <id>),"
+                " never the gate (#15905)"
+            )
         if unconcluded:
             parts.append(
-                "checks that never concluded (rerun the run -- this is not "
-                "a code failure): " + ", ".join(unconcluded)
+                "checks that never concluded (rerun the CHILD run -- the cause"
+                " is not established from the check-run alone): "
+                + ", ".join(unconcluded)
             )
         return 1, "FAIL -- " + "; ".join(parts)
     if not settled:
@@ -996,6 +1210,13 @@ def fetch_checks(repo: str, sha: str) -> list[dict]:
                     "status": run.get("status"),
                     "conclusion": run.get("conclusion"),
                     "started_at": run.get("started_at"),
+                    # #15905: `completed_at` is carried so an unconcluded check
+                    # can report how long it actually ran. Without it the gate
+                    # cannot tell a wall hit from an unknown-cause cancellation,
+                    # and the timeout clause below is silently unreachable --
+                    # measured on #15778/#15836/#15877, where the API returns
+                    # the field but this projection dropped it.
+                    "completed_at": run.get("completed_at"),
                     "id": run.get("id"),
                 }
             )
@@ -1020,6 +1241,9 @@ def fetch_checks(repo: str, sha: str) -> list[dict]:
                         "error": "failure",
                     }.get(state, "" if state == "pending" else state),
                     "started_at": status.get("created_at"),
+                    # Legacy statuses expose `updated_at`, not `completed_at`
+                    # (#15905): same duration, different field name.
+                    "completed_at": status.get("updated_at"),
                     "id": status.get("id"),
                 }
             )
@@ -1036,6 +1260,7 @@ def wait_and_decide(
     settle_polls: int,
     always_on_jobs: "frozenset[str] | None" = None,
     advisory_jobs: "frozenset[str] | None" = None,
+    declared_timeouts: "Mapping[str, int] | None" = None,
     sleep=time.sleep,
     fetch=fetch_checks,
     now=time.monotonic,
@@ -1068,6 +1293,7 @@ def wait_and_decide(
     pending: list[str] = []
     bad: list[str] = []
     adv_jobs = advisory_jobs or frozenset()
+    timeouts = declared_timeouts or {}
 
     while True:
         checks = fetch(repo, sha)
@@ -1078,7 +1304,7 @@ def wait_and_decide(
         if bad:
             # Fail fast: a failure cannot be undone by waiting longer.
             _report_advisory(advisory)
-            return verdict(pending, bad, settled=True)
+            return verdict(pending, bad, settled=True, declared_timeouts=timeouts)
 
         if pending:
             quiet_streak = 0
@@ -1096,7 +1322,7 @@ def wait_and_decide(
                     return canary
                 _report_advisory(advisory)
                 print(f"[pr-gate] settled: {len(ok)} check(s) green", flush=True)
-                return verdict(pending, bad, settled=True)
+                return verdict(pending, bad, settled=True, declared_timeouts=timeouts)
 
         if now() >= deadline:
             # Issue #11751 -- phantom FAIL when the deadline fires BETWEEN the
@@ -1130,14 +1356,20 @@ def wait_and_decide(
                     "green (phantom-FAIL recovered, #11751)",
                     flush=True,
                 )
-                return verdict(final_pending, final_bad, settled=True)
+                return verdict(
+                    final_pending, final_bad, settled=True,
+                    declared_timeouts=timeouts,
+                )
             # Genuine still-pending (or a red we just observed): fail with a
             # message that names the constituents. Empty list here would mean
             # the rule-1 invariant broke -- say so explicitly instead of the
             # former `(none listed)` placeholder that read like a degradation.
             if final_bad:
                 _report_advisory(final_advisory)
-                return verdict(final_pending, final_bad, settled=True)
+                return verdict(
+                    final_pending, final_bad, settled=True,
+                    declared_timeouts=timeouts,
+                )
             if not final_pending:
                 # Defensive: settle_polls path did not fire (timeout) and the
                 # re-read is also empty -- this is unreachable under current
@@ -1154,7 +1386,10 @@ def wait_and_decide(
                     "FAIL -- timed out with empty wait set (gate bug, see #11751)"
                 )
             _report_advisory(final_advisory)
-            return verdict(final_pending, final_bad, settled=False)
+            return verdict(
+                final_pending, final_bad, settled=False,
+                declared_timeouts=timeouts,
+            )
 
         print(
             f"[pr-gate] waiting on {len(pending)} check(s): "
@@ -1396,6 +1631,9 @@ def main(argv: Iterable[str] | None = None) -> int:
     # into ``bad`` on every PR -- the failure mode that left #12524 and #12783
     # blocked 44h/9h before the fix landed.
     advisory_jobs = derive_advisory_jobs(args.workflows_dir)
+    # #15905: the declared walls, so a job that hit its own `timeout-minutes`
+    # is reported as such instead of as a check that "never concluded".
+    declared_timeouts = derive_declared_timeouts(args.workflows_dir)
 
     detail: dict = {}
     try:
@@ -1408,6 +1646,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             args.settle_polls,
             always_on_jobs,
             advisory_jobs,
+            declared_timeouts,
             detail=detail,
         )
     except GateError as exc:

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -1911,3 +1911,214 @@ def test_the_two_surfaces_render_the_same_text(tmp_path, monkeypatch):
     assert "2026-09-07T13:55:00Z" in seen["output[summary]"]
     assert "Ne pas re-pusher" in seen["output[summary]"]
     assert body in summary.read_text(encoding="utf-8"), "step summary: le meme corps"
+
+
+# --- #15905 : un mur atteint n'est pas une "non-conclusion" ------------------
+#
+# GitHub rend un depassement de `timeout-minutes` en `conclusion: cancelled`,
+# donc la conclusion seule ne distingue pas un job qui a tape son propre mur
+# d'un job tue par une famine de runners. Le discriminant est le COUPLE
+# (duree observee, limite declaree) -- et les deux doivent etre LUS, jamais
+# supposes. Le cas fondateur : `Scripts Tests (CPU)` declare 20 min, mesure
+# six fois entre 20m21s et 20m25s.
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _timed(name, minutes, seconds, conclusion="cancelled", rid=1):
+    """Un check-run TERMINE portant ses deux horodatages.
+
+    `run()` (le helper historique) ne pose que `started_at` : c'est ce qui rend
+    toutes les assertions anterieures insensibles a ce correctif, et c'est
+    aussi la raison d'etre de ce helper-ci.
+    """
+    start = datetime(2026, 9, 12, 14, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=minutes, seconds=seconds)
+    return {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": start.isoformat().replace("+00:00", "Z"),
+        "completed_at": end.isoformat().replace("+00:00", "Z"),
+        "id": rid,
+    }
+
+
+def _decide_with_walls(checks, walls):
+    pending, bad, _ok, _adv = pr_gate.classify(checks, pr_gate.DEFAULT_SELF_NAME)
+    return pr_gate.verdict(pending, bad, settled=True, declared_timeouts=walls)
+
+
+def test_declared_wall_is_read_from_the_real_workflows():
+    """Le cas fondateur, lu sur le depot et non sur une fixture."""
+    walls = pr_gate.derive_declared_timeouts()
+    assert walls.get("Scripts Tests (CPU)") == 20
+
+
+def test_declared_timeouts_tolerate_an_unreadable_state(tmp_path):
+    """Meme contrat de robustesse que `derive_advisory_jobs` : illisible ->
+    vide, jamais une arme braquee sur toutes les PRs."""
+    assert pr_gate.derive_declared_timeouts(str(tmp_path / "absent")) == {}
+
+
+def test_ambiguous_limit_is_dropped_not_guessed(tmp_path):
+    """Deux workflows declarent le meme nom de job avec des murs DIFFERENTS :
+    le gate ne doit pas nommer une limite qu'il ne peut pas attribuer."""
+    for fname, minutes in (("a.yml", 10), ("b.yml", 30)):
+        (tmp_path / fname).write_text(
+            f"name: {fname}\njobs:\n  j:\n    name: Same Job\n"
+            f"    timeout-minutes: {minutes}\n    runs-on: ubuntu-latest\n"
+            "    steps: []\n",
+            encoding="utf-8",
+        )
+    assert "Same Job" not in pr_gate.derive_declared_timeouts(str(tmp_path))
+
+
+def test_repeated_identical_limit_keeps_the_name(tmp_path):
+    """Le nom se repete (`sweep`, `guard`, `ci` le font dans ce depot) : c'est
+    la REPETITION qui est benigne, pas la divergence de valeur."""
+    for fname in ("a.yml", "b.yml"):
+        (tmp_path / fname).write_text(
+            f"name: {fname}\njobs:\n  j:\n    name: Same Job\n"
+            "    timeout-minutes: 15\n    runs-on: ubuntu-latest\n"
+            "    steps: []\n",
+            encoding="utf-8",
+        )
+    assert pr_gate.derive_declared_timeouts(str(tmp_path)) == {"Same Job": 15}
+
+
+def test_wall_hit_is_a_timeout_not_a_non_conclusion():
+    """Le fait mesure : 20m21s contre un mur declare a 20m."""
+    code, msg = _decide_with_walls([_timed("Scripts Tests (CPU)", 20, 21)],
+                                   {"Scripts Tests (CPU)": 20})
+    assert code == 1, "fail-closed inchange : un mur atteint bloque toujours"
+    assert "hit their declared timeout-minutes" in msg
+    assert "20m21s" in msg, "la duree OBSERVEE est nommee"
+    assert "declared timeout-minutes: 20" in msg, "la limite declaree aussi"
+    assert "never concluded" not in msg, "c'est l'erreur de #15905"
+    assert "this is not a code failure" not in msg
+
+
+def test_cancelled_under_the_wall_reports_the_duration_without_claiming_a_timeout():
+    """Une annulation SOUS le mur n'est pas un timeout : le gate rapporte ce
+    qu'il a lu et n'attribue aucune cause."""
+    code, msg = _decide_with_walls([_timed("Scripts Tests (CPU)", 1, 2)],
+                                   {"Scripts Tests (CPU)": 20})
+    assert code == 1
+    assert "never concluded" in msg
+    assert "1m02s" in msg
+    assert "hit their declared timeout-minutes" not in msg
+    assert "this is not a code failure" not in msg
+
+
+def test_unreadable_duration_is_not_invented():
+    """La limite est connue mais la duree ne l'est pas : aucun timeout n'est
+    revendique, et aucune duree n'est fabriquee dans l'annotation."""
+    checks = [run("ICT tests/ (55)", "cancelled", rid=1)]
+    pending, bad, _ok, _adv = pr_gate.classify(checks, pr_gate.DEFAULT_SELF_NAME)
+    assert bad == ["ICT tests/ (55) (cancelled)"]
+    code, msg = pr_gate.verdict(pending, bad, settled=True,
+                                declared_timeouts={"ICT tests/ (55)": 1})
+    assert code == 1
+    assert "never concluded" in msg
+    assert "hit their declared timeout-minutes" not in msg
+
+
+def test_unknown_limit_keeps_the_entry_in_the_unknown_clause():
+    """Le nom n'est pas resolu par les workflows : le gate ne devine pas."""
+    code, msg = _decide_with_walls([_timed("Unlisted Job", 99, 0)], {})
+    assert code == 1
+    assert "never concluded" in msg
+    assert "hit their declared timeout-minutes" not in msg
+    assert "1h39m" in msg, "la duree lue reste rapportee"
+
+
+def test_three_clauses_coexist_in_order():
+    """Un rouge, un mur atteint et une annulation inexpliquee dans un meme
+    verdict : chacun sous sa clause, le rouge en tete."""
+    checks = [
+        _timed("Lean CI", 0, 30, conclusion="failure", rid=1),
+        _timed("Scripts Tests (CPU)", 20, 21, rid=2),
+        _timed("ICT tests/ (55)", 1, 2, rid=3),
+    ]
+    code, msg = _decide_with_walls(checks, {"Scripts Tests (CPU)": 20})
+    assert code == 1
+    assert "failing checks: Lean CI (failure)" in msg
+    index_fail = msg.index("failing checks")
+    index_wall = msg.index("hit their declared timeout-minutes")
+    index_never = msg.index("never concluded")
+    assert index_fail < index_wall < index_never
+
+
+def test_duration_formatting_shapes():
+    assert pr_gate._format_duration(1221) == "20m21s"
+    assert pr_gate._format_duration(3720) == "1h02m"
+    assert pr_gate._format_duration(0) == "0m00s"
+    assert pr_gate._format_duration(-5) == "0m00s"
+
+
+def test_duration_round_trips_through_the_annotation():
+    """Le porteur est l'annotation : `_parse_bad_entry` doit relire ce que
+    `_format_duration` a ecrit."""
+    name, conclusion, seconds = pr_gate._parse_bad_entry(
+        "Scripts Tests (CPU) (cancelled, 20m21s)"
+    )
+    assert (name, conclusion, seconds) == ("Scripts Tests (CPU)", "cancelled", 1221)
+    assert pr_gate._parse_bad_entry("Scripts Tests (CPU) (cancelled)") == (
+        "Scripts Tests (CPU)", "cancelled", None
+    )
+    assert pr_gate._parse_bad_entry("Lean CI (failure)") is None
+
+
+def _fake_check_api(completed_at="2026-09-12T14:21:22Z"):
+    """Un `_gh_api` stand-in : un check-run annule + un statut legacy."""
+    def fake(path):
+        if "/check-runs" in path:
+            return {"total_count": 1, "check_runs": [{
+                "name": "Scripts Tests (CPU)",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "started_at": "2026-09-12T14:01:01Z",
+                "completed_at": completed_at,
+                "id": 7,
+            }]}
+        return {"statuses": [{
+            "context": "legacy/check",
+            "state": "failure",
+            "created_at": "2026-09-12T14:00:00Z",
+            "updated_at": "2026-09-12T14:00:30Z",
+            "id": 8,
+        }]}
+    return fake
+
+
+def test_fetch_checks_carries_completed_at_into_the_projection(monkeypatch):
+    """#15905, le defaut qui rendait le correctif INERTE.
+
+    L'API renvoie `completed_at` ; la projection de `fetch_checks` le jetait.
+    Aucune duree n'arrivait donc a `classify` et la clause timeout etait
+    inatteignable EN PRODUCTION -- alors que les fixtures synthetiques, qui
+    posent le champ a la main, passaient au vert. Mesure sur
+    #15778/#15836/#15877 : la sortie reelle portait
+    `Scripts Tests (CPU) (cancelled)` sans duree avant ce fix.
+    """
+    monkeypatch.setattr(pr_gate, "_gh_api", _fake_check_api())
+    checks = {c["name"]: c for c in pr_gate.fetch_checks("o/r", "deadbeef")}
+    assert checks["Scripts Tests (CPU)"]["completed_at"] == "2026-09-12T14:21:22Z"
+    # Les statuts legacy exposent `updated_at`, pas `completed_at` : meme duree,
+    # autre nom de champ.
+    assert checks["legacy/check"]["completed_at"] == "2026-09-12T14:00:30Z"
+
+
+def test_timeout_clause_is_reachable_from_a_fetched_check(monkeypatch):
+    """Le correctif ne vaut que si le chemin REEL l'atteint : fetch ->
+    classify -> verdict, sur la forme exacte que l'API renvoie."""
+    monkeypatch.setattr(pr_gate, "_gh_api", _fake_check_api())
+    checks = pr_gate.fetch_checks("o/r", "deadbeef")
+    pending, bad, _ok, _adv = pr_gate.classify(checks, pr_gate.DEFAULT_SELF_NAME)
+    assert "Scripts Tests (CPU) (cancelled, 20m21s)" in bad
+    code, msg = pr_gate.verdict(
+        pending, bad, settled=True, declared_timeouts={"Scripts Tests (CPU)": 20}
+    )
+    assert code == 1
+    assert "hit their declared timeout-minutes" in msg
+    assert "never concluded" not in msg


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #15876

Closes #15905 (§4 items 1-3, all three delivered).

## What was wrong

GitHub renders a `timeout-minutes` breach as `conclusion: cancelled` -- indistinguishable from an ordinary cancellation by conclusion alone. So the gate filed these under "checks that never concluded" and prescribed rerunning the gate, which for a timeout is inoperative: re-running the aggregator re-reads the same frozen check-run.

## What this PR does (strictly §4 items 1-3)

1. **Timeout is not non-conclusion.** `derive_declared_timeouts` reads every workflow YAML and maps job name -> declared `timeout-minutes` (names resolving to more than one distinct limit are dropped rather than guessed). `classify` annotates each unconcluded check with its observed duration (`completed_at - started_at`); `verdict` splits wall-hits (duration >= declared limit) into their own clause naming both numbers:
   `checks that hit their declared timeout-minutes: Scripts Tests (CPU) (cancelled, 20m21s, declared timeout-minutes: 20) -- rerunning the gate re-reads the same frozen check-run: rerun the CHILD run that owns the job (gh run rerun <id>), never the gate (#15905)`
2. **Remedy corrected.** The wall-hit clause prescribes the gesture that actually produces a fresh check-run: rerun the child run, never the gate.
3. **"this is not a code failure" removed.** A timeout *can* be slow code; the gate now reports duration + limit and lets the reader conclude. The unknown-cause clause keeps a neutral wording.

Non-goals honored (§5 + the two retractions): no `timeout-minutes` change, no thesis on why the job lands on the slow pool, no `gh api .../actions/runners` probe.

## The defect that made the fix inert (caught live)

`fetch_checks` projected a fixed field subset and **dropped `completed_at`** -- the API returns it. Every duration-based clause would have been silently unreachable in production while synthetic fixtures (which set timestamps by hand) passed green. Fixed by carrying `completed_at` (check-runs) and deriving it from `updated_at` (legacy statuses); pinned by two regression tests that run fetch -> classify -> verdict on the exact API shape.

Read-only live demo (classify + verdict only, never `main()` -- it would PATCH another lane's check-run), before -> after on the three PRs cited in the issue:

- #15778: `Scripts Tests (CPU) (cancelled)` -> `(cancelled, 20m21s, declared timeout-minutes: 20)`
- #15836: -> `(cancelled, 20m43s, ...)`
- #15877: -> `(cancelled, 20m23s, ...)`

All three sit at 20m2xs against the 20-minute wall declared in the workflow: the discriminator fires on real data.

## Validation

- `python -m pytest scripts/tests/test_pr_gate.py` -> **118 passed**, including the 14 new #15905 tests (12 for the three-clause split, duration formatting/parsing and ambiguity handling; 2 pinning the `fetch_checks` projection).
- The 10 consumer files referencing `pr_gate` (variation tag x2, remeasure_bad_pending, sweep_select, missing, lane_claim, fast_lane, derive_rerun_workflows, unique_check_run_names, subprocess_encoding) -> **227 passed**.
- pre-commit on both files: all hooks Passed/Skipped.
- Catalogue byte-identical to main (diff touches only `scripts/pr_gate.py` + `scripts/tests/test_pr_gate.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
