### PR TITLE
fix(slides,#15695): porte de confirmation element — eteindre les chevauchements fantomes du scanner

### DIFF
--- a/scripts/notebook_tools/scan_slidev_composition.py
+++ b/scripts/notebook_tools/scan_slidev_composition.py
@@ -271,6 +271,10 @@ def measure_slide(page, slide_idx: int, canvas_w: int, canvas_h: int) -> dict:
             // (RECOUVREMENT ci-après), qui mesure le contenu rendu et
             // l'ordre de peinture au lieu de la boîte élément naïve.
             const chevauchements = [];
+            // #15695 : paires qui franchissent le seuil Range (> 1 px) mais
+            // sont éteintes par la porte de confirmation élément — comptées
+            // pour que le résumé distingue « rien détecté » de « organe muet ».
+            let chevauchementsEteints = 0;
             const textEls = Array.from(
                 root.querySelectorAll('h1, h2, h3, h4, p, li, blockquote, td, th')
             );
@@ -319,12 +323,45 @@ def measure_slide(page, slide_idx: int, canvas_w: int, canvas_h: int) -> dict:
                     const overlapX = Math.min(a.right, b.right) - Math.max(a.left, b.left);
                     const overlapY = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
                     if (overlapX > 1 && overlapY > 1) {
-                        chevauchements.push({
-                            a: a.key, b: b.key,
-                            a_bbox: [Math.round(a.left), Math.round(a.top), Math.round(a.right), Math.round(a.bottom)],
-                            b_bbox: [Math.round(b.left), Math.round(b.top), Math.round(b.right), Math.round(b.bottom)],
-                            overlap: [Math.round(overlapX), Math.round(overlapY)],
-                        });
+                        // Passe de confirmation (#15695) : le rect du Range
+                        // absorbe le padding+bordure des enfants inline à
+                        // boîte propre (<code>, <sup>, <kbd>…) et déborde la
+                        // line-box d'environ 1.2 px — un effleurement de
+                        // Range n'est pas un chevauchement rendu. Témoin
+                        // fondateur : rects Range recouverts de 1.23 px
+                        // pendant que les boîtes élément sont séparées de
+                        // +1.57 px (trois mesures indépendantes VISUAL-OK).
+                        // Les getBoundingClientRect() des éléments disent la
+                        // vérité du rendu : s'ils ne se chevauchent pas, la
+                        // paire n'existe pas à l'écran. Limite assumée : un
+                        // enfant hors flux qui déborderait seul de la boîte
+                        // de son élément voit son vrai recouvrement éteint
+                        // par cette porte — le contrôle négatif (deux blocs
+                        // absolus qui se recouvrent) n'y passe pas : leurs
+                        // boîtes élément se chevauchent aussi.
+                        const ra = a.el.getBoundingClientRect();
+                        const rb = b.el.getBoundingClientRect();
+                        const elOverlapX = Math.min(ra.right, rb.right) - Math.max(ra.left, rb.left);
+                        const elOverlapY = Math.min(ra.bottom, rb.bottom) - Math.max(ra.top, rb.top);
+                        if (elOverlapX > 0 && elOverlapY > 0) {
+                            chevauchements.push({
+                                a: a.key, b: b.key,
+                                a_bbox: [Math.round(a.left), Math.round(a.top), Math.round(a.right), Math.round(a.bottom)],
+                                b_bbox: [Math.round(b.left), Math.round(b.top), Math.round(b.right), Math.round(b.bottom)],
+                                overlap: [Math.round(overlapX), Math.round(overlapY)],
+                                // #15695 : les deux instruments côte à côte —
+                                // le graze Range qui a franchi le seuil et la
+                                // mesure élément qui confirme (ou, dans le
+                                // résumé, l'absence de paire = boîtes
+                                // élément disjointes).
+                                element_overlap: [
+                                    Math.round(elOverlapX * 100) / 100,
+                                    Math.round(elOverlapY * 100) / 100,
+                                ],
+                            });
+                        } else {
+                            chevauchementsEteints++;
+                        }
                     }
                 }
             }
@@ -523,7 +560,7 @@ def measure_slide(page, slide_idx: int, canvas_w: int, canvas_h: int) -> dict:
                 };
             }
 
-            return { horsCanvas, chevauchements, recouvrements, occupation, contentBottom: Math.round(contentBottom) };
+            return { horsCanvas, chevauchements, chevauchementsEteints, recouvrements, occupation, contentBottom: Math.round(contentBottom) };
         }""",
         [canvas_w, canvas_h],
     )
@@ -539,6 +576,7 @@ def measure_slide(page, slide_idx: int, canvas_w: int, canvas_h: int) -> dict:
         "hors_canvas": hors,
         "container_only": bool(hors) and not any(h.get("tag") in CONTENT_TAGS for h in hors),
         "chevauchements": raw.get("chevauchements", []),
+        "chevauchements_eteints": raw.get("chevauchementsEteints", 0),
         "recouvrements": raw.get("recouvrements", []),
         "occupation": raw.get("occupation"),
     }
@@ -647,7 +685,14 @@ def github_annotations(report: dict, slides_md: Path) -> list[str]:
         for c in r.get("chevauchements", [])[:3]:
             out.append(
                 f"::warning file={rel},line={line}::[CHEVAUCHEMENT] slide {r['slide']} ({head}) — "
-                f"{c['a']} × {c['b']} overlap={c['overlap']}px"
+                f"{c['a']} × {c['b']} overlap={c['overlap']}px "
+                f"element_overlap={c.get('element_overlap')}px"
+            )
+        if r.get("chevauchements_eteints"):
+            out.append(
+                f"::notice file={rel},line={line}::[CHEVAUCHEMENT-FANTOME] slide {r['slide']} ({head}) — "
+                f"{r['chevauchements_eteints']} effleurement(s) Range éteint(s) par la "
+                f"confirmation élément (#15695) : boîtes élément disjointes, rien à l'écran"
             )
         for rv in r.get("recouvrements", [])[:3]:
             out.append(
@@ -744,6 +789,7 @@ def main():
     n_total = len(results)
     n_hors = sum(1 for r in results if content_overflow(r))
     n_chev = sum(1 for r in results if r.get("chevauchements"))
+    n_eteints = sum(r.get("chevauchements_eteints") or 0 for r in results)
     n_rec = sum(1 for r in results if r.get("recouvrements"))
     n_occ = sum(1 for r in results if occupation_flagged(r, canvas_h))
 
@@ -775,6 +821,7 @@ def main():
         "n_slides": n_total,
         "n_hors_canvas": n_hors,
         "n_chevauchements": n_chev,
+        "n_chevauchements_eteints": n_eteints,
         "n_recouvrements": n_rec,
         "n_occupation_flagged": n_occ,
         "recouvrement_borne": (

--- a/scripts/tests/test_scan_slidev_composition.py
+++ b/scripts/tests/test_scan_slidev_composition.py
@@ -126,6 +126,59 @@ class TestGithubAnnotationsNonRegression:
         assert "::warning" in hc and "IMG" in hc
 
 
+class TestConfirmationElement15695:
+    """#15695 : seconde lecture -- une paire qui passe le seuil Range doit
+    AUSSI avoir des boites element qui se chevauchent ; les effleurings
+    eteints sont comptes (notice), pas taus."""
+
+    def test_paire_rapportee_porte_les_deux_mesures(self):
+        """Acceptance : la paire rapportee porte overlap (Range) ET
+        element_overlap (boites element) cote a cote."""
+        r = {
+            "slide": 6, "text_head": "vraie collision",
+            "hors_canvas": [], "chevauchements": [{
+                "a": "P.x", "b": "P.y", "a_bbox": [1, 2, 3, 4],
+                "b_bbox": [2, 3, 5, 6], "overlap": [12, 8],
+                "element_overlap": [11.5, 7.25],
+            }],
+            "chevauchements_eteints": 0,
+            "recouvrements": [], "occupation": None,
+        }
+        lines = ssc.github_annotations(_report([r]), Path("slides.md"))
+        chev = next(l for l in lines if "[CHEVAUCHEMENT]" in l)
+        assert "overlap=[12, 8]px" in chev
+        assert "element_overlap=[11.5, 7.25]px" in chev
+
+    def test_effleurement_eteint_emet_une_notice_comptee(self):
+        """Un graze Range eteint par la porte element n'est PAS un silence :
+        notice avec compte et reference -- sinon un correctif muet serait
+        indiscernable d'un organe mort."""
+        r = {
+            "slide": 16, "text_head": "graze code padding",
+            "hors_canvas": [], "chevauchements": [],
+            "chevauchements_eteints": 1,
+            "recouvrements": [], "occupation": None,
+        }
+        lines = ssc.github_annotations(_report([r]), Path("slides.md"))
+        fant = next(l for l in lines if "CHEVAUCHEMENT-FANTOME" in l)
+        assert "::notice" in fant
+        assert "1 effleurement" in fant
+        assert "#15695" in fant
+        assert not any("[CHEVAUCHEMENT]" in l for l in lines), (
+            "eteint = pas de warning CHEVAUCHEMENT"
+        )
+
+    def test_slide_propre_sans_eteints_n_emet_rien(self):
+        r = {
+            "slide": 2, "text_head": "propre",
+            "hors_canvas": [], "chevauchements": [],
+            "chevauchements_eteints": 0,
+            "recouvrements": [], "occupation": None,
+        }
+        lines = ssc.github_annotations(_report([r]), Path("slides.md"))
+        assert not any("CHEVAUCHEMENT" in l for l in lines)
+
+
 class TestBornesAdvisory:
     def test_borne_documentee_dans_docstring(self):
         """Le signal est ADVISORY : le docstring du module (charge par


### PR DESCRIPTION
## Sujet — #15695 : seconde lecture élément pour les chevauchements texte×texte du scanner slidev

`Closes #15695` — les 4 critères d'acceptance sont couverts ci-dessous, contrôles positif **et** négatif collés.

## Le correctif (1 instrument, aucun seuil relevé)

Dans `scripts/notebook_tools/scan_slidev_composition.py`, **à l'intérieur** du garde existant `if (overlapX > 1 && overlapY > 1)` : la paire qui franchit le test Range doit **aussi** avoir des `getBoundingClientRect()` éléments qui se chevauchent (`> 0` sur les deux axes), sinon elle est **éteinte** :

- paire éteinte → comptée par slide (`chevauchements_eteints`) + notice `CHEVAUCHEMENT-FANTOME` — le correctif n'est pas muet, « rien détecté » reste distinguable d'un organe mort (l'acceptance exigeait précisément cette distinguishabilité) ;
- paire rapportée → porte les **deux mesures** côte à côte : `overlap` (graze Range) + `element_overlap` (boîtes élément, arrondi au centième) — acceptance 4 ;
- résumé JSON : champ `n_chevauchements_eteints` au niveau rapport.

Le filtre ancêtre/descendant et les seuils `> 1` px sont **inchangés en substance** (le correctif ajoute une confirmation, ne relâche rien) ; les insertions décalent les lignes du bloc de +7.

## Contrôle positif — deck 05, serveur slidev live, main courant (2233ed874a)

AVANT (scanner de main, reproduit firsthand) — 4 paires fantômes :

```
n_chevauchements 4
slide 16 : 'LI.' x 'LI.' overlap [170, 1]
slide 29 : 'LI.' x 'LI.' overlap [348, 1]
slide 31 : 'LI.' x 'LI.' overlap [189, 1]
slide 48 : 'LI.' x 'LI.' overlap [691, 1]
```

APRÈS (scanner corrigé, même serveur, même deck) :

```
n_slides 54 | n_chevauchements 0 | n_eteints 4
slide 16 pairs 0 eteints 1
slide 29 pairs 0 eteints 1
slide 31 pairs 0 eteints 1
slide 48 pairs 0 eteints 1
```

**Numérotation vs 5f58dd9d9f** : l'issue cite les slides 15/27/29 au merge de #15661 ; le deck a évolué sur main depuis et les index ont dérivé de +1/+2 — mais les **signatures sont byte-identiques** : `[170, 1]`, `[348, 1]`, `[189, 1]` (les trois paires de l'issue) + une paire apparue depuis (`[691, 1]`, slide 48). Même classe de défaut, éteinte pareil.

## Contrôle négatif — obligatoire, collé

Fixture dédiée (deux `<p>` en `position:absolute`, top 130/150 px : la ligne A [130..167] recouvre la ligne B [150..187] réellement, ≥ 3 px sur les deux axes, vérifié sur les DEUX instruments) :

```
n_chevauchements 1 | n_eteints 0
slide 1 : P.fixture-a x P.fixture-b overlap [545, 21] el [580, 4]
```

Le recouvrement **réel** reste **rapporté** après correctif, avec les deux mesures côte à côte. La fixture vit hors repo (scratchpad) ; le deck 05 et le CSS du thème ne sont pas touchés (hors périmètre respecté), et le volet texte×texte de l'organe reste armé (il compte toujours dans le code retour).

## Limite assumée (documentée en commentaire dans le code)

Un enfant hors flux qui déborderait **seul** de la boîte de son élément verrait son vrai recouvrement éteint par cette porte — cas non rencontré sur le deck 05 ; le contrôle négatif (blocs absolus) n'y passe pas : leurs boîtes élément se chevauchent aussi.

## Tests

- `python -m pytest scripts/tests/test_scan_slidev_composition.py -q` → **11 passed** en 0,09 s (8 existants + 3 nouveaux : double mesure dans l'annotation, notice FANTOME comptée, slide propre silencieuse).
- Diff : 2 fichiers, +108/−8 (instrument + tests).

Grain: MED/guard — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #15925

🤖 Generated with [Claude Code](https://claude.com/claude-code)
