### PR TITLE
test(guard,#15896): pin la prescription prev-abandoned — cible, pas genre (réévaluation : prémissé fausse sur main)

### DIFF
--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -213,6 +213,25 @@ def test_prev_abandoned_blocks():
                for h in v["hits"]["prev_invalid"])
 
 
+def test_prev_abandoned_prescription_repairs_the_target_not_the_genre():
+    """#15896 : un prev-abandoned prescrit de repointer la CIBLE (vers une PR
+    de la lane mergée ou ouverte), jamais de réécrire le genre -- réécrire le
+    genre est la prescription du mode close-keyword (#10093), un finding
+    différent. Suivre la mauvaise prescription ne peut pas lever le rouge :
+    ce test pince la séparation des deux messages."""
+    v = vpg.check(_ABANDONED_BODY, current_pr=13473,
+                  prev_targets={"13465": {"kind": "pr", "state": "CLOSED",
+                                          "merged": False}})
+    assert v["guard_pass"] is False
+    # nomme le mode et la PR fautive
+    assert "prev-abandoned" in v["reason"]
+    assert "[13465]" in v["reason"]
+    # prescrit le geste qui lève le rouge : repointer la cible
+    assert "merged or still open" in v["reason"]
+    # pas la prescription de l'autre mode
+    assert "rewrite the `prev:` genre" not in v["reason"]
+
+
 def test_prev_open_abstains_the_predecessor_is_in_flight():
     # THE REPAIR. Same body, same current PR, ONE field different -- and the
     # verdict flips. A predecessor still open is not a broken lineage: it is


### PR DESCRIPTION
## Sujet — réévaluation de #15896 (protocole audit-reassessment)

**Reassessed by myia-po-2023:CoursIA : FALSE PREMISE on current main** — le défaut décrit n'existe pas sur `main` ; le résidu réel (aucun pin de la séparation des deux prescriptions) est livré ici.

## Méthodologie (pas « j'ai regardé »)

1. **Simulation firsthand** de l'échec décrit par l'issue, sur un checkout frais d'`origin/main` (2233ed874a) :

```python
body = "Grain: MED/lean — lane myia-x:CoursIA — prev: MED/lean #NNNN"
meta = {"15832": {"kind": "pr", "state": "CLOSED", "merged": False}}
vpg.check(body, [], current_pr=15869, prev_targets=meta)
```

Rendu **effectif** :

```
`prev:` reference(s) fail invariant(s) (prev-abandoned -> [NNNN]) -> point `prev:` at a
PR of the same lane, distinct from the current PR, that is merged or still open -- never
at an abandoned (closed-unmerged) PR nor at an issue. See #13475.
```

La prescription fait exactement ce que l'issue demande : elle **nomme la PR fautive** (`prev-abandoned -> [15832]`) et prescrit de **repointer la cible** vers une PR de la lane mergée ou ouverte. Elle ne prescrit **pas** de réécrire le genre. Le message « rewrite the `prev:` genre » (~L491-495) appartient au mode close-keyword (`hits_body`/`hits_commits`, genres type `fix`/`close`, #10093) — un finding différent, dont la prescription y est correcte.

2. **Datation** : la séparation des deux messages existe depuis #15211 (85911c3cdf, fusionné 2026-09-09 05:38 +0200) — **quatre jours avant** l'ouverture de #15896 (2026-09-13T02:40:49Z). Le dernier toucher au fichier (#15812, e16e05c2a4) n'affecte que la boucle commits, pas les messages.

3. **L'incident témoin** (#15869, `prev: MED/lean #NNNN` CLOSED non-mergée) a été réparé par le chemin correct : son body porte aujourd'hui `prev: DEEP/infrastructure #15839` avec une section « REPAIR c.522 (body-only) — invariant prev-abandoned levé », et toutes ses gardes sont vertes (runs 04:04:32Z).

## Livrable — le pin (1 fichier, +19)

Le résidu réel : aucun test ne punissait la séparation des deux prescriptions — or le défaut que #15896 décrit serait exactement une **re-fusion des sorties** des deux modes. `test_prev_abandoned_prescription_repairs_the_target_not_the_genre` pince :

- `"prev-abandoned" in reason` + `"[13465]" in reason` (nomme le mode et la PR) ;
- `"merged or still open" in reason` (prescrit le geste qui lève le rouge) ;
- `"rewrite the \`prev:\` genre" not in reason` (pas la prescription de l'autre mode).

## Note — le garde s'est déclenché sur sa propre citation

La première mouture de ce body portait la ligne défectueuse **verbatim dans le bloc de reproduction** ci-dessus (`prev: ... #15832`) ; prev_guard a rougi la PR sur prev-abandoned → [15832] — citation, pas trailer réel. Les citations **backtickées** sont masquées (#14780), mais le contenu d'un **bloc de code fencé** ne l'est pas pour l'extraction des cibles `prev:`. Numéros placeholderés ici (`#NNNN`) ; l'angle mort (masquer le contenu fencé dans `find_prev_target_pr_numbers`, symétrique du masque #14780) mérite un grain séparé.

## Validation

- `python -m pytest scripts/tests/test_variation_prev_guard.py -q` → **52 passed** en 0,16 s (51 existants + 1 nouveau).
- Aucun changement de code — le garde sur main est déjà correct ; ce pin l'immunise contre la régression décrite.

## Disposition

Le critère d'acceptation implicite de #15896 (« un message par mode de finding ») est satisfait sur main et désormais regression-pinné — d'où `Closes #15896`. La lane qui a rencontré l'incident (#15869) avait identifié le bon geste d'elle-même (repointer la cible) ; elle avait raison, et le garde aussi.

Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #15924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
