### PR TITLE
docs(lean,#15944): record announced resolution of Beck-Fiala/Komlos (arXiv:2609.11189), prose-only

### DIFF
--- a/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Basic.lean
+++ b/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Basic.lean
@@ -90,9 +90,17 @@ theorem degree_le_card {α : Type*} [DecidableEq α] (F : Finset (Finset α)) (x
 `C` telle que toute famille de parties de `Fin n` de degré au plus `k` admet
 une coloration `±1` de discrépance au plus `C * √k`.
 
-C'est la conjecture ouverte centrale du domaine. Bansal–Jiang (2025) la
+Longtemps la conjecture ouverte centrale du domaine. Bansal–Jiang (2025) la
 résolvent en régime grand degré `k ≥ (log n)²` — voir
-`Discrepancy.BansalJiangLargeDegree`. -/
+`Discrepancy.BansalJiangLargeDegree`. En 2026, le preprint arXiv:2609.11189
+(Guo–Fang–Lu, 10/09/2026) annonce la résolution : borne universelle
+`3√(2πt)`, soit la dépendance en `√t` prédite par la conjecture.
+
+Ce preprint n'est **pas encore revu par les pairs** et la preuve est
+existentielle (aucune implémentation revendiquée). L'énoncé ci-dessus reste
+donc un `Prop` nommé : aucune preuve formelle n'est engagée ici. Prendre garde
+à ne pas citer la borne `√(32π)` — qui circule, mais n'est pas celle du
+papier, `3√(2π) ≈ 7,52`. -/
 def BeckFialaConjecture : Prop :=
   ∃ C : ℕ, ∀ (n k : ℕ) (F : Finset (Finset (Fin n))) (_hk : maxDegree F ≤ k),
     ∃ c : Fin n → ℤ, IsColoring c ∧ discrepancy F c ≤ C * Nat.sqrt k

--- a/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Basic_en.lean
+++ b/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Basic_en.lean
@@ -100,9 +100,16 @@ theorem degree_le_card {α : Type*} [DecidableEq α] (F : Finset (Finset α)) (x
 such that every family of subsets of `Fin n` of degree at most `k` admits a
 `±1` coloring with discrepancy at most `C * √k`.
 
-This is the central open conjecture of the field. Bansal–Jiang (2025)
-resolve it in the large-degree regime `k ≥ (log n)²` — see
-`Discrepancy.BansalJiangLargeDegree`. -/
+Long the central open conjecture of the field. Bansal–Jiang (2025) resolve it
+in the large-degree regime `k ≥ (log n)²` — see
+`Discrepancy.BansalJiangLargeDegree`. In 2026, the preprint arXiv:2609.11189
+(Guo–Fang–Lu, 10/09/2026) announces a resolution: universal bound
+`3√(2πt)`, i.e. the `√t` dependence predicted by the conjecture.
+
+That preprint is **not yet peer-reviewed** and its proof is existential (no
+implementation claimed). The statement above therefore remains a named `Prop`:
+no formal proof is engaged here. Beware of citing the bound `√(32π)` — it
+circulates, but it is not the paper's, `3√(2π) ≈ 7.52`. -/
 def BeckFialaConjecture : Prop :=
   ∃ C : ℕ, ∀ (n k : ℕ) (F : Finset (Finset (Fin n))) (_hk : maxDegree F ≤ k),
     ∃ c : Fin n → ℤ, IsColoring c ∧ discrepancy F c ≤ C * Nat.sqrt k

--- a/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Komlos.lean
+++ b/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Komlos.lean
@@ -33,7 +33,15 @@ admet une coloration `±1` des colonnes dont chaque somme de ligne reste
 bornée par `C` en valeur absolue.
 
 Le théorème de Banaszczyk (1998) donne `O(√(log n))` ; la conjecture exige
-`O(1)`. Ouverte. -/
+`O(1)`. En 2026, le preprint arXiv:2609.11189 (Guo–Fang–Lu, 10/09/2026)
+annonce la résolution : la somme signée est de norme `ℓ∞` **inférieure à**
+`3√(2π) ≈ 7,52`, indépendamment de la dimension et du nombre de colonnes.
+
+Ce preprint n'est **pas encore revu par les pairs**. L'énoncé ci-dessus reste
+un `Prop` nommé — aucune preuve formelle n'est engagée. Noter qu'il est posé
+sur `ℚ` avec `C : ℚ` alors que la borne du papier est **réelle** : tout
+alignement futur devra choisir explicitement un témoin rationnel (`8`
+convient). -/
 def KomlosConjecture : Prop :=
   ∃ C : ℚ, ∀ (m n : ℕ) (A : Matrix (Fin m) (Fin n) ℚ),
     (∀ j : Fin n, ∑ i, A i j * A i j = 1) →

--- a/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Komlos_en.lean
+++ b/MyIA.AI.Notebooks/Search/discrepancy_lean/Discrepancy/Komlos_en.lean
@@ -44,7 +44,14 @@ every matrix `A` with `n` **unit** columns (`∑ i, A i j ^ 2 = 1`) admits a
 absolute value.
 
 Banaszczyk's theorem (1998) gives `O(√(log n))`; the conjecture requires
-`O(1)`. Open. -/
+`O(1)`. In 2026, the preprint arXiv:2609.11189 (Guo–Fang–Lu, 10/09/2026)
+announces a resolution: the signed sum has `ℓ∞` norm **less than**
+`3√(2π) ≈ 7.52`, independently of dimension and of the number of columns.
+
+That preprint is **not yet peer-reviewed**. The statement above remains a named
+`Prop` — no formal proof is engaged. Note it is stated over `ℚ` with `C : ℚ`,
+whereas the paper's bound is **real**: any future alignment must explicitly
+choose a rational witness (`8` works). -/
 def KomlosConjecture : Prop :=
   ∃ C : ℚ, ∀ (m n : ℕ) (A : Matrix (Fin m) (Fin n) ℚ),
     (∀ j : Fin n, ∑ i, A i j * A i j = 1) →

--- a/MyIA.AI.Notebooks/Search/discrepancy_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/Search/discrepancy_lean/FORMAL_STATUS.md
@@ -22,9 +22,9 @@ Beck-Fiala and Komlós Bounds Beyond Banaszczyk* (arXiv:2508.03961, 2025).
 | ID | Énoncé | Nature | Statut | Livré |
 |----|--------|--------|--------|-------|
 | P0 | `Discrepancy.Basic` : `IsColoring`, `discrepancy`, `degree`, `maxDegree` + 3 lemmes (`discrepancy_empty`, `discrepancy_singleton_empty`, `degree_le_card`) | fondations | **PROUVÉ** (P0) | ce PR |
-| P0 | `BeckFialaConjecture` (`O(√k)`) | conjecture ouverte | **Prop nommée** (P0) | ce PR |
+| P0 | `BeckFialaConjecture` (`O(√k)`) | **résolution annoncée** — preprint arXiv:2609.11189 (10/09/2026), non revu | **Prop nommée** (P0) | ce PR |
 | P0 | `BeckFialaClassic` (`disc ≤ 2k − 1`) | théorème classique — la « noix » | **Prop nommée** (P0) ; cible P1 | ce PR |
-| P0 | `KomlosConjecture` (`O(1)`, colonnes unitaires) | conjecture ouverte | **Prop nommée** (P0) | ce PR |
+| P0 | `KomlosConjecture` (`O(1)`, colonnes unitaires) | **résolution annoncée** — preprint arXiv:2609.11189 (10/09/2026), non revu | **Prop nommée** (P0) | ce PR |
 | P0 | `BansalJiangLargeDegree` (BF vrai dès `k ≥ log² n`) | théorème papier 2025 | **Prop nommée** (P0) ; P3 | ce PR |
 | P0 | `KomlosBansalJiangWeak` (colonnes unitaires, `C·log² n`) | forme affaiblie concrète du papier | **Prop nommée** (P0) ; P3 | ce PR |
 | b1 | Double comptage dimensionnel `card_dangerous_lt_card_floating` (lignes à `>k` flottants ⇒ \|D\| < \|X\|) + direction de noyau `exists_dangerous_kernel_vec` (Q^X → Q^D non injective) | brique P1 | **PROUVÉ** (b1) | branche `lean/b1-discrepancy-kernel` (gated P0 #12839) |
@@ -46,7 +46,21 @@ Beck-Fiala and Komlós Bounds Beyond Banaszczyk* (arXiv:2508.03961, 2025).
 | p1a | Moments de la somme de Rademacher colorée : `expect_rademacherSum_eq_zero` (`E[Z] = 0`), `expect_rademacherSum_sq` (`E[Z²] = ∑ (c i)²`), corollaire coloration (`E[Z²] = n`) + briques `sampleExpect_coord_mul_coord` (factorisation 2-coordonnées, extension kernel), `prod_two_special`, `fairCoin`/`boolSign` | brique P2 | **PROUVÉ** (p1a, 08-25) | uniformité en `c` établie ; p1b = 4ᵉ moment + Paley–Zygmund |
 | p3 (union bound) | `colorOf` (encodage booléen → coloration ; `Fin n → ℤ` n'est PAS un Fintype, les colorations sont dénombrées comme IMAGE des `2^n` booléens), `indicator_bUnion_le_sum` (indicatrice d'union ≤ somme d'indicatrices, `Finset.induction_on`), `familyExpect_sum_finset` (linéarité Finset), `familyProb_union_le` (union bound en probabilité via `sampleExpect_mono`), `card_colorings_le` (≤ 2^n par `Finset.card_image_le`), `exists_of_familyProb_pos` (probabilité > 0 ⇒ témoin), et le théorème d'application `exists_family_beats_all_colorings` : pour n ≥ 1 il existe une famille de 12n tirages battant TOUTES les colorations (ℙ[échec] ≤ 2^n·(11/12)^(12n) < 1, numérie par induction `(2·(11/12)^12)^t < 1`) | brique P2 | **PROUVÉ** (p3, 08-26) | le second passage probabiliste (existentiel) est complet ; reste p4 contrôle de degré (`hoeffding_upper_tail`) + assemblage final ErdosSpencerLB |
 | p4 (contrôle du degré + assemblage) | `rademacherSum_eq_two_sub` (identité Z = 2·(somme des coords vraies) − somme totale, pont alea signé ↔ sommes d'ensembles), `blockOf`/`drawSet`/`pairFamily` (bloc de t = k/12 points via `Fin.castLEEmb`, tirage → coordonnées vraies, FAMILLE APPARIÉE (drawSet, bloc \\ drawSet)), `blockOf_sum`/`drawSet_sum`/`drawSet_subset`, `drawSet_mem`/`compDraw_mem`, `degree_pairFamily_le` (degré ≤ m par injection vers `Finset.range m` : chaque paire est disjointe donc un point apparaît au plus une fois par tirage), et le THÉORÈME FINAL `erdos_spencer_lb_explicit` : ∀ n k ≥ 1, k ≤ n → ∃ F, maxDegree F ≤ k ∧ ∀ C coloration, Nat.sqrt k ≤ 14 * discrepancy F C — petit k < 12 singletons, gros k = 12 tirages par bloc de k/12 points, triangulaire |Z| ≤ |x| + |x−s| ≤ 2·disc, k ≤ 23t ≤ 184·disc² | brique P2 | **PROUVÉ** (p4, 08-26, axiomes [propext, Classical.choice, Quot.sound]) | **P2 EST ASSEMBLÉ** à constante explicite √k/14 ; la forme optimiste √k/2 (`ErdosSpencerLB`) reste une `Prop` OUVERTE (obstruction structurelle : Paley–Zygmund force m ≥ 12t tirages, degré force m ≤ k — documenté dans le statut du module) |
-| P3 | Banaszczyk 1998 / formes fortes du papier 2025 | aspiration | **NON ENGAGÉ** — exige SDP + dualité, indépendance spectrale affine, brownien discret guidé, concentration matricielle : **aucun de cet étage n'existe dans Mathlib** (vérifié 2026-08-24). Documenté, jamais promis. | — |
+| P3 | Banaszczyk 1998 / formes fortes des papiers 2025 **et 2026** | aspiration | **NON ENGAGÉ** — exige SDP + dualité, indépendance spectrale affine, brownien discret guidé, concentration matricielle : **aucun de cet étage n'existe dans Mathlib** (vérifié 2026-08-24). **Réaudité 2026-09-13** contre le Mathlib pinné (`520045ab`, v4.32.1) : le contournement proposé par arXiv:2609.11189 ne supprime pas l'obstruction, il la **déplace** — sa route exige la *variation totale directionnelle* d'une densité sur convexe ouvert et la *transformée de Banaszczyk* préservée sous translation, deux notions **absentes du même Mathlib** (`Banaszczyk` : 0 occurrence ; `totalVariation` n'existe que pour les mesures signées ; la théorie BV de Mathlib concerne la dérivabilité a.e. des fonctions de `ℝ`). Ce que ce papier rapproche, ce sont les *socles* : gaussiennes (`Probability/Distributions/Gaussian/*`) et `ConvexBody` (`Analysis/Convex/Body.lean`) sont présents ; le **pont** manque. Documenté, jamais promis. | — |
+
+### Statut épistémique — mise à jour 2026-09-13
+
+Le preprint **arXiv:2609.11189** (*Vector Balancing via Directional Total Variation*, Guo–Fang–Lu, soumis le 10/09/2026) annonce une borne universelle de **`3√(2π) ≈ 7,52`** pour le problème de signature de Komlós, et **`3√(2πt)`** pour Beck–Fiala au degré `t` — soit la dépendance en `√t` prédite par la conjecture. Cela **retire aux deux énoncés leur statut de conjecture ouverte**.
+
+Trois réserves, qui sont la raison pour laquelle la colonne « Statut » ci-dessus continue de dire `Prop nommée` et non « résolue » :
+
+1. le preprint a moins d'une semaine et **n'est pas revu par les pairs** ;
+2. la preuve annoncée est **existentielle** (aucune implémentation revendiquée, constante non optimale) ;
+3. les énoncés de ce lake ne sont **pas verbatim** ceux du papier — `ℚ` contre `ℝ`, `Nat.sqrt` (plancher entier) contre `√` réelle, borne stricte contre non stricte. Écrire « résolue » laisserait croire que *l'énoncé du lake* est déchargé : il ne l'est pas, aucune preuve formelle n'est engagée ici.
+
+**Attention à la constante** : `3√(2π) = √(18π) ≈ 7,5199`. La forme `√(32π) ≈ 10,0265`, qui circule, **n'est pas** celle du papier — c'est exactement 4/3 de celle-ci.
+
+Fait notable, cité verbatim depuis l'abstract : *« The proof was discovered by the Odin Automatic AI Research Agent. »*
 
 ## Découpage de la noix (P1) — grignotage multi-cycles
 


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2026:CoursIA — prev: DEEP/slides #15865

## Résumé

Le lake `discrepancy_lean` déclare `BeckFialaConjecture` et `KomlosConjecture` comme **ouvertes** dans ses docstrings et `FORMAL_STATUS.md`. Le preprint **arXiv:2609.11189** (*Vector Balancing via Directional Total Variation*, Guo–Fang–Lu, 10/09/2026) annonce leur résolution. Cette PR enregistre le **changement d'état épistémique** — en le qualifiant honnêtement — sans engager aucune preuve formelle. Édition **prose uniquement** : aucune ligne de code Lean ne bouge (preuve §3).

See #15944 — le livrable déclaré par l'issue (verdict motivé, points 1/2/5) est livré en [commentaire](https://github.com/jsboige/CoursIA/issues/15944#issuecomment-5652364861) ; cette PR exécute le point 3 (statut épistémique) et prépare le 4.

## 1. La constante du papier n'est pas celle de l'issue — corrigée contre la source

L'issue (et son titre) portent `√(32π) ≈ 10,0265`. Lu à la source (abstract intégral), le papier annonce **`3√(2π)` = `√(18π)` ≈ 7,5199** pour Komlós et **`3√(2πt)`** pour Beck–Fiala au degré `t`. Le rapport est exactement **4/3**. Recopier le corps de l'issue dans les docstrings y aurait gravé une borne qui n'est pas celle de la publication — les docstrings citent donc la constante du papier, avec l'avertissement explicite de ne pas confondre avec la forme `√(32π)` qui circule.

## 2. « Résolution annoncée », pas « résolue » — trois raisons mesurées

La colonne Statut de `FORMAL_STATUS.md` passe de `conjecture ouverte` à **`résolution annoncée — preprint arXiv:2609.11189 (10/09/2026), non revu`**, et les `Prop` **restent des `Prop`** :

1. preprint de 3 jours, **non revu par les pairs** (l'issue elle-même le préconise : « attendre l'écho communautaire… en qualifiant honnêtement ») ;
2. la preuve annoncée est **existentielle**, constante non optimale ;
3. les énoncés du lake ne sont **pas verbatim** ceux du papier — `ℚ` contre `ℝ`, `Nat.sqrt` (plancher entier) contre `√` réelle, stricte contre non stricte. Écrire « résolue » laisserait croire que *l'énoncé du lake* est déchargé : il ne l'est pas.

La docstring de `KomlosConjecture` consigne l'écart concret : l'énoncé est sur `ℚ` avec `C : ℚ` alors que la borne du papier est **réelle** — tout alignement futur devra choisir un témoin rationnel explicite (`8` convient).

## 3. Preuves — l'édition est prose-only et le lake build est SUCCESS

| Contrôle | Résultat |
|---|---|
| **`lake build` (arbre édité)** | **`Build completed successfully (8677 jobs)` · EXIT=0** (2026-09-13T09:20:05Z), toolchain **v4.32.1**, mathlib `520045ab` (cache : 8638 oleans). Les oleans `Basic.olean`, `Basic_en.olean`, `Komlos.olean`, `Komlos_en.olean` sont matérialisés ; fenêtre de build 09:14:32Z→09:20:05Z **postérieure** aux mtimes des 4 fichiers édités (09:07:59Z/09:08:11Z) — le build a compilé **mes** versions. Les seuls warnings du log appartiennent à `ErdosSpencer/Moments.lean` et `ErdosSpencer/LB.lean` (préexistants, non touchés). |
| **Identité des lignes de code** | Strip des commentaires/docstrings **nesté** (`/- -/` s'imbriquent, `--` à fin de ligne) puis comparaison des lignes porteuses de code vs blob `origin/main` : `CODE IDENTIQUE` **27→27** (Basic), **27→27** (Basic_en), **20→20** (Komlos), **20→20** (Komlos_en) — aucune ligne de code modifiée. |
| **Siblings i18n (#4980)** | `check_i18n_siblings.py` : **3/3 paires byte-identiques**, 0 consumer-pattern, 0 drift, 0 orphan, 0 unbuilt. FR et `_en` ne diffèrent que par les docstrings. |
| **Instrument canonique sorry** | `scripts/lean/count_code_sorry.py --json --lake …discrepancy_lean` : `files 14, naive_sorry 6, code_sorry 0, distinct_code_sorry 0` — l'invariant 0-`sorry` du lake est inchangé. |

## 4. Contenu par fichier

- **`Discrepancy/Basic.lean` + `Basic_en.lean`** — docstring de `BeckFialaConjecture` : « Longtemps la conjecture ouverte centrale du domaine » + le preprint, la borne `3√(2πt)`, la réserve « pas encore revu par les pairs », « reste donc un `Prop` nommé », et l'avertissement constant (`3√(2π) ≈ 7,52`, pas `√(32π)`).
- **`Discrepancy/Komlos.lean` + `Komlos_en.lean`** — même traitement pour `KomlosConjecture` + l'observation ℚ-vs-ℝ avec témoin `8`.
- **`FORMAL_STATUS.md`** — lignes P0 des deux conjectures : nature → `résolution annoncée…non revu` ; **P3 réaudité** contre le Mathlib pinné (`520045ab`, v4.32.1) : la route du papier ne supprime pas l'obstruction, elle la **déplace** (variation totale directionnelle d'une densité sur convexe ouvert, transformée de Banaszczyk : `Banaszczyk` 0 occurrence — contrôle positif `withDensity` → 1412 — ; `totalVariation` uniquement pour mesures signées ; la théorie BV de Mathlib = dérivabilité a.e. sur ℝ) ; nouvelle section **« Statut épistémique — mise à jour 2026-09-13 »** (les 3 réserves, la constante, la citation verbatim *« The proof was discovered by the Odin Automatic AI Research Agent. »*).

## 5. Résiduel nommé (hors périmètre de cette PR)

La table « course aux bornes » des notebooks `Search-09c` (×14 occurrences `2k-1`, ×6 `Banaszczyk`) et `Search-09d` (×5, ×4) — point 4 de l'issue — exige la **ré-exécution** des notebooks modifiés (C.2/H.3), pas une édition markdown. Grain séparé, maintenant débloqué : le lake build étant SUCCESS, le kernel de 09d est exécutable.

Périmètre : **5 fichiers, +54/−10**, catalogue non touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
