### PR TITLE
docs(ci,#15941): aligner runner-starvation-advisory sur sa matrice reelle (2 labels)

### DIFF
--- a/.github/workflows/runner-starvation-advisory.yml
+++ b/.github/workflows/runner-starvation-advisory.yml
@@ -1,4 +1,4 @@
-name: Runner starvation advisory (waiter+linux+lean)
+name: Runner starvation advisory (waiter+lean)
 
 # Sonde d'extinction multi-labels (issue #14846, grain c.1063 myia-po-2027).
 # Le 2026-09-05 entre 20:26Z et 00:52Z, le pool `coursia-waiter` est tombe
@@ -8,12 +8,13 @@ name: Runner starvation advisory (waiter+linux+lean)
 # L'organe `scripts/ci/check_runner_starvation.py` mesurait deja le predicat
 # EXTINCTION (zero runner online sur le label), mais le seul workflow qui
 # l'appelait (`linux-runner-starvation-advisory.yml`) ne couvrait que
-# `coursia-linux`. Cette sonde etend la couverture aux 3 labels requis par
-# `pr-gate.yml` (waiter) + workflows bloquants (linux, lean).
+# `coursia-linux`. Cette sonde etend la couverture a 2 des 3 labels requis
+# (`pr-gate.yml` waiter + workflows bloquants lean) ; le troisieme,
+# `coursia-linux`, reste couvert par `linux-runner-starvation-advisory.yml`.
 #
-# Pourquoi une matrice et pas 3 workflows dedies : un seul cron centralise
-# l'observabilite, les 3 sondes partagent la fenetre STARVATION et le secret
-# RUNNERS_READ_PAT, et la matrice GitHub Actions parallellise les 3 mesures
+# Pourquoi une matrice et pas 2 workflows dedies : un seul cron centralise
+# l'observabilite, les 2 sondes partagent la fenetre STARVATION et le secret
+# RUNNERS_READ_PAT, et la matrice GitHub Actions parallellise les 2 mesures
 # sans collision de rate-limit. Schedule dediee (cron offset 19,49 pour
 # coursia-linux + 23,53 pour les 2 autres -- l'offset disjoint evite de
 # charger le meme runner sur 2 vagues consecutives).
@@ -23,7 +24,7 @@ name: Runner starvation advisory (waiter+linux+lean)
 #   - predicat STARVATION : si jobs queued > seuil SANS aucun in_progress ->
 #     ::error:: (symptome distinct de l'extinction -- file profonde qui ne
 #     draine pas)
-#   - WARN floor configurable par label (waiter = 1, linux = 2, lean = 1)
+#   - WARN floor configurable par label (waiter = 1, lean = 1)
 #
 # Acceptance A2 (persistance systemd) deja livree par PR #14981 (waiter) +
 # PR #15401 (lean). Acceptance A3 (verification systemctl is-enabled po-2024)
@@ -53,7 +54,6 @@ jobs:
     # le label qu'il observe mourrait avec lui. Meme raisonnement que
     # linux-runner-starvation-advisory.yml l.44-46.
     runs-on: [self-hosted, coursia-ephemeral, coursia-linux]
-    if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2023:CoursIA -- prev: MED/docs #15881

Quoi: aligner `.github/workflows/runner-starvation-advisory.yml` sur sa matrice reelle (2 jambes) et retirer une garde `pull_request` inerte.
Preuve: diff semantique YAML recursif -> 2 differences exactement (`.name`, `.if` retire) ; `git diff --numstat` = `8 8`.
Perimetre: 1 fichier : .github/workflows/runner-starvation-advisory.yml — texte seul, aucun changement de comportement. Explicitement hors sujet : ajouter une jambe `linux` a la matrice.

## Le defaut

Le fichier tel que merge par #15423 **se decrit comme couvrant trois labels** (waiter + linux + lean) alors que sa matrice `include` en porte **deux** : `coursia-waiter` et `coursia-lean`. Le troisieme, `coursia-linux`, est couvert par son workflow dedie preexistant `linux-runner-starvation-advisory.yml` (cron `19,49`) — c'est le bon design, et le commentaire du cron le dit deja correctement.

Le symptome est concret : c'est le `name:` du workflow qui s'affiche dans l'onglet Actions et dans les notifications. Quelqu'un qui cherche pourquoi `coursia-linux` n'a pas rougi lit ce workflow-ci, en conclut qu'il couvre linux, et ne trouve pas le vrai. C'est exactement le fichier qu'on ouvre a 4 h du matin quand un pool vient de mourir.

## Les quatre sites divergents

| # | Ligne | Texte d'origine | Realite |
|---|---|---|---|
| 1 | 1 | `name: Runner starvation advisory (waiter+linux+lean)` | aucune jambe `linux` |
| 2 | 11-12 | « etend la couverture aux **3 labels** requis » | elle en etend deux |
| 3 | 14-16 | « pas **3** workflows dedies » / « les **3** sondes » / « parallellise les **3** mesures » | 2 sondes, 2 mesures |
| 4 | 26 | « WARN floor configurable par label (waiter = 1, **linux = 2**, lean = 1) » | aucune entree ne porte `linux = 2` |

Les sites **1, 2 et 4** sont ceux nommes par #15941. Le site **3 (l.14-16) ne l'est pas** : je l'ai trouve en relisant le fichier entier avant d'editer — le bloc « pourquoi une matrice et pas N workflows dedies » porte la meme divergence sous trois formes distinctes (`workflows dedies`, `sondes`, `mesures`). Corriger les trois sites nommes en laissant celui-la aurait reconstitue le probleme.

## La garde inopérante (l.56, retiree)

```yaml
if: github.event.pull_request.head.repo.full_name == null || github.event.pull_request.head.repo.full_name == github.repository
```

Les seuls triggers du fichier sont `schedule` et `workflow_dispatch` (l.37-40). Sur ces evenements le contexte `pull_request` n'existe pas : `head.repo.full_name` vaut `null`, la premiere branche de l'alternative est donc **toujours vraie** et la condition ne peut jamais etre fausse. C'est une copie de `pr-gate.yml`, ou la garde anti-fork a un sens — ici aucun. Inerte, mais un lecteur suivant peut la prendre pour une protection active et raisonner faux sur ce qui declenche ce workflow.

Retiree plutot que commentee : l'intention (« advisory par construction, jamais `pull_request`/`push` ») est deja ecrite l.32-35, ce qui rend la garde doublement redondante. #15941 laissait le choix entre les deux ; le retrait laisse un fichier plus court sans perdre d'information.

## Verification — texte seul, prouve

Diff semantique YAML recursif (pyyaml : chargement de l'arbre complet avant/apres, comparaison recursive) — **exactement deux differences, et rien d'autre** :

```
.jobs.starve.if: RETIRE <- 'github.event.pull_request.head.repo.full_name == null || ...github.repository'
.name: 'Runner starvation advisory (waiter+linux+lean)' -> 'Runner starvation advisory (waiter+lean)'
--- fin ---
```

Confirme inchanges : la matrice (2 jambes, `warn_floor: 1` et `starve_minutes: "15"` identiques), `runs-on: [self-hosted, coursia-ephemeral, coursia-linux]`, `timeout-minutes: 10`, `permissions`, `concurrency` et `steps`. Le corps du job est byte-identique apres parsing.

`git diff --numstat` = `8 8` (8 insertions, 8 suppressions — cinq blocs de texte, un remplacement de commentaire, une ligne retiree).

Le workflow est advisory par construction (declenche par `schedule` et `workflow_dispatch`, jamais par une PR) : un run rouge ne peut jamais bloquer une PR. Ce changement ne peut donc rien casser, et ne modifie aucun comportement observable — il ne touche que ce que le fichier dit de lui-meme.

## Ce que cette PR ne fait pas

Elle n'ajoute **pas** de jambe `linux` a la matrice. C'est l'autre remede envisage par #15941, et l'issue le qualifie elle-meme d'« autre grain, plus large » : le cron `23,53` a justement ete choisi disjoint de `19,49` pour cohabiter avec `linux-runner-starvation-advisory.yml`. Le sujet ici est la lisibilite du fichier, pas sa couverture.

Aucun fichier du catalogue touche.

Closes #15941
See #15423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
