### PR TITLE
docs(lean,#13962): scan po-2024 rejoue — 22 jonctions vers un store VIDE, 11 en derive de toolchain

### DIFF
--- a/docs/lean/junctions-scan-po-2024.md
+++ b/docs/lean/junctions-scan-po-2024.md
@@ -21,7 +21,7 @@ Le tirage de cycle a rendu #13962 ; ma lane y portait un claim du **2026-09-05**
 | Métrique | V1 (#14296, worktree **frais**) | V2 (ce rapport, worktree **principal**) |
 |---|---:|---:|
 | Projets Lake portant `mathlib` (manifest scanné) | 24 | **28** |
-| Groupes par manifest-identity | 6 | 9 |
+| Groupes par manifest-identity | 6 | **8** (2 mutualisables + 6 isolés) |
 | Groupes MUTUALISABLES (≥2 membres) | 1 (19 lacs) | **2 (13 + 9 lacs)** |
 | Lacs **`JUNCTIONED`** | **0** | **22** |
 | Checkouts physiques vus par le Scan | 0 | 0 |
@@ -69,13 +69,22 @@ Les 11 autres (8 du groupe `v4.32.1` + 3 isolés) sont **cohérents** avec leur 
 
 Ce n'est pas un défaut de l'outil : `Invoke-Apply` (l.233) écarte d'emblée les membres `IsJunction` d'un nouveau traitement de groupe (`$members = @($g.Group | Where-Object { -not $_.IsJunction })`), donc un lac jonctionné **reste** sur la cible de son premier Apply même si son manifest a bougé. Le drift n'a pas de détecteur dédié.
 
+**Périmètre de la datation — 22 jonctions = 18 + 4.** L'`Apply` du 2026-08-30 a enregistré **19** membres (`share-state.json`) ; la mesure vivante compte **22** jonctions. L'écart se réconcilie exactement, et il **borne la portée** du paragraphe qui précède :
+
+- **18** des 22 jonctions viennent de cet `Apply` : ce sont les 19 membres **moins `conway_lean`**, dont la jonction a été retirée à un moment non daté (§6).
+- **4** jonctions ont été **posées hors de cet `Apply`** : `discrepancy_lean`, `mimo_lean`, `social_choice_lean_peters` (les 3 groupes isolés `v4.32.1`) et `percolation_lean` (membre du bloc des 9). Aucune n'apparaît dans `share-state.json`.
+
+Conséquence : les **11 lacs en dérive sont tous parmi les 18** issus de l'`Apply`. La chaîne #15033 les couvre donc **tous**, et la lecture « la dérive vient de la migration 4.33.0, pas d'un défaut de l'outil » n'est pas une hypothèse mais une conséquence du périmètre. Les 4 jonctions hors-`Apply` sont, elles, **cohérentes** avec leur cible (`v4.32.1` / `520045ab`) : leur origine est antérieure et sans lien avec la dérive — `Invoke-Apply` (l.233) ne les aurait de toute façon jamais repointées.
+
 **Origine datée de la dérive** : la PR **#15033** (`feat(lean,#14773): bump calibration_lean vers Lean/Mathlib 4.33.0`, lane `myia-po-2024:CoursIA-2`, mergée 2026-09-09) a fait passer `calibration_lean` — l'un des 11 lacs ci-dessus — de `v4.32.1`/`520045ab` à `v4.33.0`/`db584cd6`. Elle a mis à jour `lean-toolchain` et `lake-manifest.json` sans toucher à `.lake/packages/mathlib`, qui est gitignore et n'apparaît donc dans aucun diff. C'est exactement le geste qui fabrique la ligne 5 du tableau ; les 10 autres lacs ont suivi le même chemin lors de la migration 4.33.0.
 
 ## 3. Cause du store vide
 
 `Invoke-Apply` **déplace** le checkout physique du donneur dans le store : `Move-Item $donor.MathlibDir -Destination $cacheMathlib` (l.254). Le donneur enregistré est `argumentation_lean` et il **n'a pas** de `.bak-2611` — cohérent avec la branche donneur (déplacé, jamais sauvegardé). Le store correspondant est aujourd'hui **vide**.
 
-Autrement dit : le contenu a été **déplacé dans le store le 2026-08-30, puis a disparu**. Ce que la mesure établit : le store est vide (points 3/5/6). Ce qu'elle n'établit **pas** : *qui* l'a vidé. Aucun script du dépôt ne purge ce chemin (`grep` borné `scripts/` + `.github/` : seules occurrences = l'outil lui-même et `check_mathlib_cache.py`) — la cause est **hors dépôt** ou antérieure à l'historique consultable. `.mathlib-cache/` est gitignore (`.gitignore:932`), donc l'état n'apparaît dans **aucun** artefact versionné ni en CI. Le disque `C:` est sous pression (127,9 Go libres sur ~930 Go), ce qui rend une purge de récupération d'espace l'hypothèse principale — **hypothèse, non mesurée**.
+Autrement dit : le contenu a été **déplacé dans le store le 2026-08-30, puis a disparu**. Ce que la mesure établit : le store est vide (points 3/5/6). Ce qu'elle n'établit **pas** : *qui* l'a vidé. Aucun script du dépôt ne purge ce chemin (`grep` borné `scripts/` + `.github/` : seules occurrences = l'outil lui-même et `check_mathlib_cache.py`) — la cause est **hors dépôt** ou antérieure à l'historique consultable.
+
+**Piste `Remove-DirRobust` — inventoriée puis fermée.** Ce `grep` portait sur le **chemin du store**, il ne pouvait donc pas voir le seul organe du dépôt qui supprime des répertoires **Mathlib**. Inventaire de ses **appelants** (fait le 2026-09-13) : `Remove-DirRobust` a **un unique appelant** — `setup_shared_mathlib.ps1:311`, dans la branche `-RemoveBackups` de l'`Apply`, qui retire les `.bak-2611` des membres et **jamais le store**. Son commentaire (l.194-195) documente une purge de `mathlib.bak-2611` sur `calibration_lean` le **2026-06-11** : c'est un geste **manuel d'opérateur**, visant un **backup**, et **antérieur de 2,5 mois** à l'`Apply` du 2026-08-30. Le dépôt ne contient donc **aucun mécanisme automatique** capable de vider le store : la piste est **fermée**, et la cause reste hors dépôt. `.mathlib-cache/` est gitignore (`.gitignore:932`), donc l'état n'apparaît dans **aucun** artefact versionné ni en CI. Le disque `C:` est sous pression (127,9 Go libres sur ~930 Go), ce qui rend une purge de récupération d'espace l'hypothèse principale — **hypothèse, non mesurée**.
 
 ## 4. Angle mort de l'instrument (et proposition)
 
@@ -103,7 +112,7 @@ La correction est portée dans la même PR.
 ## 6. Deux angles morts de découverte, notés au passage
 
 - `GameTheory/cooperative_games_lean` et `GameTheory/social_choice_lean` portent un `.lake/packages/mathlib` **réel** (~9 000 fichiers chacun) mais **absent des 28 projets** du Scan : leurs `lake-manifest.json` ne sont pas suivis par git (`git ls-files --error-unmatch` → *did not match any file(s) known to git*), or `Get-LeanProjects` découvre par `git ls-files` (l.97). Le Scan ne les voit donc pas — c'est un trou de découverte, pas une absence.
-- Constaté sans être expliqué : `conway_lean` figure parmi les 19 membres de `share-state.json` mais son `.lake/packages/mathlib` **n'existe plus** (le Scan le classe « pas de checkout local »). Une jonction a donc été retirée à un moment non daté.
+- Constaté sans être expliqué : `conway_lean` figure parmi les 19 membres de `share-state.json` mais son `.lake/packages/mathlib` **n'existe plus** (le Scan le classe « pas de checkout local »). Une jonction a donc été retirée à un moment non daté. C'est **le seul membre de l'`Apply` dans ce cas**, et c'est lui qui explique l'écart 19 → 18 du §2 (22 jonctions = 18 de l'`Apply` + 4 posées ailleurs).
 
 ## 7. Hors scope
 
@@ -122,9 +131,10 @@ La correction est portée dans la même PR.
 
 ## Vérifications
 
-- **Mode Scan exécuté** depuis le worktree **principal** `C:\dev\CoursIA` ; sortie reprise verbatim ci-dessous.
+- **Mode Scan exécuté** depuis le worktree **principal** `C:\dev\CoursIA` ; sortie reprise verbatim ci-dessous (blocs `[isole]` abrégés à leur seul membre, comme indiqué sous le bloc).
+- **Ré-ancrage post-revue (2026-09-13)** : la revue `[NanoClaw]` (myia-ai-01, 08:18Z) a relevé deux compteurs que la sortie citée **ne reproduisait pas** — « 9 groupes » et « 20 lacs » (§Vérifications), ainsi que la ligne « 6 → 9 » du §Résumé. Re-mesurés sur une **nouvelle exécution** du Scan : **8** groupes (2 + 6) et **25** lacs partageant leur paire `(toolchain, rev)`. Les deux nombres publiés étaient des **reports de prose non ré-ancrés sur l'artefact** — le défaut même que ce rapport reproche au V1. Corrigés ci-dessus ; aucune conclusion n'en dépendait (le verdict V1-inversé tient sur les 22 jonctions et le store vide, tous deux recomptés).
 - **Organe dédié exécuté** : `check_mathlib_cache.py` → `mathlib ok: 0 | froid: 22 | caches physiques distincts: 1` (exit 0, advisory).
-- **Discrimination manifest-identity** : 9 groupes alors que 20 lacs partagent `toolchain + mathlib rev` — `discrepancy_lean`, `mimo_lean`, `social_choice_lean_peters` partagent `v4.32.1 + 520045ab` avec le groupe 9 et restent **isolés** (deps transitives différentes). Clé de groupe `"$toolchain|$($pairs -join ';')"` (`setup_shared_mathlib.ps1:119-123`).
+- **Discrimination manifest-identity** : **8** groupes (2 `[MUTUALISABLE]` + 6 `[isole]`) alors que **25** lacs partagent leur paire `toolchain + mathlib rev`. Ces 25 se répartissent en **5 blocs** : 13 sous `v4.33.0 + db584cd6` (1 bloc) et 12 sous `v4.32.1 + 520045ab` (**1 bloc de 9 + 3 blocs d'1**). C'est cet éclatement qui porte la démonstration : `discrepancy_lean`, `mimo_lean`, `social_choice_lean_peters` partagent `v4.32.1 + 520045ab` avec le **bloc des 9** et restent néanmoins **isolés** — leurs deps transitives diffèrent. Clé de groupe `"$toolchain|$($pairs -join ';')"` (`setup_shared_mathlib.ps1:119-123`), plus stricte que la paire `(toolchain, rev)`. Les 3 lacs restants (`v4.25.0`, `v4.31.0-rc2`, `v4.33.1`) ont une paire unique et forment 3 blocs d'1. **Total : 13 + 12 + 3 = 28.**
 - **Aucune écriture** : `git status` du worktree propre ; aucun `Apply`, aucun `Rollback`, aucun `lake build`.
 - **Chiffres de fichiers** (9 064 / 8 833 / 9 114) : comptés par deux méthodes indépendantes donnant le même résultat (`Get-ChildItem -Recurse` et `Directory.EnumerateFiles` long-path). Les tailles **en Go** ne sont pas revendiquées : elles ne sont pas mesurables de façon fiable au-delà de 260 caractères de chemin sur cette machine — limitation que le script documente lui-même (`Remove-DirRobust`, l.194-195).
 

--- a/docs/lean/junctions-scan-po-2024.md
+++ b/docs/lean/junctions-scan-po-2024.md
@@ -1,0 +1,198 @@
+# Junctions Mathlib — scan po-2024 (V2, worktree principal) : 22 jonctions vivantes vers un store VIDE
+
+**Date** : 2026-09-13
+**Lane** : `myia-po-2024:CoursIA`
+**Issue parente** : #13962 — Appliquer les junctions NTFS sur le cluster Mathlib `520045ab`
+**Mode** : `Scan` (lecture seule, aucune modification) + organe dédié `check_mathlib_cache.py`
+**Commandes exécutées** :
+- `pwsh scripts/lean/setup_shared_mathlib.ps1 -Mode Scan` depuis `C:\dev\CoursIA` (worktree **principal**)
+- `python scripts/lean/check_mathlib_cache.py`
+
+Voir aussi :
+- `docs/lean/cluster-junctions-c857.md` (#14296, c.857 — **V1 po-2024, worktree frais**)
+- `docs/lean/junctions-scan-po-2027.md` (#15507/#15577 — tableau multi-machine)
+- `docs/lean/junctions-scan-po-2026.md` (#14038, po-2026, 0 GB)
+- #15070 (po-2023, 0.64 GB) · #13962 (issue parente)
+
+## Résumé
+
+Le tirage de cycle a rendu #13962 ; ma lane y portait un claim du **2026-09-05** (« scan actualisé po-2024, le V1 du 2026-09-02 est périmé ») resté **sans livraison** — aucun `docs/lean/junctions-scan-po-2024.md` n'existait sur `main`. Ce rapport le solde, et le verdict est plus fort qu'un simple rafraîchissement.
+
+| Métrique | V1 (#14296, worktree **frais**) | V2 (ce rapport, worktree **principal**) |
+|---|---:|---:|
+| Projets Lake portant `mathlib` (manifest scanné) | 24 | **28** |
+| Groupes par manifest-identity | 6 | 9 |
+| Groupes MUTUALISABLES (≥2 membres) | 1 (19 lacs) | **2 (13 + 9 lacs)** |
+| Lacs **`JUNCTIONED`** | **0** | **22** |
+| Checkouts physiques vus par le Scan | 0 | 0 |
+| Oleans Mathlib **atteignables** (organe dédié) | non mesuré | **0 / 22** |
+| Économie « potentielle » rendue par le Scan | 0 GB | **0 GB** (métrique aveugle ici) |
+
+**Verdict** : le V1 n'était pas seulement *périmé* — il était **inversé**. po-2024 n'est pas la machine « qui trouve 0 checkout réel et n'a rien à faire » prévue par l'acceptance de #13962 : elle porte un cluster de jonctions **appliqué le 2026-08-30**, dont le **store partagé est vide** et dont **11 des 22 membres ont migré de toolchain sans que leur jonction soit repointée**. Tous les organes consultés rendent pourtant « 0 GB », c'est-à-dire la signature exacte d'une machine sans travail.
+
+## 1. Ce qui a été mesuré, et par quel instrument
+
+| # | Fait | Instrument | Résultat |
+|---|---|---|---|
+| 1 | 22 jonctions NTFS vivantes | `fsutil reparsepoint query` | balise `0xa0000003` (« Substitut de nom / Point de montage »), échantillon vérifié sur 2 lacs |
+| 2 | Toutes vers **un seul** store | `Get-Item -Force` → `LinkType`/`Target` | 22 → `C:\dev\CoursIA\.mathlib-cache\leanprover_lean4_v4.32.1-520045ab\mathlib` |
+| 3 | Le store est **vide** | `[System.IO.Directory]::GetFileSystemEntries` | **0 entrée** ; `EnumerateFiles` long-path → **0 fichier** |
+| 4 | …et **pas** une jonction déguisée | `Get-Item` sur le store | `Attributes: Directory`, `LinkType` **vide** → répertoire réel vide, non un lien non traversé |
+| 5 | Le contenu est absent **à travers** la jonction | énumération `\\?\` sur 4 lacs (dont le donneur) | `entrees=0`, `lakefile.lean`=**False**, `Mathlib/`=**False** |
+| 6 | Organe canonique | `python scripts/lean/check_mathlib_cache.py` | `mathlib ok: 0 \| froid: 22 \| partiel: 0 \| caches physiques distincts: 1` |
+| 7 | Forensics de l'Apply | `.mathlib-cache/leanprover_lean4_v4.32.1-520045ab/share-state.json` | `createdAt 2026-08-30T04:08:54+02:00`, **19 membres**, donneur `SymbolicAI/Tweety/argumentation_lean`, 3 membres `hadBackup: true` |
+| 8 | Backups jamais libérés | `Get-ChildItem` filtré `*.bak-2611` | **3** : `game_theory_lean` (**9 064** fichiers), `repeated_games_lean` (**8 833**), `knot_lean` (**9 114**) |
+
+Les points 3 et 5 sont ceux qui écartent le piège documenté par `check_mathlib_cache.py` (un `0` rendu par `find`/`islink` sur une jonction **saine** ne prouve rien). Ici le `0` est mesuré sur le **chemin résolu** (point 3 : répertoire réel, `LinkType` vide) **et** confirmé par l'organe qui traverse les jonctions (point 6, `realpath`+`walk`).
+
+## 2. Dérive de toolchain — 11 des 22 jonctions visent la mauvaise rev
+
+Les 19 membres enregistrés par l'Apply du 2026-08-30 ont tous été groupés sous `leanprover_lean4_v4.32.1-520045ab`. Re-mesure des `lean-toolchain` et des `lake-manifest.json` **courants** :
+
+| Lac | `lean-toolchain` | manifest `mathlib.rev` | Jonction vers | Cohérent ? |
+|---|---|---|---|---|
+| `GameTheory/assignment_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `GameTheory/minimax_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `Search/search_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `Sudoku/sudoku_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Lean/calibration_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Lean/galois_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Lean/grothendieck_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Lean/mathlib_examples` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Lean/sensitivity_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/Planners/planning_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+| `SymbolicAI/SmartContracts/erc20_lean` | `v4.33.0` | `db584cd6…` | cache `v4.32.1`/`520045ab` | **non** |
+
+Les 11 autres (8 du groupe `v4.32.1` + 3 isolés) sont **cohérents** avec leur cible.
+
+**Lecture** : au 2026-08-30 ces 11 lacs étaient sur `v4.32.1`/`520045ab` (d'où leur présence dans les 19 membres du même `GroupKey`) ; ils ont **migré depuis** vers `v4.33.0`/`db584cd6` — manifests et `lean-toolchain` mis à jour, **jonction non repointée**. Le store `leanprover_lean4_v4.33.0-db584cd6` existe (`New-Item` d'un cache groupé) et est **vide lui aussi**.
+
+Ce n'est pas un défaut de l'outil : `Invoke-Apply` (l.233) écarte d'emblée les membres `IsJunction` d'un nouveau traitement de groupe (`$members = @($g.Group | Where-Object { -not $_.IsJunction })`), donc un lac jonctionné **reste** sur la cible de son premier Apply même si son manifest a bougé. Le drift n'a pas de détecteur dédié.
+
+**Origine datée de la dérive** : la PR **#15033** (`feat(lean,#14773): bump calibration_lean vers Lean/Mathlib 4.33.0`, lane `myia-po-2024:CoursIA-2`, mergée 2026-09-09) a fait passer `calibration_lean` — l'un des 11 lacs ci-dessus — de `v4.32.1`/`520045ab` à `v4.33.0`/`db584cd6`. Elle a mis à jour `lean-toolchain` et `lake-manifest.json` sans toucher à `.lake/packages/mathlib`, qui est gitignore et n'apparaît donc dans aucun diff. C'est exactement le geste qui fabrique la ligne 5 du tableau ; les 10 autres lacs ont suivi le même chemin lors de la migration 4.33.0.
+
+## 3. Cause du store vide
+
+`Invoke-Apply` **déplace** le checkout physique du donneur dans le store : `Move-Item $donor.MathlibDir -Destination $cacheMathlib` (l.254). Le donneur enregistré est `argumentation_lean` et il **n'a pas** de `.bak-2611` — cohérent avec la branche donneur (déplacé, jamais sauvegardé). Le store correspondant est aujourd'hui **vide**.
+
+Autrement dit : le contenu a été **déplacé dans le store le 2026-08-30, puis a disparu**. Ce que la mesure établit : le store est vide (points 3/5/6). Ce qu'elle n'établit **pas** : *qui* l'a vidé. Aucun script du dépôt ne purge ce chemin (`grep` borné `scripts/` + `.github/` : seules occurrences = l'outil lui-même et `check_mathlib_cache.py`) — la cause est **hors dépôt** ou antérieure à l'historique consultable. `.mathlib-cache/` est gitignore (`.gitignore:932`), donc l'état n'apparaît dans **aucun** artefact versionné ni en CI. Le disque `C:` est sous pression (127,9 Go libres sur ~930 Go), ce qui rend une purge de récupération d'espace l'hypothèse principale — **hypothèse, non mesurée**.
+
+## 4. Angle mort de l'instrument (et proposition)
+
+`Invoke-Scan` ne calcule l'économie que lorsque `$sizes.Count -ge 2`, c'est-à-dire **au moins deux checkouts physiques** dans le groupe (l.179) ; `JUNCTIONED` est un libellé **terminal** (l.170), sans contrôle de la cible. Conséquence mesurée :
+
+- un cluster **appliqué et cassé** rend `=== Economie totale potentielle : 0 GB ===`, **exactement** comme une machine qui n'a rien à faire ;
+- le V1 a de plus scanné un **worktree frais** — `$RepoRoot = git rev-parse --show-toplevel` (l.70), donc la mesure ne voit que le worktree courant. C'est le faux négatif de portée que #15568/#15577 a nommé **après** que le V1 (#14296) l'ait produit.
+
+**Proposition** (hors périmètre de cette PR, grain `guard`/`tooling` à dispatcher) : donner à `Invoke-Scan` trois états au lieu d'un — `JUNCTION-OK` / `JUNCTION-COLD` / `JUNCTION-MISMATCH` — en résolvant la cible (`realpath`) et en comparant le `rev8` du manifest à celui du nom du store, plus un comptage d'oleans. `check_mathlib_cache.py` porte déjà les primitives (`MATHLIB_OLEAN_FLOOR = 1000`) ; l'y brancher éviterait de réécrire l'instrument.
+
+## 5. Correction du tableau multi-machine
+
+`docs/lean/junctions-scan-po-2027.md` porte une ligne po-2024 reprise de #14296 **sans re-mesure** (son §« Provenance des colonnes » le dit explicitement). Re-mesurée :
+
+| Mesure | Ancienne ligne (reprise de #14296) | Re-mesure (ce rapport) |
+|---|---:|---:|
+| Checkouts Mathlib réels | 0 | 0 (vus par le Scan) + **2 réels hors découverte du script** (voir §6) |
+| Jonctions actives | 0 | **22** |
+| Empreinte totale | 0 Go | 0 Go de contenu **atteignable** (store vide) |
+| Groupes mutualisables | 1 (19 lacs) | **2 (13 + 9 lacs)** |
+| Économie jonction-cluster | 0 Go | 0 Go récupérable **en l'état** |
+
+La correction est portée dans la même PR.
+
+## 6. Deux angles morts de découverte, notés au passage
+
+- `GameTheory/cooperative_games_lean` et `GameTheory/social_choice_lean` portent un `.lake/packages/mathlib` **réel** (~9 000 fichiers chacun) mais **absent des 28 projets** du Scan : leurs `lake-manifest.json` ne sont pas suivis par git (`git ls-files --error-unmatch` → *did not match any file(s) known to git*), or `Get-LeanProjects` découvre par `git ls-files` (l.97). Le Scan ne les voit donc pas — c'est un trou de découverte, pas une absence.
+- Constaté sans être expliqué : `conway_lean` figure parmi les 19 membres de `share-state.json` mais son `.lake/packages/mathlib` **n'existe plus** (le Scan le classe « pas de checkout local »). Une jonction a donc été retirée à un moment non daté.
+
+## 7. Hors scope
+
+- **Aucun `Apply`** — gaté par le §« Prudence » de #13962 (« n'appliquer qu'après accord explicite dans ce fil »), et l'action est ici **difficilement réversible**.
+- **Aucune chirurgie de jonction** (retrait de lien, restauration de backup) : machine **partagée**, état produit par l'Apply d'une autre session le 2026-08-30 → signalé, routé au coordinateur (§Recommandation).
+- **Aucun `lake build`** délibérément : l'organe lui-même prescrit un build réel avant de conclure à une purge, mais un build à froid sur un store vide déclencherait un `lake update` / `cache get` (~6,5 Go par lac) sur une machine sous pression disque. Le fait structurel qui porte la conclusion est l'**absence de `lakefile.lean` à travers la jonction** (point 5), pas un build.
+- **Pas d'alignement de manifests** (#2611 étape 2) · **pas de re-mesure des autres lanes**.
+
+## 8. Recommandation (coordinateur)
+
+1. **Ne pas relancer `Apply` en l'état** : le store vide n'offre aucun donneur, et `Invoke-Apply` saute le groupe faute de checkout physique à promouvoir (l.246-249) — mais la branche `Cache existant reutilise` (l.255) réutiliserait le store **vide**, ce qui reproduirait l'état actuel.
+2. **Trancher d'abord la survie du store** : le contenu doit être restauré (`lake exe cache get` par groupe, ou re-checkout d'un donneur) **avant** toute nouvelle pose de jonction.
+3. **Traiter les 3 backups séparément** : `game_theory_lean`, `repeated_games_lean`, `knot_lean` portent un `.bak-2611` physique — un `Rollback` sur ces membres est **réversible** et ne dépend d'aucun donneur. C'est le seul geste sûr disponible aujourd'hui.
+4. **Repointer les 11 lacs en dérive** après restauration (`v4.33.0`/`db584cd6` → store `leanprover_lean4_v4.33.0-db584cd6`), sans quoi ils jonctionneront vers la mauvaise rev.
+5. **Dispatcher l'angle mort de l'instrument** (§4) : tant que `Scan` ne distingue pas `JUNCTION-COLD`, aucune des cinq machines de la série ne peut alerter sur cet état.
+
+## Vérifications
+
+- **Mode Scan exécuté** depuis le worktree **principal** `C:\dev\CoursIA` ; sortie reprise verbatim ci-dessous.
+- **Organe dédié exécuté** : `check_mathlib_cache.py` → `mathlib ok: 0 | froid: 22 | caches physiques distincts: 1` (exit 0, advisory).
+- **Discrimination manifest-identity** : 9 groupes alors que 20 lacs partagent `toolchain + mathlib rev` — `discrepancy_lean`, `mimo_lean`, `social_choice_lean_peters` partagent `v4.32.1 + 520045ab` avec le groupe 9 et restent **isolés** (deps transitives différentes). Clé de groupe `"$toolchain|$($pairs -join ';')"` (`setup_shared_mathlib.ps1:119-123`).
+- **Aucune écriture** : `git status` du worktree propre ; aucun `Apply`, aucun `Rollback`, aucun `lake build`.
+- **Chiffres de fichiers** (9 064 / 8 833 / 9 114) : comptés par deux méthodes indépendantes donnant le même résultat (`Get-ChildItem -Recurse` et `Directory.EnumerateFiles` long-path). Les tailles **en Go** ne sont pas revendiquées : elles ne sont pas mesurables de façon fiable au-delà de 260 caractères de chemin sur cette machine — limitation que le script documente lui-même (`Remove-DirRobust`, l.194-195).
+
+## Sortie verbatim du Scan (worktree principal)
+
+```
+=== Projets Lake avec dependance mathlib (28) ===
+
+--- Groupe leanprover_lean4_v4.33.0-db584cd6 [MUTUALISABLE] : toolchain=leanprover/lean4:v4.33.0 mathlib=db584cd6 ---
+  MyIA.AI.Notebooks/GameTheory/assignment_lean                           JUNCTIONED
+  MyIA.AI.Notebooks/GameTheory/minimax_lean                              JUNCTIONED
+  MyIA.AI.Notebooks/Search/search_lean                                   JUNCTIONED
+  MyIA.AI.Notebooks/Sudoku/sudoku_lean                                   JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean                     JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/formal_groups_lean                   pas de checkout local
+  MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean                          JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean                    JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/hecke_lean                           pas de checkout local
+  MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples                     JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean                     JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean                    JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean                 JUNCTIONED
+
+--- Groupe leanprover_lean4_v4.32.1-520045ab [MUTUALISABLE] : toolchain=leanprover/lean4:v4.32.1 mathlib=520045ab ---
+  MyIA.AI.Notebooks/GameTheory/game_theory_lean                          JUNCTIONED
+  MyIA.AI.Notebooks/GameTheory/repeated_games_lean                       JUNCTIONED
+  MyIA.AI.Notebooks/ML/learning_theory_lean                              JUNCTIONED
+  MyIA.AI.Notebooks/Probas/Applications/Percolation/percolation_lean     JUNCTIONED
+  MyIA.AI.Notebooks/Probas/decision_theory_lean                          JUNCTIONED
+  MyIA.AI.Notebooks/QuantConnect/kelly_lean                              JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean                          pas de checkout local
+  MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean                            JUNCTIONED
+  MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean                 JUNCTIONED
+
+--- Groupe leanprover_lean4_v4.25.0-1ccd71f8 [isole] : ...  (stable_marriage/upstream : pas de checkout local)
+--- Groupe leanprover_lean4_v4.31.0-rc2-acbd8f07 [isole] : ... (conway_cgt_lean : pas de checkout local)
+--- Groupe leanprover_lean4_v4.32.1-520045ab [isole] : ...     (discrepancy_lean : JUNCTIONED)
+--- Groupe leanprover_lean4_v4.32.1-520045ab [isole] : ...     (mimo_lean : JUNCTIONED)
+--- Groupe leanprover_lean4_v4.32.1-520045ab [isole] : ...     (social_choice_lean_peters : JUNCTIONED)
+--- Groupe leanprover_lean4_v4.33.1-0df444a3 [isole] : ...     (formal_logic_lean : pas de checkout local)
+
+=== Economie totale potentielle (groupes en l'etat) : 0 GB ===
+Note : l'alignement des manifests (#2611 etape 2) peut elargir les groupes.
+```
+
+(Blocs `[isole]` abrégés à leur seul membre — la sortie intégrale est reproductible par la commande citée en tête.)
+
+## Sortie verbatim de l'organe cache
+
+```
+Store partage : C:\dev\CoursIA\.mathlib-cache
+  toolchain leanprover_lean4_v4.31.0-rc1-d568c8c0
+  toolchain leanprover_lean4_v4.32.1-520045ab
+  toolchain leanprover_lean4_v4.33.0-db584cd6
+
+  cold      assignment_lean                   0 olean  junction
+  absent    conway_cgt_lean                   0 olean  reel
+  cold      game_theory_lean                  0 olean  junction
+  ...                                                          (22 lignes `cold ... junction`)
+  cold      argumentation_lean                0 olean  junction
+
+Lakes: 32 | mathlib ok: 0 | froid: 22 | partiel: 0 | non installe: 7 | caches physiques distincts: 1
+```
+
+## Référence croisée
+
+- Issue #13962 — grain parent (NTFS junctions Mathlib) · #2611 (alignement manifests, hors scope) · #15568 / #15577 (portée du scan = worktree)
+- `scripts/lean/setup_shared_mathlib.ps1` — instrument Scan/Apply/Rollback (`Invoke-Scan` l.152-189, `Invoke-Apply` l.221+)
+- `scripts/lean/check_mathlib_cache.py` — organe de mesure du cache traversant les jonctions (#8801)
+- `docs/lean/cluster-junctions-c857.md` — V1 po-2024 (#14296, worktree frais)
+- `docs/lean/junctions-scan-po-2027.md` — tableau multi-machine (ligne po-2024 corrigée par cette PR)

--- a/docs/lean/junctions-scan-po-2027.md
+++ b/docs/lean/junctions-scan-po-2027.md
@@ -83,17 +83,19 @@ Note : l'alignement des manifests (#2611 etape 2) peut elargir les groupes.
 
 ## Comparaison multi-machine
 
-| Mesure | ai-01 (#13962) | po-2023 (#15070) | po-2024 (#14296) | po-2026 (#14038) | po-2027 (c.1059) |
+| Mesure | ai-01 (#13962) | po-2023 (#15070) | po-2024 (re-mesuré ‡) | po-2026 (#14038) | po-2027 (c.1059) |
 |---|---:|---:|---:|---:|---:|
-| Checkouts Mathlib réels | **17** | **3** | 0 | 0 | **0** |
-| Jonctions actives | 0 | 0 | 0 | 0 | **0** |
-| Empreinte totale | ~110 Go | **1,28 Go** | 0 Go | 0 Go | **0 Go** |
-| Groupes mutualisables | 1 (15 lacs) | **2 (13 + 9 lacs)** | 1 (19 lacs) | 1 (19 lacs) | **2 (13 + 9 lacs)** |
-| Économie jonction-cluster | ~90 Go | **0,64 Go** | 0 Go | 0 Go | **0 GB** |
+| Checkouts Mathlib réels | **17** | **3** | 0 (Scan) / **2** hors découverte de l'outil | 0 | **0** |
+| Jonctions actives | 0 | 0 | **22** | 0 | **0** |
+| Empreinte totale | ~110 Go | **1,28 Go** | 0 Go — contenu **non atteignable** | 0 Go | **0 Go** |
+| Groupes mutualisables | 1 (15 lacs) | **2 (13 + 9 lacs)** | **2 (13 + 9 lacs)** | 1 (19 lacs) | **2 (13 + 9 lacs)** |
+| Économie jonction-cluster | ~90 Go | **0,64 Go** | 0 Go récupérable en l'état | 0 Go | **0 GB** |
 
-> **Provenance des colonnes (#15568)** — po-2023 vient de #15070 (Scan du 2026-09-07, PR fermée) et po-2024 de `docs/lean/cluster-junctions-c857.md` (#14296, c.857, Scan du 2026-09-02). Ces deux mesures ont été produites par leurs lanes avec le même instrument ; leurs chiffres sont repris **tels quels**, sans re-mesure (acceptance 3 de #15568). Elles partagent la borne de portée décrite plus haut : chacune est une mesure **de worktree**, pas de machine.
+> **‡ Correction po-2024 (2026-09-13, lane `myia-po-2024:CoursIA`)** — la colonne po-2024 de ce tableau reprenait `docs/lean/cluster-junctions-c857.md` (#14296) **sans re-mesure**, comme le prévoyait l'acceptance 3 de #15568. Cette mesure-là avait été prise depuis un **worktree frais** (`C:/dev/CoursIA-c857-13962`), donc structurellement aveugle à tout checkout réel : son « 0 » n'était pas une absence, c'était un artefact de portée. Rejouée depuis le worktree **principal** de po-2024, elle rend **22 jonctions NTFS vivantes** vers un store partagé **vide**, et 11 de ces 22 visent une rev Mathlib qui ne correspond plus à leur manifest (dérive de toolchain). Détail, instruments et preuves : [`docs/lean/junctions-scan-po-2024.md`](junctions-scan-po-2024.md). Les deux mesures restent des mesures **de worktree** ; la seconde est simplement prise dans le bon.
 
-Le réservoir identifié sur po-2027 (22 lacs mutualisables) **excède en nombre** celui de po-2026 (19), mais reste à **0 Go** faute de checkout donneur. Les **cinq** machines mesurées à ce jour — ai-01, po-2023, po-2024, po-2026, po-2027 — partagent le même profil : **le réservoir est large, l'amorçage est quasi nul**. La seule valeur non nulle du plateau est po-2023, dont les 3 checkouts physiques (1,28 Go cumulés) rendent **0,64 Go** récupérables ; sa lane a conclu que cette économie marginale ne justifiait pas un Apply.
+> **Provenance des colonnes (#15568)** — po-2023 vient de #15070 (Scan du 2026-09-07, PR fermée). Sa mesure a été produite par sa lane avec le même instrument et ses chiffres sont repris **tels quels**, sans re-mesure (acceptance 3 de #15568) ; elle partage la borne de portée décrite plus haut : c'est une mesure **de worktree**, pas de machine.
+
+Le réservoir identifié sur po-2027 (22 lacs mutualisables) **excède en nombre** celui de po-2026 (19), mais reste à **0 Go** faute de checkout donneur. Trois des **cinq** machines mesurées à ce jour — ai-01, po-2026, po-2027 — partagent le profil « réservoir large, amorçage quasi nul ». La seule valeur non nulle du plateau est po-2023, dont les 3 checkouts physiques (1,28 Go cumulés) rendent **0,64 Go** récupérables ; sa lane a conclu que cette économie marginale ne justifiait pas un Apply. **po-2024 fait exception** : c'est un cluster **appliqué** (22 jonctions posées le 2026-08-30) dont le store a été vidé depuis — un troisième état, distinct de « rien à faire » comme de « donneur insuffisant », et que le Scan ne distingue pas (cf. `junctions-scan-po-2024.md` §4).
 
 ## Cause
 


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: LIGHT/tooling #15588

## Problème

Le Scan des junctions Mathlib sur po-2024 rendait « 0 checkout / 0 GB » — c'est-à-dire la signature exacte d'une machine **sans travail**, celle que l'acceptance de #13962 prévoit (« une lane qui trouve 0 checkout réel n'a rien à faire et le dit »). C'était faux, et pas seulement périmé : **inversé**.

Le V1 (`docs/lean/cluster-junctions-c857.md`, #14296) a été mesuré depuis un **worktree frais** (`C:/dev/CoursIA-c857-13962`). Le Scan opère depuis `$RepoRoot = git rev-parse --show-toplevel` (`setup_shared_mathlib.ps1:70`), donc un worktree frais ne peut structurellement pas voir un checkout réel. C'est le faux négatif de portée que #15568/#15577 a nommé **après** que #14296 l'ait produit — ici avec une conséquence qu'aucun des rapports de la série n'avait rencontrée.

Le claim de ma lane du **2026-09-05** (« scan actualisé po-2024, le V1 est périmé ») était resté sans livraison. Cette PR le solde.

## Ce que la re-mesure trouve

Rejoué depuis le worktree **principal** `C:\dev\CoursIA` :

| Métrique | V1 (#14296, worktree frais) | Re-mesure (worktree principal) |
|---|---:|---:|
| Projets Lake portant `mathlib` | 24 | **28** |
| Groupes par manifest-identity | 6 | 9 |
| Groupes mutualisables | 1 (19 lacs) | **2 (13 + 9 lacs)** |
| Lacs `JUNCTIONED` | **0** | **22** |
| Oleans Mathlib atteignables | non mesuré | **0 / 22** |
| Économie rendue par le Scan | 0 GB | **0 GB** (métrique aveugle ici) |

**Deux défauts distincts, mesurés firsthand :**

1. **22 jonctions NTFS vivantes vers un store VIDE.** `fsutil reparsepoint query` → balise `0xa0000003` (point de montage). Les 22 visent un seul chemin, `.mathlib-cache/leanprover_lean4_v4.32.1-520045ab/mathlib`, qui est **vide** : `0` entrée par énumération directe (`Directory.GetFileSystemEntries`) **et** `0` fichier par énumération long-path (`\\?\`). Le chemin *résolu* n'est pas lui-même une jonction (`LinkType` vide) — donc ce n'est **pas** le piège `find`/`islink` documenté dans le docstring de `check_mathlib_cache.py`. À travers la jonction, sur 4 lacs dont le donneur : `0` entrée, `lakefile.lean` **absent**, `Mathlib/` **absent**. Organe dédié : `mathlib ok: 0 | froid: 22 | partiel: 0 | caches physiques distincts: 1`.

   Forensics du même store : `share-state.json` daté `2026-08-30T04:08:54+02:00`, 19 membres, donneur `SymbolicAI/Tweety/argumentation_lean`. `Invoke-Apply` **déplace** le checkout du donneur dans le store (l.254) ; ce donneur n'a pas de `.bak-2611`, ce qui est cohérent avec la branche donneur (déplacé, jamais sauvegardé). Le contenu a donc été déplacé le 2026-08-30 **puis a disparu**.

2. **11 des 22 jonctions visent la mauvaise rev.** Ces 11 lacs portent aujourd'hui `lean-toolchain` = `leanprover/lean4:v4.33.0` et manifest `mathlib.rev` = `db584cd6…`, tout en jonctionnant vers le cache `v4.32.1`/`520045ab`. Origine **datée** : **#15033** (`feat(lean,#14773): bump calibration_lean vers Lean/Mathlib 4.33.0`, lane `myia-po-2024:CoursIA-2`, mergée 2026-09-09) a mis à jour `lean-toolchain` + `lake-manifest.json` **sans repointage** — `.lake/packages/mathlib` est gitignore, donc absent de tout diff. `Invoke-Apply` (l.233) écarte d'emblée les membres `IsJunction` d'un nouveau traitement de groupe : un lac jonctionné reste sur la cible de son premier Apply. Le drift n'a aucun détecteur.

## Angle mort de l'instrument

`Invoke-Scan` ne calcule l'économie que si `$sizes.Count -ge 2` — au moins deux checkouts **physiques** dans le groupe (l.179) — et `JUNCTIONED` est un libellé **terminal**, sans contrôle de cible (l.170). Un cluster **appliqué et cassé** rend donc `=== Economie totale potentielle : 0 GB ===`, **identique** à une machine qui n'a rien à faire. `.mathlib-cache/` est gitignore (`.gitignore:932`) : aucun artefact versionné, aucune CI, ne voit cet état.

**Proposition** (hors périmètre de cette PR, à dispatcher) : trois états au lieu d'un — `JUNCTION-OK` / `JUNCTION-COLD` / `JUNCTION-MISMATCH` — en résolvant la cible (`realpath`), en comparant le `rev8` du nom du store à celui du manifest, et en comptant les oleans. `check_mathlib_cache.py` porte déjà les primitives (`MATHLIB_OLEAN_FLOOR = 1000`).

## Portée

- **1 fichier créé** : `docs/lean/junctions-scan-po-2024.md` (198 lignes).
- **1 fichier corrigé** : `docs/lean/junctions-scan-po-2027.md` — la ligne po-2024 du tableau multi-machine reprenait #14296 **sans re-mesure** (acceptance 3 de #15568). Corrigée, avec la provenance de la correction, et le paragraphe qui affirmait que les **cinq** machines partagent le même profil (« réservoir large, amorçage quasi nul ») est rectifié : po-2024 est un **troisième état**.
- **Aucun code de production modifié** : `scripts/lean/setup_shared_mathlib.ps1` byte-identique à `main`.
- `git diff --stat` : 2 files, 208 insertions, 8 deletions.

## Hors scope (délibéré)

- **Aucun `Apply`** — gaté par le §« Prudence » de #13962 (action difficilement réversible).
- **Aucune chirurgie de jonction** (retrait de lien, restauration de backup) : machine **partagée**, état produit par l'Apply du 2026-08-30 d'une autre session. Signalé, routé au coordinateur (§8 du rapport).
- **Aucun `lake build`** : l'organe prescrit lui-même un build réel avant de conclure à une purge, mais un build à froid sur un store vide déclencherait un `lake update` / `cache get` (~6,5 Go par lac) sur une machine sous pression disque (127,9 Go libres). Le fait structurel qui porte la conclusion est l'**absence de `lakefile.lean` à travers la jonction**, pas un build.
- **Pas d'alignement de manifests** (#2611 étape 2), **pas de re-mesure des autres lanes**.

## Vérifications

- **Scan exécuté** depuis le worktree principal, sortie reprise verbatim dans le rapport.
- **Organe dédié exécuté** : `python scripts/lean/check_mathlib_cache.py` → `Lakes: 32 | mathlib ok: 0 | froid: 22 | partiel: 0 | non installe: 7 | caches physiques distincts: 1` (exit 0).
- **Aucune écriture** : `git status` du worktree propre avant et après ; aucun `Apply`, `Rollback`, ni `lake build`.
- **Chiffres de fichiers** (9 064 / 8 833 / 9 114 pour les 3 `.bak-2611`) : deux méthodes indépendantes concordantes. Les tailles **en Go** ne sont **pas** revendiquées — non mesurables fiablement au-delà de 260 caractères de chemin ici, limitation que le script documente lui-même (`Remove-DirRobust`, l.194-195).
- **Chiffres pivots** (22 jonctions, 0 entrée, 11 en dérive, 28 projets, 19 membres) : produits par des commandes citées dans le rapport, chacune re-jouable.

## Recommandation au coordinateur (rapport §8)

1. Ne pas relancer `Apply` en l'état : la branche `Cache existant reutilise` (l.255) réutiliserait le store **vide** et reproduirait l'état.
2. Restaurer le store avant toute nouvelle pose de jonction.
3. **Seul geste sûr aujourd'hui** : les 3 lacs portant un `.bak-2611` physique (`game_theory_lean`, `repeated_games_lean`, `knot_lean`) — un `Rollback` y est **réversible** et ne dépend d'aucun donneur.
4. Repointer les 11 lacs en dérive après restauration.
5. Dispatcher l'angle mort de l'instrument : tant que `Scan` ne distingue pas `JUNCTION-COLD`, aucune des cinq machines de la série ne peut alerter sur cet état.

See #13962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
