### PR TITLE
feat(ci,#15709): lake-build heartbeat -- make long builds visible in the step log

### DIFF
--- a/.github/actions/lean-axiom/action.yml
+++ b/.github/actions/lean-axiom/action.yml
@@ -98,16 +98,35 @@ runs:
                           # exit != 0; See incident conway_lean HashlifeCorrectness L1058, 2026-06-14).
         if [ -n "$LAKE_BUILD_JOBS" ]; then export LEAN_NUM_THREADS="$LAKE_BUILD_JOBS"; fi
         lake exe cache get || true
-        # On failure, surface the error lines the `tail` window loses (See #8915).
-        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
-          :
-        else
-          rc=$?
-          echo "::group::Error lines from the full lake log (See #8915)"
-          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
-          echo "::endgroup::"
-          exit "$rc"
-        fi
+        # Heartbeat (#15709): `tail` renders its window only at EOF, so a long
+        # lake build is INVISIBLE from the step log — the wedged knot_lean runs
+        # (3 h 13 and 2 h 10 of total console silence, cache HIT and cache MISS
+        # alike) were cancelled blind at arbitrary durations. While the pipeline
+        # is alive, print elapsed time + the log's last line every 10 min.
+        # Read-only observability: the pipeline runs in a subshell whose exit
+        # status `wait` propagates, so the #8915 failure group and the
+        # 2026-06-14 pipefail invariant below are unchanged.
+        (
+          # On failure, surface the error lines the `tail` window loses (See #8915).
+          if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
+            :
+          else
+            rc=$?
+            echo "::group::Error lines from the full lake log (See #8915)"
+            grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+            echo "::endgroup::"
+            exit "$rc"
+          fi
+        ) &
+        _lake_pipeline=$!
+        _elapsed=0
+        while kill -0 "$_lake_pipeline" 2>/dev/null; do
+          sleep 600
+          kill -0 "$_lake_pipeline" 2>/dev/null || break
+          _elapsed=$((_elapsed + 10))
+          echo "[lake-heartbeat] still running after ${_elapsed} min - last line: $(tail -1 "$RUNNER_TEMP/lake.log" 2>/dev/null | cut -c1-160)"
+        done
+        wait "$_lake_pipeline"
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/actions/lean-build/action.yml
+++ b/.github/actions/lean-build/action.yml
@@ -186,18 +186,37 @@ runs:
                           # L1058 (rfl fail masked as CI PASS, 2026-06-14).
         if [ -n "$LAKE_BUILD_JOBS" ]; then export LEAN_NUM_THREADS="$LAKE_BUILD_JOBS"; fi
         lake exe cache get || true
-        # `tail` keeps the SUCCESS path terse, but on FAILURE it also truncates the
-        # `File.lean:L:C: error:` line — lake builds in parallel and pushes an early
-        # failure ~8000 lines out of the tail window (See #8915). Tee the full log so
-        # the error lines can be surfaced in a ::group:: on failure. `if cmd;` exempts
-        # the pipeline from errexit, but pipefail still feeds `$?` here — this is what
-        # preserves the 2026-06-14 invariant (FAILED build still exits != 0).
-        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
-          :
-        else
-          rc=$?
-          echo "::group::Error lines from the full lake log (See #8915)"
-          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
-          echo "::endgroup::"
-          exit "$rc"
-        fi
+        # Heartbeat (#15709): `tail` renders its window only at EOF, so a long
+        # lake build is INVISIBLE from the step log — the wedged knot_lean runs
+        # (3 h 13 and 2 h 10 of total console silence, cache HIT and cache MISS
+        # alike) were cancelled blind at arbitrary durations. While the pipeline
+        # is alive, print elapsed time + the log's last line every 10 min.
+        # Read-only observability: the pipeline runs in a subshell whose exit
+        # status `wait` propagates, so the #8915 failure group and the
+        # 2026-06-14 pipefail invariant below are unchanged.
+        (
+          # `tail` keeps the SUCCESS path terse, but on FAILURE it also truncates the
+          # `File.lean:L:C: error:` line — lake builds in parallel and pushes an early
+          # failure ~8000 lines out of the tail window (See #8915). Tee the full log so
+          # the error lines can be surfaced in a ::group:: on failure. `if cmd;` exempts
+          # the pipeline from errexit, but pipefail still feeds `$?` here — this is what
+          # preserves the 2026-06-14 invariant (FAILED build still exits != 0).
+          if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
+            :
+          else
+            rc=$?
+            echo "::group::Error lines from the full lake log (See #8915)"
+            grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+            echo "::endgroup::"
+            exit "$rc"
+          fi
+        ) &
+        _lake_pipeline=$!
+        _elapsed=0
+        while kill -0 "$_lake_pipeline" 2>/dev/null; do
+          sleep 600
+          kill -0 "$_lake_pipeline" 2>/dev/null || break
+          _elapsed=$((_elapsed + 10))
+          echo "[lake-heartbeat] still running after ${_elapsed} min - last line: $(tail -1 "$RUNNER_TEMP/lake.log" 2>/dev/null | cut -c1-160)"
+        done
+        wait "$_lake_pipeline"

--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -148,16 +148,35 @@ jobs:
         set -o pipefail   # propagate lake's exit code through the pipeline (FAILED must
                           # exit != 0; See incident conway_lean HashlifeCorrectness L1058, 2026-06-14).
         lake exe cache get || true
-        # On failure, surface the error lines the `tail` window loses (See #8915).
-        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
-          :
-        else
-          rc=$?
-          echo "::group::Error lines from the full lake log (See #8915)"
-          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
-          echo "::endgroup::"
-          exit "$rc"
-        fi
+        # Heartbeat (#15709): `tail` renders its window only at EOF, so a long
+        # lake build is INVISIBLE from the step log — the wedged knot_lean runs
+        # (3 h 13 and 2 h 10 of total console silence, cache HIT and cache MISS
+        # alike) were cancelled blind at arbitrary durations. While the pipeline
+        # is alive, print elapsed time + the log's last line every 10 min.
+        # Read-only observability: the pipeline runs in a subshell whose exit
+        # status `wait` propagates, so the #8915 failure group and the
+        # 2026-06-14 pipefail invariant below are unchanged.
+        (
+          # On failure, surface the error lines the `tail` window loses (See #8915).
+          if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10; then
+            :
+          else
+            rc=$?
+            echo "::group::Error lines from the full lake log (See #8915)"
+            grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+            echo "::endgroup::"
+            exit "$rc"
+          fi
+        ) &
+        _lake_pipeline=$!
+        _elapsed=0
+        while kill -0 "$_lake_pipeline" 2>/dev/null; do
+          sleep 600
+          kill -0 "$_lake_pipeline" 2>/dev/null || break
+          _elapsed=$((_elapsed + 10))
+          echo "[lake-heartbeat] still running after ${_elapsed} min - last line: $(tail -1 "$RUNNER_TEMP/lake.log" 2>/dev/null | cut -c1-160)"
+        done
+        wait "$_lake_pipeline"
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -256,18 +256,37 @@ jobs:
                           # CI step passes regardless. See incident conway_lean HashlifeCorrectness
                           # L1058 (rfl fail masked as CI PASS, 2026-06-14).
         lake exe cache get || true
-        # `tail` keeps the SUCCESS path terse, but on FAILURE it also truncates the
-        # `File.lean:L:C: error:` line — lake builds in parallel and pushes an early
-        # failure ~8000 lines out of the tail window (See #8915). Tee the full log so
-        # the error lines can be surfaced in a ::group:: on failure. `if cmd;` exempts
-        # the pipeline from errexit, but pipefail still feeds `$?` here — this is what
-        # preserves the 2026-06-14 invariant (FAILED build still exits != 0).
-        if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
-          :
-        else
-          rc=$?
-          echo "::group::Error lines from the full lake log (See #8915)"
-          grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
-          echo "::endgroup::"
-          exit "$rc"
-        fi
+        # Heartbeat (#15709): `tail` renders its window only at EOF, so a long
+        # lake build is INVISIBLE from the step log — the wedged knot_lean runs
+        # (3 h 13 and 2 h 10 of total console silence, cache HIT and cache MISS
+        # alike) were cancelled blind at arbitrary durations. While the pipeline
+        # is alive, print elapsed time + the log's last line every 10 min.
+        # Read-only observability: the pipeline runs in a subshell whose exit
+        # status `wait` propagates, so the #8915 failure group and the
+        # 2026-06-14 pipefail invariant below are unchanged.
+        (
+          # `tail` keeps the SUCCESS path terse, but on FAILURE it also truncates the
+          # `File.lean:L:C: error:` line — lake builds in parallel and pushes an early
+          # failure ~8000 lines out of the tail window (See #8915). Tee the full log so
+          # the error lines can be surfaced in a ::group:: on failure. `if cmd;` exempts
+          # the pipeline from errexit, but pipefail still feeds `$?` here — this is what
+          # preserves the 2026-06-14 invariant (FAILED build still exits != 0).
+          if lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -20; then
+            :
+          else
+            rc=$?
+            echo "::group::Error lines from the full lake log (See #8915)"
+            grep -nE "^error:|\.lean:[0-9]+:[0-9]+: (error|warning)" "$RUNNER_TEMP/lake.log" | head -100 || true
+            echo "::endgroup::"
+            exit "$rc"
+          fi
+        ) &
+        _lake_pipeline=$!
+        _elapsed=0
+        while kill -0 "$_lake_pipeline" 2>/dev/null; do
+          sleep 600
+          kill -0 "$_lake_pipeline" 2>/dev/null || break
+          _elapsed=$((_elapsed + 10))
+          echo "[lake-heartbeat] still running after ${_elapsed} min - last line: $(tail -1 "$RUNNER_TEMP/lake.log" 2>/dev/null | cut -c1-160)"
+        done
+        wait "$_lake_pipeline"


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/slides #15865

See #15709 (items 1-5 delivered as the forensic diagnosis comment; this PR delivers item 6, the "éventuelle" instrumentation PR).

## What was wrong

The Lake build step pipelines `lake -R build 2>&1 | tee "$RUNNER_TEMP/lake.log" | tail -10`, and `tail` renders its window **only at EOF** — during the whole build the step log shows nothing. The two wedged knot_lean runs diagnosed in #15709 (job 103451688746: **3 h 13:54** of total console silence after "Already decompressed 8639 file(s)", cache HIT, runner docker-2; rerun job 103592855941: **2 h 10:03**, cache MISS, runner docker-1 — same orphan signature lake+tee+tail+lean in both) were **cancelled blind at arbitrary durations**: the log file on the runner contained the real progress, but nothing surfaced it, so nobody could tell a slow serialized elaboration from a dead hang. With the CI pool under active famine, a runner pinned hours without a readable signal is exactly the failure mode to make legible.

## The fix

Run the **existing pipeline unchanged inside a subshell**, and while the subshell pid is alive, print elapsed time + the tee'd log's last line every 10 min:

- `[lake-heartbeat] still running after 30 min - last line: ⏹ info: ...` — a growing/dated last line distinguishes slow elaboration from a hang in real time, which settles hypothesis 3 of #15709 at the next occurrence instead of after the fact.
- Median build = 8 min → **zero heartbeats on the median path** (quiet by design; the log stays terse for the 95% case).

**Invariants preserved byte-for-byte** (the subshell's exit status is what `wait` returns, pipefail intact):

1. **2026-06-14 pipefail invariant** — a FAILED build still exits != 0 (verified in control below).
2. **#8915 error surfacing** — the `::group::` full-log error extraction still fires on failure (verified in control below).

Same one-subject fix on **all four carriers** of the pattern: composite twins `.github/actions/lean-build/action.yml` + `.github/actions/lean-axiom/action.yml`, and reusable workflows `.github/workflows/lean-build.yml` + `.github/workflows/lean-axiom.yml`. The lean-knot gate self-covers both action files in its `paths:` triggers (lesson #8712), so this PR exercises its own gate.

## Controls (positive + negative, per the #15709 acceptance)

Harness: exact step structure replicated, tick scaled 600 s → 2 s (scratchpad `hb_control.sh`):

```
=== POSITIVE: long build (8s), tick 2s -> expect rc=0, >=2 heartbeats ===
[lake-heartbeat] still running after 10 min - last line: progress: elaborating module 2
[lake-heartbeat] still running after 20 min - last line: progress: elaborating module 4
[lake-heartbeat] still running after 30 min - last line: progress: elaborating module 6
RESULT rc=0 heartbeats=3
=== NEGATIVE-OK: short build (1s) -> expect rc=0, 0 heartbeats ===
RESULT rc=0 heartbeats=0
=== NEGATIVE-FAIL: short failing build (1s) -> expect rc=1, 0 heartbeats, ::group:: fired ===
::group::Error lines from the full lake log (See #8915)
2:error: fake build failure
::endgroup::
RESULT rc=1 heartbeats=0
```

YAML validity of all four files re-parsed post-edit (`yaml.safe_load` OK ×4).

## Out of scope (deliberately)

- `timeout-minutes: 300` backstops (#15706/#15698): untouched — they did their job.
- Runner pool / serialization instrument (#14821 `build-jobs: "1"`): untouched.
- The "axiom leg rebuilds the lake under its own cache key" question: #14337 owns it.

## Périmètre

4 fichiers, tous sous `.github/` : `.github/actions/lean-build/action.yml`, `.github/actions/lean-axiom/action.yml`, `.github/workflows/lean-build.yml`, `.github/workflows/lean-axiom.yml`. No code, no notebooks, catalogue byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

