### PR TITLE
fix(lean,#15742): seuil R3 — énoncer le contrat réel (< 2 modèle, bande à 2 au replay)

### DIFF
--- a/docs/lean/life-components-schema.md
+++ b/docs/lean/life-components-schema.md
@@ -168,11 +168,17 @@ exactement une satisfait la congruence — le test de non-régression l'exige.
 ### Fenêtres spatiales (R3)
 
 Deux événements aux fenêtres spatiales chevauchantes, ou dont un objet vivant
-passe à moins de 3 (Chebyshev) des cellules d'une fenêtre étrangère, sont
+passe à moins de 2 (Chebyshev) des cellules d'une fenêtre étrangère, sont
 rejetés — avec une exception structurelle : un produit est *par construction*
 la dernière image de la fenêtre de son propre événement, il n'est jamais
 confronté à elle (le replay aux bornes exactes couvre déjà cette transition).
-Le seuil 3 n'est pas un réglage, c'est la mesure ci-dessous.
+La bande à distance exactement 2 passe l'élagage : l'interaction y dépend du
+contenu (mesure ci-dessous) ; c'est le replay de certification qui tranche —
+c'est lui, pas le modèle, qui produit `replay_rejected ≥ 1` sur la variante
+stricte de `two_blocks_catalyse`. Le seuil du modèle est donc 2 — à moins de
+2, les cellules sont dans le voisinage 3×3 l'une de l'autre, influence
+directe — tandis que 3 est la mesure physique de la non-interaction
+universelle, pas le seuil d'élagage.
 
 ### Dédup d'états (R1)
 
@@ -207,7 +213,10 @@ des confusions non fondées, pas par du travail évité. La sensibilité de la c
    n'interagissent jamais ; à distance 2, tout dépend du contenu. Deux blocs
    gap-1 sont stables, mais un glider à distance 2 d'un bloc engendre des
    naissances croisées — une cellule morte voit 2 voisins d'un objet plus 1 de
-   l'autre. Le seuil 3 de R3 est cette mesure, pas une heuristique.
+   l'autre. Cette mesure fixe les deux seuils : le modèle rejette sous 2
+   (influence directe, voisinage 3×3), et la bande contenu-dépendante à
+   exactement 2 est déléguée au replay de certification (cf §Fenêtres
+   spatiales).
 2. **Atteignabilité du placement déclaré.** Le placement tranche 1+2 de
    `block_catalyses_glider` démarrait au milieu de l'interaction : l'approche
    naturelle du glider annihile tout (population 0). La réaction a été

--- a/scripts/lean/life_compose.py
+++ b/scripts/lean/life_compose.py
@@ -72,9 +72,14 @@ from life_components import (  # noqa: E402
     measure_motif,
 )
 
-# Seuil de non-interaction de Conway : deux groupes de cellules à distance
-# de Chebysyshev >= 2 ne se voient pas. Gonfler chaque enveloppe de 1
-# matérialise exactement cette frontière.
+# Frontière d'influence directe de Conway : à distance de Chebyshev < 2, deux
+# groupes de cellules sont dans le voisinage 3x3 l'un de l'autre (rejet du
+# modèle) ; à distance exactement 2, seules des naissances croisées sont
+# possibles et tout dépend du contenu — la bande passe l'élagage et le replay
+# de certification tranche ; à distance >= 3, jamais d'interaction (mesuré,
+# test_chebyshev_3_est_sur_sans_interaction). Gonfler chaque enveloppe de 1
+# fait entrer toutes les paires à distance <= 2 dans le contrôle exact, qui
+# rejette alors à < 2.
 GROW = 1
 
 DEFAULT_NODE_BUDGET = 200_000
@@ -792,9 +797,11 @@ class Searcher:
                     ra = swept_rect(catalog, a, 0, t_end)
                     rb = swept_rect(catalog, b, 0, t_end)
                     if ra and rb and _rects_overlap(_grown(ra), _grown(rb)):
-                        # emprises proches : contrôle exact, instant par instant
-                        # (deux blocs séparés d'une colonne sont à Chebyshev 2 :
-                        # non-interaction réelle que les rectangles se touchent)
+                        # emprises proches (Chebyshev <= 2) : contrôle exact,
+                        # instant par instant. Rejet à < 2 (influence directe) ;
+                        # la bande à exactement 2 (naissances croisées possibles
+                        # seulement) coexiste et sera tranchée par le replay de
+                        # certification.
                         for t in range(max(t_start(a), t_start(b)), t_end + 1):
                             if _min_chebyshev(
                                 cells_at(catalog, a, t), cells_at(catalog, b, t)

--- a/scripts/lean/tests/test_life_compose.py
+++ b/scripts/lean/tests/test_life_compose.py
@@ -328,6 +328,49 @@ def test_elagage_rejette_le_spawn_dans_la_fenetre() -> None:
     assert not s._spatial_ok(state0, (gspawn, bspawn), ev1, consumed)
 
 
+def test_elagage_r3_bande_chebyshev_2_passe_le_modele() -> None:
+    """Contrat R3 du code (schéma §Fenêtres spatiales) : le rejet du modèle
+    tombe à < 2 (influence directe, voisinage 3x3) ; la bande à exactement 2
+    passe l'élagage — c'est le replay de certification qui tranche
+    (naissances croisées contenu-dépendantes, cf la leçon mesurée)."""
+    state0, _, ev0 = _state_after_e0()
+    goal = lc.OBJECTIVES["two_blocks_catalyse_free"]
+    s = lc.Searcher(CATALOG, goal, node_budget=10)
+    reaction = CATALOG.reactions[ev0.reaction_id]
+    window_ever: set = set()
+    for cells in lc.reaction_window_cells(CATALOG, reaction, ev0.offset):
+        window_ever |= cells
+    block_phase0 = lc._motif_phases(CATALOG, "block")[0]
+
+    def block_cells(anchor: tuple[int, int]) -> set:
+        return {(x + anchor[0], y + anchor[1]) for (x, y) in block_phase0}
+
+    def in_clearance(cell: tuple[int, int]) -> bool:
+        for x0, y0, w, h in reaction.clearance:
+            abs_rect = (x0 + ev0.offset[0], y0 + ev0.offset[1], w, h)
+            if lc._rect_contains_cell(abs_rect, cell):
+                return True
+        return False
+
+    def anchor_at_distance(d: int) -> tuple[int, int]:
+        for x in range(-8, 24):
+            for y in range(-8, 24):
+                cells = block_cells((x, y))
+                if lc._min_chebyshev(cells, window_ever) == d and not any(
+                    in_clearance(c) for c in cells
+                ):
+                    return (x, y)
+        raise AssertionError(f"aucune ancre de bloc à distance {d} hors clearance")
+
+    consumed = {lc.handle_key(b) for b in ev0.bindings}
+    # distance 1 : bande d'influence directe -> rejet par le modèle
+    b1 = lc.Spawn("block", anchor_at_distance(1), 0)
+    assert not s._spatial_ok(state0, (b1,), ev0, consumed)
+    # distance exactement 2 : passe l'élagage, le replay décidera
+    b2 = lc.Spawn("block", anchor_at_distance(2), 0)
+    assert s._spatial_ok(state0, (b2,), ev0, consumed)
+
+
 # ---------------------------------------------------------------------------
 # Budgets (critere 3 : contraintes bornées)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Sujet

Dissipation des **2 points CONCERNS** de la review Hermes du 2026-09-12T06:34:59Z sur #15711 (follow-up #15742) : un écart doc-vs-code et un commentaire contredisant la mesure de la tranche elle-même.

## Les deux CONCERNS, et le choix opéré

**Point 1 — seuil R3 doc vs code.** `docs/lean/life-components-schema.md` §Fenêtres spatiales énonçait : « un objet vivant passe à moins de 3 (Chebyshev) des cellules d'une fenêtre étrangère → rejetés » et « Le seuil 3 n'est pas un réglage, c'est la mesure ». Le code n'implémente pas ce seuil : pré-filtre par enveloppes gonflées (GROW=1) qui fait entrer les paires à Chebyshev ≤ 2 dans le contrôle exact, lequel rejette à `_min_chebyshev(...) < 2` — une scène à distance exactement 2 passe le modèle et ne doit son rejet qu'au replay de certification.

**Point 2 — commentaire GROW.** `life_compose.py` : « deux groupes de cellules à distance de Chebyshev >= 2 ne se voient pas » — contredit la leçon mesurée de la tranche (`test_chebyshev_2_engendre_des_naissances_croisees` : naissances croisées à distance 2) et le schéma lui-même (« ≥ 3 : jamais ; à distance 2, tout dépend du contenu »).

**Choix : option (b) de la review — corriger les formulations**, pas élever le seuil code à < 3. Raisons :

1. La bande à exactement 2 est **délibérément déléguée au replay** : c'est le contrat que `test_reutilisation_stricte_impossible_borne` vérifie end-to-end (`replay_rejected >= 1` asserté — les candidats distance-2 passent l'élagage et meurent au replay). Élever le seuil retirerait au filet sa classe d'échec-modèle témoin.
2. La table d'ablations du schéma a mesuré R3 sous ce contrat (« R3 ne change aucun verdict et coûte plus qu'il rapporte — assumé ») ; resserrer le seuil ne ferait qu'augmenter le coût mesuré.
3. Le seuil modèle < 2 est **principiel, pas arbitraire** : à moins de 2, les cellules sont dans le voisinage 3×3 l'une de l'autre (influence directe) ; à exactement 2, seules des naissances croisées sont possibles (contenu-dépendant — c'est la mesure) ; ≥ 3, jamais (propriété testée).

## Diff (3 fichiers, +68/−9, zéro changement de comportement)

- `scripts/lean/life_compose.py` : commentaire `GROW` réécrit (énonce les 3 bandes et le rôle exact du gonfllement d'enveloppe — corrigé aussi le typo « Chebysyshev ») ; commentaire inline du contrôle exact réécrit (l'ancien parenthétique « non-interaction réelle que les rectangles se touchent » était à la fois faux physiquement et obscur). Aucune ligne exécutable touchée.
- `docs/lean/life-components-schema.md` : §Fenêtres spatiales réécrit — « moins de 2 → rejetés », la bande à exactement 2 passe l'élagage et le replay tranche (c'est lui qui produit `replay_rejected ≥ 1`), « le seuil du modèle est 2, le seuil 3 est la mesure physique de la non-interaction universelle, pas le seuil d'élagage » ; leçon mesurée n°1 : la phrase finale « Le seuil 3 de R3 est cette mesure » (qui collait la mesure physique sur le seuil d'élagage) remplace l'énoncé des deux seuils.
- `scripts/lean/tests/test_life_compose.py` : nouveau `test_elagage_r3_bande_chebyshev_2_passe_le_modele` — punition du contrat désormais écrit : un bloc à Chebyshev exactement **1** de la fenêtre E0 est rejeté par le modèle ; à exactement **2** il passe `_spatial_ok` (le replay décidera). Les ancres sont calculées depuis la fenêtre réelle (`reaction_window_cells`), hors zones de clearance, via `_motif_phases("block")`.

## Validation

- Avant edits : `python -m pytest scripts/lean/tests/test_life_compose.py -q` → **26 passed** en 246,23 s (baseline reproduite).
- Nouveau test seul : **1 passed** en 0,09 s.
- Après edits : **27 passed** en 231,95 s.
- Aucune ligne exécutable de `life_compose.py` modifiée (commentaires seuls) — la stabilité des 26 tests initiaux est le contrôle négatif du « zéro changement de comportement ».

## Résiduel

Re-revue Hermes attendue sur ce follow-up (action 1 de #15742) ; clôture de l'issue après feu vert — d'où `See #15742` et non `Closes`.

Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/docs #15921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
