### PR TITLE
fix(guards,#15918): un [RELEASED] de réconciliation attribue son close à la lane CITÉE — le token nu du sujet perd

### DIFF
--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -519,13 +519,17 @@ def extract_lane(body: str | None, marker_line: str | None = None) -> str | None
     `_LANE_RE` so the two contexts never drift on what a lane token is.
 
     `#10395 Variante 1` fallback: when `marker_line` is supplied (the line of
-    the bracketed marker, stripped by the caller), and the primary `lane <x>`
-    regex misses on the whole body, the function searches ONLY that line for
-    a `<machine>:<workspace>` token matching `_LANE_FALLBACK_RE`. The marker
-    line scope is what keeps URLs / time stamps / code tokens that contain
-    colons from false-positiving -- the marker line is the human-stated intent
-    of the claim, not arbitrary prose. Without `marker_line`, behaviour is
-    unchanged (legacy callers like `parse_grain_tag` are unaffected).
+    the bracketed marker, stripped by the caller) and the primary `lane <x>`
+    regex has nothing to say FIRST on that line, the function searches ONLY
+    that line for a `<machine>:<workspace>` token matching
+    `_LANE_FALLBACK_RE`. The marker line scope is what keeps URLs / time
+    stamps / code tokens that contain colons from false-positiving -- the
+    marker line is the human-stated intent of the claim, not arbitrary prose.
+    `#15918` refines the precedence: a bare token that starts strictly before
+    the keyworded match's token ON THE MARKER LINE wins (the reconciliation
+    close names its own lane bare while citing the other lane in keyworded
+    form). Without `marker_line`, behaviour is unchanged (legacy callers like
+    `parse_grain_tag` are unaffected).
 
     Returns the `machine:workspace` string, or None when no lane token is
     found.
@@ -541,15 +545,24 @@ def extract_lane(body: str | None, marker_line: str | None = None) -> str | None
         return None
     flat = _strip_title_hashes(body.translate(_NOISE))
     m = _LANE_RE.search(flat)
-    if m:
-        return m.group(1).rstrip(".")
-    # Fallback for claim comments that omit the literal `lane` keyword (#10395
-    # Variante 1). Restricted to the marker line by the caller -- see docstring.
+    # #15918 -- marker-line proximity beats a keyworded citation further down
+    # the line. A reconciliation close names its OWN lane bare ("Claim de
+    # myia-po-2026:CoursIA retire") while the parenthetical that credits the
+    # winning lane carries the keyword ("(lane myia-po-2023:CoursIA, ouverte
+    # 00:19Z)") because that is the claim format itself. The keyworded primary
+    # then attributes the close to the CITED lane and the subject's claim stays
+    # open (measured on #15798). On the marker's own line, a bare token that
+    # starts strictly BEFORE the keyworded match's token is therefore the
+    # writer's subject. Position ties (the bare token IS the keyworded one)
+    # keep the primary -- unchanged behaviour for every well-formed marker.
     if marker_line is not None:
         flat_line = _strip_title_hashes(marker_line.translate(_NOISE))
-        m2 = _LANE_FALLBACK_RE.search(flat_line)
-        if m2:
-            return m2.group(1).rstrip(".")
+        m_bare = _LANE_FALLBACK_RE.search(flat_line)
+        m_kw = _LANE_RE.search(flat_line)
+        if m_bare is not None and (m_kw is None or m_bare.start() < m_kw.start(1)):
+            return m_bare.group(1).rstrip(".")
+    if m:
+        return m.group(1).rstrip(".")
     return None
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -6257,3 +6257,31 @@ def test_14187_truncated_flag_sur_repo_volumineux(capsys, monkeypatch):
     assert out["blocked"] is False
     assert out["free_paths_size"] == 25
     assert out["free_paths_truncated"] is True
+
+
+def test_reconciliation_release_closes_the_subject_lane_not_the_cited_one_15918():
+    # #15918 -- the founder shape of a collision reconciliation: the closing
+    # lane names ITSELF bare ("Claim de myia-po-2026:CoursIA retiré") while
+    # crediting the winning lane in keyworded form ("(lane myia-po-2023:CoursIA,
+    # ouverte 00:19Z)") -- that is the claim format itself. The keyworded
+    # primary used to attribute the close to the CITED lane, so the subject
+    # claim stayed active and blocked the winner's PR (measured on #15798:
+    # po-2026's 04:50:09Z release left the claim open against #15878).
+    events = clc._sort_events(payload(
+        comment(
+            "[CLAIMED] myia-po-2026:CoursIA -- paths: MyIA.AI.Notebooks/IIT/ICT-Series/**",
+            "2026-09-13T04:25:31Z",
+        ),
+        comment(
+            "[RELEASED] Claim de myia-po-2026:CoursIA retiré — réconcilié : la PR #15878 "
+            "(lane myia-po-2023:CoursIA, ouverte 00:19Z) couvre le grain en surensemble.",
+            "2026-09-13T04:50:09Z",
+        ),
+    ))
+    active, _unattributed = clc.compute_active_claims(events)
+    assert "myia-po-2026:CoursIA" not in active, (
+        "the reconciliation release must close the SUBJECT lane"
+    )
+    assert "myia-po-2023:CoursIA" not in active, (
+        "the cited lane never had a claim here -- the misattributed close must not open one"
+    )

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -1122,3 +1122,32 @@ def test_lane_ascii_control_unchanged():
     assert g == "myia-po-2026:CoursIA"
 
 
+
+
+_REAL_RECONCILIATION_15918 = (
+    "[RELEASED] Claim de myia-po-2026:CoursIA retiré — réconcilié : la PR #15878 "
+    "(lane myia-po-2023:CoursIA, ouverte 00:19Z) couvre le grain en surensemble."
+)
+
+
+def test_lane_bare_subject_beats_keyworded_citation_15918():
+    # #15918: a reconciliation close names its OWN lane bare ("Claim de
+    # myia-po-2026:CoursIA retiré") while the parenthetical crediting the
+    # winning lane carries the `lane` keyword -- the claim format itself.
+    # The keyworded primary used to attribute the close to the CITED lane.
+    line = _REAL_RECONCILIATION_15918
+    assert (
+        gt.extract_lane(line, marker_line=line) == "myia-po-2026:CoursIA"
+    ), "the bare subject token before the keyworded citation must win"
+
+
+def test_lane_keyworded_marker_keeps_priority_on_tie_15918():
+    # Position tie (the bare token IS the keyworded one): primary unchanged.
+    line = "[RELEASED] lane myia-po-2026:CoursIA — la lane myia-po-2023:CoursIA reprend"
+    assert gt.extract_lane(line, marker_line=line) == "myia-po-2026:CoursIA"
+
+
+def test_lane_keyword_only_in_body_still_primary_without_marker_line_15918():
+    # Legacy callers (no marker_line): the whole-body keyworded primary is
+    # untouched -- the proximity rule is scoped to the marker's own line.
+    assert gt.extract_lane(_REAL_RECONCILIATION_15918) == "myia-po-2023:CoursIA"


### PR DESCRIPTION
## Summary

`extract_lane` attribuait un `[RELEASED]` de réconciliation à la **lane citée** au lieu de la lane libérante : le close partait dans le vide, le claim du sujet restait actif et bloquait les PRs `Closes` de l'issue. Cas fondateur mesuré sur #15798 (détail complet + reproduction dans l'issue).

Fichiers (exhaustif) :
- `scripts/grain_tag.py` — `extract_lane` : sur la ligne de marker, un token **nu** qui démarre strictement AVANT le token du premier match mot-clé **de la même ligne** (comparaison sur `start(1)` du groupe token) prime. Égalité de position (le nu EST le keyworded) → primaire, inchangé. Callers legacy sans `marker_line` : inchangés.
- `scripts/tests/test_grain_tag.py` — 3 tests dont la ligne fondatrice réelle de #15798.
- `scripts/tests/test_check_lane_claim.py` — test reducer bout-en-bout : claim ouvert → release de réconciliation → plus aucun claim actif (ni le sujet ni la lane citée).

## Pourquoi la ligne de marker suffit

Dans « `[RELEASED] Claim de myia-po-2026:CoursIA retiré — ... (lane myia-po-2023:CoursIA, ouverte 00:19Z) ...` », le token du sujet est nu (~position 20) et la citation keyworded (~position 120). La règle de proximité choisit le sujet. Toutes les formes canoniques (`[CLAIMED] lane X`, `[CLAIMED] X`, `[RELEASED] lane X ... citation`) sont inchangées — vérifié par tests T2-T4 et par les 918 passes des suites consommatrices.

## Validation

- Reproduction avant : `lane: myia-po-2023:CoursIA` (FAUX) — après : `lane: myia-po-2026:CoursIA` (correct), sur la ligne réelle de po-2026 (04:50:09Z, #15798).
- Suites consommatrices intégrales : `test_grain_tag` 105, `test_check_lane_claim` 294+1skip préexistant, `test_lane_claim_required` + `test_pr_close_keyword_guard` 40, `test_check_unaddressed_nits` + `test_emit_dead_scope_warnings` + `test_lane_claim_epic_wide` + `test_list_orphan_prs` + `test_pick_child_encoding` 479 — **918 passed, 0 failed**.
- Pas de changement de comportement pour `parse_grain_tag` / G-VAR-2 (legacy sans `marker_line`), testé explicitement.

Closes #15918

Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/research-code #15878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

