### PR TITLE
fix(gametheory,#12797): un enonce par exercice + prose intermediaire

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm-Part2-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-02-NormalForm-Part2-Python.ipynb
@@ -307,6 +307,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt2p2-09i",
+   "metadata": {},
+   "source": [
+    "### Le solveur : énumération des supports, étape par étape\n",
+    "\n",
+    "La brique est posée (`subsets_of_size`) ; la cellule suivante assemble le solveur complet. Pour chaque paire de supports $(S_1, S_2)$ de même taille $k$, il résout le système d'indifférence de chaque joueur (les $k-1$ équations d'espérances égales, plus la normalisation), puis applique le double test du point 3 de l'algorithme : positivité **stricte** des probabilités sur le support, et **best-response** hors-support."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "gt2p2-10",
@@ -393,6 +403,16 @@
     "    return equilibria\n",
     "\n",
     "print(\"Support enumeration pret (Gauss + indifference + best-response check).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt2p2-10i",
+   "metadata": {},
+   "source": [
+    "### Premier vol : Pierre-Feuille-Ciseaux (3x3)\n",
+    "\n",
+    "Le solveur est assemblé — reste à le faire voler sur le cas qui a motivé la tranche : un jeu sans équilibre pur ni formule close applicable. Pierre-Feuille-Ciseaux est le candidat canonique, antisymétrique et à somme nulle. La cellule suivante construit le jeu et lance l'énumération ; la lecture du résultat (symétrie, uniformité) suit l'exécution."
    ]
   },
   {
@@ -864,7 +884,7 @@
     "- Knight, V. (2017). *Nashpy : a python library for 2-player strategic games*.\n",
     "- Twin .NET : [GameTheory-02-NormalForm-Csharp-Part2](GameTheory-02-NormalForm-Csharp-Part2.ipynb) (même algorithme en C#/BCL).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "*Tranche 2 du twin .NET⇄Python (#4956 marathon). Support enumeration = résolution exacte des équilibres mixtes, pont théorie-jeux ↔ algèbre linéaire. Vérifié contre nashpy (SOTA-OK).*"
    ]

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03c-Le-Joueur-LLM.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03c-Le-Joueur-LLM.ipynb
@@ -967,19 +967,17 @@
    "source": [
     "## 8. Exercices\n",
     "\n",
-    "Cette section rassemble **3 exercices progressifs** sur la dissociation prédire/agir.\n",
-    "\n",
+    "Cette section rassemble **3 exercices progressifs** sur la dissociation prédire/agir."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-18-e1",
+   "metadata": {},
+   "source": [
     "### Exercice 1 — Remplacer le joueur simulé par un vrai LLM (openai-compatible)\n",
     "\n",
-    "L'objectif : remplacer `sticky_preferred` par un appel provider réel. Quand `OPENAI_API_KEY` (ou équivalent) est présent dans `os.environ`, le notebook appelle le modèle ; sinon, il reste sur le stub `sticky_preferred`. C'est la cellule-type d'extension **RECOVERABLE-LOCAL** (cf [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md)).\n",
-    "\n",
-    "### Exercice 2 — Caractériser les swaps qui augmentent la dissociation\n",
-    "\n",
-    "L'objectif : pour chaque chambre X, lister **tous** les swaps qui transforment le Nash et mesurer la dissociation sticky vs BR sur chaque swap. Identifier les swaps qui **cachent** la dissociation (BattleSexes+C12) vs ceux qui la **révèlent** (Dilemme+C23).\n",
-    "\n",
-    "### Exercice 3 — Cyclicité de BattleSexes : formalisation en logique modale\n",
-    "\n",
-    "L'objectif : proposer un encodage **non-transitif** de BattleSexes qui préserve ses deux Nash (C,D) et (D,C). Indice : utiliser des préférences **lexicographiques** ou une **logique modale KD45**."
+    "L'objectif : remplacer `sticky_preferred` par un appel provider réel. Quand `OPENAI_API_KEY` (ou équivalent) est présent dans `os.environ`, le notebook appelle le modèle ; sinon, il reste sur le stub `sticky_preferred`. C'est la cellule-type d'extension **RECOVERABLE-LOCAL** (cf [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md))."
    ]
   },
   {
@@ -1163,6 +1161,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-18-e2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Caractériser les swaps qui augmentent la dissociation\n",
+    "\n",
+    "L'objectif : pour chaque chambre X, lister **tous** les swaps qui transforment le Nash et mesurer la dissociation sticky vs BR sur chaque swap. Identifier les swaps qui **cachent** la dissociation (BattleSexes+C12) vs ceux qui la **révèlent** (Dilemme+C23)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "cell-20",
@@ -1231,6 +1239,16 @@
     "print(f\"{'Swap':6s} {'d_sticky_post':15s} {'d_BR_post':15s}\")\n",
     "for swap, d_s, d_b in results_dilemme[:6]:\n",
     "    print(f\"{swap:6s} {d_s:>13.0%}  {d_b:>13.0%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-18-e3",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Cyclicité de BattleSexes : formalisation en logique modale\n",
+    "\n",
+    "L'objectif : proposer un encodage **non-transitif** de BattleSexes qui préserve ses deux Nash (C,D) et (D,C). Indice : utiliser des préférences **lexicographiques** ou une **logique modale KD45**."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03f-Parcours-Complet.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03f-Parcours-Complet.ipynb
@@ -1007,7 +1007,21 @@
    "source": [
     "## 5. Exercices\n",
     "\n",
-    "Trois exercices prolongent le parcours. Le premier retourne la section 2 (du pas vers le mur) dans l'autre sens ; le deuxième rouvre la question laissée ouverte en 3.2 ; le troisième fait courir le parcours complet sur un autre couple nommé. Comme toujours dans la série : le notebook doit s'exécuter de bout en bout même exercices non complétés -- chaque cellule est un stub inoffensif, à remplacer."
+    "Trois exercices prolongent le parcours : remonter le pas vers le mur (retour sur la section 2), chercher un contre-exemple au fait mesuré de 3.2, et faire courir le parcours complet sur un autre couple nommé. Chaque énoncé précède immédiatement son stub.\n",
+    "\n",
+    "Comme toujours dans la série : le notebook doit s'exécuter de bout en bout même exercices non complétés -- chaque cellule est un stub inoffensif, à remplacer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3f-ex1",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Le mur du pas, dans l'autre sens\n",
+    "\n",
+    "La section 2 allait du pas vers le mur ; cet exercice remonte le chemin inverse. On donne deux chambres adjacentes quelconques `(pred, cur)` et on demande de retrouver le mur traversé : identifier le côté modifié et le niveau `k` (le pas), construire le mur par fusion de niveaux, puis vérifier que `briser_le_tie(mur)` redonne exactement `{pred, cur}` — la propriété de la section 2.\n",
+    "\n",
+    "Test attendu sur `pred_ex -> cur_ex` : côté colonne, niveau 1, mur `(2, 3, 1, 1)`."
    ]
   },
   {
@@ -1058,6 +1072,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt3f-ex2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Chercher le contre-exemple au fait mesuré\n",
+    "\n",
+    "La section 3.2 a **mesuré** (10 paires nommées + 300 paires quelconques) que le chemin le plus court est aussi le moins cher sous `W = {1: 1, 2: 2, 3: 3}`. Le fait est-il robuste à un autre barème ? Choisir un autre tarif (p.ex. `W2 = {1: 1, 2: 1, 3: 3}` ou `{1: 3, 2: 1, 3: 1}`, le sommet bon marché), refaire le balayage — pour chaque paire nommée et un échantillon de 300 paires, comparer `cout_chemin(construire_chemin)` et `cout_chemin(chemin_min_cout)` — et rapporter : un barème où un détour gagne existe-t-il ?\n",
+    "\n",
+    "Indice : commencer par le barème sommet bon marché — que devient l'écart moyen ?"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "3037df0d",
@@ -1098,6 +1124,16 @@
     "\n",
     "W2 = {1: 1, 2: 2, 3: 3}  # TODO étudiant : essayer d'autres barèmes\n",
     "print(\"Exercice 2 à compléter : balayage sous barème\", W2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3f-ex3",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Capstone : POULE -> RENVERSE, le parcours complet\n",
+    "\n",
+    "Faire courir `parcours_complet` de la Poule au Renversement sous `W = {1: 1, 2: 2, 3: 3}`, puis passer le résultat à `verifier_parcours`. Questions de lecture : combien de pas, et répartis comment entre les deux joueurs ? Quels niveaux sont révisés — le trajet touche-t-il le sommet de qui que ce soit ? La facture par joueur : qui paie le plus, et pourquoi la géométrie l'impose-t-elle (cf 3.1) ?"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Loi-II-Translateur-Life.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Loi-II-Translateur-Life.ipynb
@@ -639,6 +639,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt21-ex1",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Certificat sur une autre vitesse supra-luminale\n",
+    "\n",
+    "Choisir une vitesse impossible au-dessus de la limite (ex. `(3,0,4)`, `(0,3,4)`, ou le diagonal `(2,2,4)`) et faire rendre au générateur son certificat d'épuisement. Écrire la portée exacte du certificat rendu.\n",
+    "\n",
+    "Indice : `synthetiseur(b, k, dx, dy, p)` rend toujours la structure du certificat."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "12001265",
@@ -675,6 +687,18 @@
     "# Indice : synthetiseur(b, k, dx, dy, p) rend toujours la structure du certificat.\n",
     "# TODO étudiant : lancer la recherche et commenter le verdict.\n",
     "print(\"Exercice à compléter\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt21-ex2",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Un verdict à quatre valeurs\n",
+    "\n",
+    "Le vérificateur actuel accepte un still life comme translateur de vitesse nulle. Le durcir en quatre verdicts : `TRANSLATEUR` (déplacement non nul), `STILL LIFE` (`(0,0)` à toute période), `OSCILLATEUR` (période p, déplacement nul), `INVALIDE`. Le tester sur le glider, le bloc et un blinker.\n",
+    "\n",
+    "Indice : un blinker est `[[1,1,1]]` — il oscille de période 2."
    ]
   },
   {
@@ -715,6 +739,18 @@
     "# Indice : un blinker est [[1,1,1]] -- il oscille de période 2.\n",
     "# TODO étudiant : implémenter puis tester.\n",
     "print(\"Exercice à compléter\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt21-ex3",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — La boîte compte les translations séparément\n",
+    "\n",
+    "Relancer la recherche du glider `(1,1,4)` dans une boîte 4x4 (même `k=5`) et comparer le nombre de témoins au résultat 3x3. Expliquer la différence : combien de positions distinctes un même glider 3x3 occupe-t-il dans 4x4 ?\n",
+    "\n",
+    "Indice : `C(16,<=5) = 6884` motifs — quelques secondes d'énumération."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24-Humour-Banc.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24-Humour-Banc.ipynb
@@ -380,6 +380,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt24-matrix",
+   "metadata": {},
+   "source": [
+    "### L'outil de mesure : la matrice de confusion\n",
+    "\n",
+    "Prédire instance par instance ne suffit pas à comparer deux détecteurs : il faut croiser vérité et prédiction sur tout le corpus. La cellule suivante définit l'outil — `confusion_matrix` (lignes = vérité, colonnes = prédit) et son rendu `show_matrix` — puis calcule les deux matrices en lice : `M_naive` (stimulus = rire) et `M_reframe` (partage)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "c0b708bb",
@@ -425,6 +435,16 @@
     "\n",
     "print(\"Matrice naïve :\", sum(sum(v.values()) for v in M_naive.values()), \"instances\")\n",
     "print(\"Matrice recadrage :\", sum(sum(v.values()) for v in M_reframe.values()), \"instances\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt24-shownaive",
+   "metadata": {},
+   "source": [
+    "### Affichage de la matrice naïve\n",
+    "\n",
+    "Les deux matrices sont calculées ; la cellule suivante affiche celle du détecteur naïf, la référence du banc. Sa lecture — faux positifs du côté des rires sans cadre, faux négatifs du côté des recadrages sans rire — suit l'affichage."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration/0007-2026-09-13-myia-po-2024-CoursIA.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration/0007-2026-09-13-myia-po-2024-CoursIA.yaml
@@ -1,0 +1,7 @@
+date: '2026-09-13'
+by: myia-po-2024:CoursIA
+python_sha: a22fe6223f22db9396bb6db0cd488dc61a6f08cf
+csharp_sha: ce00f38332fc86f42a5a907b5fb08e1989f5052e
+content_python_sha: 20901e4cec8a36560ca7196c3b8cea4d6fe30cf7abe23e38b89762994b8e6b7f
+content_csharp_sha: 217e7f7900bb5d747698e53ec2fb8facdf8f6ca7114be18cd005da9dad7e7ea8
+reason: "Markdown-only cote Python (#12797, tranche GameTheory) : 2 cellules markdown intermediaires inserees dans le run subsets_of_size -> support_enumeration -> RPS (geste Classe B, prose pedagogique entre etapes distinctes), aucune cellule code touchee (source/execution_count/outputs verifiees identiques vs origin/main) ; rider hook-mandate hr --- -> *** sur une cellule pre-existante. Cote C# intact (csharp_sha = HEAD). Parite de contenu algorithmique inchangee. Precedent re-baseline markdown-only cote unique : 2026-08-01 (SC-04)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/tooling #15588

Tranche GameTheory/Python de #12797 : les 5 notebooks de la série portant encore un run >= 3 cellules code consécutives (mesure depot-wide à l'instant au claim, c.5652571516), + l'audit twin de re-baseline = **6 fichiers**. **Markdown-only — aucune cellule code touchée.**

## Classe A — `three-exercises-per-notebook` l.31 (le geste de #15953 / QC-Py-23b)

Trois stubs partageaient un énoncé distant dans une cellule `## Exercices` unique :

| Notebook | Avant | Après |
|---|---|---|
| `GameTheory-03c-Le-Joueur-LLM` | statement `cell-18` = en-tête + intro + 3 blocs `### Exercice N` ; stubs ec 9/10/11 en aval | blocs déplacés **verbatim** en 3 markdowns (`cell-18-e1/e2/e3`), chacun immédiatement avant son stub ; le statement garde en-tête + intro |
| `GameTheory-03f-Parcours-Complet` | statement `1bd96f69` = une intro mappant les 3 exercices en prose | 3 markdowns `### Exercice N — <titre>` retypés (contexte / objectif / test attendu ou indice, tirés de l'intro + en-têtes des stubs) avant `07393b3d` / `3037df0d` / `8d86c3fa` ; intro allégée en conséquence |
| `GameTheory-21-Loi-II-Translateur-Life` | statement `4b8adbc8` = une phrase tri-partite (« produire un certificat, durcir le vérificateur, sonder une frontière ») | 3 markdowns retypés dépliant la tri-partition avant `12001265` / `01227c11` / `35db25cf` (statement inchangé) |

## Classe B — défaut canonique #12797 (étapes distinctes à sorties réelles sans prose intermédiaire)

| Notebook | Run éliminé | Markdowns insérés |
|---|---|---|
| `GameTheory-02-NormalForm-Part2-Python` | [9..11] `subsets_of_size` -> `support_enumeration` -> résolution RPS | 2 : l'assemblage du solveur (à partir de la brique, double test du point 3 de l'algorithme) ; le premier vol RPS (le cas sans équilibre pur) |
| `GameTheory-24-Humour-Banc` | [7..9] `reframe_detector` -> `confusion_matrix`/`show_matrix` -> affichage naïf | 2 : l'outil de mesure (croisement vérité x prédit sur tout le corpus) ; l'affichage de la matrice naïve (sa lecture reste `fd432887`, inchangé) |

## Vérification (post-dernier-commit)

- `detect_consecutive_code_cells.py` (organe #12797) sur les 5 notebooks concernés : **plus aucun run >= 3** ; `max_run` = 2 partout (03c : 2 runs de 2 — paires def/démo `simulate_player`+SCoT et `swap_payoffs`+mesure ; 24 : 1 run de 2 — setup corpus). Tous sous la ligne dure >= 3.
- Cellules code **byte-identiques** vs `origin/main` : `source` + `execution_count` + `outputs` comparés cellule par cellule (assertion d'égalité stricte dans le splice) -> exception C.2 markdown-only, re-exécution non requise.
- `detect_markdown_rendering.py --check` : OK sur les 5 (aucune nouvelle violation ERROR), un fichier par invocation.
- Pre-commit : 9 hooks Passed (H.3 inclus). Rider hook-mandate : `---` -> `***` dans une cellule markdown pré-existante de 02 (hook `fix-hr-separator`, latent au passage sur le fichier).
- **Registre twin** : 02 est une paire enregistrée (`twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml`, twin C# `GameTheory-02-NormalForm-Csharp-Part2.ipynb`) -> re-baseline `--pair ... --update --by myia-po-2024:CoursIA` dans cette PR (audit `0007-2026-09-13-myia-po-2024-CoursIA.yaml`, `reason:` renseignée, côté C# intact — `csharp_sha` = HEAD). Vérif `--check --per-pair --base origin/main` : voir commentaire de push.

## Périmètre (See #12797)

Livré : 5 notebooks Python GameTheory. Résiduel nommé (prochaines tranches) : `06-EvolutionTrust`, `06f-Bounded-Agents-Python`, `13-ImperfectInfo-CFR`, `13d-Optimistic-CFR`, + les jumeaux C#/Lean de la série.

Note de claim : le tag `prev:` du [CLAIMED] citait #15953 (encore ouverte) ; le présent tag cite #15588, dernier grain MERGÉ de la lane (règle prev-cite-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
