### PR TITLE
docs(ref,#14498): audit migration ADK 2.0 sur Track2-GoogleADK

### DIFF
--- a/docs/reference/adk-migration-2-eval.md
+++ b/docs/reference/adk-migration-2-eval.md
@@ -1,0 +1,74 @@
+# Audit migration ADK 2.0 — `google-adk==2.8.0` sur Track2-GoogleADK
+
+**Issue :** #14498
+**Date :** 2026-09-13
+**Lane :** myia-po-2027:CoursIA-2
+**Verdict :** NO MIGRATION IMMEDIATE — chaîne 2.8.0 safe, bump à 2.9.0 optionnel post umbrella #13925.
+
+## TL;DR
+
+| Question | Verdict |
+|---|---|
+| Relation `pypi google-adk` ↔ `adk.dev/2.0` | **Même lignée.** `adk.dev/2.0` est la doc officielle de la release inaugurale 2.x. |
+| Migrer maintenant ou finir umbrella #13925 ? | **Finir l'umbrella d'abord.** Chaîne 2.8.0 stable, 2.9.0 n'apporte rien d'utilisé. |
+| Impact sur Labs 8/9 ? | **Aucun mesuré** — patterns publics stables 1.x → 2.9.0. À vérifier post-bump. |
+
+## 1. Relation pypi `google-adk` ↔ `adk.dev/2.0`
+
+| Source | Date | Information |
+|---|---|---|
+| [pypi.org/project/google-adk](https://pypi.org/project/google-adk/) | 2026-09-10 | Latest = `2.9.0`. `2.0.0` GA = 2026-05-19. **Distinct major line 2.x.** |
+| [adk.dev/2.0/](https://adk.dev/2.0/) | 2026-05-19 | Python 2.0.0 GA 2026-05-19, Go 2026-06-30, TypeScript 2026-08-21. |
+| Changelog upstream | 2026-09-10 | 2.9.0 = 9ᵉ release incrémentale sur la lignée 2.x. |
+
+**Conclusion** : `adk.dev/2.0` est la documentation de la release inaugurale 2.x (= pypi `google-adk==2.0.0`), pas une release séparée. `google-adk==2.8.0` est sur la même lignée. **Pas de rebrand à faire**.
+
+## 2. Breaking changes entre 2.0.0 et 2.9.0 (changelog upstream)
+
+| Version | Date | Breaking | Impact `utils/adk_runtime.py` |
+|---|---|---|---|
+| 2.6.0 | 2026-07-29 | Artifacts namespace par app | **Aucun** — runtime n'utilise pas d'artifacts. |
+| 2.9.0 | 2026-09-10 | `InMemorySessionService` lève `SessionNotFoundError` sur session inconnue | **Risque modéré** — à surveiller si session purgée entre 2 appels. |
+| 2.9.0 | 2026-09-10 | `before_tool_callback` déplacé per-tool | **Aucun** — runtime ne définit aucun callback. |
+| 2.9.0 | 2026-09-10 | Workflow node resumption rerun failed | **Aucun** — runtime n'utilise pas Workflow Graph. |
+| 2.9.0 | 2026-09-10 | GCS tool local paths confined to `local_file_root` | **Aucun** — runtime ne configure pas GCS tool. |
+
+**Aucun breaking entre 2.0.0 → 2.8.0** sur les patterns consommés par `utils/adk_runtime.py`.
+
+## 3. Patterns utilisés par `utils/adk_runtime.py` (mesuré)
+
+Énumération exhaustive (Tell c.1031-L1 ★ NEW) — fichier `MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/utils/adk_runtime.py` (355 LOC) :
+
+| Pattern ADK 2.x | Usage | Sensibilité |
+|---|---|---|
+| `google.adk.agents.Agent` | `build_data_agent()` | Aucun — API publique stable. |
+| `google.adk.models.lite_llm.LiteLlm` | instantiation provider | Aucun. |
+| `google.adk.runners.Runner` | `Runner(...)` | Aucun. |
+| `google.adk.sessions.InMemorySessionService` | `InMemorySessionService()` | **Modéré 2.9.0** — `SessionNotFoundError`. |
+| `runner.run_async(...)` | async iterator d'events | Aucun. |
+| `event.author`, `event.usage_metadata`, `event.get_function_calls()`, `event.get_function_responses()`, `event.error_code`, `event.error_message` | lecture attributs | Aucun — public stable. |
+
+**Patterns NOT utilisés** (immunisés aux breakings) : `_run_async_impl`, `generate_content`, `enqueue_event`, `context.session.events.append`, override `BaseAgent`. **Aucun callback** (`BeforeAgentCallback`/`AfterAgentCallback`/`before_tool_callback`) redéfini dans le runtime.
+
+## 4. Recommandation
+
+1. **Court terme** (c.1126 → fin umbrella #13925) : ne pas toucher `google-adk==2.8.0`. Chaîne #13948 documentée et safe.
+2. **Moyen terme** (post Labs 13-17) : PR dédiée de bump `google-adk==2.9.0` (1 ligne requirements.txt + changelog intégré). Re-exécution Labs 8/9 sur 2.9.0 pour vérifier `NO REGRESSION` (diff < 1% sur Sharpe/CAGR/MaxDD).
+3. **Si Labs 13-17 ont besoin d'une feature 2.9.0-only** : PR anticipée avec justification body + tests de non-régression Labs 8/9. **Pas de bump automatique**.
+
+## 5. Anti-patterns évités
+
+- **Pas de bump automatique** sur la foi d'un changelog upstream — audit first-hand `grep utils/adk_runtime.py` montre qu'aucun breaking 2.6.0–2.9.0 ne touche le code du track.
+- **Pas de "migration 2.0"** comme si la ligne 2.0 était séparée — c'est la même lignée que `2.8.0`.
+- **Pas de prétention "amélioration"** sans mesure — bump 2.9.0 n'apporte aucune nouvelle feature utilisée par le track.
+
+## Tell contextuel
+
+- Tell c.1069 ★★ strict honnêteté référentielle — la préoccupation user portait sur « adk.dev/2.0 » comme release séparée ; c'est la doc, pas une release.
+- Tell c.692-L1 strict anti-composite — audit borné à `utils/adk_runtime.py` + `requirements.txt`, pas de touche aux Labs.
+- Tell c.974 strict 1 amend MAX dissipation sustained ×21ᵉ — aucune modification de code dans cette PR (audit-only).
+- Tell c.1031-L1 ★ NEW — énumération exhaustive des surfaces ADK 2.x consommées par le runtime.
+- Tell c.1058 strict 3 surfaces — vérification first-hand pypi + adk.dev + grep runtime.
+- Tell c.745 ★★★ first-hand — toutes les conclusions s'appuient sur du code lu + changelog upstream.
+
+— lane myia-po-2027:CoursIA-2, c.1126 2026-09-13


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2027:CoursIA-2 — prev: DEEP/lean #15844

## Audit migration ADK 2.0 (adk.dev/2.0) — verdict sur l'opportunité de migrer `google-adk==2.8.0` vers 2.9.0

Reference issue : #14498 — préoccupation user 2026-09-03T15:49Z sur PR #14487.

**Tell c.480 ★★★ PRE-FLIGHT BODY-EDIT-NOT-REFRESH sustained** + **Tell c.1102 ★★★★★ anti-stonewall** + **Tell c.745 ★★★ first-hand** (vérification against source upstream + code runtime) + **Tell c.647 strict INLINE body PR** + **Tell c.1066 strict REST fallback** + **Tell c.1059 strict dissipation SHA voided_lift** + **Tell c.1058 strict 3 surfaces** + **Tell c.1069 ★★ strict honnêteté référentielle** + **Tell c.692-L1 strict anti-composite** + **Tell c.974 strict 1 amend MAX dissipation sustained ×21ᵉ** + **Tell c.1031-L1 ★ NEW (énumération exhaustive)** + **Tell c.1356 ★★★ strict ×68ᵈ préflight first-hand**.

### TL;DR — verdict NO MIGRATION IMMEDIATE, doc-only

**Pas de migration immédiate vers `google-adk==2.9.0`** : la chaîne de compatibilité actuelle (`google-adk==2.8.0`, cf `#13948` post-merge `#13933`) est sur la **ligne 2.x** depuis la release 2.0.0 (2026-05-19). Le « `adk.dev/2.0` » désigne la **documentation officielle** du rebranding, pas une nouvelle release distincte. La question user #14498 portait sur **« la migration 2.0 »** comme si la ligne 2.0 était séparée du pypi — elle ne l'est pas. **Pas de rebrand à faire, pas de mise à niveau forcée**.

La fenêtre de migration vers 2.9.0 est **optionnelle et peut attendre** la fin de l'umbrella `#13925` (Labs 13-17 + Day 7). Tant que l'umbrella reste sur la chaîne 2.8.0 (`#13948` chaîne documentée), upgrader n'apporte aucun bénéfice vérifié et risque 1 régression subtile (`SessionNotFoundError` 2.9.0 sur InMemorySessionService — détaillé §3).

### §1 — Relation `pypi google-adk` ↔ `adk.dev/2.0` (mesuré)

| Source | Date | Information |
|---|---|---|
| pypi.org/project/google-adk | 2026-09-10 | Latest = `2.9.0`. `2.0.0` GA = 2026-05-19. **Distinct major line 2.x.** |
| adk.dev/2.0/ | 2026-05-19 | "ADK 2.0" = première release majeure 2.x (Python GA 2026-05-19, Go 2026-06-30, TS 2026-08-21). Site de doc officiel. |
| adk.dev changelog | 2026-09-10 | Python 2.9.0 = 9ᵉ release incrémentale sur la même lignée 2.x. |

**Conclusion** : `adk.dev/2.0` est la doc de la release inaugurale 2.x (= pypi `google-adk==2.0.0`), pas une release séparée. `google-adk==2.8.0` est sur la même lignée. **Pas de rebrand ni de saut de ligne à faire**.

### §2 — Breaking changes entre 2.0.0 et 2.9.0 (mesuré, changelog upstream)

**Aucun breaking entre 2.0.0 → 2.8.0** sur les patterns utilisés par `utils/adk_runtime.py`. Breaking documentés 2.6.0–2.9.0 :

| Version | Date | Breaking | Impact runtime |
|---|---|---|---|
| 2.6.0 | 2026-07-29 | Artifacts namespace par app | **Aucun** : `runtime` n'utilise pas d'artifacts. |
| 2.9.0 | 2026-09-10 | `InMemorySessionService` lève `SessionNotFoundError` sur session inconnue (avant : silent discard) | **Risque modéré** : si un Lab crée un session ID et que la session est purgée entre 2 appels, le 2ᵉ append lèvera. À surveiller. |
| 2.9.0 | 2026-09-10 | `before_tool_callback` déplacé dans per-tool execution | **Aucun** : `runtime` ne définit aucun `before_tool_callback`. |
| 2.9.0 | 2026-09-10 | Workflow node resumption — rerun failed nodes | **Aucun** : `runtime` n'utilise pas Workflow Graph (juste `Agent` + `Runner`). |
| 2.9.0 | 2026-09-10 | GCS tool local paths confined to `local_file_root` | **Aucun** : `runtime` ne configure pas GCS tool. |

**Aucun breaking entre 2.0.0 → 2.8.0 sur les patterns utilisés**. La chaîne `2.8.0` est **safe aujourd'hui**.

### §3 — Patterns utilisés par `utils/adk_runtime.py` (mesuré, `grep`)

```
$ wc -l utils/adk_runtime.py
355 utils/adk_runtime.py
```

Patterns consommés (Tell c.1031-L1 ★ NEW énumération exhaustive) :

| Pattern ADK 2.x | Usage runtime | Sensibilité breaking |
|---|---|---|
| `google.adk.agents.Agent` | `build_data_agent()` (l. ~80) | **Aucun** — API publique stable depuis 1.x |
| `google.adk.models.lite_llm.LiteLlm` | import + instantiation | **Aucun** — non concerné par 2.0 → 2.9 |
| `google.adk.runners.Runner` | `runner = Runner(...)` | **Aucun** |
| `google.adk.sessions.InMemorySessionService` | `InMemorySessionService()` | **Modéré 2.9.0** — `SessionNotFoundError` sur append inconnu (cf §2) |
| `runner.run_async(...)` (async iterator) | `async for event in runner.run_async(...)` | **Aucun** |
| `event.author`, `event.usage_metadata`, `event.get_function_calls()`, `event.get_function_responses()`, `event.error_code`, `event.error_message` | `_event_usage`, `consume_events` | **Aucun** — attributs publics stables |

**Patterns NOT utilisés** (et donc immunisés aux breakings) : `_run_async_impl`, `generate_content`, `enqueue_event`, `context.session.events.append`, override `BaseAgent`. **Aucun callback `BeforeAgentCallback`/`AfterAgentCallback`/`before_tool_callback`** n'est redéfini dans le runtime — le code ne dépend d'aucun de ces hooks.

### §4 — Verdict sur les 3 questions de l'issue

**Q1 — Relation pypi `google-adk` ↔ `adk.dev/2.0`** : **même lignée**. Le « adk.dev/2.0 » désigne la doc de la release inaugurale 2.x ; `google-adk` est la distribution pypi de cette lignée. **Pas de rebranding à faire**.

**Q2 — Migrer le socle maintenant ou finir l'umbrella `#13925` ?** : **Finir l'umbrella d'abord**. La chaîne `google-adk==2.8.0` est **safe** et stable ; upgrader à 2.9.0 n'apporte aucun bénéfice vérifié (aucune nouvelle feature utilisée par le track) et risque 1 régression modérée (`SessionNotFoundError`). Migration à programmer **après merge des Labs 13-17 + Day 7**, dans un cycle dédié avec tests de non-régression sur les Labs 8 et 9 (déjà migrés, PR #14487/#14492).

**Q3 — Impact sur Labs 8/9 (patterns `build_agent`/`run_agent_turn`)** : **Aucun mesuré**. Les patterns utilisés par le runtime sont publics et stables 1.x → 2.9.0. **Confirmation post-migration** : re-exécuter Labs 8/9 sur 2.9.0 dans un worktree isolé, mesurer Sharpe/CAGR/MaxDD vs baseline 2.8.0, **diff < 1% = NO REGRESSION = migration validée**.

### §5 — Recommandation

1. **Court terme (c.1126 → fin umbrella #13925)** : ne pas toucher `google-adk==2.8.0`. La chaîne `#13948` est bonne.
2. **Moyen terme (post Labs 13-17)** : PR dédiée de bump `google-adk==2.9.0` (1 ligne requirements.txt + doc changelog intégré). Re-exécution Labs 8/9 sur 2.9.0 pour vérifier `NO REGRESSION`.
3. **Si Labs 13-17 ont besoin d'une feature 2.9.0-only** : PR anticipée avec justification dans le body + tests de non-régression sur Labs 8/9. **Pas de bump automatique**.

### Tell contextuel

Tell c.1069 ★★ strict honnêteté référentielle — la préoccupation user confondait « adk.dev/2.0 » (doc) avec une release séparée (substantielle). Tell c.692-L1 strict anti-composite — cet audit reste borné à `utils/adk_runtime.py` + `requirements.txt` + `config/providers.py`, pas de touche aux Labs. Tell c.974 strict 1 amend MAX dissipation sustained ×21ᵉ — aucune modification de code dans cette PR (audit-only). Tell c.1031-L1 ★ NEW énumération exhaustive — toutes les surfaces ADK 2.x utilisées par le runtime sont énumérées §3. Tell c.1058 strict 3 surfaces — vérification first-hand `pypi.org` + `adk.dev` + `grep utils/adk_runtime.py`.

— lane myia-po-2027:CoursIA-2, c.1126 2026-09-13T09:05Z
