### PR TITLE
feat(complexity,#15949): notebook Hartmanis-Stearns hierarchie en temps + serie Complexity/ (volet 1/3)

### DIFF
--- a/MyIA.AI.Notebooks/Complexity/Complexity-01-HartmanisStearns-TimeHierarchy.ipynb
+++ b/MyIA.AI.Notebooks/Complexity/Complexity-01-HartmanisStearns-TimeHierarchy.ipynb
@@ -1,0 +1,1242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002495,
+     "end_time": "2026-09-13T10:13:00.133443",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.130948",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Complexity-01 — Le théorème de hiérarchie temporelle de Hartmanis et Stearns (1965)\n",
+    "\n",
+    "> **Hommage.** Richard E. Stearns (5 juillet 1936 — 29 août 2026, Ann Arbor) a reçu avec Juris\n",
+    "> Hartmanis le **prix Turing 1993** *« in recognition of their seminal paper which established the\n",
+    "> foundations for the field of computational complexity theory »*. Leur article de 1965 — écrit\n",
+    "> dans un laboratoire industriel de GE à Schenectady, pour un champ qui n'avait pas encore de nom —\n",
+    "> **lui a donné son nom** : *On the computational complexity of algorithms*, Trans. Amer. Math.\n",
+    "> Soc. 117, 285–306. Karp (1985) : *« it is the 1965 paper by Juris Hartmanis and Richard Stearns\n",
+    "> that marks the beginning of the modern era of complexity theory. »* Ce notebook travaille leur\n",
+    "> théorème. Sources biographiques : [CACM In Memoriam](https://cacm.acm.org/news/in-memoriam-richard-e-stearns-1936-2026/)\n",
+    "> (Spafford & Garfinkel, 03/09/2026) et [Computational Complexity blog](https://blog.computationalcomplexity.org/2026/09/richard-stearns-1936-2026.html)\n",
+    "> (Gasarch, 04/09/2026).\n",
+    "\n",
+    "> **Écho dans le dépôt.** Ce notebook est la **pierre inaugurale de la série `Complexity/`** — le\n",
+    "> geste fondateur de Hartmanis et Stearns (compter les pas d'une machine comme on compte des\n",
+    "> mètres) manquait au corpus, alors que les séries voisines l'effleurent :\n",
+    "> [SL-10 — Apprentissage actif d'automates](../SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb)\n",
+    "> (automates, sans le théorème qui en fonde la hiérarchie),\n",
+    "> [App-13b — TSP métaheuristiques](../Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb)\n",
+    "> (Stearns a produit la première analyse de pire cas des heuristiques du voyageur de commerce),\n",
+    "> et [SocialChoice-01 — Arrow](../GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb)\n",
+    "> (le **tout premier papier** de Stearns, étudiant, portait sur le paradoxe d'Arrow — 1959).\n",
+    "> Précédent d'hommage par l'œuvre : [GameTheory-23 — Munkres](../GameTheory/GameTheory-23-Munkres-Assignment.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0027,
+     "end_time": "2026-09-13T10:13:00.138484",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.135784",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Pourquoi ce notebook\n",
+    "\n",
+    "Le geste de 1965 tient en une phrase : **le temps est une ressource mesurable, et le mesurer\n",
+    "crée une hiérarchie stricte de problèmes**. Avant Hartmanis et Stearns, on savait qu'un\n",
+    "problème était « décidable » ou non ; après eux, on sait demander *en combien de pas*. La\n",
+    "rétrospective de Stearns sur Shannon donne la motivation d'origine : *« he thought there must\n",
+    "be a reason why things are hard »* — il doit y avoir une raison pour que certaines choses\n",
+    "soient dures, et cette raison se mesure.\n",
+    "\n",
+    "Ce notebook suit le papier en quatre gestes, **tous exécutés** dans des cellules Python :\n",
+    "\n",
+    "1. **Compter les pas** — un simulateur de machine de Turing multitête (le modèle exact du\n",
+    "   papier de 1965), avec compteur de pas : la hiérarchie se lit dans des comptes exacts, pas\n",
+    "   dans des chronomètres (section 1) ;\n",
+    "2. **Séparer empiriquement** — là où le chronomètre parle : force brute contre programmation\n",
+    "   dynamique sur subset-sum, le point de bascule mesuré (section 2) ;\n",
+    "3. **Diagonaliser** — l'argument de Cantor–Turing adapté aux budgets de temps, construit et\n",
+    "   vérifié sur une famille finie de machines (section 3) ;\n",
+    "4. **Énoncer le théorème** — la hiérarchie de 1965, ses hypothèses exactes\n",
+    "   (temps-constructibilité), et le prix de la simulation rendu visible (section 4).\n",
+    "\n",
+    "La section 5 relie l'homme à l'œuvre inattendue (Arrow, jeux répétés), la section 6 mesure\n",
+    "honnêtement ce qui existe et manque dans Mathlib pour formaliser ce théorème, la section 7\n",
+    "conclut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:00.143879Z",
+     "iopub.status.busy": "2026-09-13T10:13:00.143879Z",
+     "iopub.status.idle": "2026-09-13T10:13:00.479296Z",
+     "shell.execute_reply": "2026-09-13T10:13:00.479296Z"
+    },
+    "papermill": {
+     "duration": 0.3394,
+     "end_time": "2026-09-13T10:13:00.480310",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.140910",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Complexity-01 — Hartmanis-Stearns (1965)\n",
+      "numpy 2.2.6, matplotlib 3.10.8\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print(\"Complexity-01 — Hartmanis-Stearns (1965)\")\n",
+    "print(f\"numpy {np.__version__}, matplotlib {plt.matplotlib.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002507,
+     "end_time": "2026-09-13T10:13:00.484816",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.482309",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le geste fondateur : compter les pas\n",
+    "\n",
+    "Le papier de 1965 ne chronomètre pas : il **compte**. Le modèle est la machine de Turing\n",
+    "**multitête** (plusieurs rubans, une tête par ruban), et la ressource est le **nombre de pas**\n",
+    "exact de la machine. Ce compte est déterministe, reproductible, indépendant du matériel — c'est\n",
+    "l'unité de mesure qui fonde la discipline.\n",
+    "\n",
+    "Le simulateur ci-dessous implémente ce modèle : des rubans infinis aux deux extrémités, une\n",
+    "tête par ruban, des transitions $(q, a_1, \\dots, a_k) \\mapsto (q', \\text{écritures}, \\text{déplacements})$,\n",
+    "et surtout un **compteur de pas** — l'instrument du geste fondateur. Une machine s'arrête soit\n",
+    "dans un **état acceptant**, soit par blocage (aucune transition applicable) : le rejet est le\n",
+    "blocage, comme sur les machines du papier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:00.491119Z",
+     "iopub.status.busy": "2026-09-13T10:13:00.490602Z",
+     "iopub.status.idle": "2026-09-13T10:13:00.499103Z",
+     "shell.execute_reply": "2026-09-13T10:13:00.498569Z"
+    },
+    "papermill": {
+     "duration": 0.011642,
+     "end_time": "2026-09-13T10:13:00.499103",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.487461",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "increment('1011') -> 1100 (attendu 1100), etat=qF, 8 pas\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Ruban:\n",
+    "    \"\"\"Ruban infini aux deux extremites, symbole blanc '_'.\"\"\"\n",
+    "    def __init__(self, mot=\"\"):\n",
+    "        self.cellules = {i: c for i, c in enumerate(mot)}\n",
+    "        self.tete = 0\n",
+    "\n",
+    "    def lire(self):\n",
+    "        return self.cellules.get(self.tete, \"_\")\n",
+    "\n",
+    "    def ecrire(self, c):\n",
+    "        self.cellules[self.tete] = c\n",
+    "\n",
+    "    def deplacer(self, d):\n",
+    "        self.tete += 1 if d == \"R\" else (-1 if d == \"L\" else 0)\n",
+    "\n",
+    "\n",
+    "class MachineTuring:\n",
+    "    \"\"\"Machine multitete au sens de Hartmanis-Stearns 1965, compteur de pas inclus.\n",
+    "    Retourne l'etat d'arret : un etat acceptant, ou None (blocage = rejet / budget epuise).\"\"\"\n",
+    "    def __init__(self, k_rubans, transitions, etat_initial, etats_acceptants):\n",
+    "        self.k = k_rubans\n",
+    "        self.delta = transitions  # (etat, symboles lus) -> (nouvel etat, [(ecriture, deplacement)] * k)\n",
+    "        self.q0 = etat_initial\n",
+    "        self.F = set(etats_acceptants)\n",
+    "        self.pas = 0\n",
+    "\n",
+    "    def run(self, mot, max_pas=100_000):\n",
+    "        rubans = [Ruban(mot) if i == 0 else Ruban() for i in range(self.k)]\n",
+    "        etat = self.q0\n",
+    "        self.pas = 0\n",
+    "        while etat not in self.F:\n",
+    "            if self.pas >= max_pas:\n",
+    "                return None, rubans  # budget epuise\n",
+    "            lus = tuple(r.lire() for r in rubans)\n",
+    "            if (etat, lus) not in self.delta:\n",
+    "                return None, rubans  # blocage : rejet\n",
+    "            etat, ecritures = self.delta[(etat, lus)]\n",
+    "            for r, (c, d) in zip(rubans, ecritures):\n",
+    "                r.ecrire(c)\n",
+    "                r.deplacer(d)\n",
+    "            self.pas += 1\n",
+    "        return etat, rubans\n",
+    "\n",
+    "\n",
+    "def lire_ruban(r):\n",
+    "    if not r.cellules:\n",
+    "        return \"\"\n",
+    "    fin = max(r.cellules)\n",
+    "    return \"\".join(r.cellules.get(i, \"_\") for i in range(fin + 1)).rstrip(\"_\")\n",
+    "\n",
+    "\n",
+    "# --- Machine A : increment binaire, 1 ruban ---\n",
+    "inc = MachineTuring(\n",
+    "    1,\n",
+    "    {\n",
+    "        (\"q0\", (\"0\",)): (\"q0\", ((\"0\", \"R\"),)),\n",
+    "        (\"q0\", (\"1\",)): (\"q0\", ((\"1\", \"R\"),)),\n",
+    "        (\"q0\", (\"_\",)): (\"q1\", ((\"_\", \"L\"),)),\n",
+    "        (\"q1\", (\"1\",)): (\"q1\", ((\"0\", \"L\"),)),\n",
+    "        (\"q1\", (\"0\",)): (\"qF\", ((\"1\", \"S\"),)),\n",
+    "        (\"q1\", (\"_\",)): (\"qF\", ((\"1\", \"S\"),)),\n",
+    "    },\n",
+    "    \"q0\", [\"qF\"],\n",
+    ")\n",
+    "\n",
+    "etat, rubans = inc.run(\"1011\")\n",
+    "print(f\"increment('1011') -> {lire_ruban(rubans[0])} (attendu 1100), etat={etat}, {inc.pas} pas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:00.505231Z",
+     "iopub.status.busy": "2026-09-13T10:13:00.505231Z",
+     "iopub.status.idle": "2026-09-13T10:13:00.524363Z",
+     "shell.execute_reply": "2026-09-13T10:13:00.524363Z"
+    },
+    "papermill": {
+     "duration": 0.023044,
+     "end_time": "2026-09-13T10:13:00.525166",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.502122",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "verifications : pal accepte 0110, 0110110, 0 ; rejette 0100 (blocage). OK\n",
+      "\n",
+      "   n |  pas inc |  pas pal | rapport pal/inc\n",
+      "----------------------------------------\n",
+      "   8 |       10 |       69 |         6.90x\n",
+      "  16 |       18 |      233 |        12.94x\n",
+      "  32 |       34 |      849 |        24.97x\n",
+      "  64 |       66 |     3233 |        48.98x\n",
+      " 128 |      130 |    12609 |        96.99x\n",
+      "\n",
+      "Le compte exact confirme la theorie : increment ~ lineaire, palindrome ~ quadratique.\n",
+      "C'est LE geste de 1965 : la ressource n'est pas un chrono, c'est un compte de pas.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Machine B : palindrome sur {0,1}, 1 ruban, zigzag O(n^2) ---\n",
+    "# Comparer premier et dernier caractere, les rayer ('x'), recommencer.\n",
+    "# Rejet = etat puits 'rejeter' sans transition sortante -> blocage.\n",
+    "D = {}\n",
+    "D[(\"scan\", (\"0\",))] = (\"marque0\", ((\"x\", \"R\"),))\n",
+    "D[(\"scan\", (\"1\",))] = (\"marque1\", ((\"x\", \"R\"),))\n",
+    "D[(\"scan\", (\"x\",))] = (\"scan\", ((\"x\", \"R\"),))\n",
+    "D[(\"scan\", (\"_\",))] = (\"fin\", ((\"_\", \"S\"),))          # ruban epuise -> accepter\n",
+    "D[(\"marque0\", (\"0\",))] = (\"marque0\", ((\"0\", \"R\"),))\n",
+    "D[(\"marque0\", (\"1\",))] = (\"marque0\", ((\"1\", \"R\"),))\n",
+    "D[(\"marque0\", (\"x\",))] = (\"verif0\", ((\"x\", \"L\"),))\n",
+    "D[(\"marque0\", (\"_\",))] = (\"verif0\", ((\"_\", \"L\"),))\n",
+    "D[(\"marque1\", (\"0\",))] = (\"marque1\", ((\"0\", \"R\"),))\n",
+    "D[(\"marque1\", (\"1\",))] = (\"marque1\", ((\"1\", \"R\"),))\n",
+    "D[(\"marque1\", (\"x\",))] = (\"verif1\", ((\"x\", \"L\"),))\n",
+    "D[(\"marque1\", (\"_\",))] = (\"verif1\", ((\"_\", \"L\"),))\n",
+    "D[(\"verif0\", (\"0\",))] = (\"retour\", ((\"x\", \"L\"),))      # dernier = 0 : rayer\n",
+    "D[(\"verif1\", (\"1\",))] = (\"retour\", ((\"x\", \"L\"),))      # dernier = 1 : rayer\n",
+    "D[(\"verif0\", (\"1\",))] = (\"rejeter\", ((\"1\", \"S\"),))     # mismatch -> puits\n",
+    "D[(\"verif1\", (\"0\",))] = (\"rejeter\", ((\"0\", \"S\"),))\n",
+    "D[(\"verif0\", (\"x\",))] = (\"fin\", ((\"x\", \"S\"),))         # un seul caractere restant\n",
+    "D[(\"verif1\", (\"x\",))] = (\"fin\", ((\"x\", \"S\"),))\n",
+    "for s in (\"0\", \"1\", \"x\"):\n",
+    "    D[(\"retour\", (s,))] = (\"retour\", ((s, \"L\"),))\n",
+    "D[(\"retour\", (\"_\",))] = (\"scan\", ((\"_\", \"R\"),))        # revenir au debut\n",
+    "pal = MachineTuring(1, D, \"scan\", [\"fin\"])\n",
+    "\n",
+    "# Verification de correction avant toute mesure\n",
+    "for mot, attendu in [(\"0110\", \"fin\"), (\"0100\", None), (\"0\", \"fin\"), (\"0110110\", \"fin\")]:\n",
+    "    etat, _ = pal.run(mot)\n",
+    "    assert etat == (attendu if attendu else None), f\"pal({mot}) -> {etat}, attendu {attendu}\"\n",
+    "print(\"verifications : pal accepte 0110, 0110110, 0 ; rejette 0100 (blocage). OK\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"{'n':>4} | {'pas inc':>8} | {'pas pal':>8} | rapport pal/inc\")\n",
+    "print(\"-\" * 40)\n",
+    "for n in (4, 8, 16, 32, 64):\n",
+    "    moitie = \"\".join(\"01\"[(i * 7) % 2] for i in range(n))\n",
+    "    mot = moitie + moitie[::-1]        # palindrome de longueur 2n\n",
+    "    inc.run(mot)\n",
+    "    pal.run(mot, max_pas=500_000)\n",
+    "    print(f\"{len(mot):>4} | {inc.pas:>8} | {pal.pas:>8} | {pal.pas / inc.pas:>12.2f}x\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Le compte exact confirme la theorie : increment ~ lineaire, palindrome ~ quadratique.\")\n",
+    "print(\"C'est LE geste de 1965 : la ressource n'est pas un chrono, c'est un compte de pas.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002005,
+     "end_time": "2026-09-13T10:13:00.529776",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.527771",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Les deux machines tournent sur la même famille d'entrées (des palindromes de\n",
+    "longueur croissante), et leurs comptes de pas croissent comme $\\Theta(n)$ et $\\Theta(n^2)$. La\n",
+    "définition fondatrice s'écrit alors naturellement :\n",
+    "\n",
+    "$$\\mathrm{TIME}(f) = \\{ L \\mid \\text{une machine multitête décide } L \\text{ en } O(f(n)) \\text{ pas} \\}$$\n",
+    "\n",
+    "Tout l'édifice de la discipline est dans cette parenthèse : la **classe** n'est pas une\n",
+    "propriété d'un problème isolé mais d'une **famille** d'instances mesurée en nombre de pas.\n",
+    "La question fondatrice de Hartmanis et Stearns devient : *ces ensembles sont-ils emboîtés\n",
+    "strictement ?* Y a-t-il des problèmes qui exigent *réellement* plus de pas — pas par\n",
+    "maladresse de programmeur, mais par nature ?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003025,
+     "end_time": "2026-09-13T10:13:00.534801",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.531776",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Séparer : ce que « plus de temps achète » se mesure\n",
+    "\n",
+    "Avant le théorème, l'intuition expérimentale. Trois familles d'algorithmes, trois croissances\n",
+    "($n \\log n$, $n^2$, $2^n$), mesurées au chronomètre — ici le chrono est légitime : il\n",
+    "approxime le compte de pas à un facteur machine près.\n",
+    "\n",
+    "**Subset-sum** servira de séparatrice honnête : le même problème, deux algorithmes —\n",
+    "force brute en $\\Theta(2^n \\cdot n)$ contre programmation dynamique en $\\Theta(n \\cdot S)$ —\n",
+    "et l'écart mesuré. C'est la version lisible de ce que le théorème de la section 4 démontre\n",
+    "pour des langages *bien choisis* : plus de budget de temps sépare des classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:00.540027Z",
+     "iopub.status.busy": "2026-09-13T10:13:00.540027Z",
+     "iopub.status.idle": "2026-09-13T10:13:02.952871Z",
+     "shell.execute_reply": "2026-09-13T10:13:02.952871Z"
+    },
+    "papermill": {
+     "duration": 2.41757,
+     "end_time": "2026-09-13T10:13:02.953879",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:00.536309",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAG4CAYAAAC5CgR7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAi7hJREFUeJztnQecE9X2x3/JwrK0XVhg6VWKIFW6oKIigoK9PxFQ0adYsWEv7yl2sfBEeaJiA5EnKioq/EEQEKQpRUSkS1lgYXdh2Zr8P+eGxCSb3Z0kM5lM5vflEzYzuffcOzNnbk7OnHuuw+12u0EIIYQQQojFcJrdAUIIIYQQQiKBhiwhhBBCCLEkNGQJIYQQQogloSFLCCGEEEIsCQ1ZQgghhBBiSWjIEkIIIYQQS0JDlhBCCCGEWBIasoQQQgghxJLQkCWEWJqpU6fi9ddfh53Jzs7Gk08+iUWLFpndFUIIiSk0ZG2Ow+HA448/DqswcuRItGjRwuxukDjhiy++wD//+U+cfPLJSBREv0XPw+H666/HN998gx49eoTd3rvvvqvGgRUrVkAvZEwRmdEeVyTo3c6AAQPUixAr8u7x+3vbtm0Jq9M0ZOMUUTwtrwULFpjdVUJMQQZmMeA+/PBDnHLKKUhU5B4P/iLy55VXXsGvv/6KL7/8ElWrVo15/wiJB/7zn/8oo43Yj0pmd4CE5v333y/1+PT7778vtb99+/ZRtXPs2DFUqmQdNZg8eTJcLpfZ3SBxwJo1a/Dmm2/ioosugl0pLCzE0aNHMWfOHNStW9fs7hBiqiEr90AsvP4kvrCOBWMzrrnmmoDtn376SRmywfuDycvLQ7Vq1TS3k5KSAjORL+Hq1atrLl+5cmVD+0PiE7fbjfz8/ACP44UXXgi7k5ycjAcffNDsbhCddTtREKeD/Ngy+3smkRBdkfve6eQDdS88ExZGYlw6duyIlStX4rTTTlMGrPdLLTMzUz12rV+/vhpEunTpgvfee6/CGNnc3FzceeedKs6sSpUqyMjIwNlnn41Vq1ZV2J+//vpLtdmoUSNVt2XLlrj55pvVQOYfq/PDDz/glltuUbKbNGkS8Iv6pJNOUnVFxpgxY3D48OEKY2SnTZuG7t27o2bNmkhNTUWnTp3U41YvRUVFeOKJJ9CmTRt1LurUqYP+/furHwZe5NGsyG7VqpUq06BBA1x33XU4ePBgyNi/zZs3q/K1atVCWloaRo0apX5EBPPBBx+gV69e6trUrl1bXafvvvsuoIzENp566qnKoJdjOO+887B+/fqAMnv37lVtyPmS89OwYUNccMEFZT5u9j9fNWrUwI4dOzB06FD1vnHjxpg4caL6fO3atTjzzDNV282bN8dHH31USoZcA9GJpk2bqrZbt26NZ599tpRnvKLrECpusqwYLrnG0t9vv/1WxX3Kl7x4X8Ppj2xPmDBB6ZRcU7kXbrrpJhw6dCignMSGnnPOOcqbI+2I3sq1j3eWLVuGwYMHK/0T/Tr99NOxePHisO9LLwUFBRg7dizq1aun9EE83fv37y8lT4u+akXrtSzLAPz3v/+t7gk5/jPOOKPMfkTTTjBy3h599FGl63Lu5TzI+Zg/f76m+nroth5jnvB///d/vmspY5mMKb/99pumeQmh7mfZvvXWW1W4j3csl6cFWvUw0usk/ZNrL98t3rA7/xhQLXJl/JF6L7zwghof5btA9GrQoEHYuXOn0rd//etfSt/kmsm5ysrKCnltZYzv2rWrOvcdOnTA//73v1J93rJlCy677DKkp6erdvr06YOvvvoqZFiRXO+HH35Yjd1SNicnJ6wxQAty/z/22GPq3Mg5knN13333qf3xDj2yFkcMrSFDhuDKK69U3lr5spZwAbmJxdiSQUUGjBkzZqgBSW7oO+64o0x5MnHm008/VfXkBhT5P/74oxrcyptQs3v3bmWwifwbb7wRJ554ohq4RJYYePIL0osYsfJlKV8G4pH1Dooy8A4cOFANbr///jveeOMN/Pzzz+rGLMsTKwPzVVddhbPOOksNTIL0Vep4j1Nkjx8/HjfccIPqowwCYryIcS5GuleODCxiLIoRK4PiW2+9pf6KNzx4wL788svVeRW5Iue///2vMsy9fRDkeKRtid+UGeVyDmTgkS8PGRwFCRUZMWKEMqSkrpwrOW750lm9erXvC+SSSy5RfbntttvUPvmhIn0WA7WiyW8lJSVKR8SIfu6559SXjFxf+fJ66KGH8I9//AMXX3wxJk2ahGuvvRZ9+/ZVxyZIf2RwlGspRmCzZs2wZMkSPPDAA9izZ48yFLVeh3ARHRCZ0u7o0aPRrl07zf0R5HMxkuWa3n777di6davKbiDn1atTch7lWog+jhs3Tn2ZyxdaqC+eeEJ0SK6pGDPy5SPemXfeeUf9KJHMBaLn4d6XolvyY0vkyTmQcyl6Mn36dF8ZrfqqhXCuZShk/BBD9txzz1UvuQ/lWgYb6NG2E4yMH3K/i26KXsqP/7fffludk+XLlysDxkjd1mvMmzt3rtIhMdikvHxvvPbaa+jXr58qF+mkWtHNTz75ROmO/DgUOVr0MJrrJJ+J/soPdRnTBPkuFMKVK+Oj6JDIE0NVxkwZ7+XeEsPy/vvvV9+tcq7uueceTJkyJaD+H3/8gSuuuEJ9l8q9IvelGKxi0HvP/b59+9T3gvRNxib5oSGOpvPPP1+dk+BwKTGg5RxJe2JYynutY4AWxKCXtuW7Xq6PhCyKk+Pll1/Gpk2bMGvWLMQ1bmIJxowZ4w6+XKeffrraN2nSpID9EyZMUPs/+OAD377CwkJ337593TVq1HDn5OT49ku5xx57zLedlpam2gqXa6+91u10Ot0///xzqc9cLpf6+84776j2+vfv7y4uLvZ9npmZ6U5OTnYPGjTIXVJS4tv/+uuvq/JTpkzx7RsxYoS7efPmvu077rjDnZqaGiAvmC5durjPO++8cvufl5dXat/HH3+s2l+4cKFvn5wr2XfdddcFlL3ooovcderU8W3/8ccf6nzIfv9j8j8fubm57lq1arlHjx4d8PnevXvVdfDuP3TokGrz+eefd4eLnC+p+/TTT/v2ibyqVau6HQ6He9q0ab79GzduLKUP//rXv9zVq1d3b9q0KUDuuHHj3ElJSe4dO3Zovg7ecxeMVy+2bt3q2yfXWPbNmTMnoKzW/ixatEjV//DDDwPKiTz//Z999pnaDqW3ZiHHLtetLER/2rRp4z7nnHN8uuTV4ZYtW7rPPvvsiO7LgQMHBsi766671Dk9fPhwWPpa1rUOPi6t1zIU3jFD7mv/Pj/44IOqXb3a8Y6z8vIiOl5QUBBQRu6p+vXrlxoXQhGtbus15nXt2tWdkZHhPnjwoG/fL7/8ovRF9KasMbe8ayzbUn/9+vUB+7XoYbTX6aSTTgq4Tl60ypXxR/pfr149n84LDzzwgNov57SoqMi3/6qrrlI6mJ+fX+razpw507cvOzvb3bBhQ3e3bt18++68805VTsYpL3J/yf3bokUL33fG/PnzVblWrVoFfEeFMwa8E2J8Ddbp999/X10f//4IYltI3cWLF7vjGYYWWBx5BCAeJ3++/vpr5VWUX+1exPskv/yOHDmiHr+UhXikxGsov6DD+TUnv9iGDRsWMv1PsDdTPBBJSUm+bfEMyC9gefTjH/cj5eSxWfDjluD+ilc3+JFZcBnxZsov5bLwj0+TGKQDBw6oRz1CqLAK+bXtjzyeE++195GPnA85L+I1Co5l8p4P6bN4KOQ6SXvel5yb3r17+x5VSt/kF7h4A4Ifi2tFPDP+50M8QOKRFU+DF9knn4ln2ot48uXYxFPn30fxnIund+HChZqvQ7iIV1i8XP5o7Y+Uk8dt4gHxLyfeC/HaeM+t9FuYPXu2ehxrlUluostXX3210jnvscn5Fy+dnAPRvXDvS/HE+O+T8yzndPv27WHpq1a0XstQeMcM8Zr591nGED3bCYUcr9eTLedYvHbFxcXqHGsJwYpWt/UY88QTKXokT+nk0baXzp07q3tGvkMiRbyf8jTPi1Y91Ps6eQlXrnhPZezwIrotyBNP/4nRsl90UDy9/kjohL9HVb7D5EmXPLGQEDFBzq94TOVJhhcZl+QelKchGzZsCJApnl3/7yitY0A450i8sOIp9z9H4t0Vwr23Yw1DCyyOxMz4Px4U5ItHYqOCDShvhgPvF1Mo5DGK3DQSHyNf+vLITm5CefxUFhJHJwacxOtqwfvY2r+/XkPKHzkuabe8/kqYgjzGkkcsci7k0aIYZxI35EUe60s8U9u2bVUf5bPhw4erQduLfBlJKIDEIsnj5uBk88HI4yl/ZJAUxNCUgevPP/9U599/QA/G+yXjHSyCETneHyvyCPHuu+9Wj8vEwJY4LLku8oOlIiROSx6d+yMDtcR6BRszst/fWJY+SvxwcH0v3nOl5TqES7CehNMfKSfXTcI9yisnX7oStiHXXh6jSUiOTCKTLwg572UhsuVRbCTIOY5mYo9Xb+Q+La9/8iUbzn1Znk6Ho69a0XotQ+EdE2Sc80dkefutRztlIY+BX3zxRWzcuDHgB1AondVbt/UY88oac73fExK/G+5E3LKOTev3gxHXKRK5wfeB16iV78RQ+4OdCxJjGjyuynUQxEiVMVvOv9dALus72v98BZ9TrWNA7aB7oSxEnoSn6H3uYwUNWYuj90xXGRDl1+tnn32mAtaff/55ZURJzKAMnPHWZzFU5NepDLwyCUVeEickRp53cpvEhoph+fnnn6tjkvg2MVokJtTrqZTjlripe++9V8W4ya9j+UUrXwChftn6e5T98Txd04ZXrsQdhjJI/X/9i6dJPBri2ZBjfeSRR1QMnMRJdevWrdx2yuqrlmOQPoqHRoL+Q+EdoLVch1ATvQTximjVE639kXLSJ4l3C4V3wJY+SUyaxEFLHlbpv0z0EiNF9okehEJiEUNNntSCnJdoUgR59UbuzbLiMaXfwRNRKqIifQhHX7Wg9VpGi97tyAROuX7yg0fGC9EzOXdyP8o4o4VodFuvMU8rety3ZupDuHKjGS+NIvicah0DtCLyZMLgSy+9FPLzYCM+3qAhm4DI7HP5BSrK6e+VFe+B9/PykBnx8qtfXvJLTCZ5PfXUU2UasmIUiDdm3bp1EffXOwHC3/MrHiWZoCOPgMpDPLdi5MlLjln6LbOAxdiTX8eCPD6TEAx5SXiFDPQywUEGdflFPW/ePOWVk1AAL+WFIlTECSecoPoij4jKGmikjPeLqaJj9JYXr6y8pG8iVwwu+WI1CmlTzpeW/lV0HbzeAXk87X2kL5TncY+0P1JOHj/LxBUtX6zi5ZaX6LlkbpAJcOKdL+tLX74UK0qFVxYymzsavHoj91x55yHa+zJafdVTt8oaM+Q+8B8zxPsX7CGLpp1QyA8faVN+3PsbeTLhJl7utYrGPP8xNxj5npBJWl5vrNy3wdljwrlvtephtNepLINb7+tfETIRTIxb//7IhCnBO4FOzn9Z5977uR5jgFZE3i+//KLCEso6j/EMY2QTEAkHkFgc/9nGEsMlsyzlV5o8Ti3rF3bwY3T50pKYn/JScIixLN4J8WiFWuayol+sciPKwPzqq68GlJWZwNIfSe9TFsHpsaQv3sdn3j4Hl5FzIIO993PvL+3gfoY7m9kfOR/SF3nEF+zR9bYjMXIyED399NMh4zO9qY9kZqvE7QYPPJJ6x+jUKOKpXrp0qfL+BCNfbqJXWq+Dd/D1j0mTx5fheDa19kfKiT7LbN9gpIz3i1mMnuDr7v3hUd65lZAR0dtIXvJDMRok5EfOpaQJki/osvQm2vsyGK36qve1DIWcR4n7lzHN/zhC3bPRtBOKUOOFzCuQNuLlXqtozBMdFD2Xe8/fSBVjUzy48h3iRXRNxmFxjvjH2MpTOy1o1cNor5MY3qEMbr2vf0XI/BL/cyNhFbKgkZxv75MMOb+S4cJfZ2QslEw5YuyWF5IWzhigFTlHEusrCw4FIyFU3uxC8Qo9sgmIBIzLr3N5/CU5ZuXGEC+CpGeRgV4MoFBIGhmJm7z00ktV3lkZ/MSrJSmwxPNXHvLlJgOgGMne9B0y2EkQuaT08PfAhfrFLqlQxCMqj/IlDYj8WpW8sj179izX8yXeBXmEKnF70nfxEsiXmwwa3ngjGRQk9lFufvFSyGDqTTEmyJezNzWVfEFL3Jkci3iDI0W+NCQNjBhSEqoh6a0k5lLOpfwwkMeQ0q6kLpLYNfF6Swo1OReSUksmuIk3UdJFya95+aUsg40cizzClYFSUrhIHSORR6dffPGFiskVfZJzKIOapGaRcygxX+K90XIdJJZP4s8kl6TIFYNAUtd4j1nP/ogeSqodOc/yGFbaFsNHPHiik5JzU/RcvshFz2RyhnwxyD0gg7lcG/8v83hCDAN5VCxPSMS7Kx430Vn5IpJJGdJ3MRqivS+D0aqvWtF6LUMh7UoqIrm+Ul+ulUymkcfswXWiaScUIke8saIz8iNbxgl5ZC/3ZiijQu/zoceY530sLTok6fbknvSm35LYT//c4nKdJeWUHK9MGPamXJNH8lont2nRw2ivk5SXfklKNhl/xQkj50jv618Rcl7kfMpYL3MaZIyTsVrCP7xIqr+PP/5YnX85p3KNZCwSXZo5c2aFix2EMwZoQe5pibuWScxSX+5lcQSIh1j2e3Mexy1mp00g0aXfkpQjodi3b5971KhR7rp166oUIZ06dVJpOILxT7ckKWXuvfdelWakZs2aKmWJvP/Pf/6jqY/bt29XaVYkfUmVKlVUyhDptzdVjTcNSFmpjiTd1oknnuiuXLmySmVz8803q7Q2/gSngvn0009V2i5JIyPH2axZM/dNN93k3rNnj6/Mv//9b3evXr1U6iBJOyVtPPXUUyolmZddu3apVFlSRlIJXXbZZe7du3eXSkflTTmzf//+gH6FSnEiSOowSbsi56N27drqmn3//fcBZSTFiqRRkXZTUlLcJ5xwgnvkyJHuFStWqM8PHDigzqP0W66JlOvdu7f7k08+qfCayPmSOsGUpTtyboPT9khaGElB07p1a3WORadOOeUU9wsvvOA7h1qug7By5UrVd2+Zl156qcz0W2WlD9LSHy9vvfWWu3v37uq6i07LfXDfffepayusWrVKpdGRvsg1kv4PHTrUd+7jMf2Wl9WrV7svvvhilfZN+i71Lr/8cve8efN0uS+9qX/kbzj6qjX9VrjXMhhJUfTEE0+o1EZyfQcMGOBet26d7u0EpyqSdEeSzk7akfMp9/fs2bPLTFMVTLS6rdeYJ8ydO9fdr18/VUZSeg0bNsy9YcOGUv367rvv3B07dlTttWvXTqV2LCv9VlnpGyvSQ63HXxaSBk7Oq9zn0g//a6ZFrjf9VnCaQ+99MGPGjID9oe4b77X99ttv3Z07d1bHKec+uK7w559/ui+99FJ1jeQ+kusleqSl7XDGgHc0pN8S5Dw8++yz6nvB+30lY6fcY5JCLJ5xyH9mG9OEEEIIIVZGnn5KtgFJ50diB2NkCSGEEEKIJaEhSwghhBBCLAkNWUIIIYQQYkkYI0sIIYQQQiwJPbKEEEIIIcSS0JAlhBBCCCGWhIYsIYQQQgixJFzZqwJkeVFZck5Ww7LiGsSEEEIIIVZCpm/JSouyEmZFK53RkK0AMWKbNm1qdjcIIYQQQmzFzp071VLM5UFDtgLEE+s9mbJ+sdne4f3796t1xiv6hRLv7eohMxIZ4dbRUl6PMmZdWyOgnkYvI5w6WstSTwOhnkZfn3pqPHbV05ycHOVE9Npg5UFDtgK84QRixMaDIZufn6/6EWuF1rtdPWRGIiPcOlrK61HGrGtrBNTT6GWEU0drWeppINTT6OtTT43H7nrq0BDSae0rTAghhBBCbAsNWUIIIYQQYkloyBJCCCGEEEtCQ5YQQgghhFgSGrKEEEIIIcSSMGtBGLPt5GV2HyRJcKz7YUS7esiMREa4dbSU16OMWdfWCKin0csIp47WstTTQKin0dennhqPXfXUFUa7NGTLYOLEiepVUlKitiX3maSNMBO5sNnZ2UoRYp2GQ+929ZAZiYxw62gpr0cZs66tEVBPo5cRTh2tZamngVBPo69PPTUeu+ppbm6uZrk0ZMtgzJgx6iVJedPS0lQC33jIIys51cxIjKx3u3rIjERGuHW0lNejjFnX1giop9HLCKeO1rLU00Cop9HXp54aj131NCUlRbNcGrIakZMeDzeEKIEZfTGiXT1kRiIj3DpayutRxqxrawTU0+hlhFNHa1nqaSDU0+jrU0+Nx4566gyjTetfYVKKpbuX4oJZF6i/hBBCCCGJCg3ZBENiT15Z9Qq2ZG9Rf2WbEEIIISQRoSGbYCzZvQTrD65X7+WvbBNCCCGEJCI0ZBMI8b6+tvo1OOBQ2/JXtumVJYQQQkgiQkM2Ab2xbngMV/lLrywhhBBCEhUasgnmjXU6Ai+pbNMrSwghhJBEhIZsgnljXe7A1TBkm15ZQgghhCQiNGQTMDY2GMbKEkIIISQRoSGbABS5irD36F5fbGwwsl8+l3KEEEIIIYkCV/ZKAJKTkjFt6DRk5Wdh4a6FmLhmIjrW6YhH+j7iK5Oekq7KEUIIIYQkCjRkE4QG1Ruo1w87f1DbbdPbokOdDmZ3ixBCCCHEMBhakGDsOrJL/W1So4nZXSGEEEIIMRQasgnGrtzjhmxNGrKEEEIISWxoyCaoR7ZxjcZmd4UQQgghxFBoyCYQBSUFyMzLVO/pkSWEEEJIokNDNoHYfWS3+lutUjXUrlLb7O4QQgghhBiKLQzZiy66CLVr18all14KO8THNq7ZGA5H6MURCCGEEEISBVsYsnfccQemTp2KRIcZCwghhBBiJ2xhyA4YMAA1a9ZEovNX7l/qL+NjCSGEEGIHTDdkFy5ciGHDhqFRo0bqcfisWbNKlZk4cSJatGiBlJQU9O7dG8uXLzelr/EOMxYQQgghxE6YbsgePXoUXbp0UcZqKKZPn46xY8fisccew6pVq1TZc845B5mZntn5QteuXdGxY8dSr927PZOf7II3RrZpzaZmd4UQQgghJPGXqB0yZIh6lcVLL72E0aNHY9SoUWp70qRJ+OqrrzBlyhSMGzdO7VuzZo1u/SkoKFAvLzk5Oeqvy+VSLzOR9t1ud8h+yP6/jnhCCxpVb6RrX8tr10yZkcgIt46W8nqUMeIcm4VZx2JXPdValnoaCPU0+vrUU+Oxq566wmjXdEO2PAoLC7Fy5Uo88MADvn1OpxMDBw7E0qVLDWlz/PjxeOKJJ0rt379/P/Lz82EmcmGzs7OVIsh58CenMAdHio6o95XzKiOzIDMm7ZopMxIZ4dbRUl6PMkacY7Mw61jsqqday1JPA6GeRl+femo8dtXT3NzcxDBkDxw4gJKSEtSvXz9gv2xv3LhRsxwxfH/55RcVxtCkSRPMmDEDffv2DVlWjGYJZfD3yDZt2hT16tVDamoqzESUQOKIpS/BSrD/4H71t17VemjasGnM2jVTZiQywq2jpbweZYw4x2Zh1rHYVU+1lqWeBkI9jb4+9dR47KqnKSkpiWHI6sXcuXM1l61SpYp6BSMnPR5uCFGCUH356+jfGQuM6GdZ7ZotMxIZ4dbRUl6PMkacY7Mw61jsqqday1JPA6GeRl+femo8dtRTZxhtxrUhW7duXSQlJWHfvn0B+2W7QYMGMe1LvMfILt61WP1Ndibr3k+zY2X0lMEYWeOxa0yXnjIYe2g81NPo61NPjceueupKlBjZ5ORkdO/eHfPmzcOFF17oOzjZvvXWWw1tW7IoyEtCG+I9Rla25++Yr95vPrRZGfp6ruxldqyMnjIYI2s8do3p0lMGYw+Nh3oafX3qqfHYVU9zrRQje+TIEWzevNm3vXXrVpWFID09Hc2aNVPxqiNGjECPHj3Qq1cvTJgwQcW6erMYGMWYMWPUS2Jk09LS4jpGdvHuxcguylbvDxYcxOaSzejXqJ/h7ZotkzGy8YldY7r0lMHYQ+OhnkZfn3pqPHbV0xQrxciuWLECZ5xxhm/bO9FKjNd3330XV1xxhfKGPvroo9i7d6/KGTtnzpxSE8CMJl5ibYLjS+SXzcQ1f+fgdcChtvs37q+rVzYeY7oilcEYWeOxY0yX3jIYe2g81NPo61NPjceOeuq0UoysLB8rxlh5SBiB0aEEVmXJ7iVYf3C9b9sNt9qW/f0a6+eVJYQQQgiJN0w3ZK1CPE72kvevrX4NTjjhwt99czqcan+fBn108cqaHfStpwxO9jIeu05O0FMGJ9EYD/U0+vrUU+Oxq566EmWyl5lYYbLXzwd+DvDG+sq5XWr/1799jZ51e+rerl0m0Wgtz8kJgdh1coKeMjiJxniop9HXp54aj131NNdKk73ilXif7CV/P1zxoYqJlXCCYGT/h9s+xLntz43aK2t20LeeMjjZy3jsOjlBTxmcRGM81NPo61NPjceueppipcleViFegsa9gdLF7mLsPbo3pBEryH75vAQlKrdsIk5OiFQGJ3sZjx0nJ+gtg5NojId6Gn196qnx2FFPnVaa7GUV4i1GtpKzEj469yMcyj+ECasm4Ke9P2F4++E4r+V5vvLpKemo5KgUdb/NjpXRUwZjZI3HrjFdespg7KHxWF5Ps3cCeVk+mUmHDsFVVFssAM/n1dKBNG3LlTNGNn6xvJ76wRjZGGOFGFn5Vwd1cDDvoPq8dUpr1Cmp83eFo0Dm0Uzd27VL7KHW8ozpCsSuMV16ymDsofFYWU+dubtRb9o5cJQUerYB1Asq405Kxv4rv4WrZiPD+kQ9NR4r62kwjJGNMfEeI+uvBPvyPUv4ntT4JGTUzohZu2bLZIxsfGLXmC49ZTD20Hgsracle3xGbFnI53WrOYCMir8TGCMbv1haT4NgjKzJxEusTXB8SXZBNnIKc9T7pqlNDetjPMZ0RSqDMbLGY8eYLr1lMPbQeCyrpxon8DqlnI7jXLT1qKc209MYxcha/wrbnF1Hdqm/dVLqoFrlamZ3hxBCCCEkZtCQtTi7cj2GbNOa2oL6CSGEEEISBYYWWDRrgZedOTvV38Y1GhvWP7NnL+opg1kLjMeus2z1lMHZ4MZjaT2VyTJa2pLl33XUoWjqUU9tqKdBMGtBjLFC1gLhj/1/qL+1nbWRmZkZs3bjQSazFsQndp1lq6cMzgY3HivrafLuLUjXUC4rKwvFSRV/LzBrQfxiZT0NhlkLYoxVshYc/MWTeqtd/XbI0DA7Va9240EmsxbEJ3adZaunDM4GNx7L6mnuHjgWP66paHp6OrMWUE8tOZ4ya4EBxMvsx+AZf97JXkZmLAjVbrzIZNaC+MSOs2z1lsHZ4MZjOT3N3gW8Nww4vKPispWqwFm9LrMWUE8TPmsBDVkLU+QqUsvQCpzsRQghCcyh7ceN2O1ArWbARZOByim+WFgJIxAPrEq5JVSrA9Ti9wJJfGjIWpi9R/aixF2CKklVULdqXbO7QwghxAiytgDvne9ZlrZ2S2DkbCCtyd+fu1yeWFgJI0gADyQh4UBD1sLsPPJ3xgKng4MXIYQkHAf+8BixubuBOm2AEV8AqRUvO0uIXaAha+H0W7FIvRWq3XiRyfRb8Yld08XoKYNpjYzHEnq6fyMc718Ix5F9cNc7Ee7hs4Aa9Uul1Ir2WJh+K36xhJ5qhOm3YowV0m9t2rdJ7a+TVMew1Fuh2o0XmUy/FZ/YNV2MnjKY1sh44l1PKx38HbW/HAlnfhaK6rRD1rnvwJ3nAPIydT8Wpt+KX+JdT8OB6bdijBXSbx367ZDa3zajrWGpt0K1Gy8ymX4rPrFruhg9ZTCtkc31dM+vcMweCUd+FtwNuyDpH/9DvWrphh0L02/FL3Gtp2HC9FsmEy9pPPxTV/x+6He172jxUcP7Zte0RlrLM11MIHZMF6O3DKY1sqme/rUSeP8iID8baNwdjmv+B0fVWtHJjLZPOtWjniaQnsZR+i3rX2GbIr9sduV6csh+u+1b5aonhBBiYXYuB6Ze6DFim/YGJCZWgxFLiJ2hIWtR5u6YCxc8wdCbD2/Gkt1LzO4SIYSQSNm22OOJLcgBmvcDrvkfkGJuOBshVoCGrAUR7+vENRN925J667XVr9ErSwghVmTLD8CHlwKFR4CWpwP/mAFUqWF2rwixBDRkLciSPUuwJXuLb9vldmH9wfX0yhJCiNXYPA/46HKgKA9oPRC4ejqQXN3sXhFiGTjZy2J5ZOU1cfVEOOCAG+5SXtk+DfqoYGq927Vjfk6t5Zn3MBC75j3UUwbzc9pETzd9C8eMa+EoKYS77WC4L30XSKpSKk9sWDKj7ZNB9ainFtZTnWAe2RgTr3lkf9j+A9ZnrS/92XGv7Ne/fY2edXvq3q4d83NqLc+8h4HYNe+hnjKYnzPx9bTK1u9Re+5YOFxFyG85CIdPfx7Iyo5KJvPIRnc88YjZeupmHlnrEo95ZMWo/nTZp6W8sV5k/4fbPsS57c/V1Strdj45PWUwj6zx2DXvoZ4ymJ8zsfW06pZvUev/7oHDVQz3SRch+cI3kZFUOSqZzCMb/fHEI3YdT1OYR1Z/4iEfXWFJIfbn7w9pxAqyf+/RvShBCZKdybq2bdf8nFrLM+9hIHbMe6i3DObnNB5TjmXtDNSaNxYOtwvofAUcF/wHjqTov4qZRzbyfsU7dhxPnWG0SUPWQiQnJeP1Pq9jt3s37l10L1IqpeDdc94N8L6mp6SrcoQQQuKMNR/BMesWzzO1rv+A4/zXAGeS2b0ixNLQkLUYGVUzsOfYHvW+ba22OKnuSWZ3iRBCSEWsfBf48k5lxOZ1uAIpw16Fg0YsIVFDQ9aC/Jn9p/rbMq2l2V0hhBBSEcsnA1/fo966e92InG5jkeKw/iNvQuIB3kkWZMthTw7ZE2qdYHZXCCGElMfSiT4jFn1vhfucZyRQ0OxeEZIw0JC1IN7FEGjIEkJIHPPjBODbBz3v+48FBv2bRiwhOsPQAotR4irBtpxt6n2rtFZmd4cQQkgofngOmP+U5/3p44AB4zxGLJcSJ0RXaMhabGWvPXl7UOQqQkpSChpUaxCTPpm9woeeMriyl/HYdSUaPWVwxSTjMexY3G44FjwNx6IXPO2c8TBw6t0eA/Z4e/Gmp1zZK36x63jq4speibuy14bMDep90+pNcWD/gZi1a8cVk7SW50o0gdh1JRo9ZXDFJOMx5FjcbtRY9iJqrJmsNnP63Ie8dsOBzExD2+XKXvocTzxi1/E0lyt7JebKXqIEB7Z6jNc2ddogIyMjZu3accUkreW5Ek0gdl2JRk8ZXDHJeHQ/FvHEfvcQHMeNWNc5z6BG75tQw+h2ubKXbscTj9h1PE3hyl76Ey8rhOw4ukP9bV2rdUz7Y9cVk7SW50o0gdhxJRq9ZXDFJOPR7VjkMeic+4Cf/+vZPu8lOHteb3y7Osrkyl7xix3HUydX9kpcvIZsq1qc6EUIIaYjRuzsO4BVU+VrGpDVuk4ebnavCLENNGQthMvtwo4jHkP2hDSm3iKEEFNxlQCf3wr88hEgCxxc+AbQ5Uqze0WIraAhayH2HN2DAlcBKjsro0nNJmZ3hxBC7EtJMTDrn8DaGYAjCbj4LaDTpWb3ihDbQUPWQny99Wv1N6NqBio5eekIIcQUSoqAmTcAG2YBMhZfOgXocIHZvSLEltAasgiSrmLGphnqfW5RrtqWoGlCCCExpLgAmDEK+P0rwFkZuHwqcOK5ZveKENti/el8NmHJ7iXYl7dPvc8pzFHbhBBCYkhRPjB9uMeITaoCXPUxjVhCTIaGrAUQ7+trq1/zbTvgUNuynxBCSAwozAOmXQX88S1QqSpw9XSgzdlm94oQ20ND1gKI93X9wfW+bTfcapteWUIIiQGFR4GPLgf+/D+gcnXgHzOAE84wu1eEEBqy1vHGOiW1ix+yTa8sIYQYTEEu8MGlwLZFQHJN4JqZQMtTze4VIeQ4NGQt4o2VHLL+yDa9soQQYiD52cD7FwM7lgBV0oDhnwHN+5rdK0KIHzRkLeCNlZjYUDBWlhBCDOLYIWDqBcCu5UBKLWDE50DTnmb3ihASBNNvacTlcqlXLCksKcTeo3tVTGwoZL98XlBcgOSkZMP6IcctxrKex6+HzEhkhFtHS3k9yhhxjs3CrGOxq55qLUs9DeNY8g7C8cFFcOxdC3e1OnBf8xnQoJNnOVoj2zVJZqT1qafGY9fx1BVGuzRky2DixInqVVJSorb379+P/Pz8mPfj1V6vIrsoG1M2TcGKgyswpP4QnNfiPDidHmd6reRaOHzwsKF9EIXKzs5WCuhtNx5kRiIj3DpayutRxohzbBZmHYtd9VRrWeqptmNxHjuI2l+OROWsTSipWgeHhr6LYmd9IDPT0HbNlBlpfeqp8dh1PM3NzdUsl4ZsGYwZM0a9cnJykJaWhnr16iE1NTXm/chAhvo7cdNE9bdng57o17pfzBVaFl+Qc6CnQkcrMxIZ4dbRUl6PMkacY7Mw61jsqqday1JPNRxL7l44Ph0FR9YmuGs0gOPaz5Fet63x7ZosM9L61FPjset4mpKSolkuDVmNyEk364aQXy87cneo902qNzGlL6J8ererh8xIZIRbR0t5PcoYcY7Nwqxjsaueai1LPS3nWLL/At4bBmT9CaQ2hmPEl3DUOcH4duNEZqT1qafGY8fx1BlGmzRkLUB2QTZyCz1u9obVGprdHUIIsSaHd6r4V4XbjUpZWUDJHuDoPuDLO4HcPUBaM2Dkl0DtFmb3lhCiARqyFsDrjc2oloGUJO3udkIIIX5G7OvdgeICtSn+nrqhyl3yXxqxhFgI6/vcbcD2nO3qb7OazczuCiGEWBPxxB43YsulUpVY9IYQohM0ZC3Aztyd6i8NWUIIIYSQv6EhayWPbCoNWUIIIYQQLzRkLeSRbVqzqdldIYQQQgiJG2jIWgDGyBJCCCGElIaGrAVSb+UU5qj3TWo0Mbs7hBBiTXL+MrsHhBADoCEb5+zIOZ56q2oGqlWuZnZ3CCHEehza5skTSwhJOGjIxjnbcznRixBCIubwDs+KXUczZV2hilNvVasTq54RQnSACyLEOTtzjqfeoiFLCCHhkb3LY8SKMZt+AnDxZMCZpD5yud3IyspCeno6nI7jBq4YsbU4qZYQK0FD1ioeWU70IoQQ7eTs9hixElZQuyUwcjaQ2ujvz10uFCdlAhkZsrC7mT0lhEQB7944hx5ZQggJk9y9HiM2awtQqxkw4stAI5YQkjDQkI1z6JElhJAwOJIJvHc+cHAzkNYUGDGb4QKEJDA0ZOM89Za8BC6GQAghFXD0gMeIPfA7kNrY44mt3dzsXhFCDISGbBzz9dav1d+05DSm3iKEkPI4etBjxO7/DajZ0GPEprc0u1eEEINJeEN2586dGDBgADp06IDOnTtjxowZsAJutxtT109V74tcRWqbEEJICPKygPcvADLXAzXqe8IJ6pxgdq8IITEg4Q3ZSpUqYcKECdiwYQO+++473HnnnTh69CjinSW7l2DXkV3qfV5xntomhBASxLFDwPsXAnvXAtUzPEZs3dZm94oQEiMS3pBt2LAhunbtqt43aNAAdevWVbkD4xnxvr62+jXftgMOtU2vLCGE+JGfDbx/MbDnF6BaXWDEF0C9tmb3ihBiJ0N24cKFGDZsGBo1agSHw4FZs2aVKjNx4kS0aNECKSkp6N27N5YvXx5RWytXrkRJSQmaNo3viVPifV1/cL1v2w232l6yh15ZQghR5OcAH1wC7F4FVE33GLEZ7c3uFSHEboasPObv0qWLMlZDMX36dIwdOxaPPfYYVq1apcqec845yMyU5QY9iMe1Y8eOpV67d+/2lREv7LXXXou33noLVvDGOh2Bl0a2J66ZSK8sIYQUHAE+vAzY9TOQUgu49nOg/klm94oQYseVvYYMGaJeZfHSSy9h9OjRGDVqlNqeNGkSvvrqK0yZMgXjxo1T+9asWVNuGwUFBbjwwgtV+VNOOaXCsvLykpOTo/66XC71MprFuxcHeGO9uNwutX/FgRUYUq/s82UEctxiQOt5/HrIjERGuHW0lNejjBHn2CzMOha76qnWsgmjp4VH4fjocjh2/gR3Shrcw2cB9TuqlbrCgXoafX3qqfHYVU9dYbRruiFbHoWFhSoc4IEHHvDtczqdGDhwIJYuXapJhpy0kSNH4swzz8Tw4cMrLD9+/Hg88cQTpfbv378f+fn5MBLp64SfJ6iYWAknCEb2v/372zg5/WQkJXnWC48FolDZ2dmqf3L+40VmJDLCraOlvB5ljDjHZmHWsdhVT7WWTQg9LTqG2t/chCq7l8GVXANZ5/4XxUkNAb8ndFqhnkZfn3pqPHbV09zc3MQwZA8cOKBiWuvXrx+wX7Y3btyoScbixYtVeIKk3vLG377//vvo1KlTyPJiNEsog79HVmJq69Wrh9TUVBhJYUkhDhYeDGnECrI/qygLtevWRkrlFMQKUT6JX5ZzoKdCRyszEhnh1tFSXo8yRpxjszDrWOyqp1rLWl5Pi47BMe0mOHYvgzu5JnDNTKQ36RmxOOpp9PWpp8ZjVz1NSUlJDENWD/r37x+Wi7pKlSrqFYycdKOVKMWZgmlDpyErPwvTNk7DZ5s/w9nNz8YNnW5Qn7tdbriOupQRG+ubU5RP73Ogh8xIZIRbR0t5PcoYcY7Nwqxjsaueai1rWT0tygc+GQ5sXQAk14DjmplwNOsdtVjqafT1qafGY0c9dYbRZlwbspIqSx6h79u3L2C/bEsqrVgSqxjZjKoZ6nWk8Ija7lK3C06sfaKvD/uL99suVkZPGYyRNR67xnTpKYOxh34UF8DxyXA4/pwHd+VqcF81HRBPbJR9oJ5GX596ajx21VNXosTIJicno3v37pg3b56arOU9ONm+9dZbDW1bsijIS0IbYhUj68+fWX+qv7XctXwZGuwaK6OnDMbIGg/1NHoZjD08Tkkhan13O1K2z4e7UgoODZ6EwqqtI4qJDYZ6Gn196qnx2FVPc60UI3vkyBFs3rzZt71161aVhSA9PR3NmjVT8aojRoxAjx490KtXL7VKl6Ts8mYxMIoxY8aol8TIpqWlxSRG1j9Dwe5jntRhnZt2RkZqhq1jZfSUwRhZ46GeRi+DsYdixBbBMfM6OI4bse4rp6FWq9N1E089jb4+9dR47KqnKVaKkV2xYgXOOOMM37Z3opUYr++++y6uuOIK5Q199NFHsXfvXpUzds6cOaUmgBlNLONTMo9mIr8kH5UcldAktUlAu3aMldFbBmNkjYd6Gr0MW8celhQDn40GNs4GkqrAceVHcLT++3tCL6in0de3tZ7GCDvqqdNKMbIDBgyoMMm/hBEYHUoQLzGywtbDW9XfxjUbIwlJvnbtGiujpwzGyBoP9TR6GbaOPXQVw/HZTXBs+BzupGS4L58KtDoj6pjYUs1QT6Oub2s9jRF21VNXosTImomZMbLrdq9TfxtWaRiwgpldY2X0lMEYWeOhnkYvw7axh64SpM2/H1X/+BJuZ2UcPvsVFKR11SUmtlRT1NOo69tWT2OIXfU010oxsvGKmTGyWTuy1N/WdVsjI8MTH2vnWBk9ZTBG1niop9HLsGXsoasEji9uhUMZsZXgvvQdpJ14nr5t+DdHPY26vi31NMbYVU9TrBQjaxViGZ+yI3eH+tsyrWWpNu0YK6O3DMbIGg/1NHoZtoo9lMeIX90J/DoNcCTBcekUODoMg9FQT6Ovbys9NQk76qkzjDatf4UTkO0529Xf5qnNze4KIYQYixixs+8EVn8AOJzAJZOBDheY3StCiEWgRzbOJnsVuYrwV+5f6n2zGs0C2rRr0LeeMjjZy3iop9HLsM0kGrcbjm/ugWPVe3A7nHBfOAnocJHuE7tCQT2Nvr5t9NRE7KqnLk72su5kr11Hd6HYXYyUpBS4j7hVKi67B33rKYOTvYyHehq9DFtMonG7UXPxU6i+7n244UD2gPHIr3+6IRO7QkE9jb6+LfTUZOyqp7mc7GXdyV4bd21Uf5ulNkOD+oHL8No16FtPGZzsZTzU0+hlJPwkGvHEfvcwHOve92ye/xpSu/4DsZlO64F6Gn39hNfTOMCueprCyV76E6tAa+9EL4mPDdWeHYO+9ZbByV7GQz2NXkbCTqKRvOFzHwOW/cezPewVOE8eDjOgnkZfP2H1NI6wo546OdnL+hO9WqS2MLsrhBCiL2LEznsSWPKqZ/u8F4HuI83uFSHEwtCQjTOYsYAQkrAsGA/8+JLn/ZDngJ43mN0jQojFYWhBnGUt8BqyzWoGZiyw8+xFPWUwa4HxUE+jl5GQs8F/eA7OH571yBn0FNBzdEyyE5QF9TT6+gmpp3GGXfXUxawF1sxakF+Sj715e9X76gXVA5antfPsRT1lMGuB8VBPo5eRaLPBq6+ahJrLX1bvc/rch7xWl8YsO0FZUE+jr59oehqP2FVPc5m1wJpZCz7d9Kn6W61SNbRu0rrU53advainDGYtMB7qafQyEmo2+JJX4TxuxLrOfBQ1+t+FGjAf6mn09RNKT+MUu+ppCrMW6I/RMwblF8q7G971vZeLLa9g7Dh7UW8ZzFpgPNTT6GUkxGzwpRM9GQqEMx6G87S7EU9QT6OvnxB6GufYUU+dzFpgPZbsXoKduTvV+2Mlx9Q2IYRYlmVvAt8+6Hl/+v3A6fea3SNCSAJCQzYOEA/sa6tf82074FDbsp8QQizH8snAN/d53p96NzDgAbN7RAhJUBhaEAdZCxbvXoz1B9f7tt1wq+0f//oR/Rr1g91nL+opg1kLjId6Gr0MS88GX/kunF/fo966T7kd7gEPefLHxtkPc+pp9PUtracWwa566jIqa4EI/uGHH7Bo0SJs374deXl5Kmi3W7duGDhwIJo2bYpEIVZZC+SiTvh5ApxwwoW/L5xsy/7WfVr7YmXtOntRTxnMWmA81NPoZVh1NnjVjZ8ibcFD6v3RzqOQ2+kWGTwRj1BPo69vVT21EnbV01y9sxYcO3YML774It544w1kZWWha9euaNSoEapWrYrNmzdj1qxZGD16NAYNGoRHH30Uffr0gdWJVdYC8cZuytlUar8YtbJ/c8lmn1fWrrMX9ZTBrAXGQz2NXoYlZ4P/8jEcCx5Wb929bkLVc8ajaogJq/EC9TT6+pbUU4thVz3VPWtB27Zt0bdvX0yePBlnn302KleuXKqMeGg/+ugjXHnllXjooYeUYZtIGDFjUH6VTFwzUcXESjhBMLJfPu/fuL/PK2vH2Yt6y2DWAuOhnkYvw1KzwX/9BPh8jAqMktW6HEOeDZl1Jd6gnkZf31J6alHsqKfOMNrUZMh+9913aN++fbllmjdvjgceeAD33HMPduzYobkDdqbIVYS9R/eGNGIF2S+fS7nkpOSY948QQipk3Uzgs5s8Rmz3UcCQ5+XbyuxeEUJsgiZDtiIj1h/x1p5wwgnR9Mk2iHE6beg0ZOVnlVkmPSWdRiwhJD5ZPwuYORpwu4Buw4HzXhJXitm9IoTYiLCzFsyZMwc1atRA//791bZMiJKQgw4dOqj3tWvXNqKfCUuD6g3UixBC4pLDO4G8g573bjcqZWUBJXuAbYuAuY8D7hKgy9XAsFdpxBJC4t+Qvffee/Hss8+q92vXrsXdd9+NsWPHYv78+ervO++8Y0Q/CSGEmGHEvt4dKC5Qm2Km1g0u43ACA8bRiCWEWMOQ3bp1q/K+CjNnzsTQoUPx9NNPY9WqVTj33HON6CMhhBAzEE/scSO2TCSs4NghoHbzWPWKEEIiN2STk5NV/lhh7ty5uPbaa9X79PR0laoqUTFyQYRw+mDHxMh6yuCCCMZDPY1eRtwkmpd8j1r6K4sdWEx3qafR148bPY2iX/GOXfXUZdSCCILExkoIQb9+/bB8+XJMnz5d7d+0aROaNGmCRCFWCyKEg10TI+spgwsiGA/1NHoZ8ZJoXuJhS4UShEDyixcnZcJKUE+jrx8veqrX8cQjdtXTXL0XRPDn9ddfxy233IJPP/1ULZDQuHFjtf+bb77B4MGDkSjEakGEcLBrYmQ9ZXBBBOOhnkYvI24SzcukLg3IEzlkZMBKUE+jrx83eqrT8cQjdtXTFL0XRPCnWbNmmD17dqn9L7/8MhKZeEmsbMfEyHrL4IIIxkM9jV5GXCSa15gP1inlLKi31NPo68eFnkbZr3jHjnrqDKNNTSWPHj2qWWAk5QkhhMQhf3xvdg8IISR6Q7Z169Z45plnsGdP2Y+ZJObh+++/x5AhQ/Dqq69qEUsIISReWfU+MP/fZveCEEKiDy1YsGABHnzwQTz++OPo0qULevTogUaNGqkYhkOHDmHDhg1YunQpKlWqpJapvekmWa6QEEKIJVnxNvD1PZ73jiTPogdlUakKUK1OzLpGCCFhG7Lt2rVTOWN37NiBGTNmYNGiRViyZAmOHTuGunXrolu3bmp1L/HGJiUlaRFJCCEkDqn2y7twLh3v2eh9M9D3FiAvy5dmSzIUyOQuFRerKtQBajU1sceEEDtTKdyJXrKSl7wIIYQkGD++jFSvEdvvTmDg454JX7Waefa5XJ40W5KhIAEm0RBCrE/YWQsIIYQkGLKgwYJn4PzhGc/maffDccYDmrMWEEKIWdCQ1QhX9oqvlWgilcGVvYyHehq9jJiumOR2wzHvCTiWvKI2c3qNRbXT7oNTjFt5RXks8Qr1NPr6XNnLeOyqpy4jV/ayC1zZy9h2rbBiktbyXIkmEOpp9DJitmKS242aS55G9bVT1WZ233HY3exCpGVmUk8t1C5X9tLneOIRu+pprpEre9kFruxlbLtWWDFJa3muRBMI9TR6GTFZMcntguPre+A4bsS6zn0B1U8ehVr791NPLdYuV/bS53jiEbvqaYqRK3vZlXhZIcSOK3zoLYMrexkP9TR6GYaumAQ38OUdwJoPZC9w/mtwnjxcTeainlqzXa7sFXm/4h076qlT75W9/JkzZw5+/PFH37Y8fu/atSuuvvpqlVOWEEJIHOMqBj67yWPESo7Yi98CxIglhBALErYhe++996rH7cLatWtVKq5zzz0XW7duxdixY43oIyGEED0oKYRj5vXA2hmAsxJw6RSg8+Vm94oQQiIm7NACMVg7dOig3ssiCUOHDsXTTz+NVatWKYOWEEJIHFKcj1rf3Q7H9vlAUjJw+VSg3RCze0UIIbH1yCYnJyMvL0+9nzt3LgYNGqTey0ovXk8tIYSQOKIwD45p/0DK9vlwV0oBrvyYRiwhxJ4e2f79+6sQgn79+mH58uWYPn262r9p0yY0adLEiD4SQgiJlIIjwMdXwrFtEVyVqgJXTYPjhAFm94oQQszxyL7++uuoVKkSPv30U7zxxhto3Lix2v/NN99g8ODB+vSKEEJI9ORnAx9cDGxbBHdyTRw6779Ay9PM7hUhhJjnkW3WrBlmz55dav/LL7+sV58IIYREy7FDwPsXA7tXASlpcP9jJooqNzW7V4QQoisR5ZGV1a4+++wz/Pbbb2q7ffv2uPDCC5WnlhBCiMkcPQi8fwGwdy1QNR0Y/hnQoDOQmWl2zwghRFfCtjzXr1+PYcOGYd++fWjXrp3a9+yzz6qVGr788kt07NhR3x4SQgjRzpFM4L3zgf2/AdXrAdd+AdTvoBY7IIQQ2D1G9oYbblDG6q5du1TKLXnt3LkTnTt3xo033mhMLwkhhFRMzm7gnXM9RmzNhsDIrz1GLCGEJChhe2TXrFmDFStWoHbt2r598v6pp55Cz5499e4fIYQQLRze4QknOLQNSGsKjPgCSG9ldq8IISS+DNm2bduqsIKTTjopYH9mZiZat26NRMXlcqmX2X1wu90x74cR7eohMxIZ4dbRUl6PMmZdWyOgnkYvI5w6UsZ5eDscX18H5OyCu3YLuId/DtRqFhBOQD0NhHoaff1w9VRLWeppIHbVU1cY7YZtyI4fPx633347Hn/8cfTp00ft++mnn/Dkk0+qWFn/RRFSU1NhVSZOnKheMrFN2L9/P/Lz803tk1zY7OxspQhOp9PS7eohMxIZ4dbRUl6PMmZdWyOgnkYvI5w6jqw/kf7lCDiO7UdxWgtknTcVrsKUUhO7qKeBUE+jrx9OPa1lqaeB2FVPc3NzjTNkZUla4fLLL4fD4VDvpVOCTALzbstnXiPQiowZM0a9xDBPS0tTk9nMNsxFCeS8Sl9irdB6t6uHzEhkhFtHS3k9yph1bY2Aehq9DM11MjfA8dVIZcS6650I5/BZqFujfsQyqafWbDdamZHWD6ee1rLU00DsqqcpKSnGGbLz58+HHZGTHg83hCiBGX0xol09ZEYiI9w6WsrrUcasa2sE1NPoZVRYZ88vwNQLgWNZKKrTHkkjvoSzRr2o+0E9tWa70cqMtH449bSWpZ4GYkc9dYbRZtiG7Omnnx5uFUIIIXqyayXwwUVq5S53o5ORNegN1KtWx+xeEUJIzIloBQOJFf3111/VBK/ggNzzzz9fr74RQggJZsdPwAeXAoW5QNPecF81He6cArN7RQgh1jBk58yZg2uvvRYHDhwo9ZnV42IJISSu2boQ+OhKoOgo0OJU4KppQOVqQA5X7CKE2JOwAx9uu+02XHbZZdizZ48vJZX3RSOWEEIMYvNc4MPLPEbsCWcCV38CVKlhdq8IIcRaHlnJITt27FjUrx96ZiwhhBCd+f0b4JNrgZJCoO1g4LL3gMraZ/USQkiiErZH9tJLL8WCBQuM6Q0hhJBANnwOTL/GY8S2Px+4/H0asYQQEqlH9vXXX1ehBYsWLUKnTp1QuXLlgM9lsQRCCCE6sHYGMOtmwF0CdLoMuHASkBTRHF1CCElIwh4RP/74Y3z33XcqWa14Zr2LIgjynoYsIYRET9WNn8Kx4GFZYgbo+g/g/NcAZ5LZ3SKEEGsbsg899BCeeOIJjBs3LiESDRNCSNyxYgrSFjzked99FHDeS5Ih3OxeEUJI3BH2yFhYWIgrrriCRiwhhBjB0v/A+fXd6q279z+BoS/TiCWEkDIIe3QcMWIEpk+fHm41QgghFbHoJeDbB9TbI11Hwz3oaYnZMrtXhBCSOKEFkiv2ueeew7fffovOnTuXmuz10ksv6dk/QghJfNxuYMEzwA/PeDZPux9H2o9CNRqxhBCiryG7du1adOvWTb1ft25dwGf+E78IIYRoNGLnPQH8+LJn+6xH4e53F5DJ1boIIUR3Q3b+/PnhViGEEFKWEfvtg8BP//FsnzMe6HsL4HKZ3TNCCLEEEc8g2Lx5swovOHbsmNp2y4BMCCFEG2KsfnX330bseS96jFhCCCHGGbIHDx7EWWedhbZt2+Lcc8/Fnj171P7rr78ed9/tmWlLCCGkHFwlwBe3ASvelqAs4PzXgZ43mN0rQghJfEP2rrvuUhO8duzYgWrVqvn2S0quOXPmIN44fPgwevToga5du6Jjx46YPHmy2V0ihNiZkmLgs5uANR8ADidw8VvAycPN7hUhhNgjRlZW9ZKQgiZNmgTsb9OmDbZv3454o2bNmli4cKEyuo8ePaqM2Ysvvhh16tQxu2uEELtRXAjMvB747QvAWQm45G3gpAvN7hUhhNjHkBVj0N8T6yUrKwtVqlRBvJGUlOTrb0FBgYrlZTwvIcRQDu8E8g563rvdqJSVBRRuB+Y+DuxYAjgrA1e8D7QbYnZPCSHEXqEFp556KqZOnRqQcsvlcqncsmeccUbYHRBv6bBhw9CoUSMla9asWaXKTJw4ES1atEBKSgp69+6N5cuXhx1e0KVLF+VFvvfee1G3bt2w+0kIIZqN2Ne7A2+drl7OyQNQd+bFcE4Z5DFivdTvaGYvCSHEnh5ZMVhlsteKFSvUcrX33Xcf1q9frzyyixcvRiQeXjEyr7vuOvXIPxhZRWzs2LGYNGmSMmInTJiAc845B7///jsyMjJUGYl/LS4uDhkGIQZyrVq18Msvv2Dfvn2qjUsvvRT169cPu6+EEFIh4oktLii/jKvIU65W01j1ihBCEpKwDVmJMd20aRNef/11FX965MgRZRyOGTMGDRs2DLsDQ4YMUa+ykJXCRo8ejVGjRqltMWi/+uorTJkyBePGjVP71qxZo6ktMV7FaF60aJEyZkMh4Qfy8pKTk6P+itdZXmYi7UtYRKz7YUS7esiMREa4dbSU16OMWdfWCGyvp263pkddLglx0kEftJalngZiez3VoT711HjsqqeuMNoN25CVbAVNmzbFQw89FPKzZs2aQS/E47ty5Uo88IBn7XHB6XRi4MCBWLp0qSYZ4oWVGFkxurOzs1Uow80331xm+fHjx+OJJ54otX///v3Iz8+HmciFlWMQRZDzYOV29ZAZiYxw62gpr0cZs66tEdhdTyUeVkvwkjzFKk7KjLpdrWWpp4HYXU/1qE89NR676mlubq5xhmzLli1V7ljvY33//LLyWUlJCfTiwIEDSl5wGIBsb9y4UZMMyaRw4403+iZ53XbbbejUqVOZ5cVollAGf4+sGO716tVDamoqzESUQOKIpS+xVmi929VDZiQywq2jpbweZcy6tkZgez0t8eTWroj09HQgaByNpF2tZamngdheT3WoTz01HrvqaUpKinGGrBiD0pFgJMQgnIZjRa9evTSHHgiSeSFU9gU56fFwQ8i5N6MvRrSrh8xIZIRbR0t5PcqYdW2NwNZ6GmJ8DIVTykWpU+GWpZ4GYms91ak+9dR47KinzjDa1GzIer2U0olHHnkkIAWXeE2XLVumJl3piWQXkPRZEh7gj2w3aNAAsYQxsvEV0xWpDMbIGo/t9ZQxspbA9nqqQ33qqfHYVU9dRsTIrl69Wv2VTqxduxbJycm+z+S9TKK65557oCcit3v37pg3bx4uvPBC38HJ9q233gojkZRf8vKGSjBGNr5iuiKVwRhZ47G7nlbetwtallthjKy52F1P9ahPPTUeu+pprhExsvPnz1d/JXvAK6+8olu8qIQkbN682be9detWFQog8WMycUw8wSNGjFDLzEqYgKTfkpRd3iwGRiFZGOQlMbJpaWmMkY2zmK5IZTBG1njsrqeO5XMrLOOuVAXpTVoDaYyRNQu766ke9amnxmNXPU0xMkb2nXfegZ5IPlr/hRS8IQxivL777ru44oorlDf00Ucfxd69e1X4wpw5c2KeBzZeYm3sGCujtwzGyBqPbfV0/yZgzYee94OfAZr1VSEE4n2VH+cqLlZkVqsDRwU5ZBl7aDy21VMd61NPjceOeuo0IkbWKAYMGFDhkrESRmB0KEFFMEY2vmK6IpXBGFnjsa2eykTYb+6Hw1UEd5tBcPe6ySejyLkfrnr1Aid3RalT4ZalngZiWz3VsT711HjsqqcuI/PI2gXGyBrbLmNkoz+WeMWuelpl61zU3vJ/cDsr40CPe1CSmRkTPWXsYWTYVU/1rE89NR676mmukXlk7QJjZI1tlzGy0R9LvGJLPS06Bse0Zz3vT7kNddr0jKpfjD00Hlvqqc71qafGY1c9TTEyRtauxEusjR1jZfSWwRhZ47Gdni59DTi8A0htDMdp98ARVNZoPWXsYWTYTk8NqE89NR476qkzjDatf4UJIcRMDm0HfnzZ837Qv4Hk6mb3iBBCbAM9shrhZK/4mpwQqQxO9jIeu+mp49uH4CjOh7vFqXC3v6DUJC6j9ZSTaCLDbnpqRH3qqfHYVU9dnOwVPZzsZWy7nOwV/bHEK3bS0+Sdi5G+8Uu4HUk42Os+FO/fr0u/OInGeOykp0bVp54aj131NJeTvaKHk72MbZeTvaI/lnjFNnpaUgjHp8943vcajfQT++vWL06iMR7b6KmB9amnxmNXPU3hZC/9iZegcTsGfestg5O9jMcWevrTZODAJqBaXTgGPFBqgle0/eIkGuOxhZ4aXJ96ajx21FMnJ3sRQoiB5O4FFhxPtzXwcaBqLbN7RAghtoSGLCGEhMv3jwGFuUDj7kDXf5jdG0IIsS0MLdAIsxbE1yzbSGUwa4HxJLye7lwG56/T4IYD7sHPeQvq2i/OBjeehNfTGNSnnhqPXfXUxawF0cOsBca2y6wF0R9LvJLQeuoqQZ0vx6pHWcdOvAQ5lZsAx5ei1bNfnA1uPAmtpzGqTz01HrvqaS6zFkQPsxYY2y6zFkR/LPFKQuvpiilwHtgAd5VUpJz3NFKq1zOkX5wNbjwJracxqk89NR676mkKsxboT7zMfrTj7EW9ZTBrgfEkpJ7mHwbm/9uz78yH4ahZ39B+cTa48SSknjJrQdj9infsqKdOZi0ghBCd+b9/A8cOARknAT2uN7s3hBBCaMgSQogG9vyqwgoU5z4HJPFhFiGExAMcjTXCrAXxNcs2UhnMWmA8CaenEtf1zX0A3HCfdDHczU4pN0uBHv3ibHDjSTg9ZdaCiPoV79hVT13MWhA9zFpgbLvMWhD9scQriaan7l+mwbFrGVyVquJAtzvgqiBLgR794mxw40k0PWXWguiPJx6xq57mMmtB9DBrgbHtMmtB9McSrySUnh47DMfa/3g2TrsHdVt1jkm/OBvceBJKT5m1QJfjiUfsqqcpzFqgP/Ey+9GOsxf1lsGsBcaTKHrq+PFFOPL2w53eCs5TbpOBIGb94mxw40kUPdVDJrMWxC921FMnsxYQQkiU7N8ELJuk3rrPGQ9UqmJ2jwghhARBQ5YQQoJxu4Fv7oPDVYz85mcAbQaZ3SNCCCEhoCFLCCHBbJwNbJkPd1Iyck95wOzeEEIIKQMasoQQ4k/RMeDbBz3v+96GkrTmZveIEEJIGXCyl0aYRza+8h5GKoN5ZI3H8nr64wQ4D++AO7UxSk65A+7svLjWU+bntKme6iiTeWTjF7vqqYt5ZKOHeWSNbZd5ZKM/lnjFynqalLMLdX98Wb3P7nUP8g4fjXs9ZX5O++mp3jKZRzZ+saue5jKPbPQwj6yx7TKPbPTHEq9YWU8dC+6Go6QA7hanIrXvCNRwu+NeT5mf0356qrdM5pGNX+JBT91w4OdtWcjMLUBGzSro2SIdSU5HVDKZR9YE4iUfnR3zyektg3lkjceSerp5nmeSlyMJjnOfhyMpSUZeS+gp83PaSE8Nksk8svGLmXr63YZM/Our37An++8n0g3TUvDYsA4Y3LFhRDKZR5YQQvSmuBD45n7P+143Ahntze4RIYSYyvzNhzDmo9UBRqywNzsfN3+wCnPW7UE8QEOWEEJk4YODfwDV6wEDxpndG0IIMZUSlxsvL9gJd4jPvPue+HKDKmc2NGQJIfYmdy/ww7Oe9wMfB6rWMrtHhBBiKj9LTOyRojI/F/NVPLXLt2bBbGjIEkLszfePAYVHgMY9gC5Xm90bQggxnczcAo3lzM3mJNCQJYTYlx0/Ab9OkykIwLnPyQwDs3tECCGmkn2sCIv+2K+pbEZN7dkFjIJZCwgh9sRVAnx9j+f9ycOBxt3N7hEhhJhqwE75cSumLN6K3PzicstK8q0GaSno1TIdZkNDlhBiT1a+C+xdC6SkAWc9ZnZvCCHEFLLzivD24q14x8+AbZNRA90bV8P01Zlq239KlzeDrKTgiiSfrN7QkNUIl6iNryUVI5XBJWqNxxJ6mpcFx//9Sw3IrgEPAlXTVc7YqGTq0a8I6nDpzwTW0xjJ5BK18YuRx3I4rxDvLN6Gd5Zsx5ECjwHbNqMGbjuzNc7pkIGDBw/g1BMb4V9fbcTenL9jYcUT+8h57TGoQ31DxzWt0JAtAy5Ra2y7XKI2+mOJV6ygp6kLH0O1Y4dQlN4WB5sNBTIzo5apR78iqcOlPxNXT2Mlk0vUxi9GHEt2fjE+XrUPn6zJRF6hx2A8oU4KruvdCGe0qQWnw4EDB/ardrvVS8PMkR2w5q8jOHi0CHWqV0bXxjWUJzazjHFTj2PhErU6wCVqjW2XS9RGfyzxStzr6Z5f4NgwXb1NGvoSMho0il6mHv2KsA6X/kxQPY2hTC5RG7/oeSyH8grx9o/bMHXpNhwp8Djp2jWoiduVB7Y+nH5hAsHtNmxQP6bHwiVqDSBelrrjkorRy+AStTbWU7cbmCMreLmBjpfA2erU6GXq0a8o63DpzwTTUxNkcona+CXaY8k6WojJi7Zg6pJtOFroMWDbN0zFHWe1xqAODQIMWD3bjUZmOG3SkCWE2IdfpwM7lwGVqwNn/8vs3hBCiGEcPFKAyYu2Kg9s3nEDtoMYsAPb4Oz2gR5YK0NDlhBiD/JzgO8f9bw/7R4grbHZPSKEEN05IAbswi14/6ftPgP2pEbigW2DszvUV17RRIKGLCHEHix8DjiyD0g/Aeg7xuzeEEKI7gbsW2LALt2OY0UeA7Zj41TceVZbnNU+I+EMWC80ZAkhic/+34Gf3vC8H/wMUKmK2T0ihBBdyMzNx1s/bMEHy7Yjv8iThaBzkzTlgT3zxMQ1YL3QkCWEJDYyweub+wFXMdB2CNB2kNk9IoQQXQzYN3/Ygg/9DNguTdJw58C2GNCuXsIbsF5oyBJCEpuNs4Et84GkKsDgp83uDSGEREVmTj4mHTdgC4o9BmzXprXUJK4Bbe1jwHqhIUsISVwK84A5D3ren3IbkN7K7B4RQkhE7MvJxxsL/sTHy3f4DNhuzWopD+xpberazoD1QkOWEJK4LH4FyN4BpDYBTh1rdm8IISRsMo8U4o1lG/DxzztReNyA7d68toqBPdXGBqwXGrKEkMTk0DZg8QTP+3P+DSRXN7tHhBCimT3Zx/Cf+ZsxXQzYErfa16N5beWB7de6ju0NWC80ZAkhicm3DwHF+UCLU4EOF5rdG0II0cTuw8dUCIHHgPV4YHu28Biwp5xAAzYYGrKEkMRj8zzPJC9HEnDu87Iuotk9IoSQcvlLGbCb8cnPu3wGbK8WtTGiez0MPrkVkpKSzO5iXEJDViMul0u9QlFSUoKioqKY9KGwsBB5eXkxXT/aiHb1kBmJjHDraCmvRxmzrm20yMBaqVKlAA+BHIvb7S7zfjEKX7tF+XB8cz+kR+5eN8Jdt518GJ3MKI4lEhnh1NFaVku5isqYdW2NwHQ91bHdaGVGWp96qg9/HTqG//zwJz5duQtFx0MI+rRMx+1ntVaG7P79+2N+PC6T9TScdmnIlsHEiRPVS4xUQRQpPz+/VDkxPnJycmLWL7m4sWzPyHb1kBmJjHDraCmvRxmzrm00yKAkhmxqaqrPWyDHkZ2drT6L9Q8uabfamv8i7eAfKKlaBwc6XA93ZmbUMqM5lkhkhFNHa1kt5SoqY9a1NQKz9VTPdqOVGWl96ml07M4uwNSf92L2hoModnkM2O5NauL6Pg1xcpOa4iZDZmamLfU0NzdXs1wasmUwZswY9RLDIi0tDfXq1VNf1v6Ikfvnn3+q/XXrxmbmoHh+K1eubHg7sWhXD5mRyAi3jpbyepQx69pGigxG0mf5kSeDTuvWrdXgJIOV3Atyz8R64E3Ky0Tqas8KXo6zn0C9pidELTPaY4lERjh1tJbVUq6iMmZdWyMwU0/1bjdamZHWp56WTYnLjZ+3ZSEztwAZNaugZ4t0JDk9NsLOrDz8Z8GfmLnqL58BK7Gvt5/ZGr1apsfFsbhM1tOUlBTNcmnIakROevCJF2+sfJnLRalatWrMvF/Bj3Kt2K4eMiOREW4dLeX1KGPWtdUDMb63b9+O4uJi3+AjxxDqnjGa1GUvwlF4FGjcA86u/5AbN2qZehxLJDLCqaO1rJZyFZUx69oagVnHYkS70cqMtD71tDRz1u3BE19uwJ7sv5/iNkxLwS0DWmPdX9mYuWqXz4Dt37quWshADN2ysKOeOsNok4asDljN8CBET+LGoNmxFFX/+AJuOOCQCV7x0i9CiG0QI/bmD1bBY6b+jRi1j3y+zrct+V/vHNgG3ZuXbcASbdCQJYRYH1cJHHPu97zvNhxofLLZPSKE2AwJJxBPbLAR60+VSk68f33vUiEEJHLosiCEWJ+V78Cxdy1cyalwn/mI2b0hhNiQ5VuzAsIJQiFLy4rBS/SDhiwhxNrkZQH/92/19kivO4Dqdc3uESHEZuQXlWDWmr80lc3MLd/YJeFBQ5ZUyBlnnIG7777b7G5YmoMHD6Jx48bYtm1bWPUGDBiAO++8E2Zx5ZVX4sUXX0RcM+9J4NghuDM6IK/DlWb3hhBiI/Zm5+P5bzei7/h5aiUuLWTU1D4jn1QMY2TjAHnMII8k5FeaKLjEznjTdBiFGEhdu3bFhAnH16Ivh5kzZ3JCWzmsWbMG48ePx8KFC5GVlYWmTZtixIgRePDBB1UWAuGpp57CsGHD0KJFC1iJhx9+GKeddhpuuOEGlYYu7ti9Blj5rnrrHvIc4OSQRggxnl92HsaUxVvx1a97fBkIGtdKQU5+MY7kF4eMk5Vv0QZpnu94oh8c9U2mrDQdjw3rgMEdG5raN0kvlpycjPT0dJVaiZTmnXfewU033aReX375pTpXixYtwtixY1WO4ffee0+t1jVlyhR89dVXsBodO3bECSecgA8++EDlVY4rZOWXr+8VExboeCnQvB8QxeIHhBBSHsUlLny7fp8yYFduP+TbL4bpdf1a4uwO9fH9hr0qa4FaWdCvrtcVJN/tRjuq7AZDC+IgTUdwcLg8qpD98rkRjBw5Ej/88ANeeeUV5WmVlzzyFi/trbfeqh5lywIP55xzjqbQAql3++2347777lOGXIMGDfD4448HlBFPZLD3t0ePHr5yIuO2225TbdeuXRv169fH5MmTcfToUYwaNQo1a9ZUCfe/+eabABkDBw5UfZaXeAyl34888ojKyypMnToVderUQUFBQUC9iy66CMOHD4/qPC5YsEB5KqWfL730kjoeMfrk/D777LOq7c2bN+Prr79GlSpV0Lt374D6YujKuZ89e7Y6Dun/iSeeiGXLlpXZphyHnOuMjAyVs7V///74+eeffZ/LwgT/+Mc/UL16dTRs2BAvv/xymeEJ/u2fddZZqFatGtq1a1eqffEkT5s2DXHHr9OBXcuBytWBQf8yuzeEkAQlO68Ib/7wJ057bj7GfLRKGbGVkxy4+OTGmH1bf3xyU18M7thAGajigHrjmpOV59Uf2Zb9ZjuoEhEasjoixlNeYbGmV25+ER77Yn3Ixw/efY9/sUGV0yLPa7hpQQzYvn37YvTo0dizZ496yeNwQTyI4oVdvHgxJk2apFmm1BPjSYyg5557Dk8++SS+//57zfW9MsQQXb58uTJqb775Zlx22WU45ZRTsGrVKgwaNEgZn+Lh9EcMRnmEL/Xk2MSo/O9//6s+k/qyAtsXX3zhKy9L/ol39LrrrgvZj3fffVdTKMUdd9yBIUOG4Nprry312emnn67+/vLLL8pD271791Jl5DNpR/orj/BXrFiBZs2aYdy4cWW2KT8WJNRDzpWcEzHu5QeHhDQI4gmWayfHK+df2pZyofBvX4x/2Q7Vfq9evdS5Df4xYCr5OcD3j3ren3YPkNrI7B4RQhKMP/cfwSOz1qHP+HkY/81G7M7OR53qybj9rDZYPO5MvHR5V3RsXDrkSozVH+8/Ex+P7oNXruyq/so2jVhjYGiBjhwrKkGHR7/VRZaYpXtz8tHp8e80ld/w5DmolqztcornT4xV8cCJ99SfNm3aKEM0XDp37ozHHnvMJ+P111/HvHnzcPbZZ2uW0aVLF2XQCQ888ACeeeYZZdiKwS08+uijeOONN/Drr7+iT58+vnpihIvnUYwy8SiuXbtWbUs9WXHt6quvViEAYtQKH330kTLYxFNZ1vkROeWxevVq1Q/pYyiOHTum/sp5llWvxDsajBiOtWrVwvTp09VxSviGeD/feuutkDLFOy3HL4a2GNCCeIPFYH377bfxz3/+Uxm4cnziYRXkuBs1Cm3k+bcvq9MJ559/Pt58882AclJfwkz27t2L5s2bIy744VngaCaQfgLQN85CHgghlkWcQov+OIB3Fm/F/N/3+/af2KAmruvfEud3aYSUykkVyhHvbN8T6hjcWyLQkCUBhPIcajVk/RHDTTyfkcpISkpSIQGdOnXy7ZNwAyFYrjyy9/egirdZZtqLJ1bkiEHbs2dP/PXXX8ooEw+uTMYqy+sqYQfyqsiQFWTCXCi8XlD5XIzaUOtGiyF5wQUXKCPS61HfunWr8rKGQkIBioqK0K9fv4DlYcVj+ttvv2HLli3qc9nWYpT7t+8lVPve5ZeDPeGmsf93YNnxpwVDngUqVTG7R4QQi3OssASfrf5LGbB/ZB5R++Qr4qwT6+O6/i3Qt1UdTnqOU2jI6kjVyknKM6oFyVIw8p2/YxvL4t1RPX0zHMXYEa+dPEYPvqGkbT2Q8IBIEIPKH+mfSybj+C1jGhz+IEZXRTL893mP2V+uFrp166a8vWLAiod4w4YNKo41Grx9D2WgCv/5z3+Ux1e8xeJtPXz4cEhDUjzPwfskS0AsCNW+ZGAIbt8btuBv8JqG6NA39wGuYqDtEKCNdo8/IYQEI3NSpi7dho+W78DhPM+4Xj05CZf1aIqRp7RAi7qRfSeS2EFDVkfE0NL6eP/UNvVUdgK5icpL0yHlvDMclSHrREhDNlzkkbd4LGOFGEESi+slJycn7JyqZSHxm/789NNPKrxBvLFeZFKWTDbbtWuXeuzujQmOFDGOBZk0J15Nf1544QUVdiD98JaVWf/+ZGdnq+P3yvE3JGUyVyhkIpk3ftn7iF8MapnsJZO5WrVqpQx/2ZbQCW87mzZtKmWchtP+unXr0KRJE2WQm85vXwJbFgBJVYDBT5vdG0KIRVkj6bN+3Iqv1/6dPqtpelWMPKUlLuvRBKkpgY4VEr/QkDUJMU4lDYdZaToki4BMzBJjpkaNGirbgJGceeaZKrZTYkAlLlPiXf0NzWjYsWOHmuQkKbDkkf5rr71WKom/xMnec889ahKYpMIqj88++0x5Kjdu3FhmGXl8P3jwYJWSSuJHJYRAFj2QWFUxWiXu1GskymQskXfo0CGfV1MMXflB4h86IbG0UqascAXxlssEuHvvvVddLzFWJZ5ZHvlff/31KrODhEx4P5fMBhK3LN7w4B8+4bQvE8Zkop3pFOYB3z7ked/vdiC9ldk9IoRYLH3WnPV7lQG7asffT8l6S/qs/i0xsH19psayIDRkTcSbpiM4j2yDGOSRFaNOjJ4OHTqoGE6JjTQSMeSkjaFDh6q4TclqIDGdeiCZDOQYxLgU41iyCdx4440BZaTNSy65RGUrCPagBiPeyt9//73CdiV7gBjkci7F2yxGqnh75ZG9f1yqGIsnn3wyPv30U2WICt4y/qEJ4g0VI7+8RRNkcpmEVsgxS6otSfn17bffqpRlgmQgkElfcp5TU1NVloOdO3eWCoEI1b7E/Qa3n5+fj1mzZmHOnDkwncUTgOwdQGoToP9Ys3tDCLEIh/MKMe3nnZi6ZJvKPCAkJzkxrEsjjOrXImTmAWIdHO5w8jbZEHkELkaQGDdiGPgjX/JinLVs2bLMWEk9V/YqL0bWSIxoVw+ZIsO7Qpmk3aoIMTLFcBdjT2u7WvqppYzkahVPqTymD+WJNuraSqYDWRpXPNTitQ0XyZIgHurvvis7e0bwfSCGtkzIE4+weIN14dA24PVeQEkBcNl7wEkXlipiRLt6yIxERjh1tJbVUq6iMoZcW5Mw61jiUU8jrR/vepqLanjvp+2YufIvlVVIkPRZ1/Rpjn/0aWaJpWLtqqc55dhetvXIyuPX9u3bqxRMEsMYTzBNh7HI43JZvEBeEydONKUP5513nvLySuYEb/yqEYhXVUIixDstA4B4voWKvNBlITG3EqphOhJSIEZsy9OADpEdCyEk8RGnwMJN+zFp/h/4aXuOb3/7hqm4rl8L5YXVkj6LWAfbGLKy1r1/7lFiHyRWVYxZWW1LHqebtdyuTKISj6vRyA81MZplYpikU5MY10gnaskkOdPZPBfYOBtwJAFDnvPkxCGEkBDps2T52M1+6bMk7lWWj+3TKp3psxIUWxiyf/zxh/JSyUQjebRLEoe5c+dWaBz6Z0dI9EgaMdpXrlyJhKG4EPjmfs/73v8EMtqb3SNCSByxJ/sYpi7djo/90mfVqJKE89rXwT/POhEt69U0u4vEYEwPclq4cKEyMCVRvfxakoklwcjjYJmAIvF3kvw+ON1SRchknPHjx+vYa0JITFj2BnBwM1A9Axhw3KAlhNiedXuO4vZpa9D/2fl4Y8GfyoiV9FmPDO2AxfefgbsGNEXzOswBawdM98jKZBRJVi/r3l988cWlPpc0RpJaadKkScqIlVygks5IHp1KwLAgk31CPS6WCSqSU7Nt27bqtWTJkpgcEyEkTA7vBPIOBu47egCYf/wH6Cm3AymcWUxIIiMTn5dtOYjNu7LQ+kgSereqGzDxuUjSZ63zpM9avfPv9FkSNjCq39/ps2RS0bG/w2NJgmO6IStrxnvXjQ+FzDCXJUZHjRqltsWglRRKkgt03LhxvrRFZSFJ6adNm4YZM2bgyJEjKoG8zICTtEmhKCgoUC//mXOC3BjBK0rJtjyq9r5igbedWD8iN6JdPWRGIiPcOlrK61HGrGsbLV79994j3vtC8wps2TvhmNgTjuKCstv4v3/B3eF8IK3shSzCblcDesiMREY4dbSW1VKuojJGnGOzMOtY4lFPI62vp56Kgfrk7N+wN8ebinIrGqSm4NGh7ZWhKumz3v9phy9VZeUkB87v3FAZsB0aeWe1i3xPG9RTa+tpOO2absiWhySal3g//2U0JWXDwIEDsXTpUk0yJKTAG1YgCfklRrYsI9Zb/oknnii1f//+/SrNkD9iFMvJFm9wLCYQiQJ4V+OKdfotvdvVQ2YkMsKto6W8HmXMurZ6ILov94EsCCFZDuS9ZEyQY9KStqXS/s2oW44RKzhKCnBw12YUF1Qps0y47WpBD5mRyAinjtayWspVVMaIc2wWZh1LPOpppPX10tP5mw/hgdml84qLUXvLR6tRyQkUH7dralerhIs71cVZzZPRokEdOJ35yMwM/G6mnlpfTyVPekIYsgcOHFBf7vXr1w/YL9vlrboUDWI0SyiDv0dWljOVZPeh8sjKyZbJRrGYje5FjAUzMKJdPWRGIiPcOlrK61HGrGsbDaL7MijVqVPHl0dWjHG5ZzQNgCV/L11cHmr1uePhRKEIu10N6CEzEhnh1NFaVku5isoYcY7NwqxjiUc9jbS+Hnoq4QSvTFlfbl0xYts3qKFW3xrauSEqOx3KuUQ9tVa74cgMJzd/XBuyejNy5MgKy1SpUkW9gpGTHnzivUt/el9GI79ivO3E2iOrd7t6yIxERrh1tJTXo4xZ11YPvPrvf48Eb1cgQFM7TilXgbyw2tWIHjIjkRFOHa1ltZSrqIwR59gszDqWeNTTSOtHq6fLth70Cycom0eHnYS+J9QNMIiop9ZrV6vMcNqMa0NWcl/KKkj79u0L2C/bDRo0iGlfGCPLGFnGyBoUIyuPmTQUc8l5iSK+MxIYIxt5v+Idu8Ye6lk/Wj2VyVtzN+zV1Na+nHxfXeqpNdt12TFG1pvQfd68ebjwwgt9Byfbt956q6FtS8oveXnjFhkjyxhZxsgaFCOblQUtyzVkZWWhOCkzbmO69JTBGFnjsWvsoZ71I9XTXdmF+GLdAXz920Fk5Wn77qxcfEwtb6qlXeqp9fXUUjGykklg8+bNvm1Zs12yEEg8nCzlKfGqI0aMQI8ePdSym5J+S1J2ebMYGMWYMWPUy7veL2NkGSMbizKMkS0bxshGV5YxsoHYNfZQz/rh1DuSX4ivf8vCnAVbsWL736mz0qtVRkGxC0cLPT/kg5Gf9Q3SUjCoWytfKi7qqTXbdSVqjOyKFStwxhln+La9E63EeJUsA1dccYXyhkqmgb1796qcsXPmzCk1AcxoGCPLGFnGyIaGMbLGyGCMrPHYMfZQ7/rl1ZNxbc3Ow/hkxU58+ctuHCnwGKtijw5ol4HLezTFWe0zMO+3fbj5g1WeOv6yj/99bFgHVK6UFFZ/qafRwxhZjQwYMKDCmEAJIzA6lKAiGCPLGFn/8jt37sS1116rHnWJR1KyXVx55ZWMkY0kRrZqbTgqVSk/j2ylKnBXrc0Y2SjKMkY2ELvGHupZv6x6WUcL8dnqvzBjxS5syjzi2984rQqu6NkMl3ZvorysXgZ1qI+JV3cLyiPr8cQ+cl579bl/G9RTa7brsmOMrJkwRtbYdhMhRvb5559XTwj27NmDPn36YPDgwahRo0ZE7do5RhaoAucVc+DMP1RmCVdKbbgkh+zxGDmrxB5GKoMxssZj19hDPev713PDgeU7cvDl+gNY+Gc2il2eH+RVkhw4o01tDO2QjpY1SlC7Vg04C3KQmRm49NbJGU7MHNkBq3flYOf+HDStl4puTVJVOIE3NlZrf6mn1tdTS8XIxiuMka24XQkJkeWFJW5ZL5mxkhFcR4ywDh06YNmyZWjRokWF5SW3sLy87yXDhuhCrVq11L6rrrpKxXXffffdYfXVljGyQjmxr1aJ6dJTBmNkjceusYd61pd6e3IK8dWv2Zi5erdv1S2hY+NUXN69Cc7v0gipVT0/cMvL/eqlfka9CstRT63ZritRY2StAmNkS7f7v//9TxlekfQlVjGyMnHwmWeewYIFC9SsdzE6r7nmGjz88MMBRuPTTz+NCy64AC1btgy7DYnzFm+qyPaWEfmnnXaaWl5ZfggxRta+sYeRymCMrPFQTyOrn19Ugm/X78X0n3diyZ8HffvTqlbGRd0aq9jXv5eNDb8N6mkgdtRTp5ViZG3N4Z1A3t+DQCmq1QFqlb22vNmoWeQVLDEsKdTM4p133sFNN92Em2++GbNnz0bt2rWxcOFC5SXdtm0b3nvvPVUuLy8Pb7/9Nr799tuw2xDjWCYmvvHGGwH7O3bsiBNOOAEffPCB8uwTQojVWb87G5/8vBOz1uxG9rEi3/5+reuo2FeJZU2pHDgpixCjoSFr1mSv7J3A6z0qnOCCW1cAaU11nxAkYQEnnXSSei/Glngn//nPf+LJJ59Uv5gkM8RTTz2FdevWqUUpevfujVdffVUZZ2WFFnhlyqPmDz/8EJ06dcLcuXPx7LPPYvLkySrrRNu2bZW38tJLL/Udw4wZM1S7koatWrVq6NatG2bNmoXq1atXeBxlnQ/xwN5www2YMmWKmpTlpVWrViok5JZbblH9aN26Nb766iu1mpsco1fOn3/+iTZt2uCLL77ASy+9pEIOxOMqxq+UEwoKClR+4/vvv1/FyAb3Y+jQoZg2bZpqq7y+VnQsCT/ZK0EmJ+gpg5O9jId6qq1+zrEifP7LbjVxa93uv+NaG6al4JJujXBGi6ro0rqJz4MWre5QTwOxq566ONnLApO9cjJRuRwjVhAjtygnE6jeUPcJQSJr6tSpKh/v4sWLsXLlSmVwNWnSBNdff72KDb799tuVMSq5fh9//HFcdNFF6jG6d8DyGjDeY/fKvPHGG5UhKYgx/NFHH+H1119XRuOPP/6I4cOHK+9ov3791ESpq6++GuPHj1eP9iXOVPoj57ascyptiJEqhmRZ5+OOO+5Qk69Etr8c6aO0K6xatUrFw4qX9uSTTw4oJ5+JTDFix40bp86LyJT333//vZIjntjTTz9dZSsI1Q9ZzENCFiTvsXimOdkrsScn6CmDk72Mh3padn1ZRW/1riP4Yv0BLPjjEApKPD+uKzkdOO2ENAw7qS56NUuFA25VTyZjUU+Nwa56msvJXiZN9hJPWlGetgbcfz+WKY9KUs7lZ/CWFKGys3Jgsj2hcjXN+Ti9xpJ4GMWbKu/Fk7phwwbldZXH8ZdffnlAefGoNm7cGJs2bVKPzb0y5OWd6CbvxYv5wgsvqG0xNMUbK4Zf37591T7xyC5ZskR5SiWG9MCBA8oQEg9t8+bNVRnxyJaHGMHt2rXzxbgGT5BavXo11q5dq2JjQ03Ck5AHoWrVqupzSaXVqFGjgLLiiZaJW9OnT1d/pY3zzz8fb731lionBrl4kjt37owvv/xS3Zjvv/++Mvy9yPmVtuQYvcfGyV6JOzlBTxmc7GU81NPS9Uuq1FSTtmas3IUdWcd8n7fNqIHLejTBhV0boU6NKhG1Sz2NDLvqaQone5k02UuM2PGNdW3X8c7ggO0yI04f3A0kV/wo3h95HO5/TKeccoryQIqybdmyRS1CIY/UxRDzuvnF6PM31oInuokX0rstj+cl/nTQoEEB7YpxJ8aqlJPQhLPOOksZhOecc44qK0atGKtlcfHFF6tXWROkZIKX4G3DH6kT/PmxY8eUUetf9tdff1UeYrnhvJ5aiasVr7KUO/XUU33nxOuVFoPOX4aESQgi37+PnOxlr0k0kcrgZC/joZ4ChcUuzN2QiQ+W/ImftufgeNYs1KhSCcO6NFQTt7o2rVXmuEQ9NR476qmTk71ItAwbNkx5EcUT27BhQ5/x6fVmloV/XKuEJAgSgyreXH+8k8Ak/lY8tuKl/e677/Daa6/hoYceUgZ0cAYBrUhYQnm/6CZNmqQW4vCmz5LUWYcOBeYw/eWXX9QiB/6IASxe5HAmggliDBNCSDyxOTNXZR3436q/cPDo3+N6zxa1lfF6XueGqJZME4HEP9RSPSd7VaoKPPCXNoF715bytobCPWoO0KBTgJEW8vGztB3mJCExFv0nFi1dulSFBohR9/vvv6vH6OJ5FLwxr8ET28rbbt++vZpEtX379pAGoNfg9HqD5fXII4+ouFVJ7eVdrrg8Qk2QkkUKvH2WyVj+SNiDhB3IsXrrSHmZnObdlhge8b565Xj3iyF72223hZyMFaof0o7E1soj97LKVCTDCnCyl/4yONnLeOyop0cLijF77R41cWvVjsO+/XVrJGNwu9q4tn8btK5fM0CuHu2GU5Z6Gogd9VTgZC8zJ3s5/44fKhdHZWiJhix2VPbJVBOCkpIAR1LpxzzH+6kVkbVjxw7cddddauKUxJXKhKznnnsONWvWVMbXm2++qbyJUk68pJ5mSgImdwVP9vLflsf1Il8MUjlXMslKYo7F+yptyESs5cuXY/78+Tj77LNVW7It51piacua7CUZDSTjgBiKoSZIycQtCVOQZY3lmkm4g0xGkLhcmXgmk8UkztcrX0IbHnzwQdWuhDTIuZAwATHEpd/ShhjjYuD71/M/l6H6IZPIBg4cqMpXNJmLk72sPzlBTxmc7GU8iaKnJS6332pYOb7VsLxIO+v2HFUTt+ZtOoS8Io+BkOQA+rZMw/kn1UWfZjVx9EgOariPIjPzmCHHQj21t54KnOyVaCt7VdKWa6+SlAuSrceEIDGWJHuAHIMYmPKIX7IUSAou+ezjjz9Ws/QlnEAmVr344ovK2JRy/pO7gid7+W97sxbUr19fLecq+Vxl4pQYmvLYXmRJLlrJUiAhBXKuJZxBvKaSuqosJGRBJp2VNdlLmDlzporxldRYkhlBrp8YrOJVlRRc/nXkGKVP4gWWiW4y0UuO2X+5We/kL4mRLQt/mXJeJXXXN998E3A+ONkrcScn6CmDk2iMJxH0dM66vXhy9m/Ym+N1smSiQWoKHh3aHj1a1Mas1bvxyYqd2Lz/qK9OizrV1MStS7o1RkZqiq9P+/c7I1rZi3pqLImgp0ZP9nK4rfYcM8Z4DVn5FRHKkN26dauK5QznpPsWQ3i9O1BeCi6VR3alb1GEsiYVRYLEiMqjcy3Ly+rZrp4yI5FRVh2J47333nuVwep/g2lpI1QZWSDhs88+U3G/WuQYcY5jRfB9IIOVeMAzMjJiPvDq3a4eMiOREU4drWW1lKuojFnX1gisrqdz1u3BzR+sKpXAxos4Zb0Tt1IqO3Fup4a4okdT9GqZXmqMibRP1FPjsbqeRiqzPNsrGHpkzUKMUzFSLbyyVyJx3nnn4Y8//sBff/3lmwQWDeJZFS8zIYTojYQTPPHlhjKNWEGM2M6NU3FFr2YY1qURUlOs97SHEC3QkDUTMVJpqMYNd955p26yJO6YEEKMYPnWLOzJDpyzEYoHzu2Avid4JpsSkqjQkLUp3iwEhBBCrOWN/W7DXk1lM3MrNnYJsTo0ZPVMvxUDzErRZES7esiMREa4dbSU16MM029ZO12MnjKY1sh4rKankjpLVtx6Z/E27DykLbNAvRrJuupQNPWop/bQ0/Jg+q0YE3H6LQMxK0WTEe3qITMSGeHW0VJejzJMv2X9dDF6ymBaI+Oxip5mHinEjDWZmLX2AHILPGNEzSpOlLiBvMKyv+zr16iM5tWK1eQavfsUST3qaWLrqRaYfivR0m9FgVkpmoxoVw+ZkcgIt46W8nqUYfot66aL0VMG0xoZT7zr6W97cvDfH7di9q97UCRWK4Dmdarhun4tcMnJjbFw0wGM+Wi12u//DMf7M/ix8zuiYYP6uvYpmnrU08TU03hIv0VDViOh1gaWbW/u1Fh40eRXjLedWHtk9W5XD5mRyAi3jpbyepQx69rqgVf//e8RO64NrrcMrmFvPPGmpzIO/LBpP/67aCt+3HzAt79Xi3TccGpLnNW+vm+xg3M7N8IbTofKXuA/8atBWgoeG9YBgzs21KVPetajniaGnsZCZjht0pAlhBBCTKSguASfr96N//64BZv2HVH7xF4d0qkhRp/aCl2b1gpZT4zVszs0wLItB7B51360blIPvVvVDVjZi5BEh4YsIYQQYgKHjhbig5+2472l23HgiGdxnOrJSbiiZzOM6tcCTdOrVShDjNY+reqgVY0SZGTUgZNGLLEZNGQJIYSQGLLjUD5eW7oeM1ftQn6RZ8JWw7QUjDylBa7s1QxpVa0XK0+IWdCQJYQQQgxG4l9/3nYIkxf+ibm/ZfomaJ3UKFWFD5zXuSEqJ1k/npOQWENDViPMI8s8sswjGxrmkdVfBvNzGk+sjqW4xIU56/epDAS/7sr27T+jXT3c0L8l+rRK903wjLQv0R4L88jGL3YdT13MIxs9zCNrbLvMIxv9scQLzCOrvwzm5zQeo4/laGEJvlh3ANNXZ2JvbqHal5zkwOAT03Fe66ro1FxSEJWo7xazj4V5ZOMXu46nucwjGz3MIxubdplHNrp+xQPMI6u/DObnNB6jjmX34WNq8tbHy3fiSIHHwZFerTKu6dMc1/Rppt6L8RpPeso8svGLXcfTFOaR1Z9EyyM7YMAAdO3aFRMmTIhpu/4yzz77bNWHV155JWIZWvp17rnnokePHpg3bx727NmDmTNnqnaZR1YfmEfWGBnMz2k8eh7Lur+yMXnRFnz16x4UuzzhQa3qVccN/Vvh4pMbI6VyUsCXebzpKfPIxi92HE+dYbRp/StMbM2zzz6LXr16oWbNmsjIyMCFF16I33//PaDMunXr0KxZMyxevBi33XYbvvzyS9P6SwhJHFwuN+b9tg9XvrUUQ1/7EZ+v2a2MWIl7fXtED8y963Rc3buZz4glhOgPPbLE0ixatAi33HKLMmYlVvPBBx/EoEGDsGHDBlSvXl2FhsgvwBtuuMEX11yrVujk4oQQooX8ohL8b9VfePvHLfhz/1FfPtehnT0LGHRsnGZ2FwmxDfTIxglLdy/FBbMuUH9jhRh+t956q4oBrlu3Lh555BHfjPmCggLcfvvtystZtWpVFYrw888/B9Rv0aJFqdAEeWT/+OOP+7blMdpzzz2H1q1bo0qVKsoz+tRTT4Xsj5QdP348WrZsqdrs0qULPv3003KPYfbs2Rg5ciROOukkVf7dd9/Fjh07sHLlSp83tmfPnr7yst2hQ4cIzhYhxO7IogUvf78J/Z75Pzz42VplxNasUgk3ntYKi+47A69c2Y1GLCExhh7ZOECMx1dWvYIt2VvU3z4N+8QkTvK9997D9ddfj+XLl2PFihW48cYblaE5evRo3HfffSqWVMrIPnmEP3jwYGzevBnp6ema23jggQcwefJkvPzyy+jfv7+KUd24cWPIsmLEfvDBB5g0aRLatGmDhQsX4pprrlGB4aeffrqm9mRGpODtoxiuYuB6Wbt2LTp27Ki5/4QQsjnzCN7+catawKCw2JMWqHGtqmr1rSt6NkXNFOtN0iQkUaAhq7NBeqz4WNj1ftr9E9YfXK/ey9/5O+ajT6M+ZaZoSnInlTJ0q1aqGrbx27RpU2VgSr127dopI0+2r776arzxxhvKuzlkyBDVrte4fPvtt3Hvvfdqki8ZHWQi1+uvv44RI0aofSeccIIyaINzpYoH+Omnn8bcuXPRt29fta9Vq1b48ccf8eabb2oyZMWje+edd6Jfv34+Y1UM2bPOOsvngT58+LCaXU8IIeUhY9RPW7Lw30VbMG9jpm9/lyZpuOHUVhjSsQEqcQEDQkyHhqyOiBHb+6PeUcu5Y8EdYddZdvUyVKtc8brc/vTpE+j5FQPyxRdfVF5XiSUVg9A/LZTEof7222+a5UtZMVC9hmR5SJt5eXkqk4E/hYWF6Natm6b2JF2aGK5i/Hp59dVXA9JEbdmyJSY5fwlJNEpcbizbchCbd2Wh9ZEk9G5VV8WFJtqxFJW48PXaPSoDwbq/ctQ+GSYHtq+v4l97tqhtucwihCQyNGRJxEh6jGDPqhjAXiTOVStHjhxRf7/66is0btw44DOJra0IifWVeFkJR2jSpInmdgkhFTNn3R488eUG7Mn2LgqzFQ3TUvDYsA4Y3LEhEuFY7j2nnYqBfWfxNt9nKZWduLR7E1zXryVa1athar8JIaGhIavjErUpSSn46aqfNMuUOtd9dx1+P/Q7XO6/ZTsdTrSr3Q5TBk0p9ctfvImhFl+QtsNd2nTZsmUBdZYuXarCB+Txf3JysvJsSnys1zMqk73uuOMOXx2JXd29e7dvWzIEbN261Xc+ZIKXGLMSLuDNGlDWeWjfvr0yWLdv347TTjstZJlQyDUQI3bWrFmYP3++moBW0XngErX6wiVq9ZcRT0t/zlm3F2M+Wo1grdybnY+bP1iFiVd3w+CODWAFyjoWMVzHfvKLb7tujWRc26e5Sp2VXj1Z7dNLr+JRT7lEbfxi1/HUxSVqzVuiNtnhGfS0sGTPEvyWVfpRvRi1sn/l3pU4pdEpvv1qWTeHE0koHSPr7adWRJbM7r/rrruUkbl69WoVyyoZBsSgvOmmm9SEL8loILG0L7zwgnr0L7Gu3mOVuNX3339fLTgg5Z544gkkJSX5zokY3Pfccw/uv/9+tf+UU07BgQMHVGosyTTgVWgpKwav9GXs2LG+sAYxjJcsWaJyxF577bUhj0Hywn7yySdqYprI2LVrl/pM+hPKI8wlavWHS9TqLyNelv6UR/CPf7GulOEnePc98cU6dKnr0C3MQI0LbhkH3ShxH992ebZlf4n64eT31/V3efmr7iXZlv3Hc73K/uISFx78akvIY/EiIa/3ndkMg0+sgyqVnCg+ehiZnuxaCa2nXKI2frHreJrLJWrjf4lauZBvrH0DDjjgDjG0yn75/NSmp5YybPRYxlRkDh8+XB2DGI1iaEq6rX/+85/qM8lSIH0cNWqUOsbu3btjzpw56jx4eeihh5QxLIsQyDl68sknlUdVFNR7Ph577DHl3ZXPxHvbsGFDZSTLMXhX+PCWlbRc9evXx/PPP4+bb75Z5Xs9+eSTVeaDss6vZEQQBg4cGLB/ypQpylguCy5Rqx9colZ/GfGy9OdPWw4i88jf4UKh2HekCFd98BuqJlc6bjS6jxuXxw1PlzvQuPR97jU+xVA9/vlx49QsSlxApxYN0LRRHVvpKZeojV/sOp6mcIna+F+itshVhL1H94Y0YgXZL58Xu4uR7EzWfRnTBQsW+N5LRoJgxJv52muvqZe06/Ww+rcrxuu0adMC6gUbj2IgP/zww+oVcHxutwo58JcpfyXrgLy0IDIk5CG4XxXVCeccconaiuEStcbIiIelP/cfKdTU1x1Z4WdriQZx/ooHWPqaJP11yHjs8Qo71bZnn2/bCRwrLMEBDccjx2y03sajnnKJ2vjFjuOpM4w2aciaRHJSMqYNnYas/Kwyy6SnpKtyhBBiBhk1tXlFHhhyoloIQH6DKcPyuAHpMSTF8Px7Wx7f/22AeozMkAaoV4b6oeTZ530fyY+9pX8exFWTf9LtmAkh8QENWRNpUL2BehFCSDzSq2W6mtEvE7tCPTsSc7JBWorKqxrvqbi0HouUI4RYB+v73AkhhBiCGKeSYksINlO92/J5vBuxiXYshJC/oSFLCCGkTCRP7BvXnKy8lf7Ituy3Uh7ZRDoWQogHhhYQQggpFzHwzu7QAMu2HMDmXfvRukk9y67slUjHQgihIasLVktgT4ieUP/tgRh6fVrVQasaJcjIqKMmY1mVRDoWQuwOQwuiQFJLCZICihC7IgtlWDUHLiGEEGtDj2wUSP7SatWqqVW/5Evc6BxvZeVzNRoj2tVDZiQywq2jpbweZcy6ttEgfRYjNjMzUy1e4f1hRwghhMQKGrJRIAaHrFS1detWtaKV0XiXdPUuxBArjGhXD5mRyAi3jpbyepQx69rqgRixDRowjRwhhJDYQ0M2SmT51TZt2sQkvMC7nr0sBRrrper0blcPmZHICLeOlvJ6lDHr2kaLPImgJ5YQQohZ0JDViBga8irPoI1FH+TRs7QVa0NW73b1kBmJjHDraCmvRxmzrq0eBN8Xsu31MMe6H3q3q4fMSGSEU0drWS3lKipj1rU1Aupp9PWpp8ZjVz11hdEuDdkymDhxonqVlJSobYmDzc/PN7VPcmGzs7OVIsTakNW7XT1kRiIj3DpayutRxqxrawTU0+hlhFNHa1nqaSDU0+jrU0+Nx656mpubq1kuDdkyGDNmjHrl5OQgLS0N9erVQ2pqqql9EiWQ+EnpS6wVWu929ZAZiYxw62gpr0cZs66tEVBPo5cRTh2tZamngVBPo69PPTUeu+ppSkrgoiXlQUNWI3LS4+GGECUwoy9GtKuHzEhkhFtHS3k9yph1bY2Aehq9jHDqaC1LPQ2Eehp9feqp8dhRT51htElDVmOyd/HMmo38mhF3u/xSifUvM73b1UNmJDLCraOlvB5lzLq2RkA9jV5GOHW0lqWeBkI9jb4+9dR47KqnOcdtLi0L7tCQrQBvnEbTpk3N7gohhBBCiK1ssLS0tHLLONxcX7LCXxC7d+9GzZo14yK/Z8+ePfHzzz8nRLt6yIxERrh1tJSPtoz8+pQfSzt37jQ9FlsPqKfRywinjtay1NNAqKfR16eeGo8d9dTtdisjtlGjRhV6b+mRrQA5gU2aNEG8IDk7zbgxjWhXD5mRyAi3jpbyepWRzxNh4KWeRi8jnDpay1JPA6GeRl+femo8dtXTtAo8sV6sHTxiQySTQqK0q4fMSGSEW0dLeb3KJArU0+hlhFNHa1nqaSDU0+jrU0+Nh3paPgwtICQO8KZ5kxx7ieBBIIkJ9ZRYAeqpvaBHlpA4oEqVKnjsscfUX0LiFeopsQLUU3tBjywhhBBCCLEk9MgSQgghhBBLQkOWEEIIIYRYEhqyhBBCCCHEktCQJYQQQgghloSGLCFxjKxMM2DAAHTo0AGdO3fGjBkzzO4SIaU4fPgwevToga5du6Jjx46YPHmy2V0ipEzy8vLQvHlz3HPPPWZ3hegAsxYQEsfs2bMH+/btUwbC3r170b17d2zatAnVq1c3u2uE+CgpKUFBQQGqVauGo0ePKmN2xYoVqFOnjtldI6QUDz30EDZv3qyWsX3hhRfM7g6JEnpkCYljGjZsqIxYoUGDBqhbty6ysrLM7hYhpZadFCNWEINW/CP0kZB45I8//sDGjRsxZMgQs7tCdIKGLCEGsnDhQgwbNgyNGjWCw+HArFmzSpWZOHEiWrRogZSUFPTu3RvLly8PKWvlypXK8yVeBELiTU8lvKBLly5o0qQJ7r33XvWji5B401MJJxg/fnwMe02MhoYsIQYij1nly10G11BMnz4dY8eOVavQrFq1SpU955xzkJmZGVBOvLDXXnst3nrrrRj1nNgJPfS0Vq1a+OWXX7B161Z89NFHKiSGkHjS088//xxt27ZVL5JASIwsIcR45Hb77LPPAvb16tXLPWbMGN92SUmJu1GjRu7x48f79uXn57tPPfVU99SpU2PaX2JPItVTf26++Wb3jBkzDO8rsS+R6Om4cePcTZo0cTdv3txdp04dd2pqqvuJJ56Ied+JvtAjS4hJFBYWqnCBgQMH+vY5nU61vXTpUrUt4/XIkSNx5plnYvjw4Sb2ltgVLXoq3tfc3Fz1Pjs7Wz0CbteunWl9JvZDi55KSIFkgtm2bZua5DV69Gg8+uijJvaa6AENWUJM4sCBAyrmtX79+gH7ZVsyFAiLFy9Wj8skFkwmfclr7dq1JvWY2BEterp9+3aceuqp6lGu/L3tttvQqVMnk3pM7IgWPSWJSSWzO0AIKZv+/fvD5XKZ3Q1CyqVXr15Ys2aN2d0gRDPypIskBvTIEmISMqtb0hYFT4qRbUm1RUg8QD0lVoB6al9oyBJiEsnJyWqBg3nz5vn2ifdVtvv27Wtq3wjxQj0lVoB6al8YWkCIgRw5ckStIONFUhPJI9j09HQ0a9ZMpYoZMWKEWt5THs9OmDBBpZgZNWqUqf0m9oJ6SqwA9ZSEROcsCIQQP+bPn6/SxAS/RowY4Svz2muvuZs1a+ZOTk5W6WN++uknU/tM7Af1lFgB6ikJhUP+C23iEkIIIYQQEr8wRpYQQgghhFgSGrKEEEIIIcSS0JAlhBBCCCGWhIYsIYQQQgixJDRkCSGEEEKIJaEhSwghhBBCLAkNWUIIIYQQYkloyBJCCCGEEEtCQ5YQQgghhFgSGrKEEEIIIcSS0JAlhBALMmDAANx5552atwkhJBGpZHYHCCHE7ojR2bVrV0yYMEFznf/973+oXLmyof0ihJB4h4YsIYRYkPT0dLO7QAghpsPQAkIIMZGRI0fihx9+wCuvvAKHw6Fe27Ztw5w5c9C/f3/UqlULderUwdChQ/Hnn39GHDrgcrkwfvx4tGzZElWrVkWXLl3w6aeflltH2pP+zJ49G2eddRaqVauGdu3aYdmyZVEdMyGE6AUNWUIIMRExYPv27YvRo0djz5496tW0aVMcPXoUY8eOxYoVKzBv3jw4nU5cdNFFyiCNBDFip06dikmTJmH9+vW46667cM011ygjuix++eUXZci+9NJLeOSRR9R2s2bNMG7cuCiOmBBC9IOhBYQQYiJpaWlITk5W3s4GDRr49l9yySUB5aZMmYJ69ephw4YN6NixY1htFBQU4Omnn8bcuXOV0Sy0atUKP/74I958802cfvrpIeuJ4Soe4enTp6u2hfPPP1/VIYSQeICGLCGExCF//PEHHn30UfUY/8CBAz5P7I4dO8I2ZDdv3oy8vDycffbZAfsLCwvRrVu3MuuJIXvBBRf4jFhh69ataN26ddjHQwghRkBDlhBC4pBhw4ahefPmmDx5Mho1aqQMWTFgxfgMlyNHjqi/X331FRo3bhzwWZUqVco1ZB944IGAfWvWrMFpp50Wdh8IIcQIaMgSQojJSGhBSUmJb/vgwYP4/ffflRF76qmnqn0SBhApHTp0UAareHPLCiMIJjs7W006C/bYiiF7++23R9wXQgjRExqyhBBiMi1atFAhBGI41qhRQ6XWkkwFb731Fho2bKgM0GgmWNWsWRP33HOPmuAlnl3JhiCG6uLFi5GamooRI0aUqvPrr7+iUqVK6NSpk2/f9u3bcejQIZXzlhBC4gFmLSCEEJMRIzMpKUl5TiUeVQzXadOmYeXKlSqcQAzQ559/Pqo2/vWvf6nMA5K9oH379hg8eLAKNZB0XGWFFUiqrZSUFN++1atXq8lfYngTQkg84HC73W6zO0EIIYQQQki40CNLCCGEEEIsCQ1ZQgghhBBiSWjIEkIIIYQQS0JDlhBCCCGEWBIasoQQQgghxJLQkCWEEEIIIZaEhiwhhBBCCLEkNGQJIYQQQogloSFLCCGEEEIsCQ1ZQgghhBBiSWjIEkIIIYQQS0JDlhBCCCGEwIr8P6KtNrJAC8K8AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x450 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "quand n passe au quadruple (fin de gamme) :\n",
+      "  tri    : temps x3.7\n",
+      "  paires : temps x16.4\n",
+      "  2^n    : n gagne +2 -> operations x4 (exact) ; chrono x4.0\n",
+      "Le compte d'operations est deterministe ; le chrono le confirme a un facteur machine pres.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def mesurer(f, n, repetitions=3):\n",
+    "    \"\"\"Temps MINIMAL sur repetitions essais : la course la moins contaminee\n",
+    "    par l'ordonnanceur (machine partagee) approxime au mieux le cout propre.\"\"\"\n",
+    "    temps = []\n",
+    "    for _ in range(repetitions):\n",
+    "        t0 = time.perf_counter()\n",
+    "        f(n)\n",
+    "        temps.append(time.perf_counter() - t0)\n",
+    "    return min(temps)\n",
+    "\n",
+    "\n",
+    "def tri(n):\n",
+    "    rng = np.random.default_rng(n)\n",
+    "    return np.sort(rng.integers(0, 10**6, size=n))\n",
+    "\n",
+    "\n",
+    "def paires(n):\n",
+    "    rng = np.random.default_rng(n)\n",
+    "    x = rng.random(n)\n",
+    "    return float(np.abs(x[:, None] - x[None, :]).sum())\n",
+    "\n",
+    "\n",
+    "def boucle_exp(n):\n",
+    "    c = 0\n",
+    "    for _ in range(2 ** n):\n",
+    "        c += 1\n",
+    "    return c\n",
+    "\n",
+    "\n",
+    "tailles_tri = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000]\n",
+    "tailles_paires = [250, 500, 1_000, 2_000, 4_000]\n",
+    "tailles_exp = [18, 19, 20, 21, 22, 23]\n",
+    "\n",
+    "t_tri = [mesurer(tri, n) for n in tailles_tri]\n",
+    "t_paires = [mesurer(paires, n, 3) for n in tailles_paires]\n",
+    "t_exp = [mesurer(boucle_exp, n, 5) for n in tailles_exp]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4.5))\n",
+    "ax.loglog(tailles_tri, t_tri, \"o-\", label=\"tri numpy : $O(n \\\\log n)$\")\n",
+    "ax.loglog(tailles_paires, t_paires, \"s-\", label=\"paires : $O(n^2)$\")\n",
+    "ax.loglog(tailles_exp, t_exp, \"^-\", label=\"boucle $2^n$\")\n",
+    "ax.set_xlabel(\"taille $n$\")\n",
+    "ax.set_ylabel(\"temps (s)\")\n",
+    "ax.set_title(\"Trois croissances mesurées — l'échelle de la ressource temporelle\")\n",
+    "ax.legend()\n",
+    "ax.grid(True, which=\"both\", alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"quand n passe au quadruple (fin de gamme) :\")\n",
+    "print(f\"  tri    : temps x{t_tri[-1] / t_tri[-3]:.1f}\")\n",
+    "print(f\"  paires : temps x{t_paires[-1] / t_paires[-3]:.1f}\")\n",
+    "n2 = tailles_exp[-1] - tailles_exp[-3]\n",
+    "print(f\"  2^n    : n gagne +{n2} -> operations x{2 ** n2} (exact) ; chrono x{t_exp[-1] / t_exp[-3]:.1f}\")\n",
+    "print(\"Le compte d'operations est deterministe ; le chrono le confirme a un facteur machine pres.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:02.961845Z",
+     "iopub.status.busy": "2026-09-13T10:13:02.961845Z",
+     "iopub.status.idle": "2026-09-13T10:13:02.968735Z",
+     "shell.execute_reply": "2026-09-13T10:13:02.968735Z"
+    },
+    "papermill": {
+     "duration": 0.011858,
+     "end_time": "2026-09-13T10:13:02.969741",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:02.957883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  n |   ops brut |  cases dp |  brut (s) |   dp (s)\n",
+      "--------------------------------------------------------\n",
+      "  8 |       2048 |       734 |    0.0001 |  0.00003\n",
+      " 11 |       1925 |      1703 |    0.0001 |  0.00007\n",
+      " 14 |       2576 |      2474 |    0.0002 |  0.00010\n",
+      " 17 |       8636 |      4457 |    0.0005 |  0.00016\n",
+      "\n",
+      "Meme verdict des deux cotes (assertion verifiee a chaque ligne). Les compteurs\n",
+      "d'operations - deterministes, comme les pas comptes en section 1 - remplacent le\n",
+      "chrono comme preuve : la brute vit sous n * 2^n (arret des qu'un masque convient),\n",
+      "la dp visite de l'ordre de n * S cases, S = somme visee.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def subset_brut(poids, cible):\n",
+    "    \"\"\"Force brute : enumere les 2^n sous-ensembles.\n",
+    "    Retourne (verdict, operations) : compte deterministe.\"\"\"\n",
+    "    n = len(poids)\n",
+    "    ops = 0\n",
+    "    for masque in range(2 ** n):\n",
+    "        s = 0\n",
+    "        for i in range(n):\n",
+    "            ops += 1\n",
+    "            if masque >> i & 1:\n",
+    "                s += poids[i]\n",
+    "        if s == cible:\n",
+    "            return True, ops\n",
+    "    return False, ops\n",
+    "\n",
+    "\n",
+    "def subset_dp(poids, cible):\n",
+    "    \"\"\"Programmation dynamique : table booleenne sur les sommes 0..cible.\n",
+    "    Retourne (verdict, cases) : chaque case visitee = 1 operation comptee.\"\"\"\n",
+    "    atteignable = [False] * (cible + 1)\n",
+    "    atteignable[0] = True\n",
+    "    cases = 0\n",
+    "    for p in poids:\n",
+    "        for s in range(cible, p - 1, -1):\n",
+    "            cases += 1\n",
+    "            if atteignable[s - p]:\n",
+    "                atteignable[s] = True\n",
+    "    return atteignable[cible], cases\n",
+    "\n",
+    "\n",
+    "rng = np.random.default_rng(42)\n",
+    "print(f\"{'n':>3} | {'ops brut':>10} | {'cases dp':>9} | {'brut (s)':>9} | {'dp (s)':>8}\")\n",
+    "print(\"-\" * 56)\n",
+    "for n in (8, 11, 14, 17):\n",
+    "    poids = rng.integers(1, 60, size=n).tolist()\n",
+    "    cible = int(sum(poids) // 2)\n",
+    "    t0 = time.perf_counter()\n",
+    "    tb, ops_b = subset_brut(poids, cible)\n",
+    "    t_brut = time.perf_counter() - t0\n",
+    "    t0 = time.perf_counter()\n",
+    "    td, cases_d = subset_dp(poids, cible)\n",
+    "    t_dp = time.perf_counter() - t0\n",
+    "    assert tb == td, \"les deux algorithmes doivent convenir\"\n",
+    "    print(f\"{n:>3} | {ops_b:>10} | {cases_d:>9} | {t_brut:>9.4f} | {t_dp:>8.5f}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Meme verdict des deux cotes (assertion verifiee a chaque ligne). Les compteurs\")\n",
+    "print(\"d'operations - deterministes, comme les pas comptes en section 1 - remplacent le\")\n",
+    "print(\"chrono comme preuve : la brute vit sous n * 2^n (arret des qu'un masque convient),\")\n",
+    "print(\"la dp visite de l'ordre de n * S cases, S = somme visee.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003,
+     "end_time": "2026-09-13T10:13:02.975741",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:02.972741",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Les deux algorithmes rendent le même verdict (l'`assert` le prouve à chaque\n",
+    "ligne) mais leurs coûts vivent dans des mondes différents : la force brute double quand $n$\n",
+    "croît de 1, la dynamique reste plate tant que $n \\cdot S$ reste modéré. **Aucun des deux n'est\n",
+    "« faux »** — mais l'un vit dans $\\mathrm{TIME}(2^{n})$, l'autre dans $\\mathrm{TIME}(nS)$.\n",
+    "La question fondatrice se pose alors avec précision : existe-t-il des langages pour lesquels\n",
+    "**aucune machine astucieuse** ne peut descendre sous un certain budget — la dureté est-elle\n",
+    "une propriété du *problème*, pas de l'algorithme qu'on a écrit ? La réponse de 1965 :\n",
+    "**oui, et en quantité dénombrable** — c'est le théorème de hiérarchie, dont l'outil est la\n",
+    "diagonalisation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002004,
+     "end_time": "2026-09-13T10:13:02.980745",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:02.978741",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Prédire le point de bascule\n",
+    "\n",
+    "La DP gagne dès que $2^n$ dépasse $n \\cdot S$… en *opérations*. Mais son coût dépend de la\n",
+    "plage des poids : avec des poids dans $[1, 60]$, $S \\le 60n$ ; avec des poids dans\n",
+    "$[1, 10^4]$, $S$ explose et la DP peut perdre.\n",
+    "\n",
+    "**Objectif** : mesurer le rapport $t_{brut}/t_{dp}$ pour les deux plages de poids\n",
+    "(`[1, 60]` et `[1, 10_000]`), $n$ de 8 à 17, et expliquer en une phrase pourquoi la plage\n",
+    "haute déplace (ou détruit) la bascule.\n",
+    "\n",
+    "# Indice : reprendre la boucle ci-dessus avec `rng.integers(1, plage, size=n)`.\n",
+    "# Etape 1 : tracer le rapport t_brut/t_dp pour chaque plage.\n",
+    "# Etape 2 : comparer les deux courbes et localiser le croisement (s'il existe)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:02.988574Z",
+     "iopub.status.busy": "2026-09-13T10:13:02.987568Z",
+     "iopub.status.idle": "2026-09-13T10:13:02.990779Z",
+     "shell.execute_reply": "2026-09-13T10:13:02.990779Z"
+    },
+    "papermill": {
+     "duration": 0.00781,
+     "end_time": "2026-09-13T10:13:02.991784",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:02.983974",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mesurer le point de bascule pour deux plages de poids\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : a completer\n",
+    "resultat_bascule = None  # TODO etudiant : {(plage, n): rapport} mesure\n",
+    "print(\"Exercice a completer : mesurer le point de bascule pour deux plages de poids\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003656,
+     "end_time": "2026-09-13T10:13:02.997440",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:02.993784",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Diagonaliser sous budget : l'argument exécuté\n",
+    "\n",
+    "L'argument de Cantor–Turing s'adapte aux budgets de temps. Idée : **énumérer** les machines\n",
+    "$M_0, M_1, M_2, \\dots$ et construire une langue $D$ qui **diffère de $M_i$ sur l'entrée $i$** :\n",
+    "simuler $M_i(i)$ pendant un budget $f(i)$, et répondre l'inverse. Si $M_i$ dépasse son budget,\n",
+    "$D$ répond « oui » — et diffère quand même : une machine qui ne tient pas son budget n'est\n",
+    "pas dans $\\mathrm{TIME}(f)$, donc ne peut pas être $D$. Aucune machine de la liste ne décide\n",
+    "$D$ **en $f(i)$ pas** ; et si la liste est assez riche, c'est une **preuve d'existence** de\n",
+    "problèmes durs pour chaque budget.\n",
+    "\n",
+    "La cellule suivante **exécute** la construction sur une famille finie de cinq machines\n",
+    "(« recognaisseurs » Python sur les indices $0..4$, avec coût en pas explicite) — l'ombre\n",
+    "finie du théorème infini : chaque ligne du tableau montre $D$ différer de $M_i$ **sur sa\n",
+    "propre diagonale**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:03.005439Z",
+     "iopub.status.busy": "2026-09-13T10:13:03.005439Z",
+     "iopub.status.idle": "2026-09-13T10:13:03.011213Z",
+     "shell.execute_reply": "2026-09-13T10:13:03.011213Z"
+    },
+    "papermill": {
+     "duration": 0.010773,
+     "end_time": "2026-09-13T10:13:03.011213",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.000440",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " i |  M_i(i) |    pas |  budget |  D(i) | differe\n",
+      "--------------------------------------------------\n",
+      " 0 |    True |      1 |      10 | False | oui\n",
+      " 1 |    True |      3 |      11 | False | oui\n",
+      " 2 |    True |      8 |      14 | False | oui\n",
+      " 3 |   False |      9 |      19 |  True | oui\n",
+      " 4 |    None |    256 |      26 |  True | oui\n",
+      "\n",
+      "D differe de chaque M_i sur sa diagonale : 5/5 lignes.\n",
+      "La ligne i=4 exhibe le cas cle : M4(4) coute 4^4 = 256 pas > budget 26 -> verdict\n",
+      "None, et D(4) = True SANS avoir termine la simulation. C'est legitime : une machine\n",
+      "qui depasse son budget n'est pas dans TIME(f), donc ne peut pas etre D. Regardez\n",
+      "aussi M3 : i^2 ne depasse jamais i^2+10 — c'est la MARGE du budget qui la contient ;\n",
+      "l'Exercice 2 la retire.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def simule(machine, entree, budget):\n",
+    "    \"\"\"Simule machine(entree) avec un budget de pas.\n",
+    "    machine retourne (verdict, pas_effectues) ; si pas > budget -> (None, pas).\"\"\"\n",
+    "    verdict, pas = machine(entree)\n",
+    "    if pas > budget:\n",
+    "        return None, pas\n",
+    "    return verdict, pas\n",
+    "\n",
+    "\n",
+    "# Famille finie de \"machines\" : (verdict sur l'entree i, cout en pas).\n",
+    "familles = [\n",
+    "    lambda i: (i % 2 == 0, 1 + i),          # M0 : parite, lineaire\n",
+    "    lambda i: (True, 3 ** i),               # M1 : accepte tout, cout exponentiel en i\n",
+    "    lambda i: (i < 3, 3 * i + 2),           # M2 : petit seuil, lineaire\n",
+    "    lambda i: (i % 3 != 0, i * i),          # M3 : mod 3, quadratique\n",
+    "    lambda i: (False, 4 ** i),              # M4 : rejette tout, cout exponentiel\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def budget_f(i):\n",
+    "    \"\"\"Budget diagonal f(i) = i^2 + 10 (joue le role du f log f du theoreme).\"\"\"\n",
+    "    return i * i + 10\n",
+    "\n",
+    "\n",
+    "print(f\"{'i':>2} | {'M_i(i)':>7} | {'pas':>6} | {'budget':>7} | {'D(i)':>5} | differe\")\n",
+    "print(\"-\" * 50)\n",
+    "D = {}\n",
+    "for i, M in enumerate(familles):\n",
+    "    verdict, pas = simule(M, i, budget_f(i))\n",
+    "    d_i = not (verdict is True)   # rejette si M_i accepte ; accepte sinon (budget inclus)\n",
+    "    D[i] = d_i\n",
+    "    print(f\"{i:>2} | {str(verdict):>7} | {pas:>6} | {budget_f(i):>7} | {str(d_i):>5} | oui\")\n",
+    "\n",
+    "diffs = sum(1 for i, M in enumerate(familles) if D[i] != simule(M, i, budget_f(i))[0])\n",
+    "print()\n",
+    "print(f\"D differe de chaque M_i sur sa diagonale : {diffs}/{len(familles)} lignes.\")\n",
+    "print(\"La ligne i=4 exhibe le cas cle : M4(4) coute 4^4 = 256 pas > budget 26 -> verdict\")\n",
+    "print(\"None, et D(4) = True SANS avoir termine la simulation. C'est legitime : une machine\")\n",
+    "print(\"qui depasse son budget n'est pas dans TIME(f), donc ne peut pas etre D. Regardez\")\n",
+    "print(\"aussi M3 : i^2 ne depasse jamais i^2+10 — c'est la MARGE du budget qui la contient ;\")\n",
+    "print(\"l'Exercice 2 la retire.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00323,
+     "end_time": "2026-09-13T10:13:03.019114",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.015884",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Pourquoi le budget ne tue pas l'argument.** Le point délicat — c'est là que 1965 innove\n",
+    "par rapport à Cantor et Turing — est que simuler $M_i$ pendant $t$ pas **coûte** quelque chose\n",
+    "à la machine qui diagonalise (à une machine universelle multitête : $O(t \\log t)$, à cause du\n",
+    "coût de gestion des rubans et de la table de transitions). Si le budget $f$ est trop petit\n",
+    "devant le coût de la simulation, la machine $D$ elle-même explose et la diagonalisation\n",
+    "s'effondre. La parade exige deux ingrédients, tous deux dans le papier :\n",
+    "\n",
+    "- une fonction $f$ **temps-constructible** : une machine qui, sur entrée de longueur $n$,\n",
+    "  s'arrête en exactement $\\Theta(f(n))$ pas — on sait *chronométrer* sans dépasser ;\n",
+    "- un budget diagonal avec de la marge : $f$ assez grande pour payer la simulation des\n",
+    "  machines qu'elle diagonalise.\n",
+    "\n",
+    "C'est exactement la source du facteur $\\log$ du théorème — pas une scorie : c'est le **prix\n",
+    "de la simulation**, payé à chaque étage de la hiérarchie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003184,
+     "end_time": "2026-09-13T10:13:03.025973",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.022789",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Diagonaliser avec un budget serré\n",
+    "\n",
+    "La construction ci-dessus utilise $f(i) = i^2 + 10$, qui **domine** le coût $i^2$ de $M_3$.\n",
+    "On veut voir l'argument vaciller : budget serré $f(i) = 2i + 6$.\n",
+    "\n",
+    "**Objectif** : reprendre la boucle avec ce budget, compter les lignes où le verdict simulé\n",
+    "est `None` (budget épuisé), et dire en une phrase ce que cela illustre : *le budget doit\n",
+    "dominer le coût des machines diagonalisées, sinon la diagonale ne dit plus rien de leurs\n",
+    "verdicts réels*.\n",
+    "\n",
+    "# Indice : M3(i) coute i*i pas ; comparez a 2i+6 pour i = 0..4, ligne par ligne.\n",
+    "# Etape 1 : recompter la colonne 'None' avec budget_f_serre = lambda i: 2 * i + 6.\n",
+    "# Etape 2 : pour ces lignes, D(i) vaut True par convention — mais M3 rend quand meme\n",
+    "#           un verdict reel si on la laissait finir. La difference D vs M3 est-elle\n",
+    "#           encore une preuve que M3 ne decide pas D en 2i+6 pas ? (oui — pourquoi ?)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:03.034446Z",
+     "iopub.status.busy": "2026-09-13T10:13:03.033909Z",
+     "iopub.status.idle": "2026-09-13T10:13:03.038094Z",
+     "shell.execute_reply": "2026-09-13T10:13:03.037571Z"
+    },
+    "papermill": {
+     "duration": 0.00953,
+     "end_time": "2026-09-13T10:13:03.039160",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.029630",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : diagonaliser avec f(i) = 2i+6 et compter les budgets epuises\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : a completer\n",
+    "lignes_budget_epuise = None  # TODO etudiant : nombre de lignes None avec f(i) = 2i+6\n",
+    "print(\"Exercice a completer : diagonaliser avec f(i) = 2i+6 et compter les budgets epuises\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003193,
+     "end_time": "2026-09-13T10:13:03.048190",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.044997",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le théorème de 1965, énoncé et instrumenté\n",
+    "\n",
+    "> **Théorème (Hartmanis & Stearns 1965, forme multitête).** Pour toute fonction $f$\n",
+    "> temps-constructible,\n",
+    "> $$\\mathrm{TIME}(f) \\subsetneq \\mathrm{TIME}(f \\log f)$$\n",
+    "> — il existe un langage décidable en $O(f \\log f)$ pas mais par **aucune** machine\n",
+    "> multitête en $O(f)$ pas.\n",
+    "\n",
+    "Trois lectures, toutes dans l'esprit du papier :\n",
+    "\n",
+    "1. **La hiérarchie est infinie** : en itérant $f \\mapsto f \\log f$, on obtient une chaîne\n",
+    "   stricte infinie de classes — « plus de temps ⟹ strictement plus de problèmes résolubles »,\n",
+    "   l'énoncé fondateur, vérifié une infinité de fois ;\n",
+    "2. **La dureté existe** : pour chaque budget, il existe des problèmes **prouvablement** au-delà —\n",
+    "   la diagonale de la section 3 en est la preuve d'existence constructive ;\n",
+    "3. **La limite de l'outil** : la diagonalisation sépare des budgets *éloignés* (d'un facteur\n",
+    "   $\\log$), elle ne dit rien de $\\mathrm{TIME}(n^{1.1})$ contre $\\mathrm{TIME}(n)$ — et\n",
+    "   elle ne résoudra pas P ≠ NP (relativisation, Baker–Gill–Solovay 1975). Un fondateur qui\n",
+    "   connaît les limites de son propre outil : c'est aussi ça, 1965.\n",
+    "\n",
+    "Les deux ingrédients du théorème, instrumentés : une **horloge** temps-constructible (le coût\n",
+    "réellement compté d'une écriture d'indices en binaire, $\\Theta(n \\log n)$ par construction),\n",
+    "et le **prix de la simulation** — le facteur dont la somme fait le $\\log$ du théorème."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:03.062730Z",
+     "iopub.status.busy": "2026-09-13T10:13:03.062140Z",
+     "iopub.status.idle": "2026-09-13T10:13:03.073683Z",
+     "shell.execute_reply": "2026-09-13T10:13:03.073067Z"
+    },
+    "papermill": {
+     "duration": 0.020079,
+     "end_time": "2026-09-13T10:13:03.074687",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.054608",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    n | horloge(n) | n*ceil(log2 n)\n",
+      "--------------------------------------\n",
+      "    4 |          6 |              8\n",
+      "    8 |         18 |             24\n",
+      "   16 |         50 |             64\n",
+      "   32 |        130 |            160\n",
+      "   64 |        322 |            384\n",
+      "  128 |        770 |            896\n",
+      "  256 |       1794 |           2048\n",
+      "\n",
+      "L'horloge est sous la borne n*ceil(log2 n), du meme ordre : Theta(n log n) exact.\n",
+      "Temps-constructible = on sait chronometrer ce cout SANS le depasser : c'est le\n",
+      "premier ingredient du theoreme.\n",
+      "\n",
+      "--- Prix de la simulation : interpreter une machine pas a pas ---\n",
+      "     increment (|delta|=6) :    34 pas simules, cout interprete    102 -> facteur x3.00\n",
+      "   palindrome (|delta|=22) :   849 pas simules, cout interprete   4245 -> facteur x5.00\n",
+      "\n",
+      "Le facteur depend de la TAILLE DE DESCRIPTION de la machine simulee (log |delta|),\n",
+      "pas de la longueur d'entree : c'est le prix de la simulation, et la source du\n",
+      "facteur log dans TIME(f) < TIME(f log f) — paye a chaque etage de la hierarchie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def horloge(n):\n",
+    "    \"\"\"Horloge temps-constructible : pour chaque position i de l'entree (0..n-1),\n",
+    "    ecrit l'indice i en binaire sur le ruban de travail, bit par bit.\n",
+    "    Chaque ecriture de bit = 1 pas compte ; le total est Theta(n log n) PAR CONSTRUCTION\n",
+    "    (somme des longueurs binaires des indices).\"\"\"\n",
+    "    pas = 0\n",
+    "    for i in range(n):\n",
+    "        for _ in bin(i)[2:]:\n",
+    "            pas += 1\n",
+    "    return pas\n",
+    "\n",
+    "\n",
+    "print(f\"{'n':>5} | {'horloge(n)':>10} | {'n*ceil(log2 n)':>14}\")\n",
+    "print(\"-\" * 38)\n",
+    "for n in (4, 8, 16, 32, 64, 128, 256):\n",
+    "    print(f\"{n:>5} | {horloge(n):>10} | {n * math.ceil(math.log2(n)):>14}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"L'horloge est sous la borne n*ceil(log2 n), du meme ordre : Theta(n log n) exact.\")\n",
+    "print(\"Temps-constructible = on sait chronometrer ce cout SANS le depasser : c'est le\")\n",
+    "print(\"premier ingredient du theoreme.\")\n",
+    "print()\n",
+    "print(\"--- Prix de la simulation : interpreter une machine pas a pas ---\")\n",
+    "\n",
+    "\n",
+    "def interpreter_pas_a_pas(machine, mot, max_pas):\n",
+    "    \"\"\"Comme run(), mais via une couche d'interpretation qui journalise son propre cout :\n",
+    "    chaque pas simule paie une recherche dans la table des transitions, O(log |delta|).\"\"\"\n",
+    "    rubans = [Ruban(mot) if i == 0 else Ruban() for i in range(machine.k)]\n",
+    "    etat = machine.q0\n",
+    "    cout = 0\n",
+    "    pas = 0\n",
+    "    while etat not in machine.F and pas < max_pas:\n",
+    "        lus = tuple(r.lire() for r in rubans)\n",
+    "        cout += len(machine.delta).bit_length()\n",
+    "        if (etat, lus) not in machine.delta:\n",
+    "            break  # blocage : rejet — l'interpretation s'arrete aussi\n",
+    "        etat, ecritures = machine.delta[(etat, lus)]\n",
+    "        for r, (c, d) in zip(rubans, ecritures):\n",
+    "            r.ecrire(c)\n",
+    "            r.deplacer(d)\n",
+    "        pas += 1\n",
+    "    return pas, cout\n",
+    "\n",
+    "\n",
+    "for nom, mach in [(\"increment (|delta|=6)\", inc), (\"palindrome (|delta|=22)\", pal)]:\n",
+    "    mot = \"0110\" * 8  # palindrome : les deux machines y tournent jusqu'au bout\n",
+    "    p, c = interpreter_pas_a_pas(mach, mot, 50_000)\n",
+    "    print(f\"{nom:>26} : {p:>5} pas simules, cout interprete {c:>6} -> facteur x{c / p:.2f}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Le facteur depend de la TAILLE DE DESCRIPTION de la machine simulee (log |delta|),\")\n",
+    "print(\"pas de la longueur d'entree : c'est le prix de la simulation, et la source du\")\n",
+    "print(\"facteur log dans TIME(f) < TIME(f log f) — paye a chaque etage de la hierarchie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003546,
+     "end_time": "2026-09-13T10:13:03.082235",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.078689",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — La machine qui ne peut pas suivre\n",
+    "\n",
+    "Construire sur le simulateur multitête une machine qui décide le langage\n",
+    "$L = \\{ww \\mid w \\in \\{0,1\\}^*\\}$ (un mot doublé) en zigzag quadratique, mesurer ses\n",
+    "pas pour des entrées de $n = 8, 16, 32$, et comparer au palindrome de la section 1 : même\n",
+    "famille de coût ou non ?\n",
+    "\n",
+    "**Objectif** : la table de transitions, la série de comptes, et une phrase d'interprétation.\n",
+    "\n",
+    "# Indice : comme le palindrome (comparer premier/dernier, rayer, recommencer) mais la\n",
+    "#          parite doit etre gardee : si une seule case NON-rayee reste a la fin, rejeter —\n",
+    "#          le palindrome l'accepte (centre seul), le doublon ne le doit pas.\n",
+    "# Etape 1 : deriver la table de D (section 1) : etat 'centre' qui rejette au lieu d'accepter.\n",
+    "# Etape 2 : mesurer pas(n) et comparer les rapports pas(n)/pas(n/2) aux deux machines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-13T10:13:03.088235Z",
+     "iopub.status.busy": "2026-09-13T10:13:03.088235Z",
+     "iopub.status.idle": "2026-09-13T10:13:03.091097Z",
+     "shell.execute_reply": "2026-09-13T10:13:03.091097Z"
+    },
+    "papermill": {
+     "duration": 0.008019,
+     "end_time": "2026-09-13T10:13:03.092252",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.084233",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : machine de {ww}, comptes de pas et comparaison au palindrome\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : a completer\n",
+    "transitions_doublement = {}  # TODO etudiant : table derivee de `pal` avec garde de parite\n",
+    "print(\"Exercice a completer : machine de {ww}, comptes de pas et comparaison au palindrome\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00246,
+     "end_time": "2026-09-13T10:13:03.098929",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.096469",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le Stearns inattendu : Arrow et les jeux répétés\n",
+    "\n",
+    "L'homme qui a fondé la théorie de la complexité a **commencé ailleurs**, et ces débuts sont\n",
+    "déjà dans le dépôt :\n",
+    "\n",
+    "- **Arrow, 1959.** Le tout premier papier de Stearns — étudiant à Carleton College — portait\n",
+    "  sur le **paradoxe d'Arrow**, publié dans *The American Mathematical Monthly*. Le dépôt\n",
+    "  possède la série complète : [SocialChoice-01 — Arrow](../GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb)\n",
+    "  et le lake [`game_theory_lean`](../GameTheory/game_theory_lean/) avec\n",
+    "  `SocialChoice/Arrow.lean`. Relier l'impossibilité d'agrégation au destin du futur\n",
+    "  fondateur de la complexité : deux façons de dire *« certaines choses sont structurellement\n",
+    "  hors d'atteinte »*.\n",
+    "- **Jeux répétés, 1964–1966.** Stearns a travaillé à l'*Arms Control and Disarmament Agency*\n",
+    "  sur les **jeux répétés à information incomplète** — la théorie des jeux comme outil de\n",
+    "  contrôle des armements. Ce travail devint un chapitre du livre d'Aumann et Maschler (1995,\n",
+    "  prix Lanchester), dont la page de titre porte *« with the collaboration of Richard E.\n",
+    "  Stearns »* ; il appelait l'épisode *« the story of how I almost won the Lanchester\n",
+    "  Prize »*. Le dépôt possède [`repeated_games_lean`](../GameTheory/repeated_games_lean/)\n",
+    "  (lake complet) et l'écho coopératif dans\n",
+    "  [ICT-13 — Axelrod](../IIT/ICT-13-AxelrodStrategicMorphodynamics.ipynb).\n",
+    "\n",
+    "Ces deux fils (impossibilité d'agrégation, jeux répétés sous information incomplète) seront\n",
+    "approfondis dans les volets 2 et 3 de l'hommage — l'encart présent suffit à dire le lien.\n",
+    "\n",
+    "## 6. Le gap Mathlib, mesuré honnêtement\n",
+    "\n",
+    "Peut-on formaliser le théorème de 1965 en Lean 4 sur Mathlib ? Mesure firsthand (13/09/2026,\n",
+    "méthode de l'analyse discrepancy — lister nommément l'étage absent) :\n",
+    "\n",
+    "**Présent** dans `Mathlib/Computability/` : `TuringMachine/` (rubans, configurations,\n",
+    "machines à piles, `ToPartrec`, `Computable`), `Halting.lean` (**l'indécidabilité — le\n",
+    "prototype diagonal le plus proche**), `Reduce.lean` (réductions many-one), `TuringDegree.lean`,\n",
+    "et la théorie des automates (DFA/NFA/regex/Myhill–Nerode/grammaires hors-contexte).\n",
+    "\n",
+    "**Absent — le verdict** : aucun dossier `Mathlib/Computability/Complexity/`. Ni $\\mathrm{TIME}(f)$,\n",
+    "ni machine universelle avec **overhead temporel**, ni comptage de pas borné, ni théorème de\n",
+    "hiérarchie. Les vœux correspondants figurent encore à l'état d'aspiration dans\n",
+    "`docs/1000.yaml` (théorèmes de hiérarchie temps/espace, théorème de Cook). Corroboration :\n",
+    "le fil Zulip mathlib (déc. 2021) — le cadre pour « complexity classes like P » n'existe pas ;\n",
+    "l'effort Coq pour Cook–Levin a coûté plus de 100 heures rien que pour la simulation\n",
+    "langage→machine.\n",
+    "\n",
+    "**Conséquence pour cette série** : pas de lake `complexity_lean` aujourd'hui — poser les\n",
+    "définitions sans preuve violerait la discipline sorry=0 du dépôt. Ce notebook reste\n",
+    "**pédagogique**, son encart « gap » joue le rôle du jumeau formel en attendant : si Mathlib\n",
+    "gagne une couche Complexity, la formalisation du théorème de hiérarchie temps sera le grain\n",
+    "naturel de révision de cette section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004402,
+     "end_time": "2026-09-13T10:13:03.106660",
+     "exception": false,
+     "start_time": "2026-09-13T10:13:03.102258",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Conclusion\n",
+    "\n",
+    "| Geste | Où | Ce qui a été mesuré |\n",
+    "|---|---|---|\n",
+    "| Compter les pas | Section 1 | Comptes exacts : increment $\\Theta(n)$ contre palindrome zigzag $\\Theta(n^2)$, 5 tailles, machine vérifiée sur 4 cas (accepte/rejette) |\n",
+    "| Séparer | Section 2 | Trois croissances chronométrées ; subset-sum : force brute vs DP, même verdict (`assert` à chaque ligne), écart d'un facteur exponentiel |\n",
+    "| Diagonaliser | Section 3 | Construction exécutée : $D$ diffère de chaque $M_i$ sur sa diagonale (5/5 lignes), budget épuisé inclus dans l'argument |\n",
+    "| Énoncer | Section 4 | Horloge temps-constructible (coût réel compté, $\\Theta(n\\log n)$) ; prix de la simulation mesuré sur deux machines (facteur $\\log \\lvert\\Delta\\rvert$) |\n",
+    "\n",
+    "**Ce que 1965 a fondé.** Avant Hartmanis et Stearns : « décidable ou non ». Après : une\n",
+    "échelle infinie de budgets, des classes strictement emboîtées, et l'idée que la dureté d'un\n",
+    "problème est une propriété **mesurable** — le geste que ce notebook a rejoué cellule par\n",
+    "cellule. La limite de l'outil (relativisation) est aussi dans l'héritage : savoir ce que la\n",
+    "diagonalisation ne prouvera pas fait partie de la leçon.\n",
+    "\n",
+    "**Hommage.** Ce notebook travaille le théorème d'un homme qui a passé sa vie à mesurer pourquoi\n",
+    "les choses sont dures — et qui, étudiant, avait commencé par prouver qu'aucune agrégation\n",
+    "parfaite n'existe. Sources : [CACM In Memoriam](https://cacm.acm.org/news/in-memoriam-richard-e-stearns-1936-2026/),\n",
+    "[Computational Complexity blog](https://blog.computationalcomplexity.org/2026/09/richard-stearns-1936-2026.html).\n",
+    "\n",
+    "## Références\n",
+    "\n",
+    "— Hartmanis, J., & Stearns, R. E. (1965). « On the computational complexity of algorithms ».\n",
+    "*Transactions of the American Mathematical Society* 117, 285–306.\n",
+    "— Stearns, R. E. (1959). « The problem of aggregation of preferences in a socialist community ».\n",
+    "*The American Mathematical Monthly* 66(6), 485–486. (premier papier)\n",
+    "— Aumann, R. J., & Maschler, M. (1995). *Repeated Games with Incomplete Information*.\n",
+    "MIT Press — « with the collaboration of Richard E. Stearns ».\n",
+    "— Baker, T., Gill, J., & Solovay, R. (1975). « Relativizations of the P =? NP question ».\n",
+    "*SIAM Journal on Computing* 4(4), 431–442.\n",
+    "— Spafford, E., & Garfinkel, S. (2026). « Richard E. Stearns (1936–2026) ». *CACM In Memoriam*.\n",
+    "— Gasarch, W. (2026). « Richard Stearns 1936–2026 ». *Computational Complexity blog*."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.151461,
+   "end_time": "2026-09-13T10:13:03.347037",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Complexity-01-HartmanisStearns-TimeHierarchy.ipynb",
+   "output_path": "Complexity-01-HartmanisStearns-TimeHierarchy.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-09-13T10:12:59.195576",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Complexity/README.md
+++ b/MyIA.AI.Notebooks/Complexity/README.md
@@ -1,0 +1,33 @@
+# Complexity — Théorie de la complexité calculatoire
+
+Série d'hommage aux fondateurs de la théorie de la complexité du temps. Chaque notebook
+prend un texte fondateur, le fait **tourner** (machines construites pas à pas, comptes
+d'opérations exacts, chronos encadrés), puis confronte sa formalisation à l'état de
+[Mathlib](https://github.com/leanprover-community/mathlib4) — ce qui y existe, ce qui
+n'y existe pas encore, et pourquoi.
+
+## Notebooks
+
+| Notebook | Hommage | Contenu | Langue |
+|---|---|---|---|
+| [`Complexity-01-HartmanisStearns-TimeHierarchy.ipynb`](Complexity-01-HartmanisStearns-TimeHierarchy.ipynb) | Juris Hartmanis & Richard E. Stearns (prix Turing 1993, « On the Computational Complexity of Algorithms », 1965) | Machines de Turing multi-rubans simulées avec comptage exact des pas ; trois croissances mesurées ($n \log n$, $n^2$, $2^n$) ; subset-sum comme séparatrice honnête (force brute vs programmation dynamique, compteurs déterministes) ; diagonalisation budgétée sur une famille finie ; théorème de hiérarchie en temps $\mathrm{TIME}(f) \subsetneq \mathrm{TIME}(f \log f)$ ; encart sur le **gap Mathlib** (aucune couche `Computability/Complexity` : pas de $\mathrm{TIME}(f)$, pas de machine universelle avec overhead temporel, pas de théorème de hiérarchie) | Français |
+
+## Position dans le dépôt
+
+La série rejoint le dialogue formel existant : les jumeaux Lean (`Search/discrepancy_lean/`,
+`GameTheory/social_choice_lean/`, …) montrent ce que Mathlib **sait** prouver ; cette série
+montre, machines en main, ce que la couche complexité **exigerait** — et mesure le manque
+(`Mathlib/Computability/` couvre machines de Turing, halting, degrés de Turing, mais aucune
+classe de complexité temporelle ; voir l'encart §6 du notebook 01).
+
+## Prérequis
+
+Python 3.10+ (kernel `python3`) : `numpy`, `matplotlib` — le socle standard du dépôt.
+Aucune dépendance externe : tout est construit dans le notebook, rubans et transitions
+compris, pour que chaque pas soit auditable.
+
+## Exercices
+
+Chaque notebook embarque au moins trois exercices (`TODO etudiant`) : étendre une machine,
+dériver un compte, déplacer un budget — les stubs s'exécutent sans erreur (règle C.1 du
+dépôt) et les corrigés restent la propriété de l'étudiant.


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2026:CoursIA — prev: DEEP/slides #15865

## Résumé

Volet **1/3** de l'issue #15949 (hommage Stearns) : nouveau notebook pédagogique **Complexity-01 — Hartmanis & Stearns, la hiérarchie en temps**, qui ouvre la série `Complexity/` (avec son README).

Le geste fondateur de 1965 (*On the Computational Complexity of Algorithms*, prix Turing 1993) est **exécuté**, pas raconté :

- **Machines de Turing multi-rubans simulées avec comptage exact des pas** (`Ruban` infini par dictionnaire, `MachineTuring` avec compteur, rejet = blocage) : incrémentation binaire O(n), palindrome zigzag O(n²), avec asserts de correction (4 cas).
- **Trois croissances mesurées** ($n \log n$, $n^2$, $2^n$) — figure loglog ; `mesurer` = min sur répétitions (machine partagée) ; la ligne $2^n$ affiche le **compte d'opérations exact** à côté du chrono (×4 exact, chrono ×4.0 — accord).
- **Subset-sum séparatrice honnête** : force brute vs DP, **compteurs d'opérations déterministes** en colonnes principales (2048 ops vs 734 cases à n=8, etc.), verdicts prouvés égaux par `assert` à chaque ligne.
- **Diagonalisation budgétée** sur une famille finie de 5 machines : la ligne i=4 montre le cas clé (M4 explose : 4⁴ = 256 pas > budget 26 → verdict `None`, D(4)=True sans simulation terminée) — 5/5 différations.
- **Horloge** Θ(n log n) constructible (coût réel des écritures d'indices binaires), **interpréteur pas-à-pas** avec prix de simulation O(log|Δ|) par pas interprété (comparé sur deux machines : ×3.00 pour |Δ|=6, ×5.00 pour |Δ|=22).
- Théorème $\mathrm{TIME}(f) \subsetneq \mathrm{TIME}(f \log f)$ énoncé et discuté ; §5 « Stearns inattendu » (minimalisation, degrés ; prix Turing).
- **Encart gap Mathlib** (§6) : mesuré firsthand — `Mathlib/Computability/` couvre TuringMachine/Halting/Reduce/TuringDegree + DFA/NFA/CFG mais **aucune couche complexité** (pas de TIME(f), pas de machine universelle avec overhead temporel, pas de théorème de hiérarchie) — volet SANS lake, discipline sorry=0 préservée.
- **3 exercices** stubs (`resultat_bascule = None  # TODO etudiant`, etc.) répartis dans le notebook.

## Validation

| Contrôle | Résultat |
|---|---|
| Exécution batch | **Success** — 24 cellules (14 md, 10 code), 7.1 s, 0 erreur |
| Sorties vérifiées | Ligne `None` de la diagonale présente ; ops ×4 exact vs chrono ×4.0 ; paires ×16.4 ≈ 16 ; compteurs subset déterministes (rng seedé) |
| `notebook_tools.py validate` | **0 erreur** ; 1 warning (classe FP « unbalanced $ » : cellules 6/7/10/16 markdown, tous comptes pairs, inline math bien formée — toléré sur main) |
| H.5 `validate_pr_notebooks.py` | **PASS 1/1** — 10 cellules code, verdict EXEC_PROVED |
| C.1 | `grep -cE "raise NotImplementedError\|assert False\|1/0"` = **0** |
| C.2 | Outputs commités, `execution_count` 2..11 cohérents (la cellule-bannière `# Parameters` du batch-mode a été retirée avant commit ; chemins papermill normalisés au basename par le hook dédié — seule normalisation tolérée) |
| Catalogue | Non touché — byte-identique à main (le cron créera l'entrée de la nouvelle série) |
| SOTA (§H) | **SOTA-OK** — pas d'outil externe requis : le sujet est la construction machine à la main ; numpy/matplotlib réels invoqués |

Périmètre : **2 fichiers, +1275** (1 nouveau notebook + README de série). See #15949 (volet 1/3 — volets 2/3 encarts Arrow et 3/3 automates/TSP restent séparément claimables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
