### PR TITLE
fix(lean-scripts): rendre run_lean9_demos.py compilable (queue orpheline apres un `],` premature)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/_archive/run_lean9_demos.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/_archive/run_lean9_demos.py
@@ -506,10 +506,6 @@ DEMOS = [
         "complexity": "Avancee - plusieurs rewrites necessaires",
         "strategy": "rw [Nat.add_assoc, Nat.add_comm b c, ...] OU omega",
         "trap": "Un seul rewrite ne suffit pas, strategie multi-etapes"
-    }
-],
-        "complexity": "Triviale - une tactique suffit",
-        "strategy": "rfl"
     },
     {
         "name": "DEMO_2_SUCCESSOR",


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA

## Le defaut

`MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/_archive/run_lean9_demos.py` **ne compile pas sur `main`** :

```
$ python -m py_compile .../_archive/run_lean9_demos.py
Sorry: IndentationError: unexpected indent (.../run_lean9_demos.py, line 511)
```

Le fichier est commite, il est donc analyse par CodeQL a chaque execution — et il est le **seul** fichier Python du depot que l'analyseur ne peut pas lire :

```
CodeQL scanned 2036 out of 2036 Python files and 163 out of 163 GitHub Actions files
##[group]Could not process some files due to syntax errors (1 result)
  * .../_archive/run_lean9_demos.py#L511C20:20: A parse error occurred ...
```

## Origine, pinnee sur un commit precis

Le defaut est entre a **`c80aea1106`** (2026-01-31, « feat(Lean-9): Improve demo gradation with tactical traps ») :

| Revision | `py_compile` |
|---|---|
| `c7992fa149` | OK (544 lignes) |
| `6517651680` | OK (548 lignes) |
| `ef567c47a9` — **parent** | **OK (552 lignes)** |
| `c80aea1106` — le commit | **ECHEC — `IndentationError` ligne 511** |
| `2fbddf1ad3` (rename `archive` -> `_archive`) | +0/-0, contenu inchange |
| `main` aujourd'hui | ECHEC (identique) |

Ce commit devait inserer quatre demos graduees (avec leurs `"trap"`) **a la place** de l'ancien `DEMO_1_REFLEXIVITY`, en gardant la suite de la liste. Son texte insere s'est termine par `],` — une **fermeture prematuree de la liste** — et les trois dernieres lignes de l'ancien `DEMO_1_REFLEXIVITY` sont **restes en place**, orphelines apres ce `],` :

```
 509      }
 510 ],                                    <-- ferme la liste trop tot
 511          "complexity": "Triviale - une tactique suffit",
 512          "strategy": "rfl"
 513      },                                <-- accolades orphelines
 514      {
 515          "name": "DEMO_2_SUCCESSOR",     ... la liste continue jusqu'a `]` ligne 544
```

La preuve que ces trois lignes sont un **reste**, et non du contenu a restaurer : ce sont exactement les anciennes lignes **473-475 de `ef567c47a9`**, la queue de l'ancien `DEMO_1_REFLEXIVITY` — dont le remplacant est le nouveau `DEMO_1_REFLEXIVITY` (ligne 467), qui porte la **meme** intention en mieux : `"complexity": "Triviale - rfl suffit, pas de recherche"` et `"strategy": "rfl"`. Rien n'est perdu a les retirer.

## Le correctif

Quatre lignes supprimees, zero ajoutee : `],` devient la continuation `},` de `DEMO_4_COMPOSITION`, et les trois lignes orphelines disparaissent.

```diff
         "trap": "Un seul rewrite ne suffit pas, strategie multi-etapes"
-    }
-],
-        "complexity": "Triviale - une tactique suffit",
-        "strategy": "rfl"
     },
     {
         "name": "DEMO_2_SUCCESSOR",
```

## Verification

```
$ python -m py_compile .../_archive/run_lean9_demos.py   ->  COMPILE OK
```

La liste est intacte — `ast.parse` sur le fichier corrige, `DEMOS` = **7 entrees**, avec noms, complexites et strategies preserves :

| # | name | complexity |
|---|---|---|
| 1 | `DEMO_1_REFLEXIVITY` | Triviale - rfl suffit, pas de recherche |
| 2 | `DEMO_2_DECIDABLE` | Simple - mais piege tactique |
| 3 | `DEMO_3_HYPOTHESIS` | Intermediaire - comprendre et utiliser h |
| 4 | `DEMO_4_COMPOSITION` | Avancee - plusieurs rewrites necessaires |
| 5 | `DEMO_2_SUCCESSOR` | Simple - recherche de lemme |
| 6 | `DEMO_3_LIST_INDUCTION` | Intermediaire - induction + simplification |
| 7 | `DEMO_4_ALGEBRAIC` | Avancee - multiple strategies possibles |

`git diff --numstat` = `0 4` (aucune insertion, quatre suppressions).

## Portee — mesuree, pas supposee

**Ce n'est pas la cause du rouge CodeQL de #15908.** Huit PRs ouvertes echantillonnees (`#15928`, `#15913`, `#15927`, `#15909`, `#15514`, `#15862`, `#15846`, `#15799`) ont `Analyze (python)` **success** le 2026-09-13 entre 04:41Z et 07:12Z, avec ce meme fichier sur `main` : une erreur de parse est un **diagnostic** CodeQL, pas un echec de l'analyse. Les trois jambes rouges de #15908 (`Analyze (python)`, `(javascript-typescript)`, `(csharp)`) n'exposent **aucun** `##[error]`, aucune annotation, et un `output.title`/`summary` nul (`event=dynamic` = CodeQL default setup) : classe infra, sujet distinct.

**Sweep de classe, pour ne pas sur-vendre le correctif** : sur les **51** fichiers `.py` de `SymbolicAI/Lean/scripts/` (dont `_archive/`), c'est le **seul** en echec de syntaxe — et CodeQL en compte **1 sur 2036** a l'echelle du depot. Ce n'est donc pas une classe a corriger : c'est un fichier.

**Ce que cette PR ne fait pas** : elle ne renumerote pas les demos. La liste melange deux numerotations (`DEMO_2_DECIDABLE` / `DEMO_2_SUCCESSOR`, etc.) — c'est un choix de contenu de la liste, sans effet sur l'execution (le script itere par index et n'utilise que `demo['name']`), et hors du sujet d'une reparation de syntaxe. Signale ici pour ne pas le laisser decouvrir au merge.

Aucun fichier du catalogue touche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
