### PR TITLE
fix(guards,#15932): masquer les blocs fences dans la recherche de la ligne de tag

### DIFF
--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -207,10 +207,19 @@ def _first_grain_line(text: str | None) -> str | None:
     ``pr_number: None`` on it -- a line without a `<TIER>/<genre> #N` slot
     is structurally not a declaration, and returning `None` preserves the
     safety property.
+
+    Fenced blocks are masked BEFORE the line search (#15932), and with the
+    NARROW mask (`gt.mask_fenced_blocks`, inline spans kept): a reproduction
+    block that quotes a defective tag line verbatim is a citation, and when
+    it sits ABOVE the real tag line it used to win the "first line" race --
+    the guard then validated the quote's target as if it were the author's
+    `prev:` and red-lit the PR on a predecessor it never pointed at (#15925).
+    Masking inline spans here instead would break the backtick-wrapped tag
+    line that `parse_prev` relies on, hence the split surface.
     """
     if not text:
         return None
-    for line in text.splitlines():
+    for line in gt.mask_fenced_blocks(text).splitlines():
         if "Grain:" in line:
             return line
     return None

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -390,6 +390,64 @@ def mask_code_spans(text: str) -> str:
     return CODE_SPAN_RE.sub(lambda m: " " * len(m.group(0)), text)
 
 
+def _blank_keeping_shape(line: str) -> str:
+    r"""Same length, same line endings, everything else erased."""
+    return "".join(c if c in "\r\n" else " " for c in line)
+
+
+def mask_fenced_blocks(text: str) -> str:
+    r"""Blank out FENCED BLOCKS ONLY, keeping inline code spans visible.
+
+    `mask_code_spans` masks the union of both surfaces, which is what a
+    ``finditer`` sweep over a whole body needs. The TAG-LINE search needs the
+    narrow half instead, and for an asymmetric reason (#15932):
+
+    - a fence is NEVER a declaration. GitHub renders it as code; nobody reads
+      a tag line inside a reproduction block as the author's own tag;
+    - an inline-backticked tag line IS still a declaration -- it is the
+      BLIND-SPOT CONTROL `_declared_prev_pr` exists for, and `parse_prev`
+      strips the backticks. Masking it here would hand every lane a trivial
+      bypass: wrap the tag line in backticks and every `prev:` invariant goes
+      silent.
+
+    So the two masks are NOT interchangeable in this position, and the narrow
+    one is what `_first_grain_line` consumes.
+
+    The scan is line-based, not a regex, so a fence that is never closed masks
+    to the END of the text -- which is exactly what GitHub renders, and so
+    what a human reviewer sees. Both fence characters are honoured (``` and
+    ~~~), with a run of any length; a 4-space indented block is deliberately
+    NOT masked (`check_lane_claim` measured that indentation also belongs to
+    nested lists, where a marker is legitimate).
+
+    Length is preserved character for character, line endings included, so
+    the line at index N of the masked text is the line at index N of the
+    original: the caller can search masked and still return the ORIGINAL
+    line verbatim. Same contract as `check_lane_claim._mask_fenced_blocks`.
+    """
+    out: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if fence is None:
+            opener = None
+            for ch in ("`", "~"):
+                if stripped.startswith(ch * 3):
+                    opener = ch * (len(stripped) - len(stripped.lstrip(ch)))
+                    break
+            if opener is None:
+                out.append(line)
+            else:
+                fence = opener
+                out.append(_blank_keeping_shape(line))
+        else:
+            out.append(_blank_keeping_shape(line))
+            tail = stripped.rstrip()
+            if tail.startswith(fence) and not tail.strip(fence[0]):
+                fence = None
+    return "".join(out)
+
+
 # Matches `<closing-keyword> #N` in free prose (#10101). The keyword set is
 # exactly `CLOSING_KEYWORDS` (the 9 GitHub auto-close words); the `#N` tail is
 # what GitHub parses as an auto-close instruction when the text lands in a

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -617,6 +617,104 @@ def test_fenced_block_is_masked_too():
     assert vpg.find_prev_target_pr_numbers(body) == [14501]
 
 
+# --------------------------------------------------------------------------
+# #15932 -- the fence ABOVE the tag line. `test_fenced_block_is_masked_too`
+# above only holds when the real tag line comes FIRST; the first-line race is
+# what leaked.
+# --------------------------------------------------------------------------
+
+# Shape of the real #15925 body (compressed): the reproduction block is a
+# `python` fence whose first statement quotes a defective tag verbatim, and it
+# sits ABOVE the author's own trailer. `_first_grain_line` took the first
+# `Grain:` substring it met -- inside the fence -- so `_declared_prev_pr`
+# returned the QUOTE's target (15832, CLOSED/unmerged) instead of the real
+# trailer (15924, OPEN), and the guard red-lit the PR with
+# `prev-abandoned -> [15832]` on a predecessor the author never pointed at.
+#
+# The real trailer is held OPEN on purpose (the section NOTE convention): a
+# leaking mask must turn this red, and only the CLOSED quote can do that. The
+# teeth therefore sit entirely on the mask, not on the predicate.
+FENCED_CITATION_ABOVE_TAG = (
+    "## Reproduction\n"
+    "```python\n"
+    'body = "Grain: MED/lean -- lane myia-x:CoursIA -- prev: MED/lean #15832"\n'
+    "vpg.check(body, [], current_pr=15869, prev_targets=meta)\n"
+    "```\n"
+    "\n"
+    "## Suite\n"
+    "Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA -- prev: MED/tooling #15924\n"
+)
+
+FENCED_CITATION_TARGETS = {
+    "15832": {"kind": "pr", "state": "CLOSED", "merged": False},
+    "15924": {"kind": "pr", "state": "OPEN", "merged": False},
+}
+
+
+def test_fenced_citation_above_the_tag_line_is_not_a_declaration():
+    # The #15932 defect, first-hand.
+    assert vpg._declared_prev_pr(FENCED_CITATION_ABOVE_TAG) == 15924
+    assert 15832 not in vpg.find_prev_target_pr_numbers(FENCED_CITATION_ABOVE_TAG)
+    v = vpg.check(FENCED_CITATION_ABOVE_TAG, current_pr=15925,
+                  prev_targets=FENCED_CITATION_TARGETS)
+    assert v["hits"]["prev_invalid"] == []
+    assert v["guard_pass"] is True
+
+
+def test_fenced_citation_does_not_trip_prev_self():
+    # Symmetric half: the quote names the CURRENT PR (mine-po-2023's body
+    # quotes it with `current_pr=15869`), which must not read as a
+    # self-reference either -- `find_prev_self_references` falls back to
+    # `_declared_prev_pr` (l.281), the same function that leaked.
+    assert vpg.find_prev_self_references(FENCED_CITATION_ABOVE_TAG, 15832) == []
+
+
+def test_plain_citation_above_the_tag_line_still_fails():
+    # NEGATIVE CONTROL -- the mask is not a blanket amnesty on the ORDER. The
+    # SAME clause, written in plain text above the tag line, is a real
+    # declaration and must still be rejected. This is the pair that proves
+    # the pass above was earned by the fence.
+    body = ("## Reproduction\n"
+            "Grain: MED/lean -- lane myia-x:CoursIA -- prev: MED/lean #15832\n"
+            "\n"
+            "Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA -- prev: MED/tooling #15924\n")
+    assert vpg._declared_prev_pr(body) == 15832
+    v = vpg.check(body, current_pr=15925, prev_targets=FENCED_CITATION_TARGETS)
+    assert v["hits"]["prev_invalid"] == [
+        {"location": "body", "kind": "prev-abandoned", "prev_pr": 15832}]
+    assert v["guard_pass"] is False
+
+
+def test_mask_fenced_blocks_keeps_the_inline_span_surface():
+    # The narrow mask is the whole point (#15932): a fully backticked tag line
+    # must SURVIVE it, or `test_fully_backticked_tag_is_still_evaluated`'s
+    # blind-spot control becomes a silent bypass -- a lane would wrap its tag
+    # in backticks and every `prev:` invariant would go quiet.
+    backticked = "`Grain: MED/guard -- lane a:b -- prev: MED/guard #14548`\n"
+    assert gt.mask_fenced_blocks(backticked) == backticked
+    # ... while the WIDE mask does blank it (that is why the two are split).
+    assert "14548" not in gt.mask_code_spans(backticked)
+
+
+def test_mask_fenced_blocks_shape_and_both_fence_characters():
+    fenced = "avant\n```python\nGrain: MED/qc -- prev: MED/qc #14548\n```\napres\n"
+    masked = gt.mask_fenced_blocks(fenced)
+    assert "14548" not in masked
+    assert len(masked) == len(fenced)
+    lines = masked.splitlines()
+    assert len(lines) == len(fenced.splitlines())
+    assert lines[0] == "avant" and lines[-1] == "apres"
+    # every line of the fence is blanked to the SAME length as its original
+    assert all(l == " " * len(o) for l, o in zip(lines[1:-1], fenced.splitlines()[1:-1]))
+    # `~~~` is a fence too, and an UNCLOSED fence masks to the end -- which is
+    # exactly what GitHub renders, so what a reviewer sees.
+    assert "14548" not in gt.mask_fenced_blocks("avant\n~~~\nGrain: a:b -- prev: a #14548\n")
+    # A 4-space indented block is deliberately NOT masked (nested lists carry
+    # legitimate markers there -- see check_lane_claim's scope note).
+    assert gt.mask_fenced_blocks("    Grain: a:b -- prev: a #14548\n") == \
+        "    Grain: a:b -- prev: a #14548\n"
+
+
 def test_plain_prev_at_an_abandoned_pr_still_fails():
     # NEGATIVE CONTROL -- the mask is not a blanket amnesty. The SAME clause
     # as the citation above, written in plain text (the canonical tag), at


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA

## Ce que fait la PR

Closes #15932. `_first_grain_line` retournait la première ligne contenant `Grain:` **sans
masquer les blocs de code fences**. Quand un bloc de reproduction cite un tag défectueux
verbatim **et** se trouve **au-dessus** du vrai trailer, la citation gagne la course :
`_declared_prev_pr` lit la cible de la citation au lieu du trailer réel, et le garde rougit
la PR sur un prédécesseur qu'elle n'a jamais pointé.

## Reproduction — sur le body REEL de #15925

La mouture d'origine du body portait, dans un fence `python`, l'instruction de reproduction
citant `prev: MED/lean #15832` (PR CLOSED non mergée) **au-dessus** du trailer réel
`prev: MED/tooling #15924` (OPEN).

| | `_declared_prev_pr` | `find_prev_target_pr_numbers` | verdict |
|---|---|---|---|
| **avant** | `15832` (la citation) | `[15924, 15832]` | `guard_pass: false` — `prev-abandoned -> [15832]` |
| **après** | `15924` (le trailer) | `[15924]` | `guard_pass: true` |

CLI sur le body d'origine, citation **dans** le fence, cibles `{15832: CLOSED-unmerged,
15924: OPEN}` :

```
$ python scripts/ci/variation_prev_guard.py --body-file <orig> --current-pr 15925 \
      --prev-targets-file <targets>
{"guard_pass": true, "reason": "no prev: defect (close-keyword or invalid ref)",
 "hits": {"body": [], "commits": [], "prev_invalid": []}, "prev_targets_accepted": [15924]}
EXIT=0
```

**Contrôle négatif** — la même citation, sortie du fence (texte clair), doit toujours rougir :

```
{"guard_pass": false,
 "reason": "`prev:` reference(s) fail invariant(s) (prev-abandoned -> [15832]) ...",
 "hits": {"prev_invalid": [{"location": "body", "kind": "prev-abandoned", "prev_pr": 15832}]}}
EXIT=1
```

Le masque n'est donc pas une amnistie : c'est bien la **fence** qui a fait passer le cas.

## Pourquoi un masque ÉTROIT, et pas `mask_code_spans`

Le masque large (`gt.mask_code_spans`, #14780) ne peut **pas** servir ici : il masque aussi
les spans backtick **inline**, et une ligne de tag entièrement backtickée doit rester
lisible (`grain_tag.parse_prev` retire les backticks) — c'est le **BLIND-SPOT CONTROL** que
`_declared_prev_pr` existe pour préserver (`test_fully_backticked_tag_is_still_evaluated`).
Masquer plus large offrirait à chaque lane un contournement silencieux de **tous** les
invariants `prev:`. D'où une surface nommée séparément, `gt.mask_fenced_blocks`, qui masque
les **fences seulement** — le contrat est écrit dans son docstring, avec la raison de la
non-interchangeabilité.

Le balayage est **ligne-à-ligne**, pas une regex, pour hériter de la sémantique déjà
éprouvée de `check_lane_claim._mask_fenced_blocks` (même algorithme, même commentaire de
portée) :

- les **deux** caractères de fence (```` ``` ```` et `~~~`), run de longueur quelconque ;
- une fence **non refermée** masque jusqu'à la fin — c'est exactement ce que GitHub rend,
  donc ce qu'un relecteur humain voit ;
- un bloc **indenté de 4 espaces** n'est **pas** masqué (l'indentation appartient aussi aux
  listes imbriquées, où un marqueur est légitime — mesuré par `check_lane_claim`) ;
- la **longueur est préservée caractère pour caractère**, fins de ligne comprises, donc la
  ligne d'index N du texte masqué **est** la ligne d'index N de l'original : le garde cherche
  masqué et retourne la ligne **originale** verbatim.

## Acceptance de #15932

- [x] Un body avec citation fencée d'un trailer défectueux + trailer réel valide ne
      déclenche plus prev_guard → mesuré ci-dessus sur le body réel (#15925), `EXIT=0`
- [x] Test pinant le cas (bloc fencé citant une cible CLOSED, trailer réel OPEN)
- [x] Le masque inline #14780 reste couvert par ses tests existants (aucune régression)

## Tests

```
pytest scripts/tests/test_variation_prev_guard.py     -> 56 passed
pytest scripts/tests/test_grain_tag.py                -> 102 passed
pytest scripts/tests/test_check_lane_claim.py \
       scripts/tests/test_pr_close_keyword_guard.py \
       scripts/tests/test_variation_prev_lane.py \
       scripts/tests/test_variation_adjacency_guard.py \
       scripts/tests/test_variation_tag_required.py \
       scripts/tests/test_lane_claim_required.py      -> 349 passed, 1 skipped / 135 passed
```

4 tests ajoutés, dont **un contrôle négatif sur l'ORDRE** (`test_plain_citation_above_the_tag_line_still_fails`) :
la même clause en texte clair au-dessus du tag doit toujours bloquer — c'est la paire qui
prouve que le passage vient de la fence et non d'une cible que le prédicat laisse filer.

## Signalement (non traité ici — règle « ne pas toucher au code non lié »)

`scripts/check_lane_claim.py:215` porte sa **propre** `_mask_fenced_blocks` (même algorithme,
même portée). Deux copies du même masque existent maintenant là et dans `grain_tag.py`.
L'unification (importer la canonique depuis `grain_tag`) est **hors du périmètre de #15932**
(qui vise `variation_prev_guard.py` + son test) et toucherait une garde à fort trafic de
2000+ lignes : à faire dans un grain dédié, pas en rider. Signalé, pas fait.

## Périmètre

3 fichiers, +166 / -1 :

| Fichier | Δ |
|---|---|
| `scripts/grain_tag.py` | +58 (le masque étroit, surface canonique partagée) |
| `scripts/ci/variation_prev_guard.py` | +11 / -1 (la recherche de ligne l'utilise) |
| `scripts/tests/test_variation_prev_guard.py` | +98 (4 tests) |

Aucun changement de logique métier : la fonction de décision (`validate_prev_targets`,
`check`) est intacte, seul l'ensemble des lignes *scannées* change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

